### PR TITLE
Pagetree rewrite

### DIFF
--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractMove.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractMove.php
@@ -65,11 +65,6 @@ abstract class AbstractMove extends AbstractStructuralChange
 
         $this->feedbackCollection->add($removeNode);
 
-        $updateParentNodeInfo = new UpdateNodeInfo();
-        $updateParentNodeInfo->setNode($node->getParent());
-
-        $this->feedbackCollection->add($updateParentNodeInfo);
-
         parent::finish($this->getSubject());
     }
 }

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/MoveAfter.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/MoveAfter.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Neos\Ui\Domain\Model\Changes;
 
+use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
+
 class MoveAfter extends AbstractMove
 {
     public function getMode()
@@ -17,7 +19,15 @@ class MoveAfter extends AbstractMove
     {
         if ($this->canApply()) {
             $before = clone $this->getSubject();
+            $parent = $before->getParent();
+
             $this->getSubject()->moveAfter($this->getSiblingNode());
+
+            $updateParentNodeInfo = new UpdateNodeInfo();
+            $updateParentNodeInfo->setNode($parent);
+
+            $this->feedbackCollection->add($updateParentNodeInfo);
+
             $this->finish($before);
         }
     }

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/MoveBefore.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/MoveBefore.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Neos\Ui\Domain\Model\Changes;
 
+use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
+
 class MoveBefore extends AbstractMove
 {
     public function getMode()
@@ -17,7 +19,15 @@ class MoveBefore extends AbstractMove
     {
         if ($this->canApply()) {
             $before = clone $this->getSubject();
+            $parent = $before->getParent();
+
             $this->getSubject()->moveBefore($this->getSiblingNode());
+
+            $updateParentNodeInfo = new UpdateNodeInfo();
+            $updateParentNodeInfo->setNode($parent);
+
+            $this->feedbackCollection->add($updateParentNodeInfo);
+
             $this->finish($before);
         }
     }

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/MoveInto.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/MoveInto.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Neos\Ui\Domain\Model\Changes;
 
+use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
+
 class MoveInto extends AbstractMove
 {
     public function getMode()
@@ -17,7 +19,15 @@ class MoveInto extends AbstractMove
     {
         if ($this->canApply()) {
             $before = clone $this->getSubject();
+            $parent = $before->getParent();
+
             $this->getSubject()->moveInto($this->getParentNode());
+
+            $updateParentNodeInfo = new UpdateNodeInfo();
+            $updateParentNodeInfo->setNode($parent);
+
+            $this->feedbackCollection->add($updateParentNodeInfo);
+
             $this->finish($before);
         }
     }

--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.js
@@ -16,6 +16,7 @@ const REMOVAL_CONFIRMED = '@neos/neos-ui/Transient/Nodes/REMOVAL_CONFIRMED';
 const REMOVE = '@neos/neos-ui/Transient/Nodes/REMOVE';
 const COPY = '@neos/neos-ui/Transient/Nodes/COPY';
 const CUT = '@neos/neos-ui/Transient/Nodes/CUT';
+const MOVE = '@neos/neos-ui/Transient/Nodes/MOVE';
 const PASTE = '@neos/neos-ui/Transient/Nodes/PASTE';
 const HIDE = '@neos/neos-ui/Transient/Nodes/HIDE';
 const SHOW = '@neos/neos-ui/Transient/Nodes/SHOW';
@@ -33,6 +34,7 @@ export const actionTypes = {
     REMOVE,
     COPY,
     CUT,
+    MOVE,
     PASTE,
     HIDE,
     SHOW
@@ -98,6 +100,14 @@ const copy = createAction(COPY, contextPath => contextPath);
 const cut = createAction(CUT, contextPath => contextPath);
 
 /**
+ * Move a node
+ *
+ * @param {String} nodeToBeMoved The context path of the node to be moved
+ * @param {String} targetNode The context path of the target node
+ */
+const move = createAction(MOVE, (nodeToBeMoved, targetNode) => ({nodeToBeMoved, targetNode}));
+
+/**
  * Paste the contents of the node clipboard
  *
  * @param {String} contextPath The context path of the target node
@@ -132,6 +142,7 @@ export const actions = {
     remove,
     copy,
     cut,
+    move,
     paste,
     hide,
     show

--- a/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
@@ -70,7 +70,7 @@ export const makeHasChildrenSelector = allowedNodeTypes => createSelector(
     [
         (state, contextPath) => $get(['cr', 'nodes', 'byContextPath', contextPath, 'children'], state)
     ],
-    childNodeEnvelopes => childNodeEnvelopes.some(
+    childNodeEnvelopes => (childNodeEnvelopes || []).some(
         childNodeEnvelope => allowedNodeTypes.includes($get('nodeType', childNodeEnvelope))
     )
 );
@@ -80,7 +80,7 @@ export const makeChildrenOfSelector = allowedNodeTypes => createSelector(
         (state, contextPath) => $get(['cr', 'nodes', 'byContextPath', contextPath, 'children'], state),
         $get('cr.nodes.byContextPath')
     ],
-    (childNodeEnvelopes, nodesByContextPath) => childNodeEnvelopes
+    (childNodeEnvelopes, nodesByContextPath) => (childNodeEnvelopes || [])
     .filter(
         childNodeEnvelope => allowedNodeTypes.includes($get('nodeType', childNodeEnvelope))
     )

--- a/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
@@ -66,6 +66,40 @@ export const makeGetDocumentNodes = nodeTypesRegistry => createSelector(
     }
 );
 
+export const makeHasChildrenSelector = allowedNodeTypes => createSelector(
+    [
+        (state, contextPath) => $get(['cr', 'nodes', 'byContextPath', contextPath, 'children'], state)
+    ],
+    childNodeEnvelopes => childNodeEnvelopes.some(
+        childNodeEnvelope => allowedNodeTypes.includes($get('nodeType', childNodeEnvelope))
+    )
+);
+
+export const makeChildrenOfSelector = allowedNodeTypes => createSelector(
+    [
+        (state, contextPath) => $get(['cr', 'nodes', 'byContextPath', contextPath, 'children'], state),
+        $get('cr.nodes.byContextPath')
+    ],
+    (childNodeEnvelopes, nodesByContextPath) => childNodeEnvelopes
+    .filter(
+        childNodeEnvelope => allowedNodeTypes.includes($get('nodeType', childNodeEnvelope))
+    )
+    .map(
+        $get('contextPath')
+    )
+    .map(
+        contextPath => $get(contextPath, nodesByContextPath)
+    )
+);
+
+export const siteNodeSelector = createSelector(
+    [
+        $get('cr.nodes.siteNode'),
+        $get('cr.nodes.byContextPath')
+    ],
+    (siteNodeContextPath, nodesByContextPath) => $get(siteNodeContextPath, nodesByContextPath)
+);
+
 export const byContextPathSelector = defaultMemoize(
     contextPath => immutableNodeToJs(createSelector(
         [

--- a/packages/neos-ui/src/Containers/LeftSideBar/PageTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/PageTree/Node/index.js
@@ -7,37 +7,44 @@ import Tree from '@neos-project/react-ui-components/lib/Tree/';
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {neos} from '@neos-project/neos-ui-decorators';
 
-@connect(state => ({
-    getTreeNode: selectors.UI.PageTree.getTreeNodeSelector(state),
-    isFocused: selectors.UI.PageTree.getFocusedNodeContextPathSelector(state)
-}), {
-    onNodeFocus: actions.UI.PageTree.focus
-})
 @neos(globalRegistry => ({
     nodeTypesRegistry: globalRegistry.get('@neos-project/neos-ui-contentrepository')
 }))
+@connect((state, {nodeTypesRegistry}) => {
+    const allowedNodeTypes = nodeTypesRegistry.getSubTypesOf(nodeTypesRegistry.getRole('document'));
+    const childrenOfSelector = selectors.CR.Nodes.makeChildrenOfSelector(allowedNodeTypes);
+    const hasChildrenSelector = selectors.CR.Nodes.makeHasChildrenSelector(allowedNodeTypes);
+
+    return (state, {node}) => ({
+        childNodes: childrenOfSelector(state, $get('contextPath', node)),
+        hasChildren: hasChildrenSelector(state, $get('contextPath', node)),
+        currentDocumentNodeContextPath: selectors.UI.ContentCanvas.getCurrentContentCanvasContextPath(state),
+        focusedNodeContextPath: selectors.UI.PageTree.getFocused(state),
+        uncollapsedNodeContextPaths: selectors.UI.PageTree.getUncollapsed(state),
+        loadingNodeContextPaths: selectors.UI.PageTree.getLoading(state),
+        errorNodeContextPaths: selectors.UI.PageTree.getErrors(state)
+    });
+}, {
+    onNodeFocus: actions.UI.PageTree.focus
+})
 export default class Node extends PureComponent {
     static propTypes = {
-        item: PropTypes.shape({
-            hasChildren: PropTypes.bool.isRequired,
-            isCollapsed: PropTypes.bool.isRequired,
-            isActive: PropTypes.bool.isRequired,
-            isFocused: PropTypes.bool.isRequired,
-            isLoading: PropTypes.bool.isRequired,
-            isHidden: PropTypes.bool.isRequired,
-            hasError: PropTypes.bool.isRequired,
-            label: PropTypes.string.isRequired,
-            icon: PropTypes.string,
-            uri: PropTypes.string.isRequired,
-            children: PropTypes.arrayOf(
-                PropTypes.string
-            )
-        }),
+        ChildRenderer: PropTypes.object,
+        node: PropTypes.object,
+        hasChildren: PropTypes.bool,
+        childNodes: PropTypes.object,
+        currentDocumentNodeContextPath: PropTypes.string,
+        focusedNodeContextPath: PropTypes.string,
+        uncollapsedNodeContextPaths: PropTypes.object,
+        loadingNodeContextPaths: PropTypes.object,
+        errorNodeContextPaths: PropTypes.object,
+
+        nodeTypesRegistry: PropTypes.object.isRequired,
+
         getTreeNode: PropTypes.func,
         onNodeToggle: PropTypes.func,
         onNodeClick: PropTypes.func,
-        onNodeFocus: PropTypes.func,
-        nodeTypesRegistry: PropTypes.object.isRequired
+        onNodeFocus: PropTypes.func
     };
 
     constructor(props) {
@@ -48,68 +55,108 @@ export default class Node extends PureComponent {
         this.handleNodeLabelClick = this.handleNodeLabelClick.bind(this);
     }
 
-    render() {
-        const {item, nodeTypesRegistry, getTreeNode, onNodeToggle, onNodeClick, onNodeFocus} = this.props;
+    getValidChildren() {
+        const {childNodes} = this.props;
 
-        return getTreeNode ? (
+        return childNodes || [];
+    }
+
+    getIcon() {
+        const {node, nodeTypesRegistry} = this.props;
+        const nodeType = $get('nodeType', node);
+
+        return $get('ui.icon', nodeTypesRegistry.get(nodeType));
+    }
+
+    isFocused() {
+        const {node, focusedNodeContextPath} = this.props;
+
+        return focusedNodeContextPath === $get('contextPath', node);
+    }
+
+    isActive() {
+        const {node, currentDocumentNodeContextPath} = this.props;
+
+        return currentDocumentNodeContextPath === $get('contextPath', node);
+    }
+
+    isCollapsed() {
+        const {node, uncollapsedNodeContextPaths} = this.props;
+
+        return !uncollapsedNodeContextPaths.includes($get('contextPath', node));
+    }
+
+    isLoading() {
+        const {node, loadingNodeContextPaths} = this.props;
+
+        return loadingNodeContextPaths.includes($get('contextPath', node));
+    }
+
+    hasError() {
+        const {node, errorNodeContextPaths} = this.props;
+
+        return errorNodeContextPaths.includes($get('contextPath', node));
+    }
+
+    render() {
+        const {
+            ChildRenderer,
+            node,
+            childNodes,
+            hasChildren,
+            onNodeToggle,
+            onNodeClick,
+            onNodeFocus
+        } = this.props;
+
+        return (
             <Tree.Node>
                 <Tree.Node.Header
-                    item={item}
+                    hasChildren={hasChildren}
+                    isCollapsed={this.isCollapsed()}
+                    isActive={this.isActive()}
+                    isFocused={this.isFocused()}
+                    isLoading={this.isLoading()}
+                    isHidden={$get('_hidden', node)}
+                    isHiddenInIndex={$get('_hiddenInIndex', node)}
+                    hasError={this.hasError()}
+                    label={$get('label', node)}
+                    icon={this.getIcon()}
                     onToggle={this.handleNodeToggle}
                     onClick={this.handleNodeClick}
                     onLabelClick={this.handleNodeLabelClick}
                     />
-                {item.isCollapsed ? null : (
+                {this.isCollapsed() ? null : (
                     <Tree.Node.Contents>
-                        {item.children
-                            .map(contextPath => {
-                                const node = getTreeNode(
-                                    contextPath,
-                                    nodeTypesRegistry.getSubTypesOf(nodeTypesRegistry.getRole('document'))
-                                );
-
-                                if (!node) {
-                                    return null;
-                                }
-
-                                const nodeIcon = $get('ui.icon', nodeTypesRegistry.get(node.nodeType));
-
-                                return {
-                                    ...node,
-                                    icon: nodeIcon
-                                };
-                            })
-                            .filter(i => i)
-                            .map(item =>
-                                <Node
-                                    key={item.contextPath}
-                                    item={item}
-                                    getTreeNode={getTreeNode}
-                                    onNodeToggle={onNodeToggle}
-                                    onNodeClick={onNodeClick}
-                                    onNodeFocus={onNodeFocus}
-                                    nodeTypesRegistry={nodeTypesRegistry}
-                                    />
+                        {childNodes.map(node =>
+                            <ChildRenderer
+                                ChildRenderer={ChildRenderer}
+                                key={$get('contextPath', node)}
+                                node={node}
+                                onNodeToggle={onNodeToggle}
+                                onNodeClick={onNodeClick}
+                                onNodeFocus={onNodeFocus}
+                                />
                         )}
                     </Tree.Node.Contents>
                 )}
             </Tree.Node>
-        ) : null;
+        );
     }
 
     handleNodeToggle() {
-        const {item, onNodeToggle} = this.props;
-        onNodeToggle(item.contextPath);
+        const {node, onNodeToggle} = this.props;
+        onNodeToggle($get('contextPath', node));
     }
 
     handleNodeClick() {
-        const {item, onNodeFocus} = this.props;
-        onNodeFocus(item.contextPath);
+        const {node, onNodeFocus} = this.props;
+        onNodeFocus($get('contextPath', node));
     }
 
     handleNodeLabelClick() {
-        const {item, onNodeFocus, onNodeClick} = this.props;
-        onNodeFocus(item.contextPath);
-        onNodeClick(item.uri, item.contextPath);
+        const {node, onNodeFocus, onNodeClick} = this.props;
+        onNodeFocus($get('contextPath', node));
+        onNodeClick($get('uri', node), $get('contextPath', node));
     }
 }

--- a/packages/neos-ui/src/Containers/LeftSideBar/PageTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/PageTree/index.js
@@ -5,32 +5,26 @@ import {$transform, $get} from 'plow-js';
 import Tree from '@neos-project/react-ui-components/lib/Tree/';
 
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
-import {neos} from '@neos-project/neos-ui-decorators';
 
 import Node from './Node/index';
 
+import style from './style.css';
+
 @connect($transform({
-    allNodes: $get('cr.nodes.byContextPath'),
-    pageTreeState: $get('ui.pageTree'),
-    siteNodeContextPath: $get('cr.nodes.siteNode'),
-    getTreeNode: selectors.UI.PageTree.getTreeNodeSelector
+    siteNode: selectors.CR.Nodes.siteNodeSelector,
+    pageTreeState: $get('ui.pageTree')
 }), {
     onNodeToggle: actions.UI.PageTree.toggle,
     onNodeFocus: actions.UI.PageTree.focus,
     setActiveContentCanvasSrc: actions.UI.ContentCanvas.setSrc,
     setActiveContentCanvasContextPath: actions.UI.ContentCanvas.setContextPath
 })
-@neos(globalRegistry => ({
-    nodeTypesRegistry: globalRegistry.get('@neos-project/neos-ui-contentrepository')
-}))
 export default class PageTree extends PureComponent {
     static propTypes = {
-        allNodes: PropTypes.object.isRequired,
+        siteNode: PropTypes.object,
         pageTreeState: PropTypes.object.isRequired,
         nodeTypesRegistry: PropTypes.object.isRequired,
-        siteNodeContextPath: PropTypes.string,
 
-        getTreeNode: PropTypes.func,
         onNodeToggle: PropTypes.func,
         onNodeFocus: PropTypes.func,
         setActiveContentCanvasSrc: PropTypes.func,
@@ -44,32 +38,22 @@ export default class PageTree extends PureComponent {
     }
 
     render() {
-        const {siteNodeContextPath, nodeTypesRegistry, getTreeNode, onNodeToggle, onNodeFocus} = this.props;
-
-        if (!siteNodeContextPath) {
+        const {siteNode, onNodeToggle, onNodeFocus} = this.props;
+        if (!siteNode) {
             return (<div>...</div>);
         }
 
-        const siteNode = getTreeNode(siteNodeContextPath, nodeTypesRegistry.getSubTypesOf(nodeTypesRegistry.getRole('document')));
-        const siteNodeIcon = $get('ui.icon', nodeTypesRegistry.get(siteNode.nodeType));
-
-        if (siteNode) {
-            return (
-                <Tree>
-                    <Node
-                        item={{
-                            ...siteNode,
-                            icon: siteNodeIcon
-                        }}
-                        onNodeToggle={onNodeToggle}
-                        onNodeClick={this.handleNodeClick}
-                        onNodeFocus={onNodeFocus}
-                        />
-                </Tree>
-            );
-        }
-
-        return null;
+        return (
+            <Tree className={style.pageTree}>
+                <Node
+                    ChildRenderer={Node}
+                    node={siteNode}
+                    onNodeToggle={onNodeToggle}
+                    onNodeClick={this.handleNodeClick}
+                    onNodeFocus={onNodeFocus}
+                    />
+            </Tree>
+        );
     }
 
     handleNodeClick(src, contextPath) {

--- a/packages/neos-ui/src/Containers/LeftSideBar/PageTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/PageTree/index.js
@@ -17,7 +17,8 @@ import style from './style.css';
     onNodeToggle: actions.UI.PageTree.toggle,
     onNodeFocus: actions.UI.PageTree.focus,
     setActiveContentCanvasSrc: actions.UI.ContentCanvas.setSrc,
-    setActiveContentCanvasContextPath: actions.UI.ContentCanvas.setContextPath
+    setActiveContentCanvasContextPath: actions.UI.ContentCanvas.setContextPath,
+    moveNode: actions.CR.Nodes.move
 })
 export default class PageTree extends PureComponent {
     static propTypes = {
@@ -28,7 +29,29 @@ export default class PageTree extends PureComponent {
         onNodeToggle: PropTypes.func,
         onNodeFocus: PropTypes.func,
         setActiveContentCanvasSrc: PropTypes.func,
-        setActiveContentCanvasContextPath: PropTypes.func
+        setActiveContentCanvasContextPath: PropTypes.func,
+        moveNode: PropTypes.func
+    };
+
+    state = {
+        currentlyDraggedNode: null
+    };
+
+    handleNodeDrag = node => {
+        this.setState({
+            currentlyDraggedNode: node
+        });
+    };
+
+    handleNodeDrop = targetNode => {
+        const {currentlyDraggedNode} = this.state;
+        const {moveNode} = this.props;
+
+        moveNode($get('contextPath', currentlyDraggedNode), $get('contextPath', targetNode));
+
+        this.setState({
+            currentlyDraggedNode: null
+        });
     };
 
     constructor(props) {
@@ -51,6 +74,9 @@ export default class PageTree extends PureComponent {
                     onNodeToggle={onNodeToggle}
                     onNodeClick={this.handleNodeClick}
                     onNodeFocus={onNodeFocus}
+                    onNodeDrag={this.handleNodeDrag}
+                    onNodeDrop={this.handleNodeDrop}
+                    currentlyDraggedNode={this.state.currentlyDraggedNode}
                     />
             </Tree>
         );

--- a/packages/neos-ui/src/Containers/LeftSideBar/PageTree/style.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/PageTree/style.css
@@ -1,0 +1,4 @@
+.pageTree {
+    max-height: calc(100vh - 75px);
+    overflow-y: scroll;
+}

--- a/packages/neos-ui/src/Containers/LeftSideBar/style.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/style.css
@@ -1,6 +1,5 @@
 .leftSideBar {
     padding-top: 41px;
-    padding-bottom: 41px;
     transition: .2s ease transform;
     will-change: transform;
 

--- a/packages/neos-ui/src/Containers/Modals/InsertMode/index.js
+++ b/packages/neos-ui/src/Containers/Modals/InsertMode/index.js
@@ -100,6 +100,16 @@ export default class InsertModeModal extends PureComponent {
                             }}
                             />
                     }
+                    {operationType === actionTypes.CR.Nodes.MOVE &&
+                        <I18n
+                            key="move"
+                            id="Neos.Neos.Ui:Main:move__from__to--title"
+                            params={{
+                                source: this.renderNodeLabel(subjectContextPath),
+                                target: this.renderNodeLabel(referenceContextPath)
+                            }}
+                            />
+                    }
                 </span>
             </div>
         );

--- a/packages/react-ui-components/src/Tree/index.story.js
+++ b/packages/react-ui-components/src/Tree/index.story.js
@@ -101,4 +101,72 @@ storiesOf('Tree', module)
             </StoryWrapper>
         ),
         {inline: true}
+    )
+    .addWithInfo(
+        'drag and drop',
+        () => (
+            <StoryWrapper>
+                <Tree>
+                    <Tree.Node>
+                        <Tree.Node.Header
+                            hasChildren={true}
+                            isCollapsed={false}
+                            isActive={true}
+                            isFocused={true}
+                            isLoading={false}
+                            hasError={false}
+                            label="Parent Node"
+                            onNodeToggle={action('onNodeToggle')}
+                            onNodeClick={action('onNodeClick')}
+                            onNodeFocus={action('onNodeFocus')}
+                            />
+                        <Tree.Node.Contents>
+                            <Tree.Node>
+                                <Tree.Node.Header
+                                    hasChildren={false}
+                                    isCollapsed={true}
+                                    isActive={false}
+                                    isFocused={false}
+                                    isLoading={false}
+                                    hasError={false}
+                                    dragAndDropContext={{
+                                        data: 'hello',
+                                        acceptsBefore: () => true,
+                                        acceptsInto: () => false,
+                                        onDropBefore: action('dropBefore'),
+                                        onDropInto: action('dropInto')
+                                    }}
+                                    label="Normal node"
+                                    onNodeToggle={action('onNodeToggle')}
+                                    onNodeClick={action('onNodeClick')}
+                                    onNodeFocus={action('onNodeFocus')}
+                                    />
+                            </Tree.Node>
+                            <Tree.Node>
+                                <Tree.Node.Header
+                                    hasChildren={false}
+                                    isCollapsed={true}
+                                    isActive={false}
+                                    isFocused={false}
+                                    isLoading={false}
+                                    hasError={false}
+                                    dragAndDropContext={{
+                                        data: 'hello',
+                                        acceptsBefore: () => false,
+                                        acceptsInto: () => true,
+                                        onDropBefore: action('dropBefore'),
+                                        onDropInto: action('dropInto')
+                                    }}
+                                    label="Normal node"
+                                    onNodeToggle={action('onNodeToggle')}
+                                    onNodeClick={action('onNodeClick')}
+                                    onNodeFocus={action('onNodeFocus')}
+                                    />
+                            </Tree.Node>
+                        </Tree.Node.Contents>
+                    </Tree.Node>
+                </Tree>
+            </StoryWrapper>
+        ),
+        {inline: true}
     );

--- a/packages/react-ui-components/src/Tree/index.story.js
+++ b/packages/react-ui-components/src/Tree/index.story.js
@@ -11,15 +11,13 @@ storiesOf('Tree', module)
                 <Tree>
                     <Tree.Node>
                         <Tree.Node.Header
-                            item={{
-                                hasChildren: true,
-                                isCollapsed: false,
-                                isActive: true,
-                                isFocused: true,
-                                isLoading: false,
-                                hasError: false,
-                                label: 'Active focused node with children'
-                            }}
+                            hasChildren={true}
+                            isCollapsed={false}
+                            isActive={true}
+                            isFocused={true}
+                            isLoading={false}
+                            hasError={false}
+                            label="Active focused node with children"
                             onNodeToggle={action('onNodeToggle')}
                             onNodeClick={action('onNodeClick')}
                             onNodeFocus={action('onNodeFocus')}
@@ -27,15 +25,13 @@ storiesOf('Tree', module)
                         <Tree.Node.Contents>
                             <Tree.Node>
                                 <Tree.Node.Header
-                                    item={{
-                                        hasChildren: false,
-                                        isCollapsed: true,
-                                        isActive: false,
-                                        isFocused: false,
-                                        isLoading: false,
-                                        hasError: false,
-                                        label: 'Normal node'
-                                    }}
+                                    hasChildren={false}
+                                    isCollapsed={true}
+                                    isActive={false}
+                                    isFocused={false}
+                                    isLoading={false}
+                                    hasError={false}
+                                    label="Normal node"
                                     onNodeToggle={action('onNodeToggle')}
                                     onNodeClick={action('onNodeClick')}
                                     onNodeFocus={action('onNodeFocus')}
@@ -43,15 +39,13 @@ storiesOf('Tree', module)
                             </Tree.Node>
                             <Tree.Node>
                                 <Tree.Node.Header
-                                    item={{
-                                        hasChildren: false,
-                                        isCollapsed: true,
-                                        isActive: true,
-                                        isFocused: false,
-                                        isLoading: false,
-                                        hasError: false,
-                                        label: 'Active node'
-                                    }}
+                                    hasChildren={false}
+                                    isCollapsed={true}
+                                    isActive={true}
+                                    isFocused={false}
+                                    isLoading={false}
+                                    hasError={false}
+                                    label="Active node"
                                     onNodeToggle={action('onNodeToggle')}
                                     onNodeClick={action('onNodeClick')}
                                     onNodeFocus={action('onNodeFocus')}
@@ -59,15 +53,13 @@ storiesOf('Tree', module)
                             </Tree.Node>
                             <Tree.Node>
                                 <Tree.Node.Header
-                                    item={{
-                                        hasChildren: false,
-                                        isCollapsed: true,
-                                        isActive: false,
-                                        isFocused: true,
-                                        isLoading: false,
-                                        hasError: false,
-                                        label: 'Focused node'
-                                    }}
+                                    hasChildren={false}
+                                    isCollapsed={true}
+                                    isActive={false}
+                                    isFocused={true}
+                                    isLoading={false}
+                                    hasError={false}
+                                    label="Focused node"
                                     onNodeToggle={action('onNodeToggle')}
                                     onNodeClick={action('onNodeClick')}
                                     onNodeFocus={action('onNodeFocus')}
@@ -75,16 +67,14 @@ storiesOf('Tree', module)
                             </Tree.Node>
                             <Tree.Node>
                                 <Tree.Node.Header
-                                    item={{
-                                        hasChildren: false,
-                                        isCollapsed: true,
-                                        isActive: false,
-                                        isFocused: false,
-                                        isLoading: false,
-                                        isHiddenInIndex: true,
-                                        hasError: false,
-                                        label: 'Hidden in menus'
-                                    }}
+                                    hasChildren={false}
+                                    isCollapsed={true}
+                                    isActive={false}
+                                    isFocused={false}
+                                    isLoading={false}
+                                    isHiddenInIndex={true}
+                                    hasError={false}
+                                    label="Hidden in menus"
                                     onNodeToggle={action('onNodeToggle')}
                                     onNodeClick={action('onNodeClick')}
                                     onNodeFocus={action('onNodeFocus')}
@@ -92,16 +82,14 @@ storiesOf('Tree', module)
                             </Tree.Node>
                             <Tree.Node>
                                 <Tree.Node.Header
-                                    item={{
-                                        hasChildren: false,
-                                        isCollapsed: true,
-                                        isActive: false,
-                                        isFocused: false,
-                                        isLoading: false,
-                                        isHidden: true,
-                                        hasError: false,
-                                        label: 'Hidden (invisible)'
-                                    }}
+                                    hasChildren={false}
+                                    isCollapsed={true}
+                                    isActive={false}
+                                    isFocused={false}
+                                    isLoading={false}
+                                    isHidden={true}
+                                    hasError={false}
+                                    label="Hidden (invisible)"
                                     onNodeToggle={action('onNodeToggle')}
                                     onNodeClick={action('onNodeClick')}
                                     onNodeFocus={action('onNodeFocus')}

--- a/packages/react-ui-components/src/Tree/node.css
+++ b/packages/react-ui-components/src/Tree/node.css
@@ -1,7 +1,7 @@
 .header {
     composes: reset from './../reset.css';
+    margin: 0;
     position: relative;
-    height: 11px;
     line-height: 20px;
     padding-left: 15px;
 }
@@ -32,13 +32,19 @@
     color: var(--brandColorsContrastBrighter) !important;
 }
 
+.header__icon {
+    padding: 0 .4em;
+}
+
 .header__data {
     composes: reset from './../reset.css';
+    position: relative;
     display: block;
     cursor: pointer;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+    padding: .2em 0;
 }
 
 .header__data--isHiddenInIndex {
@@ -55,6 +61,16 @@
     &.header__data--isHidden {
         opacity: .8;
     }
+}
+.header__data--acceptsDrop {
+    background-color: green;
+}
+.header__data--deniesDrop {
+    background-color: red;
+}
+.header__data--acceptsDrop *,
+.header__data--deniesDrop * {
+    pointer-events: none;
 }
 .header__label {
     composes: reset from './../reset.css';

--- a/packages/react-ui-components/src/Tree/node.css
+++ b/packages/react-ui-components/src/Tree/node.css
@@ -36,6 +36,9 @@
     composes: reset from './../reset.css';
     display: block;
     cursor: pointer;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
 }
 
 .header__data--isHiddenInIndex {

--- a/packages/react-ui-components/src/Tree/node.js
+++ b/packages/react-ui-components/src/Tree/node.js
@@ -21,18 +21,17 @@ export class Node extends PureComponent {
 
 export class Header extends PureComponent {
     static propTypes = {
-        item: PropTypes.shape({
-            hasChildren: PropTypes.bool.isRequired,
-            isCollapsed: PropTypes.bool.isRequired,
-            isActive: PropTypes.bool.isRequired,
-            isFocused: PropTypes.bool.isRequired,
-            isLoading: PropTypes.bool.isRequired,
-            isHidden: PropTypes.bool,
-            isHiddenInIndex: PropTypes.bool.isRequired,
-            hasError: PropTypes.bool.isRequired,
-            label: PropTypes.string.isRequired,
-            icon: PropTypes.string
-        }),
+        hasChildren: PropTypes.bool.isRequired,
+        isCollapsed: PropTypes.bool.isRequired,
+        isActive: PropTypes.bool.isRequired,
+        isFocused: PropTypes.bool.isRequired,
+        isLoading: PropTypes.bool.isRequired,
+        isHidden: PropTypes.bool,
+        isHiddenInIndex: PropTypes.bool.isRequired,
+        hasError: PropTypes.bool.isRequired,
+        label: PropTypes.string.isRequired,
+        icon: PropTypes.string,
+
         onToggle: PropTypes.func,
         onClick: PropTypes.func,
         onLabelClick: PropTypes.func,
@@ -56,22 +55,19 @@ export class Header extends PureComponent {
     render() {
         const {
             IconComponent,
-            item,
+            hasChildren,
+            isActive,
+            isFocused,
+            isHidden,
+            isHiddenInIndex,
+            label,
+            icon,
             onClick,
             onLabelClick,
             theme,
             ...restProps
         } = this.props;
         const rest = omit(restProps, ['onToggle']);
-        const {
-            label,
-            icon,
-            hasChildren,
-            isActive,
-            isFocused,
-            isHiddenInIndex,
-            isHidden
-        } = item;
         const dataClassNames = mergeClassNames({
             [theme.header__data]: true,
             [theme['header__data--isActive']]: isActive,
@@ -96,11 +92,14 @@ export class Header extends PureComponent {
     renderCollapseControl() {
         const {
             IconComponent,
-            item,
+            isLoading,
+            isCollapsed,
+            hasError,
+            isHiddenInIndex,
+            isHidden,
             onToggle,
             theme
         } = this.props;
-        const {isLoading, isCollapsed, hasError, isHiddenInIndex, isHidden} = item;
         const classnames = mergeClassNames({
             [theme.header__chevron]: true,
             [theme['header__chevron--isCollapsed']]: isCollapsed,


### PR DESCRIPTION
Though not a full rewrite, this PR introduces still some changes:

- Retrieve nodes directry from the CR part of the store, without further conversion
- More flat prop structure for the tree component
- Add drag and drop functionality