### PR TITLE
TASK: use ButtonGroup component in InsertModeSelector

### DIFF
--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -11,6 +11,9 @@
 			<trans-unit id="insert" xml:space="preserve">
 				<source>Insert</source>
 			</trans-unit>
+			<trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/packages/neos-ui-containers/src/InsertModeSelector/index.js
+++ b/packages/neos-ui-containers/src/InsertModeSelector/index.js
@@ -1,9 +1,10 @@
 import React, {PureComponent, PropTypes} from 'react';
 
-import SelectBox from '@neos-project/react-ui-components/lib/SelectBox/';
-import Icon from '@neos-project/react-ui-components/lib/Icon/';
+import ButtonGroup from '@neos-project/react-ui-components/lib/ButtonGroup/';
+import IconButton from '@neos-project/react-ui-components/lib/IconButton/';
 
-import I18n from '@neos-project/neos-ui-i18n';
+import {neos} from '@neos-project/neos-ui-decorators';
+import {i18nService} from '@neos-project/neos-ui-i18n';
 
 const MODE_AFTER = 'after';
 const MODE_BEFORE = 'before';
@@ -32,12 +33,14 @@ const calculatePreferredInitialMode = props => {
     return null;
 };
 
+@neos()
 export default class InsertModeSelector extends PureComponent {
     static propTypes = {
         mode: PropTypes.string,
         enableAlongsideModes: PropTypes.bool.isRequired,
         enableIntoMode: PropTypes.bool.isRequired,
-        onSelect: PropTypes.func.isRequired
+        onSelect: PropTypes.func.isRequired,
+        translations: PropTypes.object.isRequired
     };
 
     constructor(...args) {
@@ -59,73 +62,46 @@ export default class InsertModeSelector extends PureComponent {
         }
     }
 
-    prepareOptions(props) {
-        const {enableAlongsideModes, enableIntoMode} = props;
-        this.options = [];
-
-        if (enableAlongsideModes) {
-            this.options.push({
-                value: MODE_BEFORE,
-                label: (
-                    <span>
-                        <I18n fallback="Insert" id="Neos.Neos.Ui:Main:insert"/>
-                        &nbsp;<I18n fallback="before" id="before"/>
-                        &nbsp;<Icon icon="level-up"/>
-                    </span>
-                )
-            });
-        }
-
-        if (enableIntoMode) {
-            this.options.push({
-                value: MODE_INTO,
-                label: (
-                    <span>
-                        <I18n fallback="Insert" id="Neos.Neos.Ui:Main:insert"/>
-                        &nbsp;<I18n fallback="into" id="into"/>
-                        &nbsp;<Icon icon="long-arrow-right"/>
-                    </span>
-                )
-            });
-        }
-
-        if (enableAlongsideModes) {
-            this.options.push({
-                value: MODE_AFTER,
-                label: (
-                    <span>
-                        <I18n fallback="Insert" id="Neos.Neos.Ui:Main:insert"/>
-                        &nbsp;<I18n fallback="after" id="after"/>
-                        &nbsp;<Icon icon="level-down"/>
-                    </span>
-                )
-            });
-        }
-    }
-
     componentWillMount() {
         this.selectPreferredInitialModeIfModeIsEmpty(this.props);
-        this.prepareOptions(this.props);
     }
 
     componentWillReceiveProps(props) {
         this.selectPreferredInitialModeIfModeIsEmpty(props);
-        this.prepareOptions(props);
     }
 
     render() {
-        const {mode} = this.props;
+        const {mode, enableIntoMode, enableAlongsideModes, translations} = this.props;
+        const translate = i18nService(translations);
 
         if (!mode) {
             return null;
         }
 
         return (
-            <SelectBox
-                options={this.options}
-                value={mode}
-                onSelect={this.handleSelect}
-                />
+            <ButtonGroup value={mode} onSelect={this.handleSelect}>
+                <IconButton
+                    id={MODE_BEFORE}
+                    isDisabled={!enableAlongsideModes}
+                    style="lighter"
+                    icon="level-up"
+                    title={`${translate('Neos.Neos.Ui:Main:insert')} ${translate('before')}`}
+                    />
+                <IconButton
+                    id={MODE_INTO}
+                    isDisabled={!enableIntoMode}
+                    style="lighter"
+                    icon="long-arrow-right"
+                    title={`${translate('Neos.Neos.Ui:Main:insert')} ${translate('into')}`}
+                    />
+                <IconButton
+                    id={MODE_AFTER}
+                    isDisabled={!enableAlongsideModes}
+                    style="lighter"
+                    icon="level-down"
+                    title={`${translate('Neos.Neos.Ui:Main:insert')} ${translate('after')}`}
+                    />
+            </ButtonGroup>
         );
     }
 

--- a/packages/neos-ui-containers/src/InsertModeSelector/index.js
+++ b/packages/neos-ui-containers/src/InsertModeSelector/index.js
@@ -4,7 +4,9 @@ import ButtonGroup from '@neos-project/react-ui-components/lib/ButtonGroup/';
 import IconButton from '@neos-project/react-ui-components/lib/IconButton/';
 
 import {neos} from '@neos-project/neos-ui-decorators';
-import {i18nService} from '@neos-project/neos-ui-i18n';
+import I18n, {i18nService} from '@neos-project/neos-ui-i18n';
+
+import style from './style.css';
 
 const MODE_AFTER = 'after';
 const MODE_BEFORE = 'before';
@@ -79,29 +81,35 @@ export default class InsertModeSelector extends PureComponent {
         }
 
         return (
-            <ButtonGroup value={mode} onSelect={this.handleSelect}>
-                <IconButton
-                    id={MODE_BEFORE}
-                    isDisabled={!enableAlongsideModes}
-                    style="lighter"
-                    icon="level-up"
-                    title={`${translate('Neos.Neos.Ui:Main:insert')} ${translate('before')}`}
-                    />
-                <IconButton
-                    id={MODE_INTO}
-                    isDisabled={!enableIntoMode}
-                    style="lighter"
-                    icon="long-arrow-right"
-                    title={`${translate('Neos.Neos.Ui:Main:insert')} ${translate('into')}`}
-                    />
-                <IconButton
-                    id={MODE_AFTER}
-                    isDisabled={!enableAlongsideModes}
-                    style="lighter"
-                    icon="level-down"
-                    title={`${translate('Neos.Neos.Ui:Main:insert')} ${translate('after')}`}
-                    />
-            </ButtonGroup>
+            <div className={style.root}>
+                <I18n id="Neos.Neos.Ui:Main:insertMode"/>:&nbsp;
+                <ButtonGroup value={mode} onSelect={this.handleSelect}>
+                    <IconButton
+                        id={MODE_BEFORE}
+                        isDisabled={!enableAlongsideModes}
+                        style="lighter"
+                        size="small"
+                        icon="level-up"
+                        title={`${translate('Neos.Neos.Ui:Main:insert')} ${translate('before')}`}
+                        />
+                    <IconButton
+                        id={MODE_INTO}
+                        isDisabled={!enableIntoMode}
+                        style="lighter"
+                        size="small"
+                        icon="long-arrow-right"
+                        title={`${translate('Neos.Neos.Ui:Main:insert')} ${translate('into')}`}
+                        />
+                    <IconButton
+                        id={MODE_AFTER}
+                        isDisabled={!enableAlongsideModes}
+                        style="lighter"
+                        size="small"
+                        icon="level-down"
+                        title={`${translate('Neos.Neos.Ui:Main:insert')} ${translate('after')}`}
+                        />
+                </ButtonGroup>
+            </div>
         );
     }
 

