### PR TITLE
BUGFIX: Image Editor preview screen not reflecting crop configuration

### DIFF
--- a/Resources/Private/JavaScript/InspectorEditors/Image/Components/PreviewScreen/index.js
+++ b/Resources/Private/JavaScript/InspectorEditors/Image/Components/PreviewScreen/index.js
@@ -56,6 +56,7 @@ export default class PreviewScreen extends Component {
                     >
                     <div className={style.cropArea} style={(thumbnail ? thumbnail.styles.cropArea : {})}>
                         <img
+                            className={style.cropArea__image}
                             src={thumbnail ? thumbnail.uri : '/_Resources/Static/Packages/TYPO3.Neos/Images/dummy-image.svg'}
                             style={thumbnail ? thumbnail.styles.thumbnail : {}}
                             role="presentation"

--- a/Resources/Private/JavaScript/InspectorEditors/Image/Components/PreviewScreen/style.css
+++ b/Resources/Private/JavaScript/InspectorEditors/Image/Components/PreviewScreen/style.css
@@ -34,3 +34,7 @@
     transform: translate(-50%, -50%);
     overflow: hidden;
 }
+
+.cropArea__image {
+    position: absolute;
+}

--- a/Resources/Private/JavaScript/InspectorEditors/Image/Components/Secondary/ImageCropper/index.js
+++ b/Resources/Private/JavaScript/InspectorEditors/Image/Components/Secondary/ImageCropper/index.js
@@ -38,11 +38,11 @@ class AspectRatioItem extends Component {
                     type="number"
                     value={width}
                     onChange={this.handleWidthInputChange}
-                    />,
+                    />
                 <IconButton
                     icon="exchange"
                     onClick={this.handleFlipAspectRatio}
-                    />,
+                    />
                 <TextInput
                     className={style.dimensionInput}
                     type="number"

--- a/Resources/Private/JavaScript/InspectorEditors/Image/index.js
+++ b/Resources/Private/JavaScript/InspectorEditors/Image/index.js
@@ -2,24 +2,13 @@ import React, {Component, PropTypes} from 'react';
 import {$set, $drop, $get, $transform} from 'plow-js';
 import {connect} from 'react-redux';
 import {PreviewScreen, Controls, Secondary} from './Components/index';
-import {Image} from './Utils/index';
+import {Image, CROP_IMAGE_ADJUSTMENT, RESIZE_IMAGE_ADJUSTMENT} from './Utils/index';
 import style from './style.css';
 
 const DEFAULT_FEATURES = {
     crop: true,
     resize: false
 };
-
-const RESIZE_IMAGE_ADJUSTMENT = [
-    'object',
-    'adjustments',
-    'TYPO3\\Media\\Domain\\Model\\Adjustment\\ResizeImageAdjustment'
-];
-const CROP_IMAGE_ADJUSTMENT = [
-    'object',
-    'adjustments',
-    'TYPO3\\Media\\Domain\\Model\\Adjustment\\CropImageAdjustment'
-];
 
 const SECONDARY_NONE = 1;
 const SECONDARY_DETAILS = 2;


### PR DESCRIPTION
The image editor preview did not change when repositioning the crop area.