### PR TITLE
FEATURE: Hide nodes

### DIFF
--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/Property.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/Property.php
@@ -28,7 +28,7 @@ class Property extends AbstractChange
     /**
      * The value, the property will be set to
      *
-     * @var mixed
+     * @var string
      */
     protected $value;
 
@@ -56,7 +56,7 @@ class Property extends AbstractChange
     /**
      * Set the value
      *
-     * @param mixed $value
+     * @param string $value
      */
     public function setValue($value)
     {
@@ -66,7 +66,7 @@ class Property extends AbstractChange
     /**
      * Get the value
      *
-     * @return mixed
+     * @return string
      */
     public function getValue()
     {
@@ -137,7 +137,11 @@ class Property extends AbstractChange
             $value = $this->nodePropertyConversionService->convert(
                 $node->getNodeType(), $this->getPropertyName(), $this->getValue(), $node->getContext());
 
-            $node->setProperty($this->getPropertyName(), $value);
+            if ($this->getPropertyName() === '_hidden') {
+                $node->setHidden($value);
+            } else {
+                $node->setProperty($this->getPropertyName(), $value);
+            }
 
             $this->updateWorkspaceInfo();
             if ($node->getNodeType()->getConfiguration('properties.' . $this->getPropertyName() . '.ui.reloadIfChanged')) {

--- a/Classes/Neos/Neos/Ui/Domain/Service/NodePropertyConversionService.php
+++ b/Classes/Neos/Neos/Ui/Domain/Service/NodePropertyConversionService.php
@@ -157,8 +157,8 @@ class NodePropertyConversionService
      */
     protected function convertBoolean($rawValue)
     {
-        if (is_string($rawValue)) {
-            return strtolower($rawValue) === 'true' ? true : false;
+        if (is_string($rawValue) && strtolower($rawValue) === 'false') {
+            return  false;
         }
 
         return (bool) $rawValue;

--- a/Classes/Neos/Neos/Ui/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Neos/Neos/Ui/Fusion/Helper/NodeInfoHelper.php
@@ -170,7 +170,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
 
         // Serialize boolean values to String
         if ($dataType === 'boolean') {
-            return $propertyValue ? 'true' : 'false';
+            return (bool) $propertyValue;
         }
 
         // Serialize array values to String

--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.js
@@ -17,6 +17,8 @@ const REMOVE = '@neos/neos-ui/Transient/Nodes/REMOVE';
 const COPY = '@neos/neos-ui/Transient/Nodes/COPY';
 const CUT = '@neos/neos-ui/Transient/Nodes/CUT';
 const PASTE = '@neos/neos-ui/Transient/Nodes/PASTE';
+const HIDE = '@neos/neos-ui/Transient/Nodes/HIDE';
+const SHOW = '@neos/neos-ui/Transient/Nodes/SHOW';
 
 //
 // Export the action types
@@ -31,7 +33,9 @@ export const actionTypes = {
     REMOVE,
     COPY,
     CUT,
-    PASTE
+    PASTE,
+    HIDE,
+    SHOW
 };
 
 /**
@@ -101,6 +105,20 @@ const cut = createAction(CUT, contextPath => contextPath);
  */
 const paste = createAction(PASTE, (contextPath, fusionPath) => ({contextPath, fusionPath}));
 
+/**
+ * Hide the given node
+ *
+ * @param {String} contextPath The context path of the node to be hidden
+ */
+const hide = createAction(HIDE, contextPath => contextPath);
+
+/**
+ * Show the given node
+ *
+ * @param {String} contextPath The context path of the node to be shown
+ */
+const show = createAction(SHOW, contextPath => contextPath);
+
 //
 // Export the actions
 //
@@ -114,7 +132,9 @@ export const actions = {
     remove,
     copy,
     cut,
-    paste
+    paste,
+    hide,
+    show
 };
 
 //
@@ -158,7 +178,9 @@ export const reducer = handleActions({
     [REMOVE]: contextPath => $drop(['cr', 'nodes', 'byContextPath', contextPath]),
     [COPY]: contextPath => $set('cr.nodes.clipboard', contextPath),
     [CUT]: contextPath => $set('cr.nodes.clipboard', contextPath),
-    [PASTE]: () => $set('cr.nodes.clipboard', '')
+    [PASTE]: () => $set('cr.nodes.clipboard', ''),
+    [HIDE]: contextPath => $set(['cr', 'nodes', 'byContextPath', contextPath, 'properties', '_hidden'], true),
+    [SHOW]: contextPath => $set(['cr', 'nodes', 'byContextPath', contextPath, 'properties', '_hidden'], false)
 });
 
 //

--- a/packages/neos-ui-redux-store/src/UI/PageTree/selectors.js
+++ b/packages/neos-ui-redux-store/src/UI/PageTree/selectors.js
@@ -62,28 +62,30 @@ export const getTreeNodeSelector = createSelector(
         //
         // Check if the requested node is existent and has the correct node type
         //
-        if (node && isNodeTypeValid(node.nodeType)) {
+        if (node && isNodeTypeValid($get('nodeType', node))) {
             //
             // Check for valid child nodes
             //
-            const validChildren = node.children.filter(node => isNodeTypeValid(node.nodeType));
-            const {contextPath, label, uri} = node;
+            const validChildren = $get('children', node).filter(node => isNodeTypeValid($get('nodeType', node)));
+            const contextPath = $get('contextPath', node);
 
             //
             // Turn the node into a data structure, that can be consumed by a tree view
             //
             return {
                 contextPath,
-                label,
-                uri,
-                nodeType: node.nodeType,
+                label: $get('label', node),
+                uri: $get('uri', node),
+                nodeType: $get('nodeType', node),
                 isActive: contextPath === activeNodeContextPath,
                 isFocused: contextPath === focusedNodeContextPath,
+                isHidden: $get('properties._hidden', node),
+                isHiddenInIndex: $get('properties._hiddenInIndex', node),
                 isCollapsed: !uncollapsedNodeContextPaths.contains(contextPath),
                 isLoading: loadingNodeContextPaths.contains(contextPath),
                 hasError: errorNodeContextPaths.contains(contextPath),
                 hasChildren: validChildren.length > 0,
-                children: validChildren.map(node => $get('contextPath', node))
+                children: validChildren.map($get('contextPath'))
             };
         }
 

--- a/packages/neos-ui/src/Containers/ContentCanvas/InlineUI/NodeToolbar/Buttons/HideSelectedNode/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/InlineUI/NodeToolbar/Buttons/HideSelectedNode/index.js
@@ -1,40 +1,57 @@
 import React, {PureComponent, PropTypes} from 'react';
+import {connect} from 'react-redux';
+import {$transform, $get} from 'plow-js';
 import IconButton from '@neos-project/react-ui-components/lib/IconButton/';
 
+import {selectors, actions} from '@neos-project/neos-ui-redux-store';
+
+@connect($transform({
+    node: selectors.CR.Nodes.focusedSelector
+}), {
+    hideNode: actions.CR.Nodes.hide,
+    showNode: actions.CR.Nodes.show
+})
 export default class HideSelectedNode extends PureComponent {
     static propTypes = {
-        isDisabled: PropTypes.bool,
-        className: PropTypes.string
-    };
-
-    static defaultProps = {
-        isDisabled: true
+        node: PropTypes.object,
+        className: PropTypes.string,
+        hideNode: PropTypes.func.isRequired,
+        showNode: PropTypes.func.isRequired
     };
 
     constructor(props) {
         super(props);
 
-        this.handleHideSelectedNodeClick = this.hideSelectedNode.bind(this);
+        this.handleHideNode = this.handleHideNode.bind(this);
+        this.handleShowNode = this.handleShowNode.bind(this);
     }
 
     render() {
-        const {
-            isDisabled,
-            className
-        } = this.props;
+        const {className, node} = this.props;
+        const isDisabled = !node || $get('isAutoCreated', node);
+        const isHidden = $get('properties._hidden', node);
 
         return (
             <IconButton
                 className={className}
+                isActive={isHidden}
                 isDisabled={isDisabled}
-                onClick={this.handleHideSelectedNodeClick}
+                onClick={isHidden ? this.handleShowNode : this.handleHideNode}
                 icon="eye-slash"
                 hoverStyle="clean"
                 />
         );
     }
 
-    hideSelectedNode() {
-        console.log('hide selected node');
+    handleHideNode() {
+        const {node, hideNode} = this.props;
+
+        hideNode($get('contextPath', node));
+    }
+
+    handleShowNode() {
+        const {node, showNode} = this.props;
+
+        showNode($get('contextPath', node));
     }
 }

--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -145,6 +145,13 @@ export default class ContentCanvas extends PureComponent {
         //
         const components = iframeDocument.querySelectorAll('[data-__neos-node-contextpath]');
         Array.prototype.forEach.call(components, node => {
+            const contextPath = node.getAttribute('data-__neos-node-contextpath');
+            const isHidden = $get([contextPath, 'properties', '_hidden'], documentInformation.nodes);
+
+            if (isHidden) {
+                node.classList.add(style.markHiddenNodeAsHidden);
+            }
+
             node.addEventListener('mouseenter', e => {
                 const oldNode = iframeDocument.querySelector(`.${style.markHoveredNodeAsHovered}`);
                 if (oldNode) {

--- a/packages/neos-ui/src/Containers/ContentCanvas/style.css
+++ b/packages/neos-ui/src/Containers/ContentCanvas/style.css
@@ -35,3 +35,6 @@
     outline-offset: .5em;
     outline: 2px solid rgba(#000, .2);
 }
+.markHiddenNodeAsHidden {
+    opacity: .5;
+}

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/HideSelectedNode/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/HideSelectedNode/index.js
@@ -1,42 +1,67 @@
 import React, {PureComponent, PropTypes} from 'react';
 import {connect} from 'react-redux';
+import {$get} from 'plow-js';
+
 import IconButton from '@neos-project/react-ui-components/lib/IconButton/';
 
-@connect()
+import {selectors, actions} from '@neos-project/neos-ui-redux-store';
+
+@connect(state => ({
+    focusedNodeContextPath: selectors.UI.PageTree.getFocusedNodeContextPathSelector(state),
+    siteNodeContextPath: $get('cr.nodes.siteNode', state),
+    getNodeByContextPath: selectors.CR.Nodes.nodeByContextPath(state)
+}), {
+    hideNode: actions.CR.Nodes.hide,
+    showNode: actions.CR.Nodes.show
+})
 export default class HideSelectedNode extends PureComponent {
     static propTypes = {
-        isDisabled: PropTypes.bool,
-        className: PropTypes.string
-    };
+        className: PropTypes.string,
 
-    static defaultProps = {
-        isDisabled: true
+        focusedNodeContextPath: PropTypes.string.isRequired,
+        siteNodeContextPath: PropTypes.string.isRequired,
+        getNodeByContextPath: PropTypes.func.isRequired,
+        hideNode: PropTypes.func.isRequired,
+        showNode: PropTypes.func.isRequired
     };
 
     constructor(props) {
         super(props);
 
-        this.handleSelectNodeClick = this.hideSelectedNode.bind(this);
+        this.handleHideNode = this.handleHideNode.bind(this);
+        this.handleShowNode = this.handleShowNode.bind(this);
     }
 
     render() {
-        const {
-            isDisabled,
-            className
-        } = this.props;
+        const {className, focusedNodeContextPath, siteNodeContextPath, getNodeByContextPath} = this.props;
+        const node = getNodeByContextPath(focusedNodeContextPath);
+        //
+        // Do not allow deletion, when there's no focused node, the focused node is auto created or the focused node
+        // is the site node
+        //
+        const isDisabled = !node || $get('isAutoCreated', node) || siteNodeContextPath === focusedNodeContextPath;
+        const isHidden = $get('properties._hidden', node);
 
         return (
             <IconButton
                 className={className}
                 isDisabled={isDisabled}
-                onClick={this.handleSelectNodeClick}
+                onClick={isHidden ? this.handleShowNode : this.handleHideNode}
                 icon="eye-slash"
                 hoverStyle="clean"
                 />
         );
     }
 
-    hideSelectedNode() {
-        console.log('hide selected node');
+    handleHideNode() {
+        const {focusedNodeContextPath, hideNode} = this.props;
+
+        hideNode(focusedNodeContextPath);
+    }
+
+    handleShowNode() {
+        const {focusedNodeContextPath, showNode} = this.props;
+
+        showNode(focusedNodeContextPath);
     }
 }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/HideSelectedNode/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/HideSelectedNode/index.js
@@ -45,6 +45,7 @@ export default class HideSelectedNode extends PureComponent {
         return (
             <IconButton
                 className={className}
+                isActive={isHidden}
                 isDisabled={isDisabled}
                 onClick={isHidden ? this.handleShowNode : this.handleHideNode}
                 icon="eye-slash"

--- a/packages/neos-ui/src/Containers/LeftSideBar/PageTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/PageTree/Node/index.js
@@ -24,6 +24,7 @@ export default class Node extends PureComponent {
             isActive: PropTypes.bool.isRequired,
             isFocused: PropTypes.bool.isRequired,
             isLoading: PropTypes.bool.isRequired,
+            isHidden: PropTypes.bool.isRequired,
             hasError: PropTypes.bool.isRequired,
             label: PropTypes.string.isRequired,
             icon: PropTypes.string,

--- a/packages/neos-ui/src/Sagas/CR/NodeOperations/index.js
+++ b/packages/neos-ui/src/Sagas/CR/NodeOperations/index.js
@@ -5,6 +5,7 @@ import {$get} from 'plow-js';
 import {selectors, actions, actionTypes} from '@neos-project/neos-ui-redux-store';
 
 import {dom} from '../../../Containers/ContentCanvas/Helpers/index';
+import style from '../../../Containers/ContentCanvas/style.css';
 
 const parentNodeContextPath = contextPath => {
     if (typeof contextPath !== 'string') {
@@ -237,6 +238,11 @@ function * cutAndPasteNode({globalRegistry}) {
 function * hideNode() {
     yield * takeLatest(actionTypes.CR.Nodes.HIDE, function * performPropertyChange(action) {
         const contextPath = action.payload;
+        const domElement = dom.find(`[data-__neos-node-contextpath="${contextPath}"]`);
+
+        if (domElement) {
+            domElement.classList.add(style.markHiddenNodeAsHidden);
+        }
 
         yield put(actions.Changes.persistChange({
             type: 'Neos.Neos.Ui:Property',
@@ -252,6 +258,11 @@ function * hideNode() {
 function * showNode() {
     yield * takeLatest(actionTypes.CR.Nodes.SHOW, function * performPropertyChange(action) {
         const contextPath = action.payload;
+        const domElement = dom.find(`[data-__neos-node-contextpath="${contextPath}"]`);
+
+        if (domElement) {
+            domElement.classList.remove(style.markHiddenNodeAsHidden);
+        }
 
         yield put(actions.Changes.persistChange({
             type: 'Neos.Neos.Ui:Property',

--- a/packages/neos-ui/src/Sagas/CR/NodeOperations/index.js
+++ b/packages/neos-ui/src/Sagas/CR/NodeOperations/index.js
@@ -234,8 +234,40 @@ function * cutAndPasteNode({globalRegistry}) {
     });
 }
 
+function * hideNode() {
+    yield * takeLatest(actionTypes.CR.Nodes.HIDE, function * performPropertyChange(action) {
+        const contextPath = action.payload;
+
+        yield put(actions.Changes.persistChange({
+            type: 'Neos.Neos.Ui:Property',
+            subject: contextPath,
+            payload: {
+                propertyName: '_hidden',
+                value: true
+            }
+        }));
+    });
+}
+
+function * showNode() {
+    yield * takeLatest(actionTypes.CR.Nodes.SHOW, function * performPropertyChange(action) {
+        const contextPath = action.payload;
+
+        yield put(actions.Changes.persistChange({
+            type: 'Neos.Neos.Ui:Property',
+            subject: contextPath,
+            payload: {
+                propertyName: '_hidden',
+                value: false
+            }
+        }));
+    });
+}
+
 export const sagas = [
     removeNodeIfConfirmed,
     copyAndPasteNode,
-    cutAndPasteNode
+    cutAndPasteNode,
+    hideNode,
+    showNode
 ];

--- a/packages/react-ui-components/src/Tree/index.story.js
+++ b/packages/react-ui-components/src/Tree/index.story.js
@@ -73,6 +73,40 @@ storiesOf('Tree', module)
                                     onNodeFocus={action('onNodeFocus')}
                                     />
                             </Tree.Node>
+                            <Tree.Node>
+                                <Tree.Node.Header
+                                    item={{
+                                        hasChildren: false,
+                                        isCollapsed: true,
+                                        isActive: false,
+                                        isFocused: false,
+                                        isLoading: false,
+                                        isHiddenInIndex: true,
+                                        hasError: false,
+                                        label: 'Hidden in menus'
+                                    }}
+                                    onNodeToggle={action('onNodeToggle')}
+                                    onNodeClick={action('onNodeClick')}
+                                    onNodeFocus={action('onNodeFocus')}
+                                    />
+                            </Tree.Node>
+                            <Tree.Node>
+                                <Tree.Node.Header
+                                    item={{
+                                        hasChildren: false,
+                                        isCollapsed: true,
+                                        isActive: false,
+                                        isFocused: false,
+                                        isLoading: false,
+                                        isHidden: true,
+                                        hasError: false,
+                                        label: 'Hidden (invisible)'
+                                    }}
+                                    onNodeToggle={action('onNodeToggle')}
+                                    onNodeClick={action('onNodeClick')}
+                                    onNodeFocus={action('onNodeFocus')}
+                                    />
+                            </Tree.Node>
                         </Tree.Node.Contents>
                     </Tree.Node>
                 </Tree>

--- a/packages/react-ui-components/src/Tree/node.css
+++ b/packages/react-ui-components/src/Tree/node.css
@@ -22,6 +22,10 @@
 .header__chevron--isCollapsed {
     transform: translateY(-35%) translateX(-25%) rotate(-90deg);
 }
+.header__chevron--isHiddenInIndex,
+.header__data--isHidden {
+    opacity: .5;
+}
 
 .header__chevron--isLoading,
 .header__chevron--isLoading:hover {
@@ -34,8 +38,20 @@
     cursor: pointer;
 }
 
+.header__data--isHiddenInIndex {
+    opacity: .5;
+}
+.header__data--isHidden {
+    opacity: .5;
+    text-decoration: line-through;
+}
 .header__data--isFocused {
     background: var(--brandColorsContrastNeutral);
+
+    &.header__data--isHiddenInIndex,
+    &.header__data--isHidden {
+        opacity: .8;
+    }
 }
 .header__label {
     composes: reset from './../reset.css';

--- a/packages/react-ui-components/src/Tree/node.js
+++ b/packages/react-ui-components/src/Tree/node.js
@@ -27,6 +27,8 @@ export class Header extends PureComponent {
             isActive: PropTypes.bool.isRequired,
             isFocused: PropTypes.bool.isRequired,
             isLoading: PropTypes.bool.isRequired,
+            isHidden: PropTypes.bool,
+            isHiddenInIndex: PropTypes.bool.isRequired,
             hasError: PropTypes.bool.isRequired,
             label: PropTypes.string.isRequired,
             icon: PropTypes.string
@@ -66,12 +68,16 @@ export class Header extends PureComponent {
             icon,
             hasChildren,
             isActive,
-            isFocused
+            isFocused,
+            isHiddenInIndex,
+            isHidden
         } = item;
         const dataClassNames = mergeClassNames({
             [theme.header__data]: true,
             [theme['header__data--isActive']]: isActive,
-            [theme['header__data--isFocused']]: isFocused
+            [theme['header__data--isFocused']]: isFocused,
+            [theme['header__data--isHiddenInIndex']]: isHiddenInIndex,
+            [theme['header__data--isHidden']]: isHidden
         });
 
         return (
@@ -94,11 +100,13 @@ export class Header extends PureComponent {
             onToggle,
             theme
         } = this.props;
-        const {isLoading, isCollapsed, hasError} = item;
+        const {isLoading, isCollapsed, hasError, isHiddenInIndex, isHidden} = item;
         const classnames = mergeClassNames({
             [theme.header__chevron]: true,
             [theme['header__chevron--isCollapsed']]: isCollapsed,
-            [theme['header__chevron--isLoading']]: isLoading
+            [theme['header__chevron--isLoading']]: isLoading,
+            [theme['header__chevron--isHiddenInIndex']]: isHiddenInIndex,
+            [theme['header__chevron--isHidden']]: isHidden
         });
         let icon;
 


### PR DESCRIPTION
TODOs:

- [x] Implement hide/show workflow for page tree
- [x] Implement hide/show workflow for content canvas

Description:

This comes with a different idea for styling the "hidden" state in the tree. Formerly, we had a small red icon indicating, that the node was hidden.

I replaced that with a strikethrough style on the node label, since I always felt, that the little red icon is a bit misleading.

So please, take this decision as a suggestion. I will gladly restore the known behavior if anything speaks against such a change.