--- a/packages/neos-ui-containers/src/InsertModeSelector/style.css
+++ b/packages/neos-ui-containers/src/InsertModeSelector/style.css
@@ -1,0 +1,4 @@
+.root {
+    display: flex;
+    align-items: center;
+}

--- a/packages/react-ui-components/src/Button/index.story.js
+++ b/packages/react-ui-components/src/Button/index.story.js
@@ -19,6 +19,7 @@ storiesOf('Button', module)
                     isActive={boolean('Active', false)}
                     isDisabled={boolean('Disabled', false)}
                     isFocused={boolean('Focused', false)}
+                    isPressed={boolean('Pressed', false)}
                     style={select('Style', validStyleKeys, 'clean')}
                     size={select('Size', validSizes, 'regular')}
                     hoverStyle={select('Hover style', validHoverStyleKeys, 'clean')}

--- a/packages/react-ui-components/src/ButtonGroup/buttonGroup.js
+++ b/packages/react-ui-components/src/ButtonGroup/buttonGroup.js
@@ -1,0 +1,64 @@
+import React, {PropTypes, PureComponent} from 'react';
+import mergeClassNames from 'classnames';
+import ButtonGroupItem from './buttonGroupItem.js';
+
+export default class ButtonGroup extends PureComponent {
+    static propTypes = {
+        /**
+         * An optional `className` to attach to the wrapper.
+         */
+        className: PropTypes.string,
+
+        /**
+         * Current value
+         */
+        value: PropTypes.any,
+
+        /**
+         * Called when new value is selected. Returns an id of the activated button
+         */
+        onSelect: PropTypes.func.isRequired,
+
+        /**
+         * The contents to be rendered within the `Bar`.
+         */
+        children: PropTypes.any.isRequired,
+
+        /**
+         * An optional css theme to be injected.
+         */
+        theme: PropTypes.shape({
+            buttonGroup: PropTypes.string
+        }).isRequired
+    }
+
+    render() {
+        const {
+            children,
+            className,
+            theme,
+            value,
+            ...rest
+        } = this.props;
+        const finalClassName = mergeClassNames({
+            [theme.buttonGroup]: true,
+            [className]: className && className.length
+        });
+
+        return (
+            <div {...rest} className={finalClassName}>
+                {React.Children.map(children, (child, index) => {
+                    return (
+                        <ButtonGroupItem
+                            {...child.props}
+                            key={index}
+                            onClick={this.props.onSelect}
+                            isPressed={value === child.props.id}
+                            element={child}
+                            />
+                    );
+                })}
+            </div>
+        );
+    }
+}

