### PR TITLE
BUGFIX: Fix several exceptions thrown in the content canvas component

### DIFF
--- a/Resources/Private/JavaScript/Host/Containers/ContentCanvas/InlineUI/NodeToolbar/index.js
+++ b/Resources/Private/JavaScript/Host/Containers/ContentCanvas/InlineUI/NodeToolbar/index.js
@@ -46,7 +46,7 @@ export default class NodeToolbar extends Component {
     componentDidMount() {
         const iframeWindow = document.getElementsByName('neos-content-main')[0].contentWindow;
 
-        iframeWindow.addEventListener('resize', debounce(::this.forceUpdate, 20));
+        iframeWindow.addEventListener('resize', debounce(() => this.forceUpdate(), 20));
     }
 
     shouldComponentUpdate(...args) {

--- a/Resources/Private/JavaScript/Host/Containers/ContentCanvas/index.js
+++ b/Resources/Private/JavaScript/Host/Containers/ContentCanvas/index.js
@@ -210,7 +210,7 @@ export default class ContentCanvas extends Component {
 
             const nodeFormattingRules = calculateEnabledFormattingRulesForNode(node);
 
-            const enabledFormattingRuleIds = nodeFormattingRules[propertyName];
+            const enabledFormattingRuleIds = nodeFormattingRules[propertyName] || [];
 
             // Build up editor config for each enabled formatting
             let editorOptions = Object.assign(


### PR DESCRIPTION
* Add a default for `enabledFormattingRuleIds`, so that it doesn't get undefined and break the subsequext `.forEach` call
* Wrap the `forceUpdate` call in the NodeToolbar component, so that it doesn't get called with unexpected actual parameters