### PR TITLE
BUGFIX: ContentCanvas' iframe is transparent

### DIFF
--- a/packages/neos-ui/src/Containers/ContentCanvas/style.css
+++ b/packages/neos-ui/src/Containers/ContentCanvas/style.css
@@ -33,6 +33,7 @@
     top: 0;
     width: 100%;
     height: 100%;
+    background-color: white;
 }
 
 .markHoveredNodeAsHovered {


### PR DESCRIPTION
On pages with transparent body gray bg shines through:

![image](https://cloud.githubusercontent.com/assets/837032/23436920/39712e5a-fe1d-11e6-836e-2eecf03a5095.png)