--- a/packages/react-ui-components/src/ButtonGroup/buttonGroupItem.js
+++ b/packages/react-ui-components/src/ButtonGroup/buttonGroupItem.js
@@ -1,0 +1,30 @@
+import React, {PropTypes, PureComponent} from 'react';
+import omit from 'lodash.omit';
+
+export default class ButtonGroupItem extends PureComponent {
+    static propTypes = {
+        id: PropTypes.string.isRequired,
+        onClick: PropTypes.func.isRequired,
+        element: PropTypes.any.isRequired
+    };
+
+    constructor(props) {
+        super(props);
+        this.handleButtonClick = this.handleButtonClick.bind(this);
+    }
+
+    handleButtonClick() {
+        this.props.onClick(this.props.id);
+    }
+
+    render() {
+        const {element, ...restProps} = this.props;
+        const rest = omit(restProps, ['onClick']);
+        return (
+            React.cloneElement(element, {
+                ...rest,
+                onClick: this.handleButtonClick
+            })
+        );
+    }
+}

--- a/packages/react-ui-components/src/ButtonGroup/index.js
+++ b/packages/react-ui-components/src/ButtonGroup/index.js
@@ -1,0 +1,6 @@
+import {themr} from 'react-css-themr';
+import identifiers from './../identifiers.js';
+import style from './style.css';
+import ButtonGroup from './buttonGroup.js';
+
+export default themr(identifiers.buttonGroup, style)(ButtonGroup);

--- a/packages/react-ui-components/src/ButtonGroup/index.story.js
+++ b/packages/react-ui-components/src/ButtonGroup/index.story.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import {storiesOf, action} from '@kadira/storybook';
+import {withKnobs} from '@kadira/storybook-addon-knobs';
+import {StoryWrapper} from './../_lib/storyUtils.js';
+import ButtonGroup from './index.js';
+import IconButton from './../IconButton/index.js';
+
+storiesOf('ButtonGroup', module)
+    .addDecorator(withKnobs)
+    .addWithInfo(
+        'default',
+        `The ButtonGroup component.`,
+        () => (
+            <StoryWrapper>
+                <ButtonGroup value="one" onSelect={action('onSelect')}>
+                    <IconButton
+                        id="one"
+                        style="lighter"
+                        icon="level-up"
+                        title="One, active"
+                        />
+                    <IconButton
+                        id="two"
+                        style="lighter"
+                        icon="long-arrow-right"
+                        isDisabled="true"
+                        title="Two (disabled)"
+                        />
+                    <IconButton
+                        id="three"
+                        style="lighter"
+                        icon="level-down"
+                        title="Three"
+                        />
+                </ButtonGroup>
+            </StoryWrapper>
+        ),
+        {inline: true}
+    );

--- a/packages/react-ui-components/src/ButtonGroup/style.css
+++ b/packages/react-ui-components/src/ButtonGroup/style.css
@@ -1,0 +1,2 @@
+.buttonGroup {
+}

--- a/packages/react-ui-components/src/ButtonGroup/style.css
+++ b/packages/react-ui-components/src/ButtonGroup/style.css
@@ -1,2 +1,3 @@
 .buttonGroup {
+    display: block;
 }

--- a/packages/react-ui-components/src/identifiers.js
+++ b/packages/react-ui-components/src/identifiers.js
@@ -7,6 +7,7 @@
 export default {
     bar: '@neos-project/react-ui-components/bar',
     button: '@neos-project/react-ui-components/button',
+    buttonGroup: '@neos-project/react-ui-components/buttonGroup',
     checkBox: '@neos-project/react-ui-components/checkBox',
     dateInput: '@neos-project/react-ui-components/dateInput',
     dialog: '@neos-project/react-ui-components/dialog',


### PR DESCRIPTION
I propose to use a button group instead of SelectBox for selecting new element's position.
Why? -- It saves one click, which is quite a lot!

The final styling could be improved with the help of a designer.

What are your thoughts?

New behaviour:

![image](https://cloud.githubusercontent.com/assets/837032/21544020/ca159fe8-cddc-11e6-9952-9a413595fb34.png)
