### PR TITLE
BUGFIX: Switch insert mode depending on allowed positions

### DIFF
--- a/packages/neos-ui-containers/src/InsertModeSelector/index.js
+++ b/packages/neos-ui-containers/src/InsertModeSelector/index.js
@@ -57,8 +57,17 @@ export default class InsertModeSelector extends PureComponent {
 
     selectPreferredInitialModeIfModeIsEmpty(props) {
         const {mode, onSelect} = props;
+        let reconsiderMode = !mode;
 
-        if (!mode) {
+        if (mode === MODE_INTO && !props.enableIntoMode) {
+            reconsiderMode = true;
+        }
+
+        if ((mode === MODE_AFTER || mode === MODE_BEFORE) && !props.enableAlongsideModes) {
+            reconsiderMode = true;
+        }
+
+        if (reconsiderMode) {
             const preferredInitialMode = calculatePreferredInitialMode(props);
 
             if (preferredInitialMode) {


### PR DESCRIPTION
If an insert position mode was preselected the component never
considered if that mode was actually enabled leading to modals
with empty groups being shown.

Fixes: #578