### PR TITLE
BUGFIX: Fix structure tree ouput and ``insert inside`` behaviour for non rendered nodes

### DIFF
--- a/Classes/Neos/Neos/Ui/Aspects/AugmentationAspect.php
+++ b/Classes/Neos/Neos/Ui/Aspects/AugmentationAspect.php
@@ -216,13 +216,22 @@ class AugmentationAspect
     }
 
     /**
+     * Clear non rendered content node metadata to prevent possible side effects.
+     */
+    protected function clearNonRenderedContentNodeMetadata() {
+        $this->nonRenderedContentNodeMetadata = '';
+    }
+
+    /**
      * @param NodeInterface $documentNode
      * @return string
      */
     public function getNonRenderedContentNodeMetadata(NodeInterface $documentNode)
     {
         $this->appendNonRenderedContentNodeMetadata($documentNode);
+        $nonRenderedContentNodeMetadata = $this->nonRenderedContentNodeMetadata;
+        $this->clearNonRenderedContentNodeMetadata();
         $this->clearRenderedNodesArray();
-        return $this->nonRenderedContentNodeMetadata;
+        return $nonRenderedContentNodeMetadata;
     }
 }

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractStructuralChange.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractStructuralChange.php
@@ -155,7 +155,11 @@ abstract class AbstractStructuralChange extends AbstractChange
         $this->feedbackCollection->add($updateParentNodeInfo);
 
         if ($node->getNodeType()->isOfType('Neos.Neos:Content') && ($this->getParentDomAddress() || $this->getSiblingDomAddress())) {
-            if ($node->getParent()->getNodeType()->isOfType('Neos.Neos:ContentCollection')) {
+            if (
+                $node->getParent()->getNodeType()->isOfType('Neos.Neos:ContentCollection') &&
+                $this->getParentDomAddress() &&
+                $this->getParentDomAddress()->getFusionPath()
+            ) {
                 $renderContentOutOfBand = new RenderContentOutOfBand();
                 $renderContentOutOfBand->setNode($node);
                 $renderContentOutOfBand->setParentDomAddress($this->getParentDomAddress());

--- a/Classes/Neos/Neos/Ui/Fusion/RenderNonRenderedNodeMetadataImplementation.php
+++ b/Classes/Neos/Neos/Ui/Fusion/RenderNonRenderedNodeMetadataImplementation.php
@@ -18,6 +18,6 @@ class RenderNonRenderedNodeMetadataImplementation extends AbstractFusionObject
 
     public function evaluate()
     {
-        return $this->augmentedAspect->appendNonRenderedContentNodeMetadata($this->fusionValue('node'));
+        return $this->augmentedAspect->getNonRenderedContentNodeMetadata($this->fusionValue('node'));
     }
 }

--- a/Classes/Neos/Neos/Ui/Fusion/RenderNonRenderedNodeMetadataImplementation.php
+++ b/Classes/Neos/Neos/Ui/Fusion/RenderNonRenderedNodeMetadataImplementation.php
@@ -1,0 +1,23 @@
+<?php
+namespace Neos\Neos\Ui\Fusion;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Fusion\FusionObjects\AbstractFusionObject;
+use Neos\Neos\Ui\Aspects\AugmentationAspect;
+
+/**
+ * Implementation to return the metadata for non rendered nodes.
+ */
+class RenderNonRenderedNodeMetadataImplementation extends AbstractFusionObject
+{
+    /**
+     * @Flow\Inject
+     * @var AugmentationAspect
+     */
+    protected $augmentedAspect;
+
+    public function evaluate()
+    {
+        return $this->augmentedAspect->appendNonRenderedContentNodeMetadata($this->fusionValue('node'));
+    }
+}

--- a/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -89,4 +89,14 @@ prototype(Neos.Neos:Page) {
             newBackend = ${Neos.Ui.Activation.enableNewBackend()}
         }
     }
+
+    //
+    // Output `<script>` tags for all non rendered node children
+    //
+    neosUiNonRenderedNodeMetadata = Neos.Neos.Ui:RenderNonRenderedNodeMetadata {
+        @position = 'before neosBackendNotification'
+        @class = 'Neos\\Neos\\Ui\\Fusion\\RenderNonRenderedNodeMetadataImplementation'
+        @if.newBackend = ${Neos.Ui.Activation.enableNewBackend()}
+        node = ${node}
+    }
 }

--- a/packages/neos-ui/src/Sagas/CR/NodeOperations/helpers.js
+++ b/packages/neos-ui/src/Sagas/CR/NodeOperations/helpers.js
@@ -49,10 +49,12 @@ export const calculateDomAddressesFromMode = (mode, contextPath, fusionPath) => 
         }
 
         default: {
+            const element = dom.findNode(contextPath, fusionPath);
+
             return {
                 parentDomAddress: {
-                    contextPath,
-                    fusionPath
+                    contextPath: element.getAttribute('data-__neos-node-contextpath'),
+                    fusionPath: element.getAttribute('data-__neos-fusion-path')
                 }
             };
         }

--- a/packages/neos-ui/src/Sagas/CR/NodeOperations/helpers.js
+++ b/packages/neos-ui/src/Sagas/CR/NodeOperations/helpers.js
@@ -53,7 +53,7 @@ export const calculateDomAddressesFromMode = (mode, contextPath, fusionPath) => 
 
             return {
                 parentDomAddress: {
-                    contextPath: element? element.getAttribute('data-__neos-node-contextpath'): contextPath,
+                    contextPath: element ? element.getAttribute('data-__neos-node-contextpath') : contextPath,
                     fusionPath: element ? element.getAttribute('data-__neos-fusion-path') : fusionPath
                 }
             };

--- a/packages/neos-ui/src/Sagas/CR/NodeOperations/helpers.js
+++ b/packages/neos-ui/src/Sagas/CR/NodeOperations/helpers.js
@@ -53,8 +53,8 @@ export const calculateDomAddressesFromMode = (mode, contextPath, fusionPath) => 
 
             return {
                 parentDomAddress: {
-                    contextPath: element.getAttribute('data-__neos-node-contextpath'),
-                    fusionPath: element.getAttribute('data-__neos-fusion-path')
+                    contextPath: element? element.getAttribute('data-__neos-node-contextpath'): contextPath,
+                    fusionPath: element ? element.getAttribute('data-__neos-fusion-path') : fusionPath
                 }
             };
         }


### PR DESCRIPTION
Child nodes not rendered within the current document node used to disappear after creating new document nodes (after first refresh). The behaviour for inserted child nodes was also fixed (before it was possible that the fusion rendering path was not available).