### PR TITLE
BUGFIX: Limit width of inspector panel to dimensions of right side bar

### DIFF
--- a/Resources/Private/JavaScript/Host/Containers/RightSideBar/Inspector/PropertyGroup/index.js
+++ b/Resources/Private/JavaScript/Host/Containers/RightSideBar/Inspector/PropertyGroup/index.js
@@ -5,7 +5,8 @@ import ToggablePanel from '@neos-project/react-ui-components/lib/ToggablePanel/'
 import {I18n} from 'Host/Containers/index';
 
 import EditorEnvelope from '../EditorEnvelope/index';
-import style from '../../style.css';
+import sidebarStyle from '../../style.css';
+import style from './style.css';
 
 export default class PropertyGroup extends Component {
     static propTypes = {
@@ -15,9 +16,12 @@ export default class PropertyGroup extends Component {
 
     render() {
         const {properties, label} = this.props;
+        const headerTheme = {
+            panel__headline: style.propertyGroupLabel // eslint-disable-line camelcase
+        };
         const propertyGroup = properties => (
-            <ToggablePanel isOpen={true} className={style.rightSideBar__section}>
-                <ToggablePanel.Header>
+            <ToggablePanel isOpen={true} className={sidebarStyle.rightSideBar__section}>
+                <ToggablePanel.Header theme={headerTheme}>
                     <I18n id={label}/>
                 </ToggablePanel.Header>
                 <ToggablePanel.Contents>

--- a/Resources/Private/JavaScript/Host/Containers/RightSideBar/Inspector/PropertyGroup/style.css
+++ b/Resources/Private/JavaScript/Host/Containers/RightSideBar/Inspector/PropertyGroup/style.css
@@ -1,0 +1,6 @@
+.propertyGroupLabel {
+    width: 100%;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+    padding: 0 40px 0 16px;
+}

--- a/Resources/Private/JavaScript/Host/Containers/RightSideBar/Inspector/TabPanel/index.js
+++ b/Resources/Private/JavaScript/Host/Containers/RightSideBar/Inspector/TabPanel/index.js
@@ -4,6 +4,8 @@ import Tabs from '@neos-project/react-ui-components/lib/Tabs/';
 
 import PropertyGroup from '../PropertyGroup/index';
 
+import style from './style.css';
+
 export default class TabPanel extends Component {
     static displayName = 'Inspector Tab Panel';
     static propTypes = {
@@ -13,7 +15,7 @@ export default class TabPanel extends Component {
     render() {
         const {groups} = this.props;
         const tabPanel = groups => (
-            <Tabs.Panel>
+            <Tabs.Panel theme={{panel: style.inspectorTabPanel}}>
                 {
                     groups.filter(g => g.properties).map(group => (
                         <PropertyGroup

--- a/Resources/Private/JavaScript/Host/Containers/RightSideBar/Inspector/TabPanel/style.css
+++ b/Resources/Private/JavaScript/Host/Containers/RightSideBar/Inspector/TabPanel/style.css
@@ -1,0 +1,4 @@
+.inspectorTabPanel {
+    width: 100%;
+    overflow-x: hidden;
+}

--- a/Resources/Private/JavaScript/Host/Containers/RightSideBar/Inspector/style.css
+++ b/Resources/Private/JavaScript/Host/Containers/RightSideBar/Inspector/style.css
@@ -1,5 +1,7 @@
 .inspector {
     height: 100%;
+    width: 100%;
+    overflow-x: hidden;
 }
 .discardBtn,
 .publishBtn {

--- a/webpack.testing.config.js
+++ b/webpack.testing.config.js
@@ -1,10 +1,6 @@
 const fs = require('fs');
 const merge = require('lodash.merge');
-const {
-    baseConfig,
-    hostConfig,
-    inspectorEditorConfig
-} = require('./webpack.base.config');
+const baseConfig = require('./webpack.config.js');
 const babelConfig = JSON.parse(fs.readFileSync('./.babelrc', 'utf8'));
 
 const testConfig = {
@@ -63,7 +59,4 @@ const testConfig = {
     }
 };
 
-module.exports = [
-    merge({}, baseConfig, hostConfig, testConfig),
-    merge({}, baseConfig, inspectorEditorConfig, testConfig)
-];
+module.exports = merge({}, baseConfig, testConfig);


### PR DESCRIPTION
This prevents horizontal scrollbars in the inspector and gives a soft character limit to property group labels (via `text-overflow: ellipsis;`).