### PR TITLE
BUGFIX: Apply fixed height to toolbar buttons

### DIFF
--- a/Resources/Private/JavaScript/Host/Containers/LeftSideBar/NodeTreeToolBar/style.css
+++ b/Resources/Private/JavaScript/Host/Containers/LeftSideBar/NodeTreeToolBar/style.css
@@ -15,4 +15,5 @@
 }
 .toolBar__btnGroup__btn {
     float: left;
+    width: 40px;
 }


### PR DESCRIPTION
This fixes the page tree toolbar breaking, due to varying button sizes within.