### PR TITLE
TASK: Fix color contrast issue in DimensionSwitcher

### DIFF
--- a/packages/neos-ui/src/Containers/SecondaryToolbar/DimensionSwitcher/index.js
+++ b/packages/neos-ui/src/Containers/SecondaryToolbar/DimensionSwitcher/index.js
@@ -84,8 +84,8 @@ export default class DimensionSwitcher extends PureComponent {
         const contentDimensionsObjectKeys = Object.keys(contentDimensionsObject);
 
         return (
-            <DropDown className={style.dropDown}>
-                <DropDown.Header className={style.dropDown__btn}>
+            <DropDown style="darker" padded={true} className={style.dropDown}>
+                <DropDown.Header>
                     {contentDimensionsObjectKeys.map(dimensionName => {
                         const dimensionConfiguration = contentDimensionsObject[dimensionName];
                         const icon = $get('icon', dimensionConfiguration) && $get('icon', dimensionConfiguration);
@@ -99,7 +99,7 @@ export default class DimensionSwitcher extends PureComponent {
                         );
                     })}
                 </DropDown.Header>
-                <DropDown.Contents className={style.dropDown__contents}>
+                <DropDown.Contents>
                     {contentDimensionsObjectKeys.map(dimensionName => {
                         const dimensionConfiguration = contentDimensionsObject[dimensionName];
                         const icon = $get('icon', dimensionConfiguration) && $get('icon', dimensionConfiguration);

--- a/packages/neos-ui/src/Containers/SecondaryToolbar/DimensionSwitcher/style.css
+++ b/packages/neos-ui/src/Containers/SecondaryToolbar/DimensionSwitcher/style.css
@@ -1,15 +1,6 @@
 .dropDown {
-    display: inline-block;
     max-width: 352px;
-}
-.dropDown__btn {
-    height: var(--goldenUnit);
-    border: 0;
-    background: 0;
 }
 .dropDown__btnIcon {
     margin-right: .5em;
-}
-.dropDown__contents {
-    padding: var(--spacing);
 }

--- a/packages/react-ui-components/src/DropDown/header.js
+++ b/packages/react-ui-components/src/DropDown/header.js
@@ -19,7 +19,8 @@ const ShallowDropDownHeader = props => {
     const iconName = isOpen ? 'chevron-up' : 'chevron-down';
     const finalClassName = mergeClassNames({
         [theme.dropDown__btn]: true,
-        [className]: className && className.length
+        [className]: className && className.length,
+        [theme['dropDown__btn--open']]: isOpen
     });
 
     return (

--- a/packages/react-ui-components/src/DropDown/index.story.js
+++ b/packages/react-ui-components/src/DropDown/index.story.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import {storiesOf} from '@kadira/storybook';
-import {withKnobs, text} from '@kadira/storybook-addon-knobs';
+import {withKnobs, text, boolean, select} from '@kadira/storybook-addon-knobs';
 import {StoryWrapper} from './../_lib/storyUtils.js';
 import DropDown from './index.js';
+
+const validStyles = ['default', 'darker'];
 
 storiesOf('DropDown', module)
     .addDecorator(withKnobs)
@@ -11,7 +13,11 @@ storiesOf('DropDown', module)
         '',
         () => (
             <StoryWrapper>
-                <DropDown isOpen={true}>
+                <DropDown
+                    isOpen={true}
+                    padded={boolean('Padded', false)}
+                    style={select('Size', validStyles)}
+                    >
                     <DropDown.Header>
                         {text('Header', 'Dropdown header')}
                     </DropDown.Header>

--- a/packages/react-ui-components/src/DropDown/style.css
+++ b/packages/react-ui-components/src/DropDown/style.css
@@ -25,6 +25,9 @@
         outline: unset;
     }
 }
+.dropDown__btn--open {
+
+}
 .dropDown__btnLabel {
     composes: reset from './../reset.css';
     margin-right: .5em;
@@ -51,4 +54,21 @@
 }
 .dropDown__contents--isOpen {
     display: block;
+}
+.dropDown--default {
+
+}
+.dropDown--darker {
+    > .dropDown__btn--open {
+        background-color: var(--brandColorsContrastDarker);
+    }
+
+    > .dropDown__contents {
+        background-color: var(--brandColorsContrastDarker);
+    }
+}
+.dropDown--padded {
+    > .dropDown__contents {
+        padding: var(--spacing);
+    }
 }

--- a/packages/react-ui-components/src/DropDown/style.css
+++ b/packages/react-ui-components/src/DropDown/style.css
@@ -25,9 +25,6 @@
         outline: unset;
     }
 }
-.dropDown__btn--open {
-
-}
 .dropDown__btnLabel {
     composes: reset from './../reset.css';
     margin-right: .5em;
@@ -54,9 +51,6 @@
 }
 .dropDown__contents--isOpen {
     display: block;
-}
-.dropDown--default {
-
 }
 .dropDown--darker {
     > .dropDown__btn--open {

--- a/packages/react-ui-components/src/DropDown/wrapper.js
+++ b/packages/react-ui-components/src/DropDown/wrapper.js
@@ -14,6 +14,16 @@ export class DropDownWrapper extends PureComponent {
         className: PropTypes.string,
 
         /**
+         * An optional style variant (default, darker)
+         */
+        style: PropTypes.string,
+
+        /**
+         * An optional padding around the contents
+         */
+        padded: PropTypes.bool,
+
+        /**
          * This prop controls the initial visual opened state of the `DropDown`.
          */
         isOpen: PropTypes.bool.isRequired,
@@ -37,7 +47,8 @@ export class DropDownWrapper extends PureComponent {
     };
 
     static defaultProps = {
-        isOpen: false
+        isOpen: false,
+        style: 'default'
     };
 
     static childContextTypes = {
@@ -73,9 +84,12 @@ export class DropDownWrapper extends PureComponent {
     }
 
     render() {
-        const {children, className, theme, ...restProps} = this.props;
+        const {children, className, theme, style, padded, ...restProps} = this.props;
         const rest = omit(restProps, ['isOpen', 'onToggle']);
+        const styleClassName = `dropDown--${style}`;
         const finalClassName = mergeClassNames({
+            [theme[styleClassName]]: true,
+            [theme['dropDown--padded']]: padded,
             [className]: className && className.length,
             [theme.dropDown]: true
         });

--- a/packages/react-ui-components/src/DropDown/wrapper.js
+++ b/packages/react-ui-components/src/DropDown/wrapper.js
@@ -86,9 +86,9 @@ export class DropDownWrapper extends PureComponent {
     render() {
         const {children, className, theme, style, padded, ...restProps} = this.props;
         const rest = omit(restProps, ['isOpen', 'onToggle']);
-        const styleClassName = `dropDown--${style}`;
+        const styleClassName = style ? `dropDown--${style}` : false;
         const finalClassName = mergeClassNames({
-            [theme[styleClassName]]: true,
+            [theme[styleClassName]]: styleClassName,
             [theme['dropDown--padded']]: padded,
             [className]: className && className.length,
             [theme.dropDown]: true


### PR DESCRIPTION
Now the DropDown component accept a new style attributes. The default rendering is not touched. You can use ```darker``` to have the color styling used in the DimensionSwitcher. The ```padded``` attributes is added to add padding around the content area of the DropDown.

The change on the DropDown make it more self contains and allow us to remove most of the styling from the DimensionSwitcher. 

Lerna story is updated so you can test the different rendering.

Fixes: #587