### PR TITLE
BUGFIX: Set removed image to empty string

### DIFF
--- a/packages/neos-ui-editors/src/Image/index.js
+++ b/packages/neos-ui-editors/src/Image/index.js
@@ -167,14 +167,12 @@ export default class ImageEditor extends Component {
 
     onRemoveFile() {
         const {commit} = this.props;
-        const value = this.getValue();
-        const newAsset = $set('__identity', '', value);
 
         this.handleCloseSecondaryScreen();
         this.setState({
             image: null
         }, () => {
-            commit(newAsset);
+            commit('');
         });
     }
 


### PR DESCRIPTION
Before an exception was thrown, now empty string will be used for removed images within the inspector (the empty string is consistent with how removed images are handled in the current UI).