### PR TITLE
BUGFIX: Remove leftover CSS

### DIFF
--- a/Resources/Private/Templates/Backend/Guest.html
+++ b/Resources/Private/Templates/Backend/Guest.html
@@ -3,6 +3,5 @@
     <script src="{f:uri.resource(path: 'resource://Neos.Neos.Ui/Public/JavaScript/Vendor.js')}"></script>
     <script src="{f:uri.resource(path: 'resource://Neos.Neos.Ui/Public/Plugins/ckeditor/ckeditor.js')}"></script>
     <script src="{f:uri.resource(path: 'resource://Neos.Neos.Ui/Public/JavaScript/Guest.js')}"></script>
-    <link rel="stylesheet" href="{f:uri.resource(path: 'resource://Neos.Neos.Ui/Public/Styles/Vendor.css')}">
     <link rel="stylesheet" href="{f:uri.resource(path: 'resource://Neos.Neos.Ui/Public/Styles/Host.css')}">
 </f:section>


### PR DESCRIPTION
The vendor.css in the Guest.html was still there