### PR TITLE
Revert "chore(package): update css-loader to version 0.27.3 (#560)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "codeclimate-test-reporter": "^0.4.0",
     "cpx": "^1.3.1",
     "cross-env": "^3.0.0",
-    "css-loader": "^0.27.3",
+    "css-loader": "^0.26.0",
     "enzyme": "^2.4.1",
     "eslint": "^3.1.1",
     "extract-text-webpack-plugin": "^1.0.1",


### PR DESCRIPTION
This reverts commit 78833d7906acdfa11e661b98af2c80b545a1e143.

Newer version is causing weird errors that I'm not able to fix quickly:

```
ERROR in ./packages/neos-ui/src/Containers/style.css
Module build failed: ModuleNotFoundError: Module not found: Error: Cannot resolve module 'base64-js' in /home/dimaip/docker/sfi.ru/sfi20151230/data/www/releases/current/Packages/Application/Neos.Neos.Ui/node_modules/buffer
```