### PR TITLE
FEATURE: Add history pushstate calls for whenever the document node changes

### DIFF
--- a/Resources/Private/JavaScript/Host/Sagas/Browser/index.js
+++ b/Resources/Private/JavaScript/Host/Sagas/Browser/index.js
@@ -1,0 +1,15 @@
+import {takeEvery} from 'redux-saga';
+
+import {actionTypes} from 'Host/Redux/index';
+
+function * watchContentURIChange() {
+    yield * takeEvery(actionTypes.UI.ContentCanvas.SET_CONTEXT_PATH, function * reflectChangeInAddressBar(action) {
+        const {contextPath} = action.payload;
+
+        yield history.pushState({}, '', `?node=${contextPath}`);
+    });
+}
+
+export const sagas = [
+    watchContentURIChange
+];

--- a/Resources/Private/JavaScript/Host/Sagas/index.js
+++ b/Resources/Private/JavaScript/Host/Sagas/index.js
@@ -1,3 +1,4 @@
+import {sagas as BrowserSagas} from './Browser/index';
 import {sagas as ChangesSagas} from './Changes/index';
 import {sagas as CRSagas} from './CR/index';
 import {sagas as PublishSagas} from './Publish/index';
@@ -7,6 +8,7 @@ import {sagas as UISagas} from './UI/index';
 import {sagas as ViewSagas} from './View/index';
 
 export default [
+    ...BrowserSagas,
     ...ChangesSagas,
     ...CRSagas,
     ...PublishSagas,


### PR DESCRIPTION
This adds a `history.pushState` call when the `SET_CONTEXT_PATH` action of the ContentCanvas is performed. This way, the change of the document node is reflected in the address bar and calling the resulting URI already leads to the expecteded result.

solves #88 