### PR TITLE
TASK: Turn CR.Nodes.add into a bulk action

### DIFF
--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.spec.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.spec.js
@@ -95,8 +95,10 @@ test(`The reducer should add nodes to the store`, t => {
         }
     });
     const contextPath = '/path/top/my/node@user-username;language=en_US';
-    const nextState = reducer(state, actions.add(contextPath, {
-        foo: 'bar'
+    const nextState = reducer(state, actions.add({
+        [contextPath]: {
+            foo: 'bar'
+        }
     }));
 
     const addedItem = nextState.get('cr').get('nodes').get('byContextPath').get(contextPath);

--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -33,7 +33,7 @@ const closestContextPath = el => {
     setActiveDimensions: actions.CR.ContentDimensions.setActive,
     formattingUnderCursor: actions.UI.ContentCanvas.formattingUnderCursor,
     setCurrentlyEditedPropertyName: actions.UI.ContentCanvas.setCurrentlyEditedPropertyName,
-    addNode: actions.CR.Nodes.add,
+    addNodes: actions.CR.Nodes.add,
     focusNode: actions.CR.Nodes.focus,
     unFocusNode: actions.CR.Nodes.unFocus,
     persistChange: actions.Changes.persistChange
@@ -52,7 +52,7 @@ export default class ContentCanvas extends PureComponent {
         setContextPath: PropTypes.func.isRequired,
         setPreviewUrl: PropTypes.func.isRequired,
         setActiveDimensions: PropTypes.func.isRequired,
-        addNode: PropTypes.func.isRequired,
+        addNodes: PropTypes.func.isRequired,
         formattingUnderCursor: PropTypes.func.isRequired,
         setCurrentlyEditedPropertyName: PropTypes.func.isRequired,
         focusNode: PropTypes.func.isRequired,
@@ -120,7 +120,7 @@ export default class ContentCanvas extends PureComponent {
             setContextPath,
             setPreviewUrl,
             setActiveDimensions,
-            addNode,
+            addNodes,
             formattingUnderCursor,
             setCurrentlyEditedPropertyName,
             unFocusNode,
@@ -139,10 +139,7 @@ export default class ContentCanvas extends PureComponent {
         // TODO: convert to single action: "guestFrameChange"
 
         // Add nodes before setting the new context path to prevent action ordering issues
-        Object.keys(documentInformation.nodes).forEach(contextPath => {
-            const node = documentInformation.nodes[contextPath];
-            addNode(contextPath, node);
-        });
+        addNodes(documentInformation.nodes);
 
         setContextPath(documentInformation.metaData.contextPath);
         setPreviewUrl(documentInformation.metaData.previewUrl);

--- a/packages/neos-ui/src/Sagas/UI/PageTree/index.js
+++ b/packages/neos-ui/src/Sagas/UI/PageTree/index.js
@@ -42,9 +42,12 @@ function * requestChildrenForContextPath(action) {
     yield put(actions.UI.PageTree.setAsLoaded(contextPath));
 
     if (childNodes && parentNodes) {
-        const nodes = parentNodes.concat(childNodes);
+        const nodes = parentNodes.concat(childNodes).reduce((nodeMap, node) => {
+            nodeMap[node.contextPath] = node;
+            return nodeMap;
+        }, {});
 
-        yield nodes.map(node => put(actions.CR.Nodes.add(node.contextPath, node)));
+        yield put(actions.CR.Nodes.add(nodes));
 
         if (unCollapse) {
             yield put(actions.UI.PageTree.uncollapse(contextPath));


### PR DESCRIPTION
As previously stated, it doesn't make sense to fire actions for each and every discovered node. So now, we'll add them in bulk by default.