### PR TITLE
BUGFIX: preserve ordering of nodetype groups and don't fallback to 'general'

### DIFF
--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -1,5 +1,6 @@
 'Neos.Neos:Document':
   ui:
+    group: 'general'
     creationDialog:
       elements:
         title:

--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
@@ -53,8 +53,7 @@ export default class NodeTypesRegistry extends SynchronousRegistry {
 
         // Distribute nodetypes into groups
         const groups = nodeTypes.reduce((groups, nodeType) => {
-            // Fallback to 'general' group
-            const groupName = nodeType.ui && nodeType.ui.group ? nodeType.ui.group : 'general';
+            const groupName = nodeType.ui && nodeType.ui.group;
             if (groupName in this._groups) {
                 const group = groups[groupName] || Object.assign({}, this._groups[groupName]);
 

--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.spec.js
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.spec.js
@@ -56,7 +56,8 @@ test(`"getGroupedNodeTypeList" should return a list of grouped node types.`, t =
         name: 'Neos.Neos.NodeTypes:Page',
         label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label',
         ui: {
-            label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label'
+            label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label',
+            group: 'general'
         }
     });
     nodeTypesRegistry.add('Test:Page', {
@@ -81,13 +82,13 @@ test(`"getGroupedNodeTypeList" should return a list of grouped node types.`, t =
             label: 'Neos.Neos:Main:nodeTypes.groups.general',
             position: 'start'
         },
-        plugins: {
-            label: 'Neos.Neos:Main:nodeTypes.groups.plugins',
-            position: 200
-        },
         structure: {
             label: 'Neos.Neos:Main:nodeTypes.groups.structure',
             position: 100
+        },
+        plugins: {
+            label: 'Neos.Neos:Main:nodeTypes.groups.plugins',
+            position: 200
         }
     });
 
@@ -101,7 +102,8 @@ test(`"getGroupedNodeTypeList" should return a list of grouped node types.`, t =
                     name: 'Neos.Neos.NodeTypes:Page',
                     label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label',
                     ui: {
-                        label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label'
+                        label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label',
+                        group: 'general'
                     }
                 }
             ]
@@ -139,7 +141,8 @@ test(`"getGroupedNodeTypeList" should take the given nodeType filter into accoun
         name: 'Neos.Neos.NodeTypes:Page',
         label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label',
         ui: {
-            label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label'
+            label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label',
+            group: 'general'
         }
     });
     nodeTypesRegistry.add('Test:Page', {
@@ -173,7 +176,6 @@ test(`"getGroupedNodeTypeList" should take the given nodeType filter into accoun
             position: 100
         }
     });
-
     t.deepEqual(nodeTypesRegistry.getGroupedNodeTypeList(['Test:Page', 'Neos.Neos.NodeTypes:Page']), [
         {
             name: 'general',
@@ -184,7 +186,8 @@ test(`"getGroupedNodeTypeList" should take the given nodeType filter into accoun
                     name: 'Neos.Neos.NodeTypes:Page',
                     label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label',
                     ui: {
-                        label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label'
+                        label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label',
+                        group: 'general'
                     }
                 }
             ]
@@ -216,7 +219,8 @@ test(`"getGroupedNodeTypeList" should take the given nodeType filter into accoun
                     name: 'Neos.Neos.NodeTypes:Page',
                     label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label',
                     ui: {
-                        label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label'
+                        label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label',
+                        group: 'general'
                     }
                 }
             ]


### PR DESCRIPTION
It's important to preserve the ordering of `this._groups` as we can't
sort them again by position in JS (sorting logic is too complex).

To avoid adding special condition for filtering for `Neos.Neos:Content`
nodes when inserting content, let's add a default group of "general" to
`Neos.Neos:Document` and assume that nodetypes without a group are a
system nodetypes that don't need to be listed.