### PR TITLE
BUGFIX: allow Redux-Devtools to work again

### DIFF
--- a/Resources/Private/JavaScript/Host/Containers/SecondaryToolbar/EditorToolbar/StyleSelect.js
+++ b/Resources/Private/JavaScript/Host/Containers/SecondaryToolbar/EditorToolbar/StyleSelect.js
@@ -4,6 +4,7 @@ import React, {Component, PropTypes} from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
 import {connect} from 'react-redux';
 import {$get, $transform} from 'plow-js';
+import {selectors} from 'Host/Redux/index';
 
 // Predicate matching all "element.id"s starting with "prefix".
 const startsWith = prefix => element =>
@@ -14,7 +15,7 @@ const startsWith = prefix => element =>
  */
 @connect($transform({
     activeFormatting: $get('ui.contentCanvas.activeFormatting'),
-    context: $get('guest.context')
+    context: selectors.Guest.context
 }))
 export default class StyleSelect extends Component {
 

--- a/Resources/Private/JavaScript/Host/Containers/SecondaryToolbar/EditorToolbar/index.js
+++ b/Resources/Private/JavaScript/Host/Containers/SecondaryToolbar/EditorToolbar/index.js
@@ -7,6 +7,7 @@ import {$get, $transform} from 'plow-js';
 import style from './style.css';
 
 import registry from 'Host/Extensibility/Registry/index';
+import {selectors} from 'Host/Redux/index';
 
 // a component is top-level if it does not contain slashes in the name.
 const topLevelToolbarComponent = componentDefinition =>
@@ -33,7 +34,7 @@ const renderToolbarComponents = (context, toolbarComponents, activeFormatting) =
 
 @connect($transform({
     activeFormatting: $get('ui.contentCanvas.activeFormatting'),
-    context: $get('guest.context')
+    context: selectors.Guest.context
 }))
 export default class Toolbar extends Component {
     static propTypes = {

--- a/Resources/Private/JavaScript/Host/Redux/Guest/index.js
+++ b/Resources/Private/JavaScript/Host/Redux/Guest/index.js
@@ -1,6 +1,7 @@
 import {createAction} from 'redux-actions';
 import {Map} from 'immutable';
-import {$set} from 'plow-js';
+import {$set, $get} from 'plow-js';
+import {createSelector} from 'reselect';
 
 import {handleActions} from 'Shared/Utilities/index';
 import {actionTypes as system} from 'Host/Redux/System/index';
@@ -8,9 +9,11 @@ import {actionTypes as system} from 'Host/Redux/System/index';
 const SET_CONTEXT = '@neos/neos-ui/Guest/SET_CONTEXT';
 
 /**
- * Sets the current context of the guest frame.
+ * Sets the current context (DOM window) of the guest frame.
  */
-const setContext = createAction(SET_CONTEXT, node => ({node}));
+const setContext = createAction(SET_CONTEXT, context => ({
+    contextAccessorFunction: () => context
+}));
 
 //
 // Export the actions
@@ -33,13 +36,27 @@ export const reducer = handleActions({
             //
             // Will be populated with the guests window object once the iframe loads.
             //
+            // HINT: if we store a reference towards a DOM node directly, this BREAKS
+            // Redux-Devtools - it just waits forever probably because it tries to serialize the full DOM.
+            // That's why "context" will contain a function; and when you call it (without) arguments
+            // you get back the actual context value.
             context: null
         })
     ),
-    [SET_CONTEXT]: ({node}) => $set('guest.context', node)
+    [SET_CONTEXT]: ({contextAccessorFunction}) => $set('guest.context', contextAccessorFunction)
 });
+
+const contextSelector = createSelector(
+    [
+        $get('guest.context')
+    ],
+    contextAccessorFunction =>
+        contextAccessorFunction()
+);
 
 //
 // Export the selectors
 //
-export const selectors = {};
+export const selectors = {
+    context: contextSelector
+};


### PR DESCRIPTION
We cannot store references to DOM nodes or Window in the store; as this will
break Redux-Devtools. However, we can store functions returning these values
:-)