### PR TITLE
refactor(Icon): stop printing errors/warnings

### DIFF
--- a/Resources/Private/JavaScript/Components/Icon/index.js
+++ b/Resources/Private/JavaScript/Components/Icon/index.js
@@ -1,11 +1,7 @@
 import React, {PropTypes} from 'react';
 import mergeClassNames from 'classnames';
-import {service} from 'Shared/index';
 import style from './style.css';
 import {fontAwesome} from 'Shared/Utilities/index';
-const {logger} = service;
-
-const cachedWarnings = {};
 
 const Icon = props => {
     const {size, padded} = props;
@@ -26,29 +22,10 @@ const Icon = props => {
         <i className={classNames}></i>
     );
 };
+
 Icon.propTypes = {
     // The icon key of Font-Awesome.
-    icon(props, propName) {//eslint-disable-line
-        const id = props[propName];
-        const {isValid, isMigrationNeeded, iconName} = fontAwesome.validateId(id);
-
-        if (!isValid) {
-            if (isMigrationNeeded && iconName && !cachedWarnings[iconName]) {
-                cachedWarnings[iconName] = true;
-                logger.warn(`Font-Awesome has been updated. The icon name "${id}" has been renamed.
-
-Please adjust the icon configurations in your .yaml files to the new icon name "${iconName}".
-
-https://github.com/FortAwesome/Font-Awesome/wiki/Upgrading-from-3.2.1-to-4`);
-            } else if (!iconName || !cachedWarnings[iconName]) {
-                return new Error(`Icon name "${id}" was not a found in Font-Awesome 4.5.
-Please use the icon names from the Font-Awesome website.
-
-http://fortawesome.github.io/Font-Awesome/icons/`);
-            }
-        }
-    },
-
+    icon: PropTypes.string,
     // Style related propTypes.
     size: PropTypes.oneOf(['big', 'small', 'tiny']),
     padded: PropTypes.oneOf(['none', 'left', 'right']),


### PR DESCRIPTION
Currently per each legacy/incorrect icon name the `Icon` component console logs 3 lines of warnings/errors. Clean console is important for each developer to quickly spot any warnings/errors they have just caused.

I suggest coming back to logging some stuff once we begin integration of `neos-ui`.