### PR TITLE
FEATURE: Dimension switcher

### DIFF
--- a/Classes/Neos/Neos/Ui/TypoScript/Helper/ContentDimensionsHelper.php
+++ b/Classes/Neos/Neos/Ui/TypoScript/Helper/ContentDimensionsHelper.php
@@ -1,0 +1,31 @@
+<?php
+namespace Neos\Neos\Ui\TypoScript\Helper;
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Eel\ProtectedContextAwareInterface;
+use TYPO3\Neos\Domain\Service\ContentDimensionPresetSourceInterface;
+
+class ContentDimensionsHelper implements ProtectedContextAwareInterface
+{
+    /**
+     * @Flow\Inject
+     * @var ContentDimensionPresetSourceInterface
+     */
+    protected $contentDimensionsPresetSource;
+
+    /**
+     * @return array Dimensions indexed by name with presets indexed by name
+     */
+    public function contentDimensionsByName() {
+        return $this->contentDimensionsPresetSource->getAllPresets();
+    }
+
+    /**
+     * @param string $methodName
+     * @return boolean
+     */
+    public function allowsCallOfMethod($methodName)
+    {
+        return true;
+    }
+}

--- a/Classes/Neos/Neos/Ui/TypoScript/Helper/ContentDimensionsHelper.php
+++ b/Classes/Neos/Neos/Ui/TypoScript/Helper/ContentDimensionsHelper.php
@@ -21,6 +21,26 @@ class ContentDimensionsHelper implements ProtectedContextAwareInterface
     }
 
     /**
+     * @param array $dimensions Dimension values indexed by dimension name
+     * @return array Allowed preset names for the given dimension combination indexed by dimension name
+     */
+    public function allowedPresetsByName(array $dimensions) {
+        $allowedPresets = array();
+        $preselectedDimensionPresets = array();
+        foreach ($dimensions as $dimensionName => $dimensionValues) {
+            $preset = $this->contentDimensionsPresetSource->findPresetByDimensionValues($dimensionName, $dimensionValues);
+            if ($preset !== null) {
+                $preselectedDimensionPresets[$dimensionName] = $preset['identifier'];
+            }
+        }
+        foreach ($preselectedDimensionPresets as $dimensionName => $presetName) {
+            $presets = $this->contentDimensionsPresetSource->getAllowedDimensionPresetsAccordingToPreselection($dimensionName, $preselectedDimensionPresets);
+            $allowedPresets[$dimensionName] = array_keys($presets[$dimensionName]['presets']);
+        }
+        return $allowedPresets;
+    }
+
+    /**
      * @param string $methodName
      * @return boolean
      */

