### PR TITLE
BUGFIX: Close button in codemirror

### DIFF
--- a/packages/neos-ui-inspector/src/SecondaryInspector/style.css
+++ b/packages/neos-ui-inspector/src/SecondaryInspector/style.css
@@ -26,5 +26,5 @@
     font-size: 18px;
     border-right-width: 0;
     border-top-width: 0;
-    z-index: 1;
+    z-index: 10;
 }


### PR DESCRIPTION
Codemirror sets z-index 1 for codelines which are not empty (in some cases it gets up to z-index 6), this lays over the close button and it is not clickable

see #671 