### PR TITLE
BUGFIX: when creating new documents, directly show the newly created document

### DIFF
--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractCreate.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractCreate.php
@@ -162,9 +162,9 @@ abstract class AbstractCreate extends AbstractStructuralChange
 
         $this->applyNodeCreationHandlers($node);
 
-        $this->addDocumentNodeCreatedFeedback($node);
-
         $this->finish($node);
+        // NOTE: we need to run "finish" before "addDocumentNodeCreatedFeedback" to ensure the new node already exists when the last feedback is processed
+        $this->addDocumentNodeCreatedFeedback($node);
 
         return $node;
     }


### PR DESCRIPTION
Without this change, the ContentCanvas stayed empty because the node was not
yet loaded, and thus no URL could be determined.