### PR TITLE
WIP: fix "insert into" constraints for auto-created child nodes

### DIFF
--- a/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
@@ -184,7 +184,7 @@ const getPathInNode = (state, contextPath, propertyPath) => {
 
 export const makeGetAllowedChildNodeTypesSelector = (nodeTypesRegistry, elevator = id => id) => createSelector(
     [
-        (state, {subject}) => getPathInNode(state, subject, 'isAutoCreated'),
+        (state, {reference}) => getPathInNode(state, elevator(reference), 'isAutoCreated'),
         (state, {reference}) => getPathInNode(state, elevator(reference), 'name'),
         (state, {reference}) => getPathInNode(state, elevator(reference), 'nodeType'),
         (state, {reference}) => getPathInNode(state, elevator(parentNodeContextPath(reference)), 'nodeType')


### PR DESCRIPTION
## How to reproduce the bug

* Ensure you have a content constraint for Auto Created Child nodes (e.g. "Main") set up.
* you will see ALL node types are displayed, not just the correct ones in the "add node" dialog.

I am not sure if the solution above is actually correct or has weird side-effects. @grebaldi would be great to have some more docs on the selectors :)

All the best,
Sebastian