### PR TITLE
Bugfix: loading indicator

### DIFF
--- a/packages/neos-ui-redux-store/src/UI/ContentCanvas/index.js
+++ b/packages/neos-ui-redux-store/src/UI/ContentCanvas/index.js
@@ -1,6 +1,6 @@
 import {createAction} from 'redux-actions';
 import {Map} from 'immutable';
-import {$set, $get, $all} from 'plow-js';
+import {$set, $get} from 'plow-js';
 
 import {handleActions} from '@neos-project/utils-redux';
 

--- a/packages/neos-ui-redux-store/src/UI/ContentCanvas/index.js
+++ b/packages/neos-ui-redux-store/src/UI/ContentCanvas/index.js
@@ -72,10 +72,13 @@ export const reducer = handleActions({
         return state;
     },
     [SET_PREVIEW_URL]: ({previewUrl}) => $set('ui.contentCanvas.previewUrl', previewUrl),
-    [SET_SRC]: ({src}) => src ? $all(
-        $set('ui.contentCanvas.src', src),
-        $set('ui.contentCanvas.isLoading', true)
-    ) : state => state,
+    [SET_SRC]: ({src}) => state => {
+        if (src !== $get('ui.contentCanvas.src', state)) {
+            state = $set('ui.contentCanvas.src', src, state);
+            state = $set('ui.contentCanvas.isLoading', true, state);
+        }
+        return state;
+    },
     [FORMATTING_UNDER_CURSOR]: ({formatting}) => $set('ui.contentCanvas.formattingUnderCursor', new Map(formatting)),
     [SET_CURRENTLY_EDITED_PROPERTY_NAME]: ({propertyName}) => $set('ui.contentCanvas.currentlyEditedPropertyName', propertyName),
     [STOP_LOADING]: () => $set('ui.contentCanvas.isLoading', false)

--- a/packages/neos-ui/src/Containers/SecondaryToolbar/LoadingIndicator/style.css
+++ b/packages/neos-ui/src/Containers/SecondaryToolbar/LoadingIndicator/style.css
@@ -1,13 +1,14 @@
 .loadingIndicator__container {
 	left: 50%;
+    top: 39px;
 	position: absolute;
-	transform: translate(-50%, -50%);
+	transform: translateX(-50%);
     padding: 0 320px;
     width: 100%;
 }
 
 .loadingIndicator {
-	height: .25em;
+	height: 2px;
 	position: relative;
     width: 100%;
 }


### PR DESCRIPTION
Fixes some-times-broken loading indicator positioning and issues #597 & #595 where it would not stop loading if the current page was clicked again.