### PR TITLE
Fix remaining issues after namespace change

### DIFF
--- a/Classes/Neos/Neos/Ui/Aspects/ActivationAspect.php
+++ b/Classes/Neos/Neos/Ui/Aspects/ActivationAspect.php
@@ -7,7 +7,7 @@ namespace Neos\Neos\Ui\Aspects;
  *                                                                        */
 
 use Neos\Flow\Annotations as Flow;
-use TYPO3\FLOW\Aop\JoinPointInterface;
+use Neos\Flow\Aop\JoinPointInterface;
 use Neos\Flow\Session\SessionInterface;
 use Neos\Fusion\Core\Cache\ContentCache;
 

--- a/Classes/Neos/Neos/Ui/Controller/BackendServiceController.php
+++ b/Classes/Neos/Neos/Ui/Controller/BackendServiceController.php
@@ -6,7 +6,7 @@ namespace Neos\Neos\Ui\Controller;
  *                                                                        *
  *                                                                        */
 
-use Neos\Neos\Ui\TypoScript\Helper\NodeInfoHelper;
+use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Mvc\RequestInterface;

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -6,6 +6,10 @@ Neos:
         Neos.Neos.Ui: true
     Ui:
       frontendDevelopmentMode: false
+      nodeTypeRoles:
+        document: 'Neos.Neos:Document'
+        content: 'Neos.Neos:Content'
+        contentCollection: 'Neos.Neos:ContentCollection'
       asyncModuleMapping:
         'resource://Neos.Neos.Ui/Public/JavaScript/InspectorEditors.js':
           'Neos.UI:Inspector.TextField': true

--- a/Resources/Private/Fusion/Backend/Root.fusion
+++ b/Resources/Private/Fusion/Backend/Root.fusion
@@ -21,6 +21,7 @@ backend = Neos.Fusion:Template {
     }
 
     nodeTypes = Neos.Fusion:RawArray {
+        roles = ${Configuration.setting('Neos.Neos.Ui.nodeTypeRoles')}
         byName = ${Neos.Ui.NodeTypes.nodeTypesByName()}
         constraints = ${Neos.Ui.NodeTypes.nodeTypeConstraints()}
         inheritanceMap = ${Neos.Ui.NodeTypes.nodeTypeInheritanceMap()}

--- a/packages/neos-ui-backend-connector/src/FlowQuery/index.spec.js
+++ b/packages/neos-ui-backend-connector/src/FlowQuery/index.spec.js
@@ -197,7 +197,7 @@ test(`
 
     q.applyMiddleware(middleware);
 
-    q('myContextPath').children('[instanceof TYPO3.Neos:Document]');
+    q('myContextPath').children('[instanceof Neos.Neos:Document]');
 
     t.true(middleware.calledOnce);
 });
@@ -210,7 +210,7 @@ test(`
 
     q.applyMiddleware(middleware);
 
-    q('myContextPath', true).children('[instanceof TYPO3.Neos:Document]');
+    q('myContextPath', true).children('[instanceof Neos.Neos:Document]');
 
     t.false(middleware.called);
 });

