### PR TITLE
TASK: automatically include subroutes via settings

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -136,7 +136,8 @@ Neos:
                   controllerObjectNamePattern: 'Neos\Neos\Ui\Controller\.*|Neos\Neos\Controller\.*|Neos\Neos\Service\.*|Neos\Media\Controller\.*'
     mvc:
       routes:
-        'Neos.Neos.Ui': true
+        'Neos.Neos.Ui':
+          position: 'before Neos.Neos'
   Fusion:
     defaultContext:
       Neos.Ui.Activation: Neos\Neos\Ui\Fusion\Helper\ActivationHelper

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -134,6 +134,9 @@ Neos:
                 pattern: ControllerObjectName
                 patternOptions:
                   controllerObjectNamePattern: 'Neos\Neos\Ui\Controller\.*|Neos\Neos\Controller\.*|Neos\Neos\Service\.*|Neos\Media\Controller\.*'
+    mvc:
+      routes:
+        'Neos.Neos.Ui': true
   Fusion:
     defaultContext:
       Neos.Ui.Activation: Neos\Neos\Ui\Fusion\Helper\ActivationHelper

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ You can use this composer.json for that.
         "phpunit/phpunit": "~4.8 || ~5.4.0",
         "symfony/css-selector": "~2.0",
         "flowpack/behat": "dev-master",
+        "neos/neos-ui-compiled": "dev-master",
         "neos/neos-ui": "dev-master"
     },
     "suggest": {
@@ -74,18 +75,10 @@ You can use this composer.json for that.
 
 2. Run the following commands:
    ```
-   composer require neos/neos-ui:dev-master # install our package (you only need this, if you are NOT using the composer.json from above)
+   # install our package (you only need this, if you are NOT using the composer.json from above)
+   composer require neos/neos-ui-compiled:dev-master neos/neos-ui:dev-master
    ```
 
-3. Paste the following configuration into the **head** of your global `Routes.yaml` which is located in `Configuration/`
-   ```yaml
-  -
-    name: 'Neos UI'
-    uriPattern: '<NeosUiSubroutes>'
-    subRoutes:
-      'NeosUiSubroutes':
-        package: 'Neos.Neos.Ui'
-   ```
 
 Now you are all set up and can open the sub-route `/neos!` to login to the new interface.
 


### PR DESCRIPTION
Also updates the readme to include `neos-ui-compiled` in demo composer.json, which solves this issue:

```
Problem 1
    - Installation request for neos/neos-ui dev-master -> satisfiable by neos/neos-ui[dev-master].
    - neos/neos-ui dev-master requires neos/neos-ui-compiled dev-master -> satisfiable by neos/neos-ui-compiled[dev-master] but these conflict with your requirements or minimum-stability.
```