### PR TITLE
BUGFIX: make console clean AGAIN

### DIFF
--- a/packages/neos-ui-editors/src/Image/Components/Secondary/ImageCropper/model.js
+++ b/packages/neos-ui-editors/src/Image/Components/Secondary/ImageCropper/model.js
@@ -95,7 +95,6 @@ export class AspectRatioOption {
     }
 
     getNextAspectRatioStrategy(currentAspectRatioStrategy) {
-        console.log(currentAspectRatioStrategy);
         return this.__aspectRatioStrategyFactory(currentAspectRatioStrategy);
     }
 }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -88,13 +88,13 @@ export default class Node extends PureComponent {
     isLoading() {
         const {node, loadingNodeContextPaths} = this.props;
 
-        return loadingNodeContextPaths && loadingNodeContextPaths.includes($get('contextPath', node));
+        return loadingNodeContextPaths ? loadingNodeContextPaths.includes($get('contextPath', node)) : false;
     }
 
     hasError() {
         const {node, errorNodeContextPaths} = this.props;
 
-        return errorNodeContextPaths && errorNodeContextPaths.includes($get('contextPath', node));
+        return errorNodeContextPaths ? errorNodeContextPaths.includes($get('contextPath', node)) : false;
     }
 
     getDragAndDropContext() {

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/RefreshPageTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/RefreshPageTree/index.js
@@ -20,7 +20,7 @@ export default class RefreshPageTree extends PureComponent {
     }
 
     render() {
-        const {isLoading, className, ...rest} = this.props;
+        const {isLoading, className} = this.props;
         const finalClassName = mergeClassNames({
             [style.spinning]: isLoading,
             [className]: className && className.length
@@ -28,7 +28,6 @@ export default class RefreshPageTree extends PureComponent {
 
         return (
             <IconButton
-                {...rest}
                 className={finalClassName}
                 isDisabled={isLoading}
                 onClick={this.handleClick}

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
@@ -35,6 +35,10 @@ export default class NodeTreeToolBar extends PureComponent {
         reloadTree: PropTypes.func.isRequired
     }
 
+    static defaultProps = {
+        isHidden: false
+    };
+
     handleAddNode = contextPath => {
         const {addNode} = this.props;
 

--- a/packages/react-ui-components/src/Frame/frame.js
+++ b/packages/react-ui-components/src/Frame/frame.js
@@ -23,7 +23,6 @@ export default class Frame extends PureComponent {
         document.addEventListener('Neos.Neos.Ui.ContentReady', this.renderFrameContents);
     }
     renderFrameContents = () => {
-        console.log(this);
         const doc = ReactDOM.findDOMNode(this).contentDocument; // eslint-disable-line react/no-find-dom-node
         const win = ReactDOM.findDOMNode(this).contentWindow; // eslint-disable-line react/no-find-dom-node
         const mountTarget = doc.querySelector(this.props.mountTarget);

--- a/packages/react-ui-components/src/SelectBox/searchableSelectBox.js
+++ b/packages/react-ui-components/src/SelectBox/searchableSelectBox.js
@@ -14,7 +14,10 @@ export default class SearchableSelectBox extends PureComponent {
         /**
          * This prop represents the current label to show. Can be a placeholder or the label of the selected value.
          */
-        label: PropTypes.string,
+        label: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.object
+        ]),
 
         /**
          * This prop represents the current icon to show. Can be empty, or a placeholder or the icon of the selected value

--- a/packages/react-ui-components/src/Tree/node.js
+++ b/packages/react-ui-components/src/Tree/node.js
@@ -27,7 +27,7 @@ export class Header extends PureComponent {
         isFocused: PropTypes.bool.isRequired,
         isLoading: PropTypes.bool.isRequired,
         isHidden: PropTypes.bool,
-        isHiddenInIndex: PropTypes.bool.isRequired,
+        isHiddenInIndex: PropTypes.bool,
         hasError: PropTypes.bool.isRequired,
         label: PropTypes.string.isRequired,
         icon: PropTypes.string,


### PR DESCRIPTION
One last error in the console is from prop validation for `icon-folder-open-alt` icon, which got removed from Fontawesome.