### PR TITLE
TASK: persist ui state to local storage

### DIFF
--- a/packages/neos-ui-redux-store/src/UI/AddNodeModal/index.js
+++ b/packages/neos-ui-redux-store/src/UI/AddNodeModal/index.js
@@ -1,6 +1,6 @@
 import {createAction} from 'redux-actions';
 import {Map} from 'immutable';
-import {$all, $set, $toggle} from 'plow-js';
+import {$all, $get, $set, $toggle} from 'plow-js';
 
 import {handleActions} from '@neos-project/utils-redux';
 import {actionTypes as system} from '../../System/index';
@@ -60,12 +60,12 @@ export const errorMessages = {
 // Export the reducer
 //
 export const reducer = handleActions({
-    [system.INIT]: () => $set(
+    [system.INIT]: state => $set(
         'ui.addNodeModal',
         new Map({
             contextPath: '',
             fusionPath: '',
-            collapsedGroups: []
+            collapsedGroups: $get('ui.addNodeModal.collapsedGroups', state) ? $get('ui.addNodeModal.collapsedGroups', state) : []
         })
     ),
     [OPEN]: ({contextPath, fusionPath}) => {

--- a/packages/neos-ui-redux-store/src/UI/Drawer/index.js
+++ b/packages/neos-ui-redux-store/src/UI/Drawer/index.js
@@ -1,6 +1,6 @@
 import {createAction} from 'redux-actions';
-import {Map} from 'immutable';
-import {$toggle, $set} from 'plow-js';
+import Immutable from 'immutable';
+import {$toggle, $get, $set} from 'plow-js';
 
 import {handleActions} from '@neos-project/utils-redux';
 
@@ -39,11 +39,9 @@ export const actions = {
 // Export the reducer
 //
 export const reducer = handleActions({
-    [system.INIT]: () => $set(
+    [system.INIT]: payload => $set(
         'ui.drawer',
-        new Map({
-            isHidden: true
-        })
+        Immutable.fromJS($get('ui.drawer', payload) ? $get('ui.drawer', payload) : {isHidden: true})
     ),
     [TOGGLE]: () => $toggle('ui.drawer.isHidden'),
     [HIDE]: () => $set('ui.drawer.isHidden', true)

--- a/packages/neos-ui-redux-store/src/UI/EditModePanel/index.js
+++ b/packages/neos-ui-redux-store/src/UI/EditModePanel/index.js
@@ -1,6 +1,6 @@
 import {createAction} from 'redux-actions';
-import {Map} from 'immutable';
-import {$set, $toggle} from 'plow-js';
+import Immutable from 'immutable';
+import {$get, $set, $toggle} from 'plow-js';
 
 import {handleActions} from '@neos-project/utils-redux';
 import {actionTypes as system} from '../../System/index';
@@ -30,11 +30,9 @@ export const actions = {
 // Export the reducer
 //
 export const reducer = handleActions({
-    [system.INIT]: () => $set(
+    [system.INIT]: payload => $set(
         'ui.editModePanel',
-        new Map({
-            isHidden: true
-        })
+        Immutable.fromJS($get('ui.editModePanel', payload) ? $get('ui.editModePanel', payload) : {isHidden: true})
     ),
     [TOGGLE]: () => $toggle('ui.editModePanel.isHidden')
 });

--- a/packages/neos-ui-redux-store/src/UI/FullScreen/index.js
+++ b/packages/neos-ui-redux-store/src/UI/FullScreen/index.js
@@ -1,6 +1,6 @@
 import {createAction} from 'redux-actions';
-import {Map} from 'immutable';
-import {$set, $toggle} from 'plow-js';
+import Immutable from 'immutable';
+import {$get, $set, $toggle} from 'plow-js';
 
 import {handleActions} from '@neos-project/utils-redux';
 import {actionTypes as system} from '../../System/index';
@@ -30,11 +30,9 @@ export const actions = {
 // Export the reducer
 //
 export const reducer = handleActions({
-    [system.INIT]: () => $set(
+    [system.INIT]: payload => $set(
         'ui.fullScreen',
-        new Map({
-            isFullScreen: false
-        })
+        Immutable.fromJS($get('ui.fullScreen', payload) ? $get('ui.fullScreen', payload) : {isFullScreen: false})
     ),
     [TOGGLE]: () => $toggle('ui.fullScreen.isFullScreen')
 });

--- a/packages/neos-ui-redux-store/src/UI/LeftSideBar/index.js
+++ b/packages/neos-ui-redux-store/src/UI/LeftSideBar/index.js
@@ -1,6 +1,6 @@
 import {createAction} from 'redux-actions';
-import {Map} from 'immutable';
-import {$set, $toggle} from 'plow-js';
+import Immutable from 'immutable';
+import {$get, $set, $toggle} from 'plow-js';
 
 import {handleActions} from '@neos-project/utils-redux';
 import {actionTypes as system} from '../../System/index';
@@ -30,11 +30,9 @@ export const actions = {
 // Export the reducer
 //
 export const reducer = handleActions({
-    [system.INIT]: () => $set(
+    [system.INIT]: state => $set(
         'ui.leftSideBar',
-        new Map({
-            isHidden: false
-        })
+        Immutable.fromJS($get('ui.leftSideBar', state))
     ),
     [TOGGLE]: () => $toggle('ui.leftSideBar.isHidden')
 });

--- a/packages/neos-ui-redux-store/src/UI/LeftSideBar/index.js
+++ b/packages/neos-ui-redux-store/src/UI/LeftSideBar/index.js
@@ -30,9 +30,9 @@ export const actions = {
 // Export the reducer
 //
 export const reducer = handleActions({
-    [system.INIT]: state => $set(
+    [system.INIT]: payload => $set(
         'ui.leftSideBar',
-        Immutable.fromJS($get('ui.leftSideBar', state))
+        Immutable.fromJS($get('ui.leftSideBar', payload) ? $get('ui.leftSideBar', payload) : {isHidden: false})
     ),
     [TOGGLE]: () => $toggle('ui.leftSideBar.isHidden')
 });

--- a/packages/neos-ui-redux-store/src/UI/RightSideBar/index.js
+++ b/packages/neos-ui-redux-store/src/UI/RightSideBar/index.js
@@ -1,5 +1,5 @@
 import {createAction} from 'redux-actions';
-import {Map} from 'immutable';
+import Immutable from 'immutable';
 import {$toggle, $set, $get} from 'plow-js';
 
 import {handleActions} from '@neos-project/utils-redux';
@@ -30,11 +30,9 @@ export const actions = {
 // Export the reducer
 //
 export const reducer = handleActions({
-    [system.INIT]: () => $set(
+    [system.INIT]: state => $set(
         'ui.rightSideBar',
-        new Map({
-            isHidden: false
-        })
+        Immutable.fromJS($get('ui.rightSideBar', state))
     ),
     [TOGGLE]: () => $toggle('ui.rightSideBar.isHidden')
 });

--- a/packages/neos-ui-redux-store/src/UI/RightSideBar/index.js
+++ b/packages/neos-ui-redux-store/src/UI/RightSideBar/index.js
@@ -30,9 +30,9 @@ export const actions = {
 // Export the reducer
 //
 export const reducer = handleActions({
-    [system.INIT]: state => $set(
+    [system.INIT]: payload => $set(
         'ui.rightSideBar',
-        Immutable.fromJS($get('ui.rightSideBar', state))
+        Immutable.fromJS($get('ui.rightSideBar', payload) ? $get('ui.rightSideBar', payload) : {isHidden: false})
     ),
     [TOGGLE]: () => $toggle('ui.rightSideBar.isHidden')
 });

--- a/packages/neos-ui/src/Containers/ContentCanvas/style.css
+++ b/packages/neos-ui/src/Containers/ContentCanvas/style.css
@@ -13,7 +13,7 @@
     padding-right: 0;
 }
 .contentCanvas--isMovedDown {
-    padding: 192px var(--sidebarWidth) 0; /* height of EditModePanel added */
+    padding-top: 192px; /* height of EditModePanel added */
 }
 .contentCanvas--isFullScreen {
     padding: 0;

--- a/packages/neos-ui/src/localStorageMiddleware.js
+++ b/packages/neos-ui/src/localStorageMiddleware.js
@@ -1,0 +1,34 @@
+import {$get} from 'plow-js';
+
+//
+// Local storage middleware.
+//
+// Saves "ui" part of the state to local storage on every action
+// that matches the "persistentActionsPattern"
+//
+const localStorageMiddleware = ({getState}) => {
+    let timer = null;
+    const debounceLocalStorageTimeout = 2000;
+    const persistentActionsPattern = '@neos/neos-ui/UI';
+
+    return next => action => {
+        const returnValue = next(action);
+
+        // If UI kind of action, persist state to local storage
+        if (action.type.startsWith(persistentActionsPattern)) {
+            clearTimeout(timer);
+            timer = setTimeout(() => {
+                const uiState = $get('ui', getState());
+                const persistentStateSubset = {
+                    ui: uiState && uiState.toJS()
+                };
+                localStorage.setItem('persistedState', JSON.stringify(persistentStateSubset));
+                timer = null;
+            }, debounceLocalStorageTimeout);
+        }
+
+        return returnValue;
+    };
+};
+
+export default localStorageMiddleware;

--- a/packages/neos-ui/src/localStorageMiddleware.js
+++ b/packages/neos-ui/src/localStorageMiddleware.js
@@ -8,7 +8,7 @@ import {$get} from 'plow-js';
 //
 const localStorageMiddleware = ({getState}) => {
     let timer = null;
-    const debounceLocalStorageTimeout = 2000;
+    const debounceLocalStorageTimeout = 1000;
     const persistentActionsPattern = '@neos/neos-ui/UI';
 
     return next => action => {


### PR DESCRIPTION
Saves the `ui` part of the state to local storage on every action that
matches the `persistentActionsPattern`.

TODO:

- [x] Init other parts of the state, not only left and right sidebars

Closes: #13 