### PR TITLE
BUGFIX: Show preview image in inspector on first selection

### DIFF
--- a/packages/neos-ui-editors/src/Image/index.js
+++ b/packages/neos-ui-editors/src/Image/index.js
@@ -106,10 +106,9 @@ export default class ImageEditor extends Component {
         // Re-Load the image metadata in case a new image was selected.
         //
         if (
-            this.props.value &&
             nextProps.value &&
             nextProps.value.__identity &&
-            nextProps.value.__identity !== this.props.value.__identity
+            nextProps.value.__identity !== (this.props.value && this.props.value.__identity)
         ) {
             loadImageMetadata(nextProps.value.__identity)
                 .then(image => {


### PR DESCRIPTION
The preview image in the inspector was not shown, unless another element has been selected before.

Fixes: #542 