### PR TITLE
BUGFIX: correct DimensionSwitcher width

### DIFF
--- a/Resources/Private/JavaScript/Host/Containers/SecondaryToolbar/DimensionSwitcher/style.css
+++ b/Resources/Private/JavaScript/Host/Containers/SecondaryToolbar/DimensionSwitcher/style.css
@@ -1,6 +1,6 @@
 .dropDown {
     display: inline-block;
-    min-width: 352px;
+    max-width: 352px;
 }
 .dropDown__btn {
     height: var(--goldenUnit);


### PR DESCRIPTION
Right now the DimensionSwitcher takes up the whole width:

![image](https://cloud.githubusercontent.com/assets/837032/18828005/81ff82f2-83de-11e6-934e-3e6929d69611.png)
