### PR TITLE
BUGFIX: Correct typo for packages and version constraint of compiled ui package

### DIFF
--- a/Classes/Neos/Neos/Ui/TypoScript/Helper/StaticResourcesHelper.php
+++ b/Classes/Neos/Neos/Ui/TypoScript/Helper/StaticResourcesHelper.php
@@ -19,9 +19,9 @@ class StaticResourcesHelper implements ProtectedContextAwareInterface
     public function compiledResourcePackage()
     {
         if ($this->frontendDevelopmentMode) {
-            return 'Neos.Neos.UI';
+            return 'Neos.Neos.Ui';
         } else {
-            return 'Neos.Neos.UI.Compiled';
+            return 'Neos.Neos.Ui.Compiled';
         }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "typo3/flow": "*",
         "typo3/neos": "*",
-        "neos/neos-ui-compiled": "*"
+        "neos/neos-ui-compiled": "dev-master"
     },
     "provide": {
         "flowpack/neos-frontendlogin": "*"


### PR DESCRIPTION
I had troubles setting the UI up after this merge:
https://github.com/neos/neos-ui/commit/3410810d2b1b319d194015c4ab24b5d9bf3202a4

I think this should work now.