### PR TITLE
TASK: make storybooks work again

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:components": "lerna run --scope @neos-project/react-ui-components build",
     "build:components:watch": "lerna run --scope @neos-project/react-ui-components build:watch",
     "build": "npm run build:components && npm run build:ui",
+    "start-storybook": "lerna run --scope @neos-project/react-ui-components start",
     "coverage:generate": "lerna run coverage:generate --concurrency 1",
     "coverage:publish": "lerna run coverage:publish --concurrency 1",
     "test": "lerna run test --concurrency 1",
@@ -18,9 +19,6 @@
   "devDependencies": {
     "@inkdpixels/commit-analyzer": "^1.0.0",
     "@inkdpixels/release-notes-generator": "^1.0.0",
-    "@kadira/react-storybook-addon-info": "^3.2.1",
-    "@kadira/storybook": "^2.11.0",
-    "@kadira/storybook-addon-knobs": "^1.2.0",
     "@neos-project/brand": "^1.1.0",
     "@neos-project/eslint-config-neos": "^1.1.1",
     "ava": "^0.16.0",

--- a/packages/build-essentials/src/webpack.config.js
+++ b/packages/build-essentials/src/webpack.config.js
@@ -6,6 +6,12 @@ const env = require('./environment');
 const brand = require('@neos-project/brand');
 
 //
+// Prevent from failing, when NEOS_BUILD_ROOT env variable isn't set
+// (e.g. when extending this config from storybook)
+//
+const rootPath = env.rootPath || __dirname;
+
+//
 // Create the vars object for brand vars like colors and font settings
 // for the `postcss-css-variables` plugin.
 //
@@ -75,7 +81,7 @@ const webpackConfig = {
 
     resolve: {
         modulesDirectories: [
-            path.resolve(env.rootPath, './node_modules')
+            path.resolve(rootPath, './node_modules')
         ]
     },
 

--- a/packages/react-ui-components/.storybook/webpack.config.js
+++ b/packages/react-ui-components/.storybook/webpack.config.js
@@ -1,60 +1,26 @@
-const path = require('path');
-const brand = require('@neos-project/brand');
-const brandVars = brand.generateCssVarsObject(brand.config, 'brand');
-
+const sharedWebPackConfig = require('@neos-project/build-essentials/src/webpack.config.js');
 module.exports = {
     module: {
         loaders: [
-            //
-            // The CSS modules compliant loader.
-            //
             {
-                test: /\.css$/,
-                loader: 'style!css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss-loader',
-                include: [
-                    path.resolve(__dirname, '../src/')
-                ]
+                test: /\.js$/,
+                exclude: /(node_modules)/,
+                loader: 'babel'
             },
-
-            //
-            // If you want to use the <Icon/> component, this loader is
-            // required since the FA source will be included.
-            //
+            {
+                test: /\.json$/,
+                exclude: /(node_modules)/,
+                loader: 'json-loader'
+            },
             {
                 test: /\.(woff|woff2)$/,
                 loader: 'url?limit=100000'
+            },
+            {
+                test: /\.css$/,
+                loader: 'style!css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss-loader'
             }
         ]
     },
-
-    //
-    // Note these plugins if you want to use webpack with to compile your application.
-    //
-    postcss: [
-        require('autoprefixer')({
-            browsers: ['last 2 versions']
-        }),
-        require('postcss-css-variables')({
-            variables: Object.assign({
-                //
-                // Spacings
-                //
-                '--goldenUnit': '40px',
-                '--spacing': '16px',
-                '--halfSpacing': '8px',
-
-                //
-                // Sizes
-                //
-                '--sidebarWidth': '320px',
-
-                //
-                // Font sizes
-                //
-                '--baseFontSize': '14px'
-            }, brandVars)
-        }),
-        require('postcss-nested')(),
-        require('postcss-hexrgba')()
-    ]
+    postcss: sharedWebPackConfig.postcss
 };

--- a/packages/react-ui-components/package.json
+++ b/packages/react-ui-components/package.json
@@ -48,7 +48,10 @@
     "generateNotes": "@inkdpixels/release-notes-generator"
   },
   "devDependencies": {
-    "@neos-project/build-essentials": "^4.4.8"
+    "@neos-project/build-essentials": "^4.4.8",
+    "@kadira/react-storybook-addon-info": "^3.2.1",
+    "@kadira/storybook": "^2.11.0",
+    "@kadira/storybook-addon-knobs": "^1.2.0"
   },
   "peerDependencies": {
     "@neos-project/brand": "^1.1.0",


### PR DESCRIPTION
We intentionally leave storybooks inside react-ui-components, as it
would hardly ever be needed anywhere outside.

## Usage

From root of the project run `npm run start-storybook`