### PR TITLE
BUGFIX: fix creation dialog inputs

### DIFF
--- a/packages/neos-ui-editors/src/Boolean/index.js
+++ b/packages/neos-ui-editors/src/Boolean/index.js
@@ -35,7 +35,7 @@ const BooleanEditor = props => {
 BooleanEditor.propTypes = {
     identifier: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
-    value: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]).isRequired,
+    value: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
     commit: PropTypes.func.isRequired
 };
 

--- a/packages/neos-ui-editors/src/DateTime/index.js
+++ b/packages/neos-ui-editors/src/DateTime/index.js
@@ -8,7 +8,7 @@ const DateTime = props => {
     return <DateInput value={mappedVal} onChange={commit}/>;
 };
 DateTime.propTypes = {
-    value: PropTypes.string.isRequired,
+    value: PropTypes.string,
     commit: PropTypes.func.isRequired
 };
 

--- a/packages/neos-ui-editors/src/SelectBox/index.js
+++ b/packages/neos-ui-editors/src/SelectBox/index.js
@@ -14,7 +14,7 @@ const SelectBoxEditor = props => {
 };
 SelectBoxEditor.propTypes = {
     commit: PropTypes.func.isRequired,
-    value: PropTypes.any.isRequired,
+    value: PropTypes.any,
     options: PropTypes.any.isRequired
 };
 

--- a/packages/neos-ui-editors/src/TextArea/index.js
+++ b/packages/neos-ui-editors/src/TextArea/index.js
@@ -7,7 +7,7 @@ const TextAreaEditor = props => {
     return <TextArea value={value} onChange={commit}/>;
 };
 TextAreaEditor.propTypes = {
-    value: PropTypes.string.isRequired,
+    value: PropTypes.string,
     commit: PropTypes.func.isRequired
 };
 

--- a/packages/neos-ui-editors/src/TextField/index.js
+++ b/packages/neos-ui-editors/src/TextField/index.js
@@ -7,7 +7,7 @@ const TextField = props => {
     return <TextInput value={value} onChange={commit}/>;
 };
 TextField.propTypes = {
-    value: PropTypes.string.isRequired,
+    value: PropTypes.string,
     commit: PropTypes.func.isRequired
 };
 

--- a/packages/neos-ui/src/Containers/Modals/AddNode/index.js
+++ b/packages/neos-ui/src/Containers/Modals/AddNode/index.js
@@ -152,7 +152,6 @@ export default class AddNodeModal extends PureComponent {
                         label={$get('ui.label', element)}
                         editor={$get('ui.editor', element)}
                         options={$get('ui.editorOptions', element)}
-                        value={this.state.elementValues[elementName] ? this.state.elementValues[elementName] : ''}
                         commit={onCommit}
                         />);
                 })}

--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -20,7 +20,10 @@ export default class SelectBox extends PureComponent {
                         PropTypes.string,
                         PropTypes.object
                     ]).isRequired,
-                    label: PropTypes.string.isRequired
+                    label: PropTypes.oneOfType([
+                        PropTypes.string,
+                        PropTypes.object
+                    ]).isRequired
                 })
             ),
             PropTypes.func


### PR DESCRIPTION
For the fix we have to make `value` not a required prop.
Require `react-ui-components` to be rebuilt obviously.