### PR TITLE
BUGFIX: correct propType for canBePasted

### DIFF
--- a/packages/neos-ui/src/Containers/ContentCanvas/InlineUI/NodeToolbar/Buttons/PasteClipBoardNode/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/InlineUI/NodeToolbar/Buttons/PasteClipBoardNode/index.js
@@ -18,7 +18,7 @@ import {selectors, actions} from '@neos-project/neos-ui-redux-store';
 export default class PasteClipBoardNode extends PureComponent {
     static propTypes = {
         className: PropTypes.string,
-        canBePasted: PropTypes.bool,
+        canBePasted: PropTypes.func,
 
         contextPath: PropTypes.string,
         fusionPath: PropTypes.string,


### PR DESCRIPTION
Merging as a no-brainer, forgot to include it in the previous clean-up PR.