### PR TITLE
BUGFIX: make CSS reset more robust by resetting the spacings

### DIFF
--- a/packages/react-ui-components/src/reset.css
+++ b/packages/react-ui-components/src/reset.css
@@ -2,6 +2,8 @@
     font-family: '\var(--brandFontsCopyFamily)', sans-serif;
     font-weight: var(--brandFontsCopyCssWeight);
     color: #FFF;
+    margin: 0;
+    padding: 0;
 
     &,
     &:before,


### PR DESCRIPTION
Otherwise I get issues like this when the site's styles override our styles:

![image](https://cloud.githubusercontent.com/assets/837032/25589327/defb7e76-2eb4-11e7-8aef-b28d2443e171.png)
