### PR TITLE
BUGFIX: fix elements loosing focus in creation dialog

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/AddNode/index.js
+++ b/packages/neos-ui/src/Containers/Modals/AddNode/index.js
@@ -161,7 +161,7 @@ export default class AddNodeModal extends PureComponent {
     }
 
     handleDialogEditorValueChange(elementName, value) {
-        const newValues = Object.assign({}, this.state.elementValues);
+        const newValues = this.state.elementValues;
         newValues[elementName] = value;
         this.setState({elementValues: newValues});
     }


### PR DESCRIPTION
If `elementValues` becomes a new object each time, React decides to
recreate all editors from scratch, thus they loose focus.