### PR TITLE
BUGFIX: Fix overflowing in inspector

### DIFF
--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/style.css
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/style.css
@@ -1,4 +1,5 @@
 .inspectorTabPanel {
     width: 100%;
+    height: 100%;
     overflow-x: hidden;
 }

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -111,7 +111,11 @@ export default class Inspector extends PureComponent {
 
         return (
             <div className={style.inspector}>
-                <Tabs theme={{tabs__content: style.tabs}}>
+                <Tabs
+                    theme={{
+                        tabs__content: style.tabs // eslint-disable-line camelcase
+                    }}
+                    >
                     {viewConfiguration.tabs
                         //
                         // Only display tabs, that have groups

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -111,7 +111,7 @@ export default class Inspector extends PureComponent {
 
         return (
             <div className={style.inspector}>
-                <Tabs>
+                <Tabs theme={{tabs__content: style.tabs}}>
                     {viewConfiguration.tabs
                         //
                         // Only display tabs, that have groups

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/style.css
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/style.css
@@ -12,3 +12,6 @@
 .publishBtn:hover {
     background: var(--brandColorsSuccess) !important;
 }
+.tabs > div {
+    height: 100%;
+}


### PR DESCRIPTION
Previously, if the content of a inspector tab did not cover the
entire height of the inspector, it would cut off overflowing
elements (like select boxes) on y-axis.

This fix will let inspector tabs always occupy the entire height of
the inspector.