### PR TITLE
[FIXUP] Fixed content wrapping

### DIFF
--- a/Classes/Neos/Neos/Ui/Aspects/AugmentationAspect.php
+++ b/Classes/Neos/Neos/Ui/Aspects/AugmentationAspect.php
@@ -116,9 +116,10 @@ class AugmentationAspect
         ];
 
         $serializedNode = json_encode($this->nodeInfoHelper->renderNode($node, $this->controllerContext));
-        $content .= "<script>(function(){(this['@Neos.Neos.Ui:Nodes'] = this['@Neos.Neos.Ui:Nodes'] || {})['{$node->getContextPath()}'] = {$serializedNode}})()</script>";
 
-        return $this->htmlAugmenter->addAttributes($content, $attributes, 'div');
+        $wrappedContent = $this->htmlAugmenter->addAttributes($content, $attributes, 'div');
+        $wrappedContent .= "<script>(function(){(this['@Neos.Neos.Ui:Nodes'] = this['@Neos.Neos.Ui:Nodes'] || {})['{$node->getContextPath()}'] = {$serializedNode}})()</script>";;
+        return $wrappedContent;
     }
 
     /**


### PR DESCRIPTION
Script tag with nodeType information is added
below the current node and not inside. Now the 
html argument does not add a new wrapping around the
current node.