### PR TITLE
FEATURE: inline creation of nodes

### DIFF
--- a/Resources/Private/JavaScript/Guest/Containers/NodeToolbar/Buttons/AddNode/index.js
+++ b/Resources/Private/JavaScript/Guest/Containers/NodeToolbar/Buttons/AddNode/index.js
@@ -4,8 +4,12 @@ import {
     Icon
 } from 'Components/index';
 
+// TODO: hackish! What is the proper way to call `ui` methods?
+const {ui} = window.neos;
+
 export default class AddNode extends Component {
     static propTypes = {
+        node: PropTypes.object,
         className: PropTypes.string
     };
 
@@ -29,16 +33,20 @@ export default class AddNode extends Component {
                     className={this.props.className}
                     icon="plus"
                     modeIcon={modeIcon}
-                    onClick={() => console.log(`${this.state.currentMode} node`)}
+                    onClick={this.openModal.bind(this)}
                     onItemSelect={this.onModeChanged.bind(this)}
                     directButtonProps={directButtonProps}
                     >
-                    <Icon dropDownId="prepend" icon="long-arrow-up" />
+                    <Icon dropDownId="prepend" icon="level-up" />
                     <Icon dropDownId="insert" icon="long-arrow-right" />
-                    <Icon dropDownId="append" icon="long-arrow-down" />
+                    <Icon dropDownId="append" icon="level-down" />
                 </IconButtonDropDown>
             </span>
         );
+    }
+
+    openModal() {
+        ui.openAddNodeModal(this.props.node.contextPath, this.state.currentMode);
     }
 
     getCurrentModeIcon() {
@@ -46,10 +54,10 @@ export default class AddNode extends Component {
 
         switch (this.state.currentMode) {
             case 'prepend':
-                modeIcon = 'long-arrow-up';
+                modeIcon = 'level-up';
                 break;
             case 'append':
-                modeIcon = 'long-arrow-down';
+                modeIcon = 'level-down';
                 break;
             default:
                 modeIcon = 'long-arrow-right';

--- a/Resources/Private/JavaScript/Guest/Containers/NodeToolbar/index.js
+++ b/Resources/Private/JavaScript/Guest/Containers/NodeToolbar/index.js
@@ -22,14 +22,16 @@ export default class NodeToolbar extends Component {
         toolbar: PropTypes.shape({
             x: PropTypes.number.isRequired,
             y: PropTypes.number.isRequired,
-            isVisible: PropTypes.bool.isRequired
+            isVisible: PropTypes.bool.isRequired,
+            node: PropTypes.object
         }).isRequired,
         isEditorToolbarVisible: PropTypes.bool.isRequired
     };
 
     render() {
         const props = {
-            className: style.toolBar__btnGroup__btn
+            className: style.toolBar__btnGroup__btn,
+            node: this.props.toolbar.node
         };
         const {x, y, isVisible} = this.props.toolbar;
         const {isEditorToolbarVisible} = this.props;

--- a/Resources/Private/JavaScript/Guest/Process/Synchronization.js
+++ b/Resources/Private/JavaScript/Guest/Process/Synchronization.js
@@ -13,6 +13,7 @@ export default (ui, connection, dispatch) => {
             const {x, y} = position(dom);
 
             dispatch(actions.NodeToolbar.setPosition(x - 9, y - 49));
+            dispatch(actions.NodeToolbar.setNode(node));
             dispatch(actions.NodeToolbar.show());
         } else {
             dispatch(actions.NodeToolbar.hide());

--- a/Resources/Private/JavaScript/Guest/Redux/NodeToolbar/index.js
+++ b/Resources/Private/JavaScript/Guest/Redux/NodeToolbar/index.js
@@ -2,6 +2,7 @@ import {createAction} from 'redux-actions';
 import {$set, $override} from 'plow-js';
 
 const SET_POSITION = '@neos/neos-ui/GUEST/NodeToolbar/SET_POSITION';
+const SET_NODE = '@neos/neos-ui/GUEST/NodeToolbar/SET_NODE';
 const SHOW = '@neos/neos-ui/GUEST/NodeToolbar/SHOW';
 const HIDE = '@neos/neos-ui/GUEST/NodeToolbar/HIDE';
 
@@ -10,11 +11,13 @@ const HIDE = '@neos/neos-ui/GUEST/NodeToolbar/HIDE';
 //
 export const actionTypes = {
     SET_POSITION,
+    SET_NODE,
     SHOW,
     HIDE
 };
 
 const setPosition = createAction(SET_POSITION, (x, y) => ({x, y}));
+const setNode = createAction(SET_NODE, node => node);
 const show = createAction(SHOW);
 const hide = createAction(HIDE);
 
@@ -23,6 +26,7 @@ const hide = createAction(HIDE);
 //
 export const actions = {
     setPosition,
+    setNode,
     show,
     hide
 };
@@ -33,7 +37,8 @@ export const actions = {
 export const initialState = {
     x: 0,
     y: 0,
-    isVisible: false
+    isVisible: false,
+    node: null
 };
 
 //
@@ -41,6 +46,7 @@ export const initialState = {
 //
 export const reducer = {
     [SET_POSITION]: ({x, y}) => $override('nodeToolbar', {x, y}),
+    [SET_NODE]: node => $set('nodeToolbar.node', node),
     [SHOW]: () => $set('nodeToolbar.isVisible', true),
     [HIDE]: () => $set('nodeToolbar.isVisible', false)
 };

--- a/Resources/Private/JavaScript/Host/Plugins/UI/Methods/OpenAddNodeModal/index.js
+++ b/Resources/Private/JavaScript/Host/Plugins/UI/Methods/OpenAddNodeModal/index.js
@@ -1,0 +1,5 @@
+import {actions} from 'Host/Redux/index';
+
+export default dispatch => (contextPath, mode) => {
+    dispatch(actions.UI.AddNodeModal.open(contextPath, mode));
+};

--- a/Resources/Private/JavaScript/Host/Plugins/UI/Methods/index.js
+++ b/Resources/Private/JavaScript/Host/Plugins/UI/Methods/index.js
@@ -3,6 +3,7 @@ import addFlashMessage from './AddFlashMessage/index';
 import blurNode from './BlurNode/index';
 import focusNode from './FocusNode/index';
 import hoverNode from './HoverNode/index';
+import openAddNodeModal from './OpenAddNodeModal/index';
 import unhoverNode from './UnhoverNode/index';
 import setDocumentInformation from './SetDocumentInformation/index';
 
@@ -22,6 +23,7 @@ export default initializeMethods({
     blurNode,
     focusNode,
     hoverNode,
+    openAddNodeModal,
     unhoverNode,
     setDocumentInformation
 });

--- a/Resources/Private/JavaScript/Host/Selectors/CR/Constraints/index.js
+++ b/Resources/Private/JavaScript/Host/Selectors/CR/Constraints/index.js
@@ -19,9 +19,10 @@ export const allowedNodeTypesSelector = createSelector(
     [
         parentNodeSelector,
         allowedChildNodeTypesSelector,
+        allowedChildNodeTypesForAutocreatedNodeSelector,
         byNameSelector
     ],
-    (getParentNode, getAllowedChildNodeTypes, getNodeTypeByName) =>
+    (getParentNode, getAllowedChildNodeTypes, getAllowedChildNodeTypesForAutoCreatedNode, getNodeTypeByName) =>
         (referenceNode, mode) => {
             if (!referenceNode) {
                 throw new Error('Reference node not defined');
@@ -38,13 +39,12 @@ export const allowedNodeTypesSelector = createSelector(
                 throw new Error('Base node does not have the nodetype set');
             }
             const allowedNodeTypes = baseNode.isAutoCreated ?
-                allowedChildNodeTypesForAutocreatedNodeSelector(getParentNode(baseNode.nodeType.name), baseNode.name) :
+                getAllowedChildNodeTypesForAutoCreatedNode(getParentNode(baseNode).nodeType.name, baseNode.name) :
                 getAllowedChildNodeTypes(baseNode.nodeType.name);
 
             if (!allowedNodeTypes) {
                 return [];
             }
-
             return allowedNodeTypes.map(nodeTypeName => {
                 const nodeType = getNodeTypeByName(nodeTypeName);
                 return nodeType && {


### PR DESCRIPTION
TODO: 

- [ ] reflect allowed insert positions in AddNode button, both inline and in tree
- [ ] refactor toolbar into a presentational component and use it from both tree and inline.
- [ ] how do we lazily append a newly created node, without making a full reload of the guest frame?
- [ ] learn to use `neos.ui` api properly (see comment)