### PR TITLE
BUGFIX: Switch order of dispatched actions in content canvas

### DIFF
--- a/Resources/Private/JavaScript/Host/Containers/ContentCanvas/index.js
+++ b/Resources/Private/JavaScript/Host/Containers/ContentCanvas/index.js
@@ -121,13 +121,15 @@ export default class ContentCanvas extends Component {
         const documentInformation = iframeWindow['@Neos.Neos.Ui:DocumentInformation'];
 
         // TODO: convert to single action: "guestFrameChange"
-        setContextPath(documentInformation.metaData.contextPath);
-        setPreviewUrl(documentInformation.metaData.previewUrl);
 
+        // Add nodes before setting the new context path to prevent action ordering issues
         Object.keys(documentInformation.nodes).forEach(contextPath => {
             const node = documentInformation.nodes[contextPath];
             addNode(contextPath, node);
         });
+
+        setContextPath(documentInformation.metaData.contextPath);
+        setPreviewUrl(documentInformation.metaData.previewUrl);
 
         //
         // Initialize node components


### PR DESCRIPTION
This fixes an issue where switching dimensions when navigating
causes an error because the context path was set before nodes were added
from the document information.

This needs a refactoring (e.g. single action) but fixes the issue for now.