### PR TITLE
BUGFIX: Remove trailing comma to satisfy linter

### DIFF
--- a/packages/neos-ui/src/Containers/LeftSideBar/PageTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/PageTree/Node/index.js
@@ -30,7 +30,7 @@ export default class Node extends PureComponent {
             uri: PropTypes.string.isRequired,
             children: PropTypes.arrayOf(
                 PropTypes.string
-            ),
+            )
         }),
         getTreeNode: PropTypes.func,
         onNodeToggle: PropTypes.func,


### PR DESCRIPTION
There was a trailing comma which the linter doesn't like :)