--- a/Classes/Neos/Neos/Ui/TypoScript/Helper/NodeInfoHelper.php
+++ b/Classes/Neos/Neos/Ui/TypoScript/Helper/NodeInfoHelper.php
@@ -106,7 +106,8 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
 
     public function uri(NodeInterface $node, ControllerContext $controllerContext)
     {
-        return $this->linkingService->createNodeUri($controllerContext, $node);
+        // Create an absolute URI without resolving shortcuts
+        return $this->linkingService->createNodeUri($controllerContext, $node, null, null, true, array(), '', false, array(), false);
     }
 
     /**

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -58,6 +58,9 @@ Neos:
           metaData:
             contextPath: '${q(documentNode).property("_contextPath")}'
             previewUrl: '${Neos.Ui.NodeInfo.uri(q(documentNode).context({workspaceName: "live"}).get(0), controllerContext)}'
+            contentDimensions:
+              active: '${documentNode.context.dimensions}'
+              allowedPresets: '${Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.context.dimensions)}'
         backend:
           changes:
             pending: []
@@ -78,6 +81,7 @@ Neos:
             contentDimensions:
               byName: ${Neos.Ui.ContentDimensions.contentDimensionsByName()}
               active: ${documentNode.context.dimensions}
+              allowedPresets: ${Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.context.dimensions)}
               # TODO Target dimensions
           ui:
             contentCanvas:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -51,6 +51,7 @@ Neos:
           'Neos.Ui.Workspace': 'Neos\Neos\Ui\TypoScript\Helper\WorkspaceHelper'
           'Neos.Ui.NodeInfo': 'Neos\Neos\Ui\TypoScript\Helper\NodeInfoHelper'
           'Neos.Ui.NodeTypes': 'Neos\Neos\Ui\TypoScript\Helper\NodeTypesHelper'
+          'Neos.Ui.ContentDimensions': 'Neos\Neos\Ui\TypoScript\Helper\ContentDimensionsHelper'
 
         documentNode:
           nodes: '${Neos.Ui.NodeInfo.renderDocumentNodeAndChildContent(documentNode, controllerContext)}'
@@ -74,6 +75,10 @@ Neos:
             workspaces:
               byName: ${Neos.Ui.Workspace.initializeWorkspacesByName()}
               active: ${Neos.Ui.Workspace.getPersonalWorkspaceName()}
+            contentDimensions:
+              byName: ${Neos.Ui.ContentDimensions.contentDimensionsByName()}
+              active: ${documentNode.context.dimensions}
+              # TODO Target dimensions
           ui:
             contentCanvas:
               src: ${Neos.Ui.NodeInfo.uri(documentNode, controllerContext)}

--- a/Resources/Private/JavaScript/API/FlowQuery/Operations/Context/index.js
+++ b/Resources/Private/JavaScript/API/FlowQuery/Operations/Context/index.js
@@ -1,0 +1,4 @@
+export default () => contextProperties => ({
+    type: 'CONTEXT',
+    payload: [contextProperties]
+});

--- a/Resources/Private/JavaScript/API/FlowQuery/Operations/index.js
+++ b/Resources/Private/JavaScript/API/FlowQuery/Operations/index.js
@@ -1,7 +1,9 @@
 import children from './Children/index';
+import context from './Context/index';
 import get from './Get/index';
 
 export {
     children,
+    context,
     get
 };

--- a/Resources/Private/JavaScript/Host/Containers/ContentCanvas/index.js
+++ b/Resources/Private/JavaScript/Host/Containers/ContentCanvas/index.js
@@ -28,6 +28,7 @@ const closestContextPath = el => {
     setContextPath: actions.UI.ContentCanvas.setContextPath,
     setPreviewUrl: actions.UI.ContentCanvas.setPreviewUrl,
     setActiveFormatting: actions.UI.ContentCanvas.setActiveFormatting,
+    setActiveDimensions: actions.CR.ContentDimensions.setActive,
     addNode: actions.CR.Nodes.add,
     focusNode: actions.CR.Nodes.focus,
     unFocusNode: actions.CR.Nodes.unFocus,
@@ -46,6 +47,7 @@ export default class ContentCanvas extends Component {
         setPreviewUrl: PropTypes.func.isRequired,
         addNode: PropTypes.func.isRequired,
         setActiveFormatting: PropTypes.func.isRequired,
+        setActiveDimensions: PropTypes.func.isRequired,
         focusNode: PropTypes.func.isRequired,
         unFocusNode: PropTypes.func.isRequired,
         hoverNode: PropTypes.func.isRequired,
@@ -109,6 +111,7 @@ export default class ContentCanvas extends Component {
             hoverNode,
             unHoverNode,
             setActiveFormatting,
+            setActiveDimensions,
             unFocusNode,
             persistChange
         } = this.props;
@@ -130,6 +133,7 @@ export default class ContentCanvas extends Component {
 
         setContextPath(documentInformation.metaData.contextPath);
         setPreviewUrl(documentInformation.metaData.previewUrl);
+        setActiveDimensions(documentInformation.metaData.contentDimensions.active);
 
         //
         // Initialize node components

--- a/Resources/Private/JavaScript/Host/Containers/SecondaryToolbar/DimensionSwitcher/index.js
+++ b/Resources/Private/JavaScript/Host/Containers/SecondaryToolbar/DimensionSwitcher/index.js
@@ -60,8 +60,8 @@ DimensionSelector.propTypes = {
 };
 
 @connect($transform({
-    contentDimensions: $get('cr.contentDimensions.byName'),
-    allowedPresets: $get('cr.contentDimensions.allowedPresets'),
+    contentDimensions: selectors.CR.ContentDimensions.byName,
+    allowedPresets: selectors.CR.ContentDimensions.allowedPresets,
     activePresets: selectors.CR.ContentDimensions.activePresets
 }), {
     selectPreset: actions.CR.ContentDimensions.selectPreset

--- a/Resources/Private/JavaScript/Host/Containers/SecondaryToolbar/DimensionSwitcher/index.js
+++ b/Resources/Private/JavaScript/Host/Containers/SecondaryToolbar/DimensionSwitcher/index.js
@@ -20,7 +20,7 @@ const SelectedPreset = props => {
             {presetLabel}
         </span>
     );
-}
+};
 SelectedPreset.propTypes = {
     icon: PropTypes.string.isRequired,
     dimensionLabel: PropTypes.string.isRequired,
@@ -43,9 +43,9 @@ const DimensionSelector = props => {
     return (
         <li key={dimensionName} className={style.dimensionCategory}>
             <Icon icon={icon} padded="right" className={style.dimensionCategory__icon}/>
-            <I18n id={dimensionLabel} />
+            <I18n id={dimensionLabel}/>
             <br/>
-            <SelectBox options={presetOptions} onSelect={onPresetSelect} value={activePreset} />
+            <SelectBox options={presetOptions} onSelect={onPresetSelect} value={activePreset}/>
         </li>
     );
 };
@@ -69,7 +69,8 @@ export default class DimensionSwitcher extends Component {
     static propTypes = {
         contentDimensions: PropTypes.object.isRequired,
         activePresets: PropTypes.object.isRequired,
-        allowedPresets: PropTypes.object.isRequired
+        allowedPresets: PropTypes.object.isRequired,
+        selectPreset: PropTypes.func.isRequired
     };
 
     static defaultProps = {
@@ -90,21 +91,25 @@ export default class DimensionSwitcher extends Component {
                 <DropDown.Header className={style.dropDown__btn}>
                     {contentDimensions.map((dimensionConfiguration, dimensionName) =>
                         <SelectedPreset
+                            key={dimensionName}
                             dimensionName={dimensionName}
                             icon={dimensionConfiguration.get('icon')}
                             dimensionLabel={dimensionConfiguration.get('label')}
-                            presetLabel={activePresets.get(dimensionName).get('label')} />
+                            presetLabel={activePresets.get(dimensionName).get('label')}
+                            />
                     )}
                 </DropDown.Header>
                 <DropDown.Contents className={style.dropDown__contents}>
                     {contentDimensions.map((dimensionConfiguration, dimensionName) =>
                         <DimensionSelector
+                            key={dimensionName}
                             dimensionName={dimensionName}
                             icon={dimensionConfiguration.get('icon')}
                             dimensionLabel={dimensionConfiguration.get('label')}
                             presets={dimensionConfiguration.get('presets').filter((presetConfiguration, presetName) => allowedPresets.get(dimensionName).contains(presetName))}
                             activePreset={activePresets.get(dimensionName).get('name')}
-                            onSelect={selectPreset} />
+                            onSelect={selectPreset}
+                            />
                     )}
                 </DropDown.Contents>
             </DropDown>

--- a/Resources/Private/JavaScript/Host/Containers/SecondaryToolbar/DimensionSwitcher/index.js
+++ b/Resources/Private/JavaScript/Host/Containers/SecondaryToolbar/DimensionSwitcher/index.js
@@ -60,6 +60,7 @@ DimensionSelector.propTypes = {
 
 @connect($transform({
     contentDimensions: $get('cr.contentDimensions.byName'),
+    allowedPresets: $get('cr.contentDimensions.allowedPresets'),
     activePresets: selectors.CR.ContentDimensions.activePresets
 }), {
     selectPreset: actions.CR.ContentDimensions.selectPreset
@@ -67,11 +68,13 @@ DimensionSelector.propTypes = {
 export default class DimensionSwitcher extends Component {
     static propTypes = {
         contentDimensions: PropTypes.object.isRequired,
-        activePresets: PropTypes.object.isRequired
+        activePresets: PropTypes.object.isRequired,
+        allowedPresets: PropTypes.object.isRequired
     };
 
     static defaultProps = {
         contentDimensions: new Map(),
+        allowedPresets: new Map(),
         activePresets: new Map()
     };
 
@@ -80,7 +83,7 @@ export default class DimensionSwitcher extends Component {
     }
 
     render() {
-        const {contentDimensions, activePresets, selectPreset} = this.props;
+        const {contentDimensions, activePresets, allowedPresets, selectPreset} = this.props;
 
         return (
             <DropDown className={style.dropDown}>
@@ -99,7 +102,7 @@ export default class DimensionSwitcher extends Component {
                             dimensionName={dimensionName}
                             icon={dimensionConfiguration.get('icon')}
                             dimensionLabel={dimensionConfiguration.get('label')}
-                            presets={dimensionConfiguration.get('presets')}
+                            presets={dimensionConfiguration.get('presets').filter((presetConfiguration, presetName) => allowedPresets.get(dimensionName).contains(presetName))}
                             activePreset={activePresets.get(dimensionName).get('name')}
                             onSelect={selectPreset} />
                     )}

--- a/Resources/Private/JavaScript/Host/Redux/CR/ContentDimensions/index.js
+++ b/Resources/Private/JavaScript/Host/Redux/CR/ContentDimensions/index.js
@@ -1,6 +1,6 @@
 import {createAction} from 'redux-actions';
 import Immutable, {List, Map} from 'immutable';
-import {$set, $head, $get} from 'plow-js';
+import {$set, $get} from 'plow-js';
 
 import {handleActions} from 'Shared/Utilities/index';
 import {actionTypes as system} from 'Host/Redux/System/index';
@@ -22,7 +22,7 @@ const selectPreset = createAction(SELECT_PRESET, (name, presetName) => ({name, p
 /**
  * Sets the currently active content dimensions
  */
