### PR TITLE
TASK: adjust Image editor to use icons instead of buttons for controls

### DIFF
--- a/packages/neos-ui-editors/src/Image/Components/Controls/index.js
+++ b/packages/neos-ui-editors/src/Image/Components/Controls/index.js
@@ -1,15 +1,15 @@
 import React, {PureComponent, PropTypes} from 'react';
 import style from './style.css';
 
-import Button from '@neos-project/react-ui-components/lib/Button/';
-import I18n from '@neos-project/neos-ui-i18n';
+import IconButton from '@neos-project/react-ui-components/lib/IconButton/';
 
 export default class Controls extends PureComponent {
     static propTypes = {
         onChooseFromMedia: PropTypes.func.isRequired,
         onChooseFromLocalFileSystem: PropTypes.func.isRequired,
         onRemove: PropTypes.func.isRequired,
-        onCrop: PropTypes.func
+        onCrop: PropTypes.func,
+        translate: PropTypes.func.isRequired
     };
 
     render() {
@@ -25,49 +25,53 @@ export default class Controls extends PureComponent {
         const {
             onChooseFromMedia,
             onChooseFromLocalFileSystem,
-            onRemove
+            onRemove,
+            translate
         } = this.props;
 
         return (
-            <div>
-                <Button
+            <span>
+                <IconButton
+                    icon="camera"
                     size="small"
                     style="lighter"
                     onClick={onChooseFromMedia}
-                    >
-                    <I18n id="Neos.Neos:Main:media" fallback="Media"/>
-                </Button>
-                <Button
+                    className={style.button}
+                    title={translate('Neos.Neos:Main:media')}
+                    />
+                <IconButton
+                    icon="upload"
                     size="small"
                     style="lighter"
                     onClick={onChooseFromLocalFileSystem}
-                    >
-                    <I18n id="Neos.Neos:Modules:media.chooseFile" fallback="Choose file"/>
-                </Button>
-                <Button
+                    className={style.button}
+                    title={translate('Neos.Neos:Modules:media.chooseFile')}
+                    />
+                <IconButton
+                    icon="remove"
                     size="small"
                     style="lighter"
                     onClick={onRemove}
-                    >
-                    <I18n id="Neos.Neos:Main:remove" fallback="Remove"/>
-                </Button>
-            </div>
+                    className={style.button}
+                    title={translate('Neos.Neos:Main:remove')}
+                    />
+            </span>
         );
     }
 
     renderisCropperVisibleButton() {
-        const {onCrop} = this.props;
+        const {onCrop, translate} = this.props;
 
         if (onCrop) {
             return (
-                <Button
+                <IconButton
+                    icon="crop"
                     size="small"
                     style="lighter"
                     className={style.cropButton}
                     onClick={onCrop}
-                    >
-                    <I18n id="Neos.Neos:Main:crop" fallback="Crop"/>
-                </Button>
+                    title={translate('Neos.Neos:Main:crop')}
+                    />
             );
         }
 

--- a/packages/neos-ui-editors/src/Image/Components/Controls/style.css
+++ b/packages/neos-ui-editors/src/Image/Components/Controls/style.css
@@ -1,3 +1,6 @@
 .cropButton {
     float: right;
 }
+.button {
+    margin-right: var(--quarterSpacing);
+}

--- a/packages/neos-ui-editors/src/Image/index.js
+++ b/packages/neos-ui-editors/src/Image/index.js
@@ -45,7 +45,9 @@ export default class ImageEditor extends Component {
         allowedFileTypes: PropTypes.string,
 
         siteNode: PropTypes.string,
-        siteNodePath: PropTypes.string
+        siteNodePath: PropTypes.string,
+
+        translate: PropTypes.func.isRequired
     };
 
     static defaultProps = {
@@ -257,6 +259,7 @@ export default class ImageEditor extends Component {
                     onChooseFromLocalFileSystem={this.handleChooseFile}
                     onRemove={this.handleRemoveFile}
                     onCrop={this.isFeatureEnabled('crop') && this.handleOpenImageCropper}
+                    translate={this.props.translate}
                     />
             </div>
         );

--- a/packages/react-ui-components/src/Button/index.story.js
+++ b/packages/react-ui-components/src/Button/index.story.js
@@ -6,6 +6,7 @@ import Button from './index.js';
 
 const validStyleKeys = ['clean', 'brand', 'lighter', 'transparent'];
 const validHoverStyleKeys = ['clean', 'brand', 'darken'];
+const validSizes = ['small', 'regular'];
 
 storiesOf('Button', module)
     .addDecorator(withKnobs)
@@ -19,6 +20,7 @@ storiesOf('Button', module)
                     isDisabled={boolean('Disabled', false)}
                     isFocused={boolean('Focused', false)}
                     style={select('Style', validStyleKeys, 'clean')}
+                    size={select('Size', validSizes, 'regular')}
                     hoverStyle={select('Hover style', validHoverStyleKeys, 'clean')}
                     onClick={action('onClick')}
                     onMouseEnter={action('onMouseEnter')}

--- a/packages/react-ui-components/src/IconButton/iconButton.js
+++ b/packages/react-ui-components/src/IconButton/iconButton.js
@@ -8,12 +8,17 @@ const IconButton = props => {
         className,
         theme,
         icon,
+        size,
         ...rest
     } = props;
-    const finalClassName = mergeClassNames(theme.iconButton, className);
+    const finalClassName = mergeClassNames({
+        [className]: className && className.length,
+        [theme.iconButton]: true,
+        [theme[`size-${size}`]]: true
+    });
 
     return (
-        <ButtonComponent {...rest} className={finalClassName}>
+        <ButtonComponent {...rest} size={size} className={finalClassName}>
             <IconComponent icon={icon}/>
         </ButtonComponent>
     );
@@ -30,6 +35,11 @@ IconButton.propTypes = {
     className: PropTypes.string,
 
     /**
+     * Defines the size of the icon button.
+     */
+    size: PropTypes.oneOf(['small', 'regular']),
+
+    /**
     * An optional css theme to be injected.
     */
     theme: PropTypes.shape({/* eslint-disable quote-props */
@@ -43,6 +53,7 @@ IconButton.propTypes = {
     ButtonComponent: PropTypes.any.isRequired
 };
 IconButton.defaultProps = {
+    size: 'regular',
     style: 'transparent',
     hoverStyle: 'brand'
 };

--- a/packages/react-ui-components/src/IconButton/index.story.js
+++ b/packages/react-ui-components/src/IconButton/index.story.js
@@ -6,6 +6,7 @@ import IconButton from './index.js';
 
 const validStyleKeys = ['clean', 'brand', 'lighter', 'transparent'];
 const validHoverStyleKeys = ['clean', 'brand', 'darken'];
+const validSizes = ['small', 'regular'];
 
 storiesOf('IconButton', module)
     .addDecorator(withKnobs)
@@ -17,6 +18,7 @@ storiesOf('IconButton', module)
                     icon={text('Icon', 'close')}
                     onClick={action('onClick')}
                     style={select('Style', validStyleKeys, 'clean')}
+                    size={select('Size', validSizes, 'regular')}
                     hoverStyle={select('Hover style', validHoverStyleKeys, 'clean')}
                     />
             </StoryWrapper>

--- a/packages/react-ui-components/src/IconButton/style.css
+++ b/packages/react-ui-components/src/IconButton/style.css
@@ -7,6 +7,6 @@
 }
 
 .size-small {
-    width: 32px;
-    min-width: 32px;
+    width: 32px !important;
+    min-width: 32px !important;
 }

--- a/packages/react-ui-components/src/IconButton/style.css
+++ b/packages/react-ui-components/src/IconButton/style.css
@@ -5,3 +5,8 @@
     padding-left: 0;
     padding-right: 0;
 }
+
+.size-small {
+    width: 32px;
+    min-width: 32px;
+}


### PR DESCRIPTION
This follows the design descision taken in the current UI.

![image](https://cloud.githubusercontent.com/assets/837032/21545199/93f134c2-cde6-11e6-9235-6aa7b7c8083a.png)
