### PR TITLE
TASK: Remove outline from focused editables

### DIFF
--- a/packages/neos-ui-validators/src/Count/index.js
+++ b/packages/neos-ui-validators/src/Count/index.js
@@ -17,15 +17,14 @@ const Count = (value, validatorOptions) => {
         logger.error('The minimum count can not be less than zero');
     }
 
-
-    if (typeof value !== 'array' || typeof value !== 'oject') {
-        return <I18n id='content.inspector.validators.countValidator.notCountable'/>;
+    if (typeof value !== 'object') {
+        return <I18n id="content.inspector.validators.countValidator.notCountable"/>;
     }
 
-    const length = Object.keys(object).length;
+    const length = Object.keys(value).length;
 
     if (length < minimum || length > maximum) {
-        return <I18n id='content.inspector.validators.countValidator.countBetween' params={{minimum, maximum}}>
+        return <I18n id="content.inspector.validators.countValidator.countBetween" params={{minimum, maximum}}/>;
     }
 
     return null;

--- a/packages/neos-ui/src/Containers/ContentCanvas/Helpers/initializeCkEditorForDomNode.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/Helpers/initializeCkEditorForDomNode.js
@@ -3,6 +3,8 @@ import {$get} from 'plow-js';
 import calculateEnabledFormattingRulesForNodeTypeFactory from './calculateEnabledFormattingRulesForNodeType';
 import * as dom from './dom';
 
+import style from '../style.css';
+
 export default function initializeCkEditorForDomNode(domNode, dependencies) {
     const {byContextPathDynamicAccess, globalRegistry, persistChange} = dependencies;
 
@@ -23,6 +25,8 @@ export default function initializeCkEditorForDomNode(domNode, dependencies) {
             console.warn('No node found at path: ' + contextPath);
             return;
         }
+
+        domNode.classList.add(style.editable);
 
         const nodeFormattingRules = calculateEnabledFormattingRulesForNodeType(node.nodeType);
         const placeholderLabel = $get(['properties', propertyName, 'ui', 'aloha', 'placeholder'], nodeTypesRegistry.get(node.nodeType));

--- a/packages/neos-ui/src/Containers/ContentCanvas/style.css
+++ b/packages/neos-ui/src/Containers/ContentCanvas/style.css
@@ -38,3 +38,7 @@
 .markHiddenNodeAsHidden {
     opacity: .5;
 }
+
+.editable:focus {
+    outline: none;
+}


### PR DESCRIPTION
This removes the outline from focused editables, to not interfere with
the Neos styling.