-const setActive = createAction(SET_ACTIVE, (dimensionValues) => ({dimensionValues}));
+const setActive = createAction(SET_ACTIVE, dimensionValues => ({dimensionValues}));
 
 //
 // Export the actions

--- a/Resources/Private/JavaScript/Host/Redux/CR/ContentDimensions/index.js
+++ b/Resources/Private/JavaScript/Host/Redux/CR/ContentDimensions/index.js
@@ -15,7 +15,7 @@ export const actionTypes = {
 /**
  * Selects a preset for the given content dimension
  */
-const selectPreset = createAction(SELECT_PRESET, (name, presetName) => {name, presetName});
+const selectPreset = createAction(SELECT_PRESET, (name, presetName) => ({name, presetName}));
 
 //
 // Export the actions
@@ -35,7 +35,10 @@ export const reducer = handleActions({
             active: Immutable.fromJS($get('cr.contentDimensions.active', state))
         })
     ),
-    [SELECT_PRESET]: ({name, presetName}) => $set(['cr', 'contentDimensions', 'active', name], Immutable.fromJS($get('cr', 'contentDimensions', 'byName', name, 'presets', presetName, 'values')))
+    [SELECT_PRESET]: ({name, presetName}) => state => {
+        const dimensionValues = Immutable.fromJS($get(['cr', 'contentDimensions', 'byName', name, 'presets', presetName, 'values'], state));
+        return $set(['cr', 'contentDimensions', 'active', name], dimensionValues, state);
+    }
 });
 
 const active = $get('cr.contentDimensions.active');

