### PR TITLE
BUGFIX: sorting messes up order for not positioned properties

### DIFF
--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
@@ -1,6 +1,7 @@
-import {map, mapObjIndexed, values, sort, compose} from 'ramda';
+import {map} from 'ramda';
 import {$get, $transform} from 'plow-js';
 import {SynchronousRegistry} from '@neos-project/neos-ui-extensibility/src/registry';
+import getNormalizedDeepStructureFromNodeType from './getNormalizedDeepStructureFromNodeType';
 
 export default class NodeTypesRegistry extends SynchronousRegistry {
     _constraints = [];
@@ -104,18 +105,6 @@ export default class NodeTypesRegistry extends SynchronousRegistry {
             return this._inspectorViewConfigurationCache[nodeTypeName];
         }
 
-        const withId = mapObjIndexed((subject, id) => ({
-            ...subject,
-            id
-        }));
-        const getPosition = subject => ($get(['ui', 'inspector', 'position'], subject) || $get(['ui', 'position'], subject) || $get('position', subject) || 0);
-        const positionalArraySorter = sort((a, b) => (a.id - b.id) || (getPosition(a) - getPosition(b)));
-        const getNormalizedDeepStructureFromNodeType = path => compose(
-            positionalArraySorter,
-            values,
-            withId,
-            $get(path)
-        );
         const tabs = getNormalizedDeepStructureFromNodeType('ui.inspector.tabs')(nodeType);
         const groups = getNormalizedDeepStructureFromNodeType('ui.inspector.groups')(nodeType);
         const views = getNormalizedDeepStructureFromNodeType('ui.inspector.views')(nodeType);

--- a/packages/neos-ui-contentrepository/src/registry/getNormalizedDeepStructureFromNodeType.js
+++ b/packages/neos-ui-contentrepository/src/registry/getNormalizedDeepStructureFromNodeType.js
@@ -1,0 +1,33 @@
+import {mapObjIndexed, values, sort, compose} from 'ramda';
+import {$get} from 'plow-js';
+
+const withId = mapObjIndexed((subject, id) => ({
+    ...subject,
+    id
+}));
+const getPosition = subject => ($get(['ui', 'inspector', 'position'], subject) || $get(['ui', 'position'], subject) || $get('position', subject) || 0);
+const positionalArraySorter = sort((a, b) => {
+    // If both items don't have position, retain order
+    if (getPosition(a) === 0 && getPosition(b) === 0) {
+        return 0;
+    }
+    // If only item `a` doesn't have position, push it down
+    if (getPosition(a) === 0) {
+        return 1;
+    }
+    // If only item `b` doesn't have position, push it down
+    if (getPosition(b) === 0) {
+        return -1;
+    }
+    // If both items have position, sort them in a standard way
+    return getPosition(a) - getPosition(b);
+});
+
+const getNormalizedDeepStructureFromNodeType = path => compose(
+    positionalArraySorter,
+    values,
+    withId,
+    $get(path)
+);
+
+export default getNormalizedDeepStructureFromNodeType;

--- a/packages/neos-ui-contentrepository/src/registry/getNormalizedDeepStructureFromNodeType.spec.js
+++ b/packages/neos-ui-contentrepository/src/registry/getNormalizedDeepStructureFromNodeType.spec.js
@@ -1,0 +1,71 @@
+import getNormalizedDeepStructureFromNodeType from './getNormalizedDeepStructureFromNodeType';
+
+test(`
+    "getNormalizedDeepStructureFromNodeType" should sort things correctly`, () => {
+    const nodeType = {
+        properties: {
+            last: {
+                ui: {
+                    label: 'last',
+                    inspector: {
+                        position: 100
+                    }
+                }
+            },
+            notPositionedOne: {
+                ui: {
+                    label: 'notPositionedOne'
+                }
+            },
+            notPositionedTwo: {
+                ui: {
+                    label: 'notPositionedTwo'
+                }
+            },
+            first: {
+                ui: {
+                    label: 'first',
+                    inspector: {
+                        position: 1
+                    }
+                }
+            }
+        }
+    };
+
+    const expectedResult = [
+        {
+            id: 'first',
+            ui: {
+                label: 'first',
+                inspector: {
+                    position: 1
+                }
+            }
+        },
+        {
+            id: 'last',
+            ui: {
+                label: 'last',
+                inspector: {
+                    position: 100
+                }
+            }
+        },
+        {
+            id: 'notPositionedOne',
+            ui: {
+                label: 'notPositionedOne'
+            }
+        },
+        {
+            id: 'notPositionedTwo',
+            ui: {
+                label: 'notPositionedTwo'
+            }
+        }
+    ];
+
+    const sortedProperties = getNormalizedDeepStructureFromNodeType('properties')(nodeType);
+    expect(sortedProperties).toEqual(expectedResult);
+});


### PR DESCRIPTION
Currently the sorter doesn't sort unpositioned elements correctly. They should retain the order defined in source code.
Also I extracted the logic to make it more clear and easier to test, and actually written a test for this sorting behavior.