--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
@@ -6,6 +6,7 @@ export default class NodeTypesRegistry extends SynchronousRegistry {
     _constraints = [];
     _inheritanceMap = [];
     _groups = [];
+    _roles = [];
 
     _inspectorViewConfigurationCache = {};
 
@@ -19,6 +20,18 @@ export default class NodeTypesRegistry extends SynchronousRegistry {
 
     setGroups(groups) {
         this._groups = groups;
+    }
+
+    setRoles(roles) {
+        this._roles = roles;
+    }
+
+    getRole(roleName) {
+        return this._roles[roleName];
+    }
+
+    hasRole(nodeTypeName, roleName) {
+        return this.isOfType(nodeTypeName, this.getRole(roleName));
     }
 
     getAllowedChildNodeTypes(nodeTypeName) {

--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
@@ -71,11 +71,11 @@ export default class NodeTypesRegistry extends SynchronousRegistry {
         // Sort both groups and nodetypes within the group and return as array
         return Object.keys(groups).map(i => {
             if (groups[i].nodeTypes) {
-                groups[i].nodeTypes.sort((a, b) => a.ui.position > b.ui.position ? 1 : -1);
+                groups[i].nodeTypes.sort((a, b) => $get('ui.position', a) > $get('ui.position', b) ? 1 : -1);
             }
             groups[i].name = i;
             return groups[i];
-        }).filter(i => i.nodeTypes).sort((a, b) => a.position > b.position ? 1 : -1);
+        }).filter(i => i.nodeTypes).sort((a, b) => $get('position', a) > $get('position', b) ? 1 : -1);
     }
 
     isOfType(nodeTypeName, referenceNodeTypeName) {

--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.spec.js
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.spec.js
@@ -8,21 +8,21 @@ test(`
     const nodeTypesRegistry = new NodeTypesRegistry(``);
 
     nodeTypesRegistry.setConstraints({
-        'TYPO3.Neos.NodeTypes:Page': {
+        'Neos.Neos.NodeTypes:Page': {
             nodeTypes: {
-                'TYPO3.Neos.NodeTypes:Page': true,
+                'Neos.Neos.NodeTypes:Page': true,
                 'Test:Page': true,
                 'Test:Page2': true
             }
         }
     });
 
-    t.deepEqual(nodeTypesRegistry.getAllowedChildNodeTypes('TYPO3.Neos.NodeTypes:Page'), [
-        'TYPO3.Neos.NodeTypes:Page',
+    t.deepEqual(nodeTypesRegistry.getAllowedChildNodeTypes('Neos.Neos.NodeTypes:Page'), [
+        'Neos.Neos.NodeTypes:Page',
         'Test:Page',
         'Test:Page2'
     ]);
-    t.deepEqual(nodeTypesRegistry.getAllowedChildNodeTypes('TYPO3.Neos.NodeTypes:NotExistent'), []);
+    t.deepEqual(nodeTypesRegistry.getAllowedChildNodeTypes('Neos.Neos.NodeTypes:NotExistent'), []);
 });
 
 test(`
@@ -31,7 +31,7 @@ test(`
     const nodeTypesRegistry = new NodeTypesRegistry(``);
 
     nodeTypesRegistry.setConstraints({
-        'TYPO3.Neos.NodeTypes:Page': {
+        'Neos.Neos.NodeTypes:Page': {
             childNodes: {
                 main: {
                     nodeTypes: {
@@ -42,21 +42,21 @@ test(`
         }
     });
 
-    t.deepEqual(nodeTypesRegistry.getAllowedGrandChildNodeTypes('TYPO3.Neos.NodeTypes:Page', 'main'), [
+    t.deepEqual(nodeTypesRegistry.getAllowedGrandChildNodeTypes('Neos.Neos.NodeTypes:Page', 'main'), [
         'Test:Page'
     ]);
-    t.deepEqual(nodeTypesRegistry.getAllowedGrandChildNodeTypes('TYPO3.Neos.NodeTypes:Page', 'not-existent'), []);
-    t.deepEqual(nodeTypesRegistry.getAllowedGrandChildNodeTypes('TYPO3.Neos.NodeTypes:NotExistent', 'main'), []);
+    t.deepEqual(nodeTypesRegistry.getAllowedGrandChildNodeTypes('Neos.Neos.NodeTypes:Page', 'not-existent'), []);
+    t.deepEqual(nodeTypesRegistry.getAllowedGrandChildNodeTypes('Neos.Neos.NodeTypes:NotExistent', 'main'), []);
 });
 
 test(`"getGroupedNodeTypeList" should return a list of grouped node types.`, t => {
     const nodeTypesRegistry = new NodeTypesRegistry(``);
 
-    nodeTypesRegistry.add('TYPO3.Neos.NodeTypes:Page', {
-        name: 'TYPO3.Neos.NodeTypes:Page',
-        label: 'TYPO3.Neos.NodeTypes:NodeTypes.Page:ui.label',
+    nodeTypesRegistry.add('Neos.Neos.NodeTypes:Page', {
+        name: 'Neos.Neos.NodeTypes:Page',
+        label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label',
         ui: {
-            label: 'TYPO3.Neos.NodeTypes:NodeTypes.Page:ui.label'
+            label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label'
         }
     });
     nodeTypesRegistry.add('Test:Page', {
@@ -78,15 +78,15 @@ test(`"getGroupedNodeTypeList" should return a list of grouped node types.`, t =
 
     nodeTypesRegistry.setGroups({
         general: {
-            label: 'TYPO3.Neos:Main:nodeTypes.groups.general',
+            label: 'Neos.Neos:Main:nodeTypes.groups.general',
             position: 'start'
         },
         plugins: {
-            label: 'TYPO3.Neos:Main:nodeTypes.groups.plugins',
+            label: 'Neos.Neos:Main:nodeTypes.groups.plugins',
             position: 200
         },
         structure: {
-            label: 'TYPO3.Neos:Main:nodeTypes.groups.structure',
+            label: 'Neos.Neos:Main:nodeTypes.groups.structure',
             position: 100
         }
     });
@@ -94,21 +94,21 @@ test(`"getGroupedNodeTypeList" should return a list of grouped node types.`, t =
     t.deepEqual(nodeTypesRegistry.getGroupedNodeTypeList(), [
         {
             name: 'general',
-            label: 'TYPO3.Neos:Main:nodeTypes.groups.general',
+            label: 'Neos.Neos:Main:nodeTypes.groups.general',
             position: 'start',
             nodeTypes: [
                 {
-                    name: 'TYPO3.Neos.NodeTypes:Page',
-                    label: 'TYPO3.Neos.NodeTypes:NodeTypes.Page:ui.label',
+                    name: 'Neos.Neos.NodeTypes:Page',
+                    label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label',
                     ui: {
-                        label: 'TYPO3.Neos.NodeTypes:NodeTypes.Page:ui.label'
+                        label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label'
                     }
                 }
             ]
         },
         {
             name: 'structure',
-            label: 'TYPO3.Neos:Main:nodeTypes.groups.structure',
+            label: 'Neos.Neos:Main:nodeTypes.groups.structure',
             position: 100,
             nodeTypes: [
                 {
@@ -135,11 +135,11 @@ test(`"getGroupedNodeTypeList" should return a list of grouped node types.`, t =
 test(`"getGroupedNodeTypeList" should take the given nodeType filter into account.`, t => {
     const nodeTypesRegistry = new NodeTypesRegistry(``);
 
-    nodeTypesRegistry.add('TYPO3.Neos.NodeTypes:Page', {
-        name: 'TYPO3.Neos.NodeTypes:Page',
-        label: 'TYPO3.Neos.NodeTypes:NodeTypes.Page:ui.label',
+    nodeTypesRegistry.add('Neos.Neos.NodeTypes:Page', {
+        name: 'Neos.Neos.NodeTypes:Page',
+        label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label',
         ui: {
-            label: 'TYPO3.Neos.NodeTypes:NodeTypes.Page:ui.label'
+            label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label'
         }
     });
     nodeTypesRegistry.add('Test:Page', {
@@ -161,37 +161,37 @@ test(`"getGroupedNodeTypeList" should take the given nodeType filter into accoun
 
     nodeTypesRegistry.setGroups({
         general: {
-            label: 'TYPO3.Neos:Main:nodeTypes.groups.general',
+            label: 'Neos.Neos:Main:nodeTypes.groups.general',
             position: 'start'
         },
         plugins: {
-            label: 'TYPO3.Neos:Main:nodeTypes.groups.plugins',
+            label: 'Neos.Neos:Main:nodeTypes.groups.plugins',
             position: 200
         },
         structure: {
-            label: 'TYPO3.Neos:Main:nodeTypes.groups.structure',
+            label: 'Neos.Neos:Main:nodeTypes.groups.structure',
             position: 100
         }
     });
 
-    t.deepEqual(nodeTypesRegistry.getGroupedNodeTypeList(['Test:Page', 'TYPO3.Neos.NodeTypes:Page']), [
+    t.deepEqual(nodeTypesRegistry.getGroupedNodeTypeList(['Test:Page', 'Neos.Neos.NodeTypes:Page']), [
         {
             name: 'general',
-            label: 'TYPO3.Neos:Main:nodeTypes.groups.general',
+            label: 'Neos.Neos:Main:nodeTypes.groups.general',
             position: 'start',
             nodeTypes: [
                 {
-                    name: 'TYPO3.Neos.NodeTypes:Page',
-                    label: 'TYPO3.Neos.NodeTypes:NodeTypes.Page:ui.label',
+                    name: 'Neos.Neos.NodeTypes:Page',
+                    label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label',
                     ui: {
-                        label: 'TYPO3.Neos.NodeTypes:NodeTypes.Page:ui.label'
+                        label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label'
                     }
                 }
             ]
         },
         {
             name: 'structure',
-            label: 'TYPO3.Neos:Main:nodeTypes.groups.structure',
+            label: 'Neos.Neos:Main:nodeTypes.groups.structure',
             position: 100,
             nodeTypes: [
                 {
@@ -206,17 +206,17 @@ test(`"getGroupedNodeTypeList" should take the given nodeType filter into accoun
         }
     ]);
 
-    t.deepEqual(nodeTypesRegistry.getGroupedNodeTypeList(['TYPO3.Neos.NodeTypes:Page']), [
+    t.deepEqual(nodeTypesRegistry.getGroupedNodeTypeList(['Neos.Neos.NodeTypes:Page']), [
         {
             name: 'general',
-            label: 'TYPO3.Neos:Main:nodeTypes.groups.general',
+            label: 'Neos.Neos:Main:nodeTypes.groups.general',
             position: 'start',
             nodeTypes: [
                 {
-                    name: 'TYPO3.Neos.NodeTypes:Page',
-                    label: 'TYPO3.Neos.NodeTypes:NodeTypes.Page:ui.label',
+                    name: 'Neos.Neos.NodeTypes:Page',
+                    label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label',
                     ui: {
-                        label: 'TYPO3.Neos.NodeTypes:NodeTypes.Page:ui.label'
+                        label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label'
                     }
                 }
             ]

--- a/packages/neos-ui-editors/src/Image/Components/Controls/index.js
+++ b/packages/neos-ui-editors/src/Image/Components/Controls/index.js
@@ -35,21 +35,21 @@ export default class Controls extends PureComponent {
                     style="lighter"
                     onClick={onChooseFromMedia}
                     >
-                    <I18n id="TYPO3.Neos:Main:media" fallback="Media"/>
+                    <I18n id="Neos.Neos:Main:media" fallback="Media"/>
                 </Button>
                 <Button
                     size="small"
                     style="lighter"
                     onClick={onChooseFromLocalFileSystem}
                     >
-                    <I18n id="TYPO3.Neos:Modules:media.chooseFile" fallback="Choose file"/>
+                    <I18n id="Neos.Neos:Modules:media.chooseFile" fallback="Choose file"/>
                 </Button>
                 <Button
                     size="small"
                     style="lighter"
                     onClick={onRemove}
                     >
-                    <I18n id="TYPO3.Neos:Main:remove" fallback="Remove"/>
+                    <I18n id="Neos.Neos:Main:remove" fallback="Remove"/>
                 </Button>
             </div>
         );
@@ -66,7 +66,7 @@ export default class Controls extends PureComponent {
                     className={style.cropButton}
                     onClick={onCrop}
                     >
-                    <I18n id="TYPO3.Neos:Main:crop" fallback="Crop"/>
+                    <I18n id="Neos.Neos:Main:crop" fallback="Crop"/>
                 </Button>
             );
         }

--- a/packages/neos-ui-editors/src/Image/Components/PreviewScreen/index.js
+++ b/packages/neos-ui-editors/src/Image/Components/PreviewScreen/index.js
@@ -52,7 +52,7 @@ export default class PreviewScreen extends PureComponent {
                     <div className={style.cropArea} style={(thumbnail ? thumbnail.styles.cropArea : {})}>
                         <img
                             className={style.cropArea__image}
-                            src={thumbnail ? thumbnail.uri : '/_Resources/Static/Packages/TYPO3.Neos/Images/dummy-image.svg'}
+                            src={thumbnail ? thumbnail.uri : '/_Resources/Static/Packages/Neos.Neos/Images/dummy-image.svg'}
                             style={thumbnail ? thumbnail.styles.thumbnail : {}}
                             role="presentation"
                             />

--- a/packages/neos-ui-editors/src/Image/Components/Secondary/ImageCropper/index.js
+++ b/packages/neos-ui-editors/src/Image/Components/Secondary/ImageCropper/index.js
@@ -126,7 +126,7 @@ export default class ImageCropper extends PureComponent {
         const aspectRatioLocked = false;
         const aspectRatioLockIcon = (aspectRatioLocked ? <Icon icon="lock"/> : null);
         const {sourceImage, onComplete} = this.props;
-        const src = sourceImage.previewUri || '/_Resources/Static/Packages/TYPO3.Neos/Images/dummy-image.svg';
+        const src = sourceImage.previewUri || '/_Resources/Static/Packages/Neos.Neos/Images/dummy-image.svg';
 
         return (
             <div style={{textAlign: 'center'}}>

--- a/packages/neos-ui-editors/src/Image/Components/Secondary/MediaDetailsScreen/index.js
+++ b/packages/neos-ui-editors/src/Image/Components/Secondary/MediaDetailsScreen/index.js
@@ -10,7 +10,7 @@ const MediaDetailsScreen = props => {
         }
     };
 
-    const uri = `/neos/content/images/edit.html?asset[__identity]=${props.imageIdentity}`;
+    const uri = `/neos/module/media/browser/image/edit.html?asset[__identity]=${props.imageIdentity}`;
 
     return (
         <iframe src={uri} className={style.iframe}/>

--- a/packages/neos-ui-editors/src/Image/Components/Secondary/MediaSelectionScreen/index.js
+++ b/packages/neos-ui-editors/src/Image/Components/Secondary/MediaSelectionScreen/index.js
@@ -12,7 +12,7 @@ const MediaSelectionScreen = props => {
 
     // TODO: hard-coded url
     return (
-        <iframe src="/neos/content/images.html" className={style.iframe}/>
+        <iframe src="/neos/module/media/browser/image.html" className={style.iframe}/>
     );
 };
 MediaSelectionScreen.propTypes = {

--- a/packages/neos-ui-i18n/src/index.js
+++ b/packages/neos-ui-i18n/src/index.js
@@ -28,7 +28,7 @@ export default class I18n extends Component {
     };
 
     static defaultProps = {
-        packageKey: 'TYPO3.Neos',
+        packageKey: 'Neos.Neos',
         sourceName: 'Main',
         params: {}
     };

--- a/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
@@ -60,7 +60,7 @@ export const makeGetDocumentNodes = nodeTypesRegistry => createSelector(
         nodes
     ],
     nodesMap => {
-        const documentSubNodeTypes = nodeTypesRegistry.getSubTypesOf('TYPO3.Neos:Document');
+        const documentSubNodeTypes = nodeTypesRegistry.getSubTypesOf(nodeTypesRegistry.getRole('document'));
 
         return nodesMap.filter(node => documentSubNodeTypes.includes(node.get('nodeType')));
     }

--- a/packages/neos-ui/src/Containers/LeftSideBar/PageTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/PageTree/Node/index.js
@@ -64,7 +64,7 @@ export default class Node extends PureComponent {
                             .map(contextPath => {
                                 const node = getTreeNode(
                                     contextPath,
-                                    nodeTypesRegistry.getSubTypesOf('TYPO3.Neos:Document')
+                                    nodeTypesRegistry.getSubTypesOf(nodeTypesRegistry.getRole('document'))
                                 );
 
                                 if (!node) {

--- a/packages/neos-ui/src/Containers/LeftSideBar/PageTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/PageTree/index.js
@@ -50,7 +50,7 @@ export default class PageTree extends PureComponent {
             return (<div>...</div>);
         }
 
-        const siteNode = getTreeNode(siteNodeContextPath);
+        const siteNode = getTreeNode(siteNodeContextPath, nodeTypesRegistry.getSubTypesOf(nodeTypesRegistry.getRole('document')));
         const siteNodeIcon = $get('ui.icon', nodeTypesRegistry.get(siteNode.nodeType));
 
         if (siteNode) {

--- a/packages/neos-ui/src/Containers/Modals/AddNode/nodeTypeItem.js
+++ b/packages/neos-ui/src/Containers/Modals/AddNode/nodeTypeItem.js
@@ -44,8 +44,8 @@ class NodeTypeItem extends PureComponent {
                     className={style.nodeType}
                     onClick={this.handleNodeTypeClick}
                     >
-                    <Icon icon={ui.icon} className={style.nodeType__icon} padded="right"/>
-                    <I18n id={ui.label} fallback={ui.label}/>
+                    <Icon icon={$get('icon', ui)} className={style.nodeType__icon} padded="right"/>
+                    <I18n id={$get('label', ui)} fallback={$get('label', ui)}/>
                 </Button>
             </Grid.Col>
         );

--- a/packages/neos-ui/src/Containers/Modals/AddNode/step1.js
+++ b/packages/neos-ui/src/Containers/Modals/AddNode/step1.js
@@ -62,7 +62,7 @@ class Step1 extends PureComponent {
                 hoverStyle="brand"
                 onClick={this.props.onHandleClose}
                 >
-                <I18n id="TYPO3.Neos:Main:cancel" fallback="Cancel"/>
+                <I18n id="Neos.Neos:Main:cancel" fallback="Cancel"/>
             </Button>
         );
     }

--- a/packages/neos-ui/src/Containers/Modals/AddNode/step2.js
+++ b/packages/neos-ui/src/Containers/Modals/AddNode/step2.js
@@ -25,7 +25,7 @@ export default class Step2 extends PureComponent {
                 hoverStyle="brand"
                 onClick={this.props.onHandleBack}
                 >
-                <I18n id="TYPO3.Neos:Main:back" fallback="Back"/>
+                <I18n id="Neos.Neos:Main:back" fallback="Back"/>
             </Button>
         );
     }
@@ -39,7 +39,7 @@ export default class Step2 extends PureComponent {
                 hoverStyle="brand"
                 onClick={this.props.onHandleSave}
                 >
-                <I18n id="TYPO3.Neos:Main:createNew" fallback="Create"/>
+                <I18n id="Neos.Neos:Main:createNew" fallback="Create"/>
             </Button>
         );
     }

--- a/packages/neos-ui/src/index.js
+++ b/packages/neos-ui/src/index.js
@@ -91,6 +91,7 @@ function * application() {
     nodeTypesRegistry.setConstraints(nodeTypes.constraints);
     nodeTypesRegistry.setInheritanceMap(nodeTypes.inheritanceMap);
     nodeTypesRegistry.setGroups(nodeTypes.groups);
+    nodeTypesRegistry.setRoles(nodeTypes.roles);
 
     //
     // Load frontend configuration (edit/preview modes)

--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -31,7 +31,7 @@ manifest('main', {}, globalRegistry => {
     inspector.add('editors', new SynchronousRegistry(`
         Contains all inspector editors.
 
-        The key is an editor name (such as TYPO3.Neos/Inspector/Editors/SelectBoxEditor), and the values
+        The key is an editor name (such as Neos.Neos/Inspector/Editors/SelectBoxEditor), and the values
         are objects of the following form:
             {
                 component: TextInput // the React editor component to use.
@@ -89,7 +89,7 @@ manifest('main', {}, globalRegistry => {
     globalRegistry.add('validators', new SynchronousRegistry(`
         Contains all validators.
 
-        The key is a validator name (such as TYPO3.Neos/Validation/NotEmptyValidator) and the values
+        The key is a validator name (such as Neos.Neos/Validation/NotEmptyValidator) and the values
         are validator options.
     `));
 


### PR DESCRIPTION
- [x] Fix `YPO3\FLOW\Aop...` typo in activation aspect
- [x] Replace literal uses of `TYPO3.Neos:Content`, `TYPO3.Neos:ContentCollection` and `TYPO3.Neos:Document` with configured values.
- [x] Replace remaining uses of TYPO3.Neos (mostly translation labels)
- [x] Use correct URIs for Media Browser

Proposed configuration structure for node type roles:

```yaml
nodeTypeRoles:
  document: 'Neos.Neos:Document'
  content: 'Neos.Neos:Content'
  contentCollection: 'Neos.Neos:ContentCollection'
```