--- a/Resources/Private/JavaScript/Host/Redux/CR/ContentDimensions/index.js
+++ b/Resources/Private/JavaScript/Host/Redux/CR/ContentDimensions/index.js
@@ -1,5 +1,5 @@
 import {createAction} from 'redux-actions';
-import Immutable, {Map} from 'immutable';
+import Immutable, {List, Map} from 'immutable';
 import {$set, $head, $get} from 'plow-js';
 
 import {handleActions} from 'Shared/Utilities/index';
@@ -7,9 +7,11 @@ import {actionTypes as system} from 'Host/Redux/System/index';
 import {createSelector} from 'reselect';
 
 const SELECT_PRESET = '@neos/neos-ui/CR/ContentDimensions/SELECT_PRESET';
+const SET_ACTIVE = '@neos/neos-ui/CR/ContentDimensions/SET_ACTIVE';
 
 export const actionTypes = {
-    SELECT_PRESET
+    SELECT_PRESET,
+    SET_ACTIVE
 };
 
 /**
@@ -17,12 +19,22 @@ export const actionTypes = {
  */
 const selectPreset = createAction(SELECT_PRESET, (name, presetName) => ({name, presetName}));
 
+/**
+ * Sets the currently active content dimensions
+ */
+const setActive = createAction(SET_ACTIVE, (dimensionValues) => ({dimensionValues}));
+
 //
 // Export the actions
 //
 export const actions = {
-    selectPreset
+    selectPreset,
+    setActive
 };
+
+const active = $get('cr.contentDimensions.active');
+const byName = $get('cr.contentDimensions.byName');
+const allowedPresets = $get('cr.contentDimensions.allowedPresets');
 
 //
 // Export the reducer
@@ -31,23 +43,27 @@ export const reducer = handleActions({
     [system.INIT]: state => $set(
         'cr.contentDimensions',
         new Map({
-            byName: Immutable.fromJS($get('cr.contentDimensions.byName', state)),
-            active: Immutable.fromJS($get('cr.contentDimensions.active', state))
+            byName: Immutable.fromJS(byName(state)),
+            active: Immutable.fromJS(active(state)),
+            allowedPresets: Immutable.fromJS(allowedPresets(state))
         })
     ),
     [SELECT_PRESET]: ({name, presetName}) => state => {
-        const dimensionValues = Immutable.fromJS($get(['cr', 'contentDimensions', 'byName', name, 'presets', presetName, 'values'], state));
+        const dimensionValues = $get(['cr', 'contentDimensions', 'byName', name, 'presets', presetName, 'values'], state);
         return $set(['cr', 'contentDimensions', 'active', name], dimensionValues, state);
+    },
+    [SET_ACTIVE]: ({dimensionValues}) => state => {
+        const previousActive = active(state);
+        const newActive = previousActive.toSeq().map((values, dimensionName) => new List(dimensionValues[dimensionName])).toMap();
+        return $set('cr.contentDimensions.active', newActive, state);
     }
 });
-
-const active = $get('cr.contentDimensions.active');
-const byName = $get('cr.contentDimensions.byName');
 
 const activePresets = createSelector([
     active,
     byName
 ], (active, byName) => {
+    // TODO We might want to use the selected preset values (pass from host frame or content canvas) instead of individual dimension values
     return active.map((dimensionValues, name) => {
         const dimensionConfiguration = byName.get(name);
         const presets = dimensionConfiguration.get('presets');

--- a/Resources/Private/JavaScript/Host/Redux/CR/ContentDimensions/index.js
+++ b/Resources/Private/JavaScript/Host/Redux/CR/ContentDimensions/index.js
@@ -1,0 +1,62 @@
+import {createAction} from 'redux-actions';
+import Immutable, {Map} from 'immutable';
+import {$set, $head, $get} from 'plow-js';
+
+import {handleActions} from 'Shared/Utilities/index';
+import {actionTypes as system} from 'Host/Redux/System/index';
+import {createSelector} from 'reselect';
+
+const SELECT_PRESET = '@neos/neos-ui/CR/ContentDimensions/SELECT_PRESET';
+
+export const actionTypes = {
+    SELECT_PRESET
+};
+
+/**
+ * Selects a preset for the given content dimension
+ */
+const selectPreset = createAction(SELECT_PRESET, (name, presetName) => {name, presetName});
+
+//
+// Export the actions
+//
+export const actions = {
+    selectPreset
+};
+
+//
+// Export the reducer
+//
+export const reducer = handleActions({
+    [system.INIT]: state => $set(
+        'cr.contentDimensions',
+        new Map({
+            byName: Immutable.fromJS($get('cr.contentDimensions.byName', state)),
+            active: Immutable.fromJS($get('cr.contentDimensions.active', state))
+        })
+    ),
+    [SELECT_PRESET]: ({name, presetName}) => $set(['cr', 'contentDimensions', 'active', name], Immutable.fromJS($get('cr', 'contentDimensions', 'byName', name, 'presets', presetName, 'values')))
+});
+
+const active = $get('cr.contentDimensions.active');
+const byName = $get('cr.contentDimensions.byName');
+
+const activePresets = createSelector([
+    active,
+    byName
+], (active, byName) => {
+    return active.map((dimensionValues, name) => {
+        const dimensionConfiguration = byName.get(name);
+        const presets = dimensionConfiguration.get('presets');
+        const activePreset = presets.findKey(preset => preset.get('values').equals(dimensionValues));
+        const presetName = activePreset || dimensionConfiguration.get('defaultPreset');
+        return presets.get(presetName).set('name', presetName);
+    });
+});
+
+//
+// Export the selectors
+//
+export const selectors = {
+    activePresets
+};

--- a/Resources/Private/JavaScript/Host/Redux/CR/ContentDimensions/index.js
+++ b/Resources/Private/JavaScript/Host/Redux/CR/ContentDimensions/index.js
@@ -132,5 +132,8 @@ const activePresets = createSelector([
 // Export the selectors
 //
 export const selectors = {
-    activePresets
+    active,
+    activePresets,
+    allowedPresets,
+    byName
 };

--- a/Resources/Private/JavaScript/Host/Redux/CR/ContentDimensions/index.js
+++ b/Resources/Private/JavaScript/Host/Redux/CR/ContentDimensions/index.js
@@ -65,10 +65,10 @@ const activePresets = createSelector([
 ], (active, byName) => {
     // TODO We might want to use the selected preset values (pass from host frame or content canvas) instead of individual dimension values
     return active.map((dimensionValues, name) => {
-        const dimensionConfiguration = byName.get(name);
-        const presets = dimensionConfiguration.get('presets');
+        const dimensionConfiguration = $get(name, byName);
+        const presets = $get('presets', dimensionConfiguration);
         const activePreset = presets.findKey(preset => preset.get('values').equals(dimensionValues));
-        const presetName = activePreset || dimensionConfiguration.get('defaultPreset');
+        const presetName = activePreset || $get('defaultPreset', dimensionConfiguration);
         return presets.get(presetName).set('name', presetName);
     });
 });

--- a/Resources/Private/JavaScript/Host/Redux/CR/ContentDimensions/index.js
+++ b/Resources/Private/JavaScript/Host/Redux/CR/ContentDimensions/index.js
@@ -32,9 +32,51 @@ export const actions = {
     setActive
 };
 
+/**
+ * Get the currently active dimension values by dimension name
+ *
+ * Structure:
+ *
+ *   {
+ *     language: ["fr"]
+ *   }
+ */
 const active = $get('cr.contentDimensions.active');
-const byName = $get('cr.contentDimensions.byName');
+
+/**
+ * Get the allowed presets for the currently active dimension values by dimension name
+ *
+ * Structure:
+ *
+ *   {
+ *     language: ["en_US", "en_UK", "de", "fr", ...]
+ *   }
+ */
 const allowedPresets = $get('cr.contentDimensions.allowedPresets');
+
+/**
+ * Get dimension configurations by dimension name
+ *
+ * Structure:
+ *
+ *   {
+ *     language: {
+ *       label: "Language",
+ *       icon: "fa-language",
+ *       default: "en_US",
+ *       defaultPreset: "en_US",
+ *       presets: {
+ *         en_US: {
+ *           label: "English (US)",
+ *           values: ["en_US"],
+ *           uriSegment: "en"
+ *         },
+ *         ...
+ *       }
+ *     }
+ *   }
+ */
+const byName = $get('cr.contentDimensions.byName');
 
 //
 // Export the reducer
@@ -59,6 +101,19 @@ export const reducer = handleActions({
     }
 });
 
+/**
+ * Get the currently active dimension presets by dimension name
+ *
+ * Structure:
+ *
+ *   {
+ *     language: {
+ *       name: "da",
+ *       label: "Danish",
+ *       values: ["da"]
+ *     }
+ *   }
+ */
 const activePresets = createSelector([
     active,
     byName

--- a/Resources/Private/JavaScript/Host/Redux/CR/index.js
+++ b/Resources/Private/JavaScript/Host/Redux/CR/index.js
@@ -2,12 +2,13 @@ import {map, keys} from 'ramda';
 
 import {handleActions} from 'Shared/Utilities/index';
 
+import * as ContentDimensions from './ContentDimensions/index';
 import * as Images from './Images/index';
 import * as Nodes from './Nodes/index';
 import * as NodeTypes from './NodeTypes/index';
 import * as Workspaces from './Workspaces/index';
 
-const all = {Images, Nodes, NodeTypes, Workspaces};
+const all = {ContentDimensions, Images, Nodes, NodeTypes, Workspaces};
 
 //
 // Export the actionTypes

--- a/Resources/Private/JavaScript/Host/Sagas/CR/ContentDimensions/index.js
+++ b/Resources/Private/JavaScript/Host/Sagas/CR/ContentDimensions/index.js
@@ -1,14 +1,12 @@
 import {takeLatest} from 'redux-saga';
 import {put, select} from 'redux-saga/effects';
 
-import {actions, actionTypes} from 'Host/Redux/index';
+import {actions, actionTypes, selectors} from 'Host/Redux/index';
 import {currentDocumentNode} from 'Host/Selectors/CR/Nodes/index';
 import {api} from 'Shared/Utilities/';
 
-import {$get} from 'plow-js';
-
 function * updateContentCanvasSrc() {
-    const activeDimensions = yield select($get('cr.contentDimensions.active'));
+    const activeDimensions = yield select(selectors.CR.ContentDimensions.active);
     const contextPath = yield select(currentDocumentNode);
 
     const {q} = api.get();

--- a/Resources/Private/JavaScript/Host/Sagas/CR/ContentDimensions/index.js
+++ b/Resources/Private/JavaScript/Host/Sagas/CR/ContentDimensions/index.js
@@ -1,0 +1,26 @@
+import {takeLatest} from 'redux-saga';
+import {call, put, select} from 'redux-saga/effects';
+
+import {actionTypes, actions} from 'Host/Redux/index';
+import {publish, discard} from 'API/Endpoints/index';
+
+import {$get} from 'plow-js';
+
+function * updateContentCanvasSrc(action) {
+    const {name, presetName} = action.payload;
+
+    console.debug('🍅 selected preset', name, presetName);
+
+    // Get src for node in selected dimension
+    const activeDimensions = yield select($get('cr.contentDimensions.active'));
+
+    console.debug('🌠 active dimensions', activeDimensions.toJS());
+}
+
+function * watchSelectPreset() {
+    yield * takeLatest(actionTypes.CR.ContentDimensions.SELECT_PRESET, updateContentCanvasSrc);
+}
+
+export const sagas = [
+    watchSelectPreset
+];

--- a/Resources/Private/JavaScript/Host/Sagas/CR/ContentDimensions/index.js
+++ b/Resources/Private/JavaScript/Host/Sagas/CR/ContentDimensions/index.js
@@ -1,8 +1,7 @@
 import {takeLatest} from 'redux-saga';
-import {call, put, select} from 'redux-saga/effects';
+import {select} from 'redux-saga/effects';
 
-import {actionTypes, actions} from 'Host/Redux/index';
-import {publish, discard} from 'API/Endpoints/index';
+import {actionTypes} from 'Host/Redux/index';
 
 import {$get} from 'plow-js';
 
@@ -11,13 +10,15 @@ function * updateContentCanvasSrc(action) {
 
     console.debug('🍅 selected preset', name, presetName);
 
-    // Get src for node in selected dimension
     const activeDimensions = yield select($get('cr.contentDimensions.active'));
 
     console.debug('🌠 active dimensions', activeDimensions.toJS());
+
+    // TODO Get src for current node in active dimension
 }
 
 function * watchSelectPreset() {
+    // It is okay to cancel previous preset selections
     yield * takeLatest(actionTypes.CR.ContentDimensions.SELECT_PRESET, updateContentCanvasSrc);
 }
 

--- a/Resources/Private/JavaScript/Host/Sagas/CR/index.js
+++ b/Resources/Private/JavaScript/Host/Sagas/CR/index.js
@@ -1,4 +1,4 @@
-import {sagas as ContentDimensionSagas } from './ContentDimensions/index';
+import {sagas as ContentDimensionSagas} from './ContentDimensions/index';
 
 export const sagas = [
     ...ContentDimensionSagas

--- a/Resources/Private/JavaScript/Host/Sagas/CR/index.js
+++ b/Resources/Private/JavaScript/Host/Sagas/CR/index.js
@@ -1,0 +1,5 @@
+import {sagas as ContentDimensionSagas } from './ContentDimensions/index';
+
+export const sagas = [
+    ...ContentDimensionSagas
+];

--- a/Resources/Private/JavaScript/Host/Sagas/index.js
+++ b/Resources/Private/JavaScript/Host/Sagas/index.js
@@ -1,4 +1,5 @@
 import {sagas as ChangesSagas} from './Changes/index';
+import {sagas as CRSagas} from './CR/index';
 import {sagas as PublishSagas} from './Publish/index';
 import {sagas as ServerFeedbackSagas} from './ServerFeedback/index';
 import {sagas as SystemSagas} from './System/index';
@@ -7,6 +8,7 @@ import {sagas as ViewSagas} from './View/index';
 
 export default [
     ...ChangesSagas,
+    ...CRSagas,
     ...PublishSagas,
     ...ServerFeedbackSagas,
     ...SystemSagas,


### PR DESCRIPTION
- [x] Get available dimensions and presets from server and render in drop down
- [x] Update allowed presets after selecting a different dimension combination (implemented via guest `metaData` for now, could be improved to use an API service and async update via saga)
- [x] Update selected presets when navigating in the content canvas
- [x] Resolve URI after changing dimensions and update content canvas src