### PR TITLE
BUGFIX: Update Redux-Saga to 0.11.0

### DIFF
--- a/Resources/Private/JavaScript/Host/Sagas/Changes/index.js
+++ b/Resources/Private/JavaScript/Host/Sagas/Changes/index.js
@@ -14,7 +14,7 @@ export function* watchPersist() {
         try {
             const feedback = yield call(change, changes);
             yield put(actions.UI.Remote.finishSaving());
-            yield put(feedbackManager.handleFeedback.bind(feedbackManager)(feedback));
+            feedbackManager.handleFeedback.bind(feedbackManager)(feedback);
         } catch (error) {
             console.error('Failed to persist changes', error);
         }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "react-redux": "^4.4.5",
     "redux": "^3.4.0",
     "redux-actions": "^0.10.0",
-    "redux-saga": "^0.9.5",
+    "redux-saga": "^0.11.0",
     "reselect": "^2.4.0",
     "uuid": "^2.0.2",
     "whatwg-fetch": "^1.0.0"


### PR DESCRIPTION
The method feedbackManager.handleFeedback() has never returned
anything; that's why we are not allowed to create an action from
it using put().