### PR TITLE
BUGFIX: Fix the selection of a new media asset.

### DIFF
--- a/packages/neos-ui-editors/src/Image/index.js
+++ b/packages/neos-ui-editors/src/Image/index.js
@@ -162,19 +162,26 @@ export default class ImageEditor extends Component {
         this.props.renderSecondaryInspector(undefined, undefined);
     }
 
+    getValue() {
+        return this.props.value ? this.props.value : {};
+    }
+
     onRemoveFile() {
-        const {commit, value} = this.props;
+        const {commit} = this.props;
+        const value = this.getValue();
+        const newAsset = $set('__identity', '', value);
 
         this.handleCloseSecondaryScreen();
         this.setState({
             image: null
         }, () => {
-            commit($set('__identity', '', value));
+            commit(newAsset);
         });
     }
 
     onMediaSelected(assetIdentifier) {
-        const {commit, value} = this.props;
+        const {commit} = this.props;
+        const value = this.getValue();
         const newAsset = $set('__identity', assetIdentifier, value);
 
         this.setState({


### PR DESCRIPTION
Previously to this commit plow-js threw an error stating that it couldnt set the  property on a string, which is the current value for new media nodes. Due to the error the image wasnt being applied correctly to the store, and therefore noe change from the initial placeholder image was possible