### PR TITLE
BUGFIX: Apply new images in the inspector without throwing exceptions

### DIFF
--- a/Classes/Neos/Neos/Ui/Controller/BackendServiceController.php
+++ b/Classes/Neos/Neos/Ui/Controller/BackendServiceController.php
@@ -123,7 +123,7 @@ class BackendServiceController extends ActionController
     {
         try {
             $count = $changes->count();
-            $changes->compress()->apply();
+            $changes->apply();
 
             $success = new Info();
             $success->setMessage(sprintf('%d change(s) successfully applied.', $count));

--- a/Classes/Neos/Neos/Ui/Domain/Model/ChangeCollection.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/ChangeCollection.php
@@ -25,30 +25,6 @@ class ChangeCollection
     }
 
     /**
-     * Reduce this collection to a minimal set of changes with the same outcome
-     *
-     * @return ChangeCollection
-     */
-    public function compress()
-    {
-        $compressedChangeCollection = new ChangeCollection();
-
-        while ($change = array_shift($this->changes)) {
-            if ($subsequentChange = array_shift($this->changes)) {
-                if ($change->canMerge($subsequentChange)) {
-                    $change = $change->merge($subsequentChange);
-                } else {
-                    array_unshift($this->changes, $subsequentChange);
-                }
-            }
-
-            $compressedChangeCollection->add($change);
-        }
-
-        return $compressedChangeCollection;
-    }
-
-    /**
      * Apply all changes
      *
      * @return void

--- a/Classes/Neos/Neos/Ui/Domain/Model/ChangeInterface.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/ChangeInterface.php
@@ -25,22 +25,6 @@ interface ChangeInterface
     public function getSubject();
 
     /**
-     * Checks whether this change can be merged with a subsequent change
-     *
-     * @param  ChangeInterface $subsequentChange
-     * @return boolean
-     */
-    public function canMerge(ChangeInterface $subsequentChange);
-
-    /**
-     * Merges this change with a subsequent change
-     *
-     * @param  ChangeInterface $subsequentChange
-     * @return void
-     */
-    public function merge(ChangeInterface $subsequentChange);
-
-    /**
      * Checks whether this change can be applied to the subject
      *
      * @return boolean

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractCopy.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractCopy.php
@@ -16,38 +16,6 @@ abstract class AbstractCopy extends AbstractStructuralChange
     protected $contentRepositoryNodeService;
 
     /**
-     * Checks whether this change can be merged with a subsequent change
-     *
-     * @param  ChangeInterface $subsequentChange
-     * @return boolean
-     */
-    public function canMerge(ChangeInterface $subsequentChange)
-    {
-        if (!$subsequentChange instanceof AbstractCopy) {
-            return false;
-        }
-
-        if ($subsequentChange->getSubject() !== $this->getSubject()) {
-            return false;
-        }
-
-        return $subsequentChange->canApply();
-    }
-
-    /**
-     * Merges this change with a subsequent change
-     *
-     * @param  ChangeInterface $subsequentChange
-     * @return void
-     */
-    public function merge(ChangeInterface $subsequentChange)
-    {
-        if ($this->canMerge($subsequentChange)) {
-            return $subsequentChange;
-        }
-    }
-
-    /**
      * Checks whether this change can be applied to the subject
      *
      * @return boolean

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractCreate.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractCreate.php
@@ -116,38 +116,6 @@ abstract class AbstractCreate extends AbstractStructuralChange
     }
 
     /**
-     * Checks whether this change can be merged with a subsequent change
-     *
-     * @param  ChangeInterface $subsequentChange
-     * @return boolean
-     */
-    public function canMerge(ChangeInterface $subsequentChange)
-    {
-        if (!$subsequentChange instanceof AbstractCreate) {
-            return false;
-        }
-
-        if ($subsequentChange->getSubject() !== $this->getSubject()) {
-            return false;
-        }
-
-        return $subsequentChange->canApply();
-    }
-
-    /**
-     * Merges this change with a subsequent change
-     *
-     * @param  ChangeInterface $subsequentChange
-     * @return void
-     */
-    public function merge(ChangeInterface $subsequentChange)
-    {
-        if ($this->canMerge($subsequentChange)) {
-            return $subsequentChange;
-        }
-    }
-
-    /**
      * Creates a new node beneath $parent
      *
      * @param  NodeInterface $parent

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractMove.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractMove.php
@@ -9,38 +9,6 @@ use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
 abstract class AbstractMove extends AbstractStructuralChange
 {
     /**
-     * Checks whether this change can be merged with a subsequent change
-     *
-     * @param  ChangeInterface $subsequentChange
-     * @return boolean
-     */
-    public function canMerge(ChangeInterface $subsequentChange)
-    {
-        if (!$subsequentChange instanceof AbstractMove) {
-            return false;
-        }
-
-        if ($subsequentChange->getSubject() !== $this->getSubject()) {
-            return false;
-        }
-
-        return $subsequentChange->canApply();
-    }
-
-    /**
-     * Merges this change with a subsequent change
-     *
-     * @param  ChangeInterface $subsequentChange
-     * @return void
-     */
-    public function merge(ChangeInterface $subsequentChange)
-    {
-        if ($this->canMerge($subsequentChange)) {
-            return $subsequentChange;
-        }
-    }
-
-    /**
      * Checks whether this change can be applied to the subject
      *
      * @return boolean

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/Property.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/Property.php
@@ -82,44 +82,6 @@ class Property extends AbstractChange
     }
 
     /**
-     * Checks whether this change can be merged with a subsequent change
-     *
-     * @param  ChangeInterface $subsequentChange
-     * @return boolean
-     */
-    public function canMerge(ChangeInterface $subsequentChange)
-    {
-        if (!$subsequentChange instanceof Property) {
-            return false;
-        }
-
-        if ($subsequentChange->getSubject() !== $this->getSubject()) {
-            return false;
-        }
-
-        if ($subsequentChange->getPropertyName() !== $this->getPropertyName()) {
-            return false;
-        }
-
-        return $subsequentChange->canApply();
-    }
-
-    /**
-     * Merges this change with a subsequent change
-     *
-     * @param  ChangeInterface $subsequentChange
-     * @return ChangeInterface|null
-     */
-    public function merge(ChangeInterface $subsequentChange)
-    {
-        if ($this->canMerge($subsequentChange)) {
-            return $subsequentChange;
-        }
-
-        return null;
-    }
-
-    /**
      * Checks whether this change can be applied to the subject
      *
      * @return boolean

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/Remove.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/Remove.php
@@ -13,40 +13,6 @@ use Neos\Neos\Ui\Domain\Model\Feedback\Operations\RemoveNode;
 class Remove extends AbstractChange
 {
     /**
-     * Checks whether this change can be merged with a subsequent change
-     *
-     * @param  ChangeInterface $subsequentChange
-     * @return boolean
-     */
-    public function canMerge(ChangeInterface $subsequentChange)
-    {
-        if ($subsequentChange->getSubject() !== $this->getSubject()) {
-            return false;
-        }
-
-        if ($subsequentChange->getPropertyName() !== $this->getPropertyName()) {
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * Merges this change with a subsequent change
-     *
-     * @param  ChangeInterface $subsequentChange
-     * @return ChangeInterface|null
-     */
-    public function merge(ChangeInterface $subsequentChange)
-    {
-        if ($this->canMerge($subsequentChange)) {
-            return $this;
-        }
-
-        return null;
-    }
-
-    /**
      * Checks whether this change can be applied to the subject
      *
      * @return boolean

--- a/Classes/Neos/Neos/Ui/TypeConverter/ChangeCollectionConverter.php
+++ b/Classes/Neos/Neos/Ui/TypeConverter/ChangeCollectionConverter.php
@@ -22,6 +22,7 @@ use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Neos\Ui\Domain\Model\ChangeCollection;
 use Neos\Neos\Ui\Domain\Model\ChangeInterface;
 use Neos\Neos\Ui\ContentRepository\Service\NodeService;
+use Neos\Neos\Ui\Domain\Model\Changes\Property;
 
 /**
  * An Object Converter for ChangeCollections.
@@ -164,7 +165,13 @@ class ChangeCollectionConverter extends AbstractTypeConverter
                     $methodParameter = current($methodParameters);
                     $targetType = $methodParameter['type'];
 
-                    $value = $this->propertyMapper->convert($value, $targetType);
+                    // Fixme: The type conversion runs depending on the target node property type inside Property::class
+                    // This is why we are not allowed to modify the value in any way.
+                    // Without this condition the object was parsed to a string leading to fatal errors when changing images
+                    // in the UI.
+                    if ($propertyName !== 'value' && $targetType !== Property::class)  {
+                        $value = $this->propertyMapper->convert($value, $targetType);
+                    }
 
                     ObjectAccess::setProperty($changeClassInstance, $propertyName, $value);
                 }


### PR DESCRIPTION
Before this change an type conversion exception was thrown when trying to change the image inside the image inspector.