### PR TITLE
BUGFIX: make react-dom accessible through extensibility API

### DIFF
--- a/EXTENSIBILITY.md
+++ b/EXTENSIBILITY.md
@@ -10,6 +10,7 @@ The following external libraries are shipped within Neos; and you can simply req
 without specifying them in package.json.
 
 - React 15.4.0
+    - React-DOM 15.4.0
 - immutable.js 3.8.0
 - plow-js 1.2.0
 - classnames 2.2.3

--- a/packages/neos-ui-extensibility/scripts/helpers/webpack.config.js
+++ b/packages/neos-ui-extensibility/scripts/helpers/webpack.config.js
@@ -43,6 +43,7 @@ module.exports = function(neosPackageJson) {
         resolve: { // override config!
             alias: {
                 'react': '@neos-project/neos-ui-extensibility/src/shims/vendor/react/index',
+                'react-dom': '@neos-project/neos-ui-extensibility/src/shims/vendor/react-dom/index',
                 'immutable': '@neos-project/neos-ui-extensibility/src/shims/vendor/immutable/index',
                 'plow-js': '@neos-project/neos-ui-extensibility/src/shims/vendor/plow-js/index',
                 'classnames': '@neos-project/neos-ui-extensibility/src/shims/vendor/classnames/index',

--- a/packages/neos-ui-extensibility/src/shims/vendor/react-dom/index.js
+++ b/packages/neos-ui-extensibility/src/shims/vendor/react-dom/index.js
@@ -1,0 +1,3 @@
+import readFromConsumerApi from '../../../readFromConsumerApi';
+
+module.exports = readFromConsumerApi('vendor')().ReactDOM;

--- a/packages/neos-ui/src/apiExposureMap.js
+++ b/packages/neos-ui/src/apiExposureMap.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import Immutable from 'immutable';
 import * as plow from 'plow-js';
 import classnames from 'classnames';
@@ -17,6 +18,7 @@ import NeosUiI18n from '@neos-project/neos-ui-i18n';
 export default {
     '@vendor': () => ({
         React,
+        ReactDOM,
         Immutable,
         plow,
         classnames,


### PR DESCRIPTION
The error without this line was ` Module not found: Error: Cannot resolve module 'react-dom'` when trying to compile https://github.com/cvette/neos-ui-location-editor.

This change fixes the issue.




for reference, the full error message was as follows:

```

> @ build /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor
> neos-react-scripts build



   ;@@@@@@@@#                +@@@@@@@+
  @#@       @'              @@       +
'@, '#       @            .@.@       +
+    @'      ,@          #@  @       +
+     @       @:        @+   @       +
+     ,@       @      .@'    @       +
+      @,      '@     .:     @       +
+       @       #+    .:     @       +
+       '@       @    .:     @       +
+        #'       @   .:     @       +
+         @       ;#  .:     @       +
+          @       @. .:     @       +
+          '#       @ .:     @       +
+           @'      .@.:     @       +
+            @       @+:     @       +
+            ,@       @:     @       +
+      :      @:      '@     @       +
+      @       @       ++    @       +
+      @@      '@       @'   @       +
+      @+'      #+       @   @       +
+      @ @       @       :#  @       +
+      @  @       @       @. @       +
+      @  ;#      ;#       @ @       +
+      @   @'      @.      .@@       +
+      @    @       @       #@       +
+      @    ,@      .@       @       +
+      @     @:      @:      '       +
+      @      @       @              +
+      @      :@      '@             +
+      @      :@+      ++            +
+      @      :.@       @'           +
+      @      :. @       @           +
+      @      :. '#      :#          +
+      @      :.  @.      @.         +
+      @      :.   @       @         +
+      @      :.   ,@      .@        +
+      @      +.    @:      #:       +
+    .@.     @#      @       @@@@@@@@+
+   #@     .@.       '@            #@
+  @'     #@          #+          @'
+,@'     @'            @        ;@
+@@@@@@@@'              @@@@@@@@@

{ ModuleNotFoundError: Module not found: Error: Cannot resolve module 'react-dom' in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib
    at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/webpack/lib/Compilation.js:229:38
    at onDoneResolving (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/webpack/lib/NormalModuleFactory.js:29:20)
    at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/webpack/lib/NormalModuleFactory.js:85:20
    at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:726:13
    at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:52:16
    at done (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:241:17)
    at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:44:16
    at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:723:17
    at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:167:37
    at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/UnsafeCachePlugin.js:24:19
  name: 'ModuleNotFoundError',
  message: 'Module not found: Error: Cannot resolve module \'react-dom\' in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib',
  details: 'resolve module react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib\n  looking for modules in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n    /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist (module as directory)\n    resolve \'file\' react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n      resolve file\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.webpack.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.web.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.json doesn\'t exist',
  missing:
   [ '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom',
     '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom',
     '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.webpack.js',
     '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.web.js',
     '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.js',
     '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.json' ],
  module:
   DependenciesBlock {
     dependencies:
      [ [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object] ],
     blocks: [],
     variables: [],
     context: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib',
     reasons: [ [Object] ],
     debugId: 1025,
     lastId: -1,
     id: 228,
     index: 228,
     index2: 224,
     chunks: [ [Object] ],
     warnings: [],
     dependenciesWarnings: [],
     errors: [],
     dependenciesErrors: [ [Circular] ],
     request: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js',
     userRequest: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js',
     rawRequest: './Popup',
     parser:
      Parser {
        _plugins: [Object],
        options: undefined,
        scope: undefined,
        state: undefined,
        _currentPluginApply: undefined },
     resource: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js',
     loaders: [],
     fileDependencies: [ '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js' ],
     contextDependencies: [],
     error: null,
     _source:
      OriginalSource {
        _value: '\'use strict\';\n\nObject.defineProperty(exports, "__esModule", {\n  value: true\n});\n\nvar _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();\n\nvar _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };\n\nvar _leaflet = require(\'leaflet\');\n\nvar _propTypes = require(\'prop-types\');\n\nvar _propTypes2 = _interopRequireDefault(_propTypes);\n\nvar _react = require(\'react\');\n\nvar _reactDom = require(\'react-dom\');\n\nvar _latlng = require(\'./propTypes/latlng\');\n\nvar _latlng2 = _interopRequireDefault(_latlng);\n\nvar _map = require(\'./propTypes/map\');\n\nvar _map2 = _interopRequireDefault(_map);\n\nvar _MapComponent2 = require(\'./MapComponent\');\n\nvar _MapComponent3 = _interopRequireDefault(_MapComponent2);\n\nfunction _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }\n\nfunction _defaults(obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; var value = Object.getOwnPropertyDescriptor(defaults, key); if (value && value.configurable && obj[key] === undefined) { Object.defineProperty(obj, key, value); } } return obj; }\n\nfunction _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }\n\nfunction _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }\n\nfunction _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn\'t been initialised - super() hasn\'t been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }\n\nfunction _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : _defaults(subClass, superClass); }\n\nvar Popup = function (_MapComponent) {\n  _inherits(Popup, _MapComponent);\n\n  function Popup() {\n    var _ref;\n\n    var _temp, _this, _ret;\n\n    _classCallCheck(this, Popup);\n\n    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {\n      args[_key] = arguments[_key];\n    }\n\n    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Popup.__proto__ || Object.getPrototypeOf(Popup)).call.apply(_ref, [this].concat(args))), _this), _this.onPopupOpen = function (_ref2) {\n      var popup = _ref2.popup;\n\n      if (popup === _this.leafletElement) {\n        _this.renderPopupContent();\n      }\n    }, _this.onPopupClose = function (_ref3) {\n      var popup = _ref3.popup;\n\n      if (popup === _this.leafletElement) {\n        _this.removePopupContent();\n      }\n    }, _this.renderPopupContent = function () {\n      if (_this.props.children) {\n        (0, _reactDom.render)(_react.Children.only(_this.props.children), _this.leafletElement._contentNode);\n        _this.leafletElement.update();\n      } else {\n        _this.removePopupContent();\n      }\n    }, _this.removePopupContent = function () {\n      if (_this.leafletElement._contentNode) {\n        (0, _reactDom.unmountComponentAtNode)(_this.leafletElement._contentNode);\n      }\n    }, _temp), _possibleConstructorReturn(_this, _ret);\n  }\n\n  _createClass(Popup, [{\n    key: \'createLeafletElement\',\n    value: function createLeafletElement(props) {\n      var _children = props.children,\n          options = _objectWithoutProperties(props, [\'children\']);\n\n      return (0, _leaflet.popup)(this.getOptions(options), this.context.popupContainer);\n    }\n  }, {\n    key: \'updateLeafletElement\',\n    value: function updateLeafletElement(fromProps, toProps) {\n      if (toProps.position !== fromProps.position) {\n        this.leafletElement.setLatLng(toProps.position);\n      }\n    }\n  }, {\n    key: \'componentWillMount\',\n    value: function componentWillMount() {\n      _get(Popup.prototype.__proto__ || Object.getPrototypeOf(Popup.prototype), \'componentWillMount\', this).call(this);\n      this.leafletElement = this.createLeafletElement(this.props);\n\n      this.context.map.on({\n        popupopen: this.onPopupOpen,\n        popupclose: this.onPopupClose\n      });\n    }\n  }, {\n    key: \'componentDidMount\',\n    value: function componentDidMount() {\n      var position = this.props.position;\n      var _context = this.context,\n          map = _context.map,\n          popupContainer = _context.popupContainer;\n\n      var el = this.leafletElement;\n\n      if (popupContainer) {\n        // Attach to container component\n        popupContainer.bindPopup(el);\n      } else {\n        // Attach to a Map\n        if (position) {\n          el.setLatLng(position);\n        }\n        el.openOn(map);\n      }\n    }\n  }, {\n    key: \'componentDidUpdate\',\n    value: function componentDidUpdate(prevProps) {\n      this.updateLeafletElement(prevProps, this.props);\n\n      if (this.leafletElement.isOpen()) {\n        this.renderPopupContent();\n      }\n    }\n  }, {\n    key: \'componentWillUnmount\',\n    value: function componentWillUnmount() {\n      this.removePopupContent();\n\n      this.context.map.off({\n        popupopen: this.onPopupOpen,\n        popupclose: this.onPopupClose\n      });\n      this.context.map.removeLayer(this.leafletElement);\n\n      _get(Popup.prototype.__proto__ || Object.getPrototypeOf(Popup.prototype), \'componentWillUnmount\', this).call(this);\n    }\n  }, {\n    key: \'render\',\n    value: function render() {\n      return null;\n    }\n  }]);\n\n  return Popup;\n}(_MapComponent3.default);\n\nPopup.propTypes = {\n  children: _propTypes2.default.node,\n  position: _latlng2.default\n};\nPopup.contextTypes = {\n  map: _map2.default,\n  popupContainer: _propTypes2.default.object,\n  pane: _propTypes2.default.string\n};\nexports.default = Popup;',
        _name: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js' },
     meta: {},
     assets: {},
     built: true,
     _cachedSource: { source: [Object], hash: 'a3df61da18e5c2cae5c8d71c7962b2d5' },
     issuer: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/index.js',
     optional: false,
     useSourceMap: true,
     building: undefined,
     buildTimestamp: 1496061010337,
     cacheable: true },
  error:
   { Error: Cannot resolve module 'react-dom' in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib
       at innerCallback (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:91:16)
       at loggingCallbackWrapper (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/createInnerCallback.js:21:19)
       at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/tapable/lib/Tapable.js:134:6
       at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/ModulesInDirectoriesPlugin.js:54:23
       at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:191:15
       at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/ModulesInDirectoriesPlugin.js:45:26
       at loggingCallbackWrapper (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/createInnerCallback.js:21:19)
       at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/tapable/lib/Tapable.js:134:6
       at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:122:33
       at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:191:15
     details: 'resolve module react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib\n  looking for modules in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n    /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist (module as directory)\n    resolve \'file\' react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n      resolve file\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.webpack.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.web.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.json doesn\'t exist',
     missing:
      [ '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom',
        '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom',
        '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.webpack.js',
        '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.web.js',
        '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.js',
        '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.json' ] },
  dependencies:
   [ CommonJsRequireDependency {
       module: null,
       request: 'react-dom',
       userRequest: 'react-dom',
       range: [Object],
       loc: [Object],
       optional: false } ],
  origin:
   DependenciesBlock {
     dependencies:
      [ [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object] ],
     blocks: [],
     variables: [],
     context: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib',
     reasons: [ [Object] ],
     debugId: 1025,
     lastId: -1,
     id: 228,
     index: 228,
     index2: 224,
     chunks: [ [Object] ],
     warnings: [],
     dependenciesWarnings: [],
     errors: [],
     dependenciesErrors: [ [Circular] ],
     request: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js',
     userRequest: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js',
     rawRequest: './Popup',
     parser:
      Parser {
        _plugins: [Object],
        options: undefined,
        scope: undefined,
        state: undefined,
        _currentPluginApply: undefined },
     resource: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js',
     loaders: [],
     fileDependencies: [ '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js' ],
     contextDependencies: [],
     error: null,
     _source:
      OriginalSource {
        _value: '\'use strict\';\n\nObject.defineProperty(exports, "__esModule", {\n  value: true\n});\n\nvar _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();\n\nvar _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };\n\nvar _leaflet = require(\'leaflet\');\n\nvar _propTypes = require(\'prop-types\');\n\nvar _propTypes2 = _interopRequireDefault(_propTypes);\n\nvar _react = require(\'react\');\n\nvar _reactDom = require(\'react-dom\');\n\nvar _latlng = require(\'./propTypes/latlng\');\n\nvar _latlng2 = _interopRequireDefault(_latlng);\n\nvar _map = require(\'./propTypes/map\');\n\nvar _map2 = _interopRequireDefault(_map);\n\nvar _MapComponent2 = require(\'./MapComponent\');\n\nvar _MapComponent3 = _interopRequireDefault(_MapComponent2);\n\nfunction _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }\n\nfunction _defaults(obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; var value = Object.getOwnPropertyDescriptor(defaults, key); if (value && value.configurable && obj[key] === undefined) { Object.defineProperty(obj, key, value); } } return obj; }\n\nfunction _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }\n\nfunction _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }\n\nfunction _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn\'t been initialised - super() hasn\'t been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }\n\nfunction _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : _defaults(subClass, superClass); }\n\nvar Popup = function (_MapComponent) {\n  _inherits(Popup, _MapComponent);\n\n  function Popup() {\n    var _ref;\n\n    var _temp, _this, _ret;\n\n    _classCallCheck(this, Popup);\n\n    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {\n      args[_key] = arguments[_key];\n    }\n\n    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Popup.__proto__ || Object.getPrototypeOf(Popup)).call.apply(_ref, [this].concat(args))), _this), _this.onPopupOpen = function (_ref2) {\n      var popup = _ref2.popup;\n\n      if (popup === _this.leafletElement) {\n        _this.renderPopupContent();\n      }\n    }, _this.onPopupClose = function (_ref3) {\n      var popup = _ref3.popup;\n\n      if (popup === _this.leafletElement) {\n        _this.removePopupContent();\n      }\n    }, _this.renderPopupContent = function () {\n      if (_this.props.children) {\n        (0, _reactDom.render)(_react.Children.only(_this.props.children), _this.leafletElement._contentNode);\n        _this.leafletElement.update();\n      } else {\n        _this.removePopupContent();\n      }\n    }, _this.removePopupContent = function () {\n      if (_this.leafletElement._contentNode) {\n        (0, _reactDom.unmountComponentAtNode)(_this.leafletElement._contentNode);\n      }\n    }, _temp), _possibleConstructorReturn(_this, _ret);\n  }\n\n  _createClass(Popup, [{\n    key: \'createLeafletElement\',\n    value: function createLeafletElement(props) {\n      var _children = props.children,\n          options = _objectWithoutProperties(props, [\'children\']);\n\n      return (0, _leaflet.popup)(this.getOptions(options), this.context.popupContainer);\n    }\n  }, {\n    key: \'updateLeafletElement\',\n    value: function updateLeafletElement(fromProps, toProps) {\n      if (toProps.position !== fromProps.position) {\n        this.leafletElement.setLatLng(toProps.position);\n      }\n    }\n  }, {\n    key: \'componentWillMount\',\n    value: function componentWillMount() {\n      _get(Popup.prototype.__proto__ || Object.getPrototypeOf(Popup.prototype), \'componentWillMount\', this).call(this);\n      this.leafletElement = this.createLeafletElement(this.props);\n\n      this.context.map.on({\n        popupopen: this.onPopupOpen,\n        popupclose: this.onPopupClose\n      });\n    }\n  }, {\n    key: \'componentDidMount\',\n    value: function componentDidMount() {\n      var position = this.props.position;\n      var _context = this.context,\n          map = _context.map,\n          popupContainer = _context.popupContainer;\n\n      var el = this.leafletElement;\n\n      if (popupContainer) {\n        // Attach to container component\n        popupContainer.bindPopup(el);\n      } else {\n        // Attach to a Map\n        if (position) {\n          el.setLatLng(position);\n        }\n        el.openOn(map);\n      }\n    }\n  }, {\n    key: \'componentDidUpdate\',\n    value: function componentDidUpdate(prevProps) {\n      this.updateLeafletElement(prevProps, this.props);\n\n      if (this.leafletElement.isOpen()) {\n        this.renderPopupContent();\n      }\n    }\n  }, {\n    key: \'componentWillUnmount\',\n    value: function componentWillUnmount() {\n      this.removePopupContent();\n\n      this.context.map.off({\n        popupopen: this.onPopupOpen,\n        popupclose: this.onPopupClose\n      });\n      this.context.map.removeLayer(this.leafletElement);\n\n      _get(Popup.prototype.__proto__ || Object.getPrototypeOf(Popup.prototype), \'componentWillUnmount\', this).call(this);\n    }\n  }, {\n    key: \'render\',\n    value: function render() {\n      return null;\n    }\n  }]);\n\n  return Popup;\n}(_MapComponent3.default);\n\nPopup.propTypes = {\n  children: _propTypes2.default.node,\n  position: _latlng2.default\n};\nPopup.contextTypes = {\n  map: _map2.default,\n  popupContainer: _propTypes2.default.object,\n  pane: _propTypes2.default.string\n};\nexports.default = Popup;',
        _name: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js' },
     meta: {},
     assets: {},
     built: true,
     _cachedSource: { source: [Object], hash: 'a3df61da18e5c2cae5c8d71c7962b2d5' },
     issuer: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/index.js',
     optional: false,
     useSourceMap: true,
     building: undefined,
     buildTimestamp: 1496061010337,
     cacheable: true } } 0 [ { ModuleNotFoundError: Module not found: Error: Cannot resolve module 'react-dom' in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/webpack/lib/Compilation.js:229:38
      at onDoneResolving (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/webpack/lib/NormalModuleFactory.js:29:20)
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/webpack/lib/NormalModuleFactory.js:85:20
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:726:13
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:52:16
      at done (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:241:17)
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:44:16
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:723:17
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:167:37
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/UnsafeCachePlugin.js:24:19
    name: 'ModuleNotFoundError',
    message: 'Module not found: Error: Cannot resolve module \'react-dom\' in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib',
    details: 'resolve module react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib\n  looking for modules in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n    /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist (module as directory)\n    resolve \'file\' react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n      resolve file\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.webpack.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.web.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.json doesn\'t exist',
    missing:
     [ '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom',
       '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom',
       '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.webpack.js',
       '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.web.js',
       '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.js',
       '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.json' ],
    module:
     DependenciesBlock {
       dependencies: [Object],
       blocks: [],
       variables: [],
       context: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib',
       reasons: [Object],
       debugId: 1025,
       lastId: -1,
       id: 228,
       index: 228,
       index2: 224,
       chunks: [Object],
       warnings: [],
       dependenciesWarnings: [],
       errors: [],
       dependenciesErrors: [Object],
       request: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js',
       userRequest: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js',
       rawRequest: './Popup',
       parser: [Object],
       resource: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js',
       loaders: [],
       fileDependencies: [Object],
       contextDependencies: [],
       error: null,
       _source: [Object],
       meta: {},
       assets: {},
       built: true,
       _cachedSource: [Object],
       issuer: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/index.js',
       optional: false,
       useSourceMap: true,
       building: undefined,
       buildTimestamp: 1496061010337,
       cacheable: true },
    error:
     { Error: Cannot resolve module 'react-dom' in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib
         at innerCallback (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:91:16)
         at loggingCallbackWrapper (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/createInnerCallback.js:21:19)
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/tapable/lib/Tapable.js:134:6
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/ModulesInDirectoriesPlugin.js:54:23
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:191:15
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/ModulesInDirectoriesPlugin.js:45:26
         at loggingCallbackWrapper (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/createInnerCallback.js:21:19)
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/tapable/lib/Tapable.js:134:6
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:122:33
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:191:15
       details: 'resolve module react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib\n  looking for modules in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n    /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist (module as directory)\n    resolve \'file\' react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n      resolve file\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.webpack.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.web.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.json doesn\'t exist',
       missing: [Object] },
    dependencies: [ [Object] ],
    origin:
     DependenciesBlock {
       dependencies: [Object],
       blocks: [],
       variables: [],
       context: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib',
       reasons: [Object],
       debugId: 1025,
       lastId: -1,
       id: 228,
       index: 228,
       index2: 224,
       chunks: [Object],
       warnings: [],
       dependenciesWarnings: [],
       errors: [],
       dependenciesErrors: [Object],
       request: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js',
       userRequest: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js',
       rawRequest: './Popup',
       parser: [Object],
       resource: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js',
       loaders: [],
       fileDependencies: [Object],
       contextDependencies: [],
       error: null,
       _source: [Object],
       meta: {},
       assets: {},
       built: true,
       _cachedSource: [Object],
       issuer: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/index.js',
       optional: false,
       useSourceMap: true,
       building: undefined,
       buildTimestamp: 1496061010337,
       cacheable: true } },
  { ModuleNotFoundError: Module not found: Error: Cannot resolve module 'react-dom' in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/webpack/lib/Compilation.js:229:38
      at onDoneResolving (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/webpack/lib/NormalModuleFactory.js:29:20)
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/webpack/lib/NormalModuleFactory.js:85:20
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:726:13
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:52:16
      at done (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:241:17)
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:44:16
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:723:17
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:167:37
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/UnsafeCachePlugin.js:24:19
    name: 'ModuleNotFoundError',
    message: 'Module not found: Error: Cannot resolve module \'react-dom\' in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib',
    details: 'resolve module react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib\n  looking for modules in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n    /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist (module as directory)\n    resolve \'file\' react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n      resolve file\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.webpack.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.web.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.json doesn\'t exist',
    missing:
     [ '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom',
       '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom',
       '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.webpack.js',
       '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.web.js',
       '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.js',
       '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.json' ],
    module:
     DependenciesBlock {
       dependencies: [Object],
       blocks: [],
       variables: [],
       context: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib',
       reasons: [Object],
       debugId: 1029,
       lastId: -1,
       id: 232,
       index: 232,
       index2: 228,
       chunks: [Object],
       warnings: [],
       dependenciesWarnings: [],
       errors: [],
       dependenciesErrors: [Object],
       request: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js',
       userRequest: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js',
       rawRequest: './Tooltip',
       parser: [Object],
       resource: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js',
       loaders: [],
       fileDependencies: [Object],
       contextDependencies: [],
       error: null,
       _source: [Object],
       meta: {},
       assets: {},
       built: true,
       _cachedSource: [Object],
       issuer: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/index.js',
       optional: false,
       useSourceMap: true,
       building: undefined,
       buildTimestamp: 1496061010338,
       cacheable: true },
    error:
     { Error: Cannot resolve module 'react-dom' in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib
         at innerCallback (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:91:16)
         at loggingCallbackWrapper (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/createInnerCallback.js:21:19)
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/tapable/lib/Tapable.js:134:6
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/ModulesInDirectoriesPlugin.js:54:23
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:191:15
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/ModulesInDirectoriesPlugin.js:45:26
         at loggingCallbackWrapper (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/createInnerCallback.js:21:19)
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/tapable/lib/Tapable.js:134:6
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:122:33
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:191:15
       details: 'resolve module react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib\n  looking for modules in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n    /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist (module as directory)\n    resolve \'file\' react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n      resolve file\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.webpack.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.web.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.json doesn\'t exist',
       missing: [Object] },
    dependencies: [ [Object] ],
    origin:
     DependenciesBlock {
       dependencies: [Object],
       blocks: [],
       variables: [],
       context: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib',
       reasons: [Object],
       debugId: 1029,
       lastId: -1,
       id: 232,
       index: 232,
       index2: 228,
       chunks: [Object],
       warnings: [],
       dependenciesWarnings: [],
       errors: [],
       dependenciesErrors: [Object],
       request: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js',
       userRequest: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js',
       rawRequest: './Tooltip',
       parser: [Object],
       resource: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js',
       loaders: [],
       fileDependencies: [Object],
       contextDependencies: [],
       error: null,
       _source: [Object],
       meta: {},
       assets: {},
       built: true,
       _cachedSource: [Object],
       issuer: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/index.js',
       optional: false,
       useSourceMap: true,
       building: undefined,
       buildTimestamp: 1496061010338,
       cacheable: true } } ]
{ ModuleNotFoundError: Module not found: Error: Cannot resolve module 'react-dom' in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib
    at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/webpack/lib/Compilation.js:229:38
    at onDoneResolving (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/webpack/lib/NormalModuleFactory.js:29:20)
    at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/webpack/lib/NormalModuleFactory.js:85:20
    at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:726:13
    at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:52:16
    at done (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:241:17)
    at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:44:16
    at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:723:17
    at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:167:37
    at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/UnsafeCachePlugin.js:24:19
  name: 'ModuleNotFoundError',
  message: 'Module not found: Error: Cannot resolve module \'react-dom\' in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib',
  details: 'resolve module react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib\n  looking for modules in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n    /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist (module as directory)\n    resolve \'file\' react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n      resolve file\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.webpack.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.web.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.json doesn\'t exist',
  missing:
   [ '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom',
     '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom',
     '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.webpack.js',
     '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.web.js',
     '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.js',
     '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.json' ],
  module:
   DependenciesBlock {
     dependencies:
      [ [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object] ],
     blocks: [],
     variables: [],
     context: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib',
     reasons: [ [Object] ],
     debugId: 1029,
     lastId: -1,
     id: 232,
     index: 232,
     index2: 228,
     chunks: [ [Object] ],
     warnings: [],
     dependenciesWarnings: [],
     errors: [],
     dependenciesErrors: [ [Circular] ],
     request: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js',
     userRequest: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js',
     rawRequest: './Tooltip',
     parser:
      Parser {
        _plugins: [Object],
        options: undefined,
        scope: undefined,
        state: undefined,
        _currentPluginApply: undefined },
     resource: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js',
     loaders: [],
     fileDependencies: [ '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js' ],
     contextDependencies: [],
     error: null,
     _source:
      OriginalSource {
        _value: '\'use strict\';\n\nObject.defineProperty(exports, "__esModule", {\n  value: true\n});\n\nvar _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();\n\nvar _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };\n\nvar _leaflet = require(\'leaflet\');\n\nvar _propTypes = require(\'prop-types\');\n\nvar _propTypes2 = _interopRequireDefault(_propTypes);\n\nvar _react = require(\'react\');\n\nvar _reactDom = require(\'react-dom\');\n\nvar _map = require(\'./propTypes/map\');\n\nvar _map2 = _interopRequireDefault(_map);\n\nvar _MapComponent2 = require(\'./MapComponent\');\n\nvar _MapComponent3 = _interopRequireDefault(_MapComponent2);\n\nfunction _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }\n\nfunction _defaults(obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; var value = Object.getOwnPropertyDescriptor(defaults, key); if (value && value.configurable && obj[key] === undefined) { Object.defineProperty(obj, key, value); } } return obj; }\n\nfunction _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }\n\nfunction _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }\n\nfunction _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn\'t been initialised - super() hasn\'t been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }\n\nfunction _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : _defaults(subClass, superClass); }\n\nvar Tooltip = function (_MapComponent) {\n  _inherits(Tooltip, _MapComponent);\n\n  function Tooltip() {\n    var _ref;\n\n    var _temp, _this, _ret;\n\n    _classCallCheck(this, Tooltip);\n\n    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {\n      args[_key] = arguments[_key];\n    }\n\n    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Tooltip.__proto__ || Object.getPrototypeOf(Tooltip)).call.apply(_ref, [this].concat(args))), _this), _this.onTooltipOpen = function (_ref2) {\n      var tooltip = _ref2.tooltip;\n\n      if (tooltip === _this.leafletElement) {\n        _this.renderTooltipContent();\n      }\n    }, _this.onTooltipClose = function (_ref3) {\n      var tooltip = _ref3.tooltip;\n\n      if (tooltip === _this.leafletElement) {\n        _this.removeTooltipContent();\n      }\n    }, _this.renderTooltipContent = function () {\n      if (_this.props.children) {\n        (0, _reactDom.render)(_react.Children.only(_this.props.children), _this.leafletElement._contentNode);\n        _this.leafletElement.update();\n      } else {\n        _this.removeTooltipContent();\n      }\n    }, _this.removeTooltipContent = function () {\n      if (_this.leafletElement._contentNode) {\n        (0, _reactDom.unmountComponentAtNode)(_this.leafletElement._contentNode);\n      }\n    }, _temp), _possibleConstructorReturn(_this, _ret);\n  }\n\n  _createClass(Tooltip, [{\n    key: \'createLeafletElement\',\n    value: function createLeafletElement(props) {\n      var _children = props.children,\n          options = _objectWithoutProperties(props, [\'children\']);\n\n      return (0, _leaflet.tooltip)(this.getOptions(options), this.context.popupContainer);\n    }\n  }, {\n    key: \'componentWillMount\',\n    value: function componentWillMount() {\n      _get(Tooltip.prototype.__proto__ || Object.getPrototypeOf(Tooltip.prototype), \'componentWillMount\', this).call(this);\n      this.leafletElement = this.createLeafletElement(this.props);\n\n      this.context.popupContainer.on({\n        tooltipopen: this.onTooltipOpen,\n        tooltipclose: this.onTooltipClose\n      });\n    }\n  }, {\n    key: \'componentDidMount\',\n    value: function componentDidMount() {\n      this.context.popupContainer.bindTooltip(this.leafletElement);\n    }\n  }, {\n    key: \'componentDidUpdate\',\n    value: function componentDidUpdate() {\n      if (this.leafletElement.isOpen()) {\n        this.renderTooltipContent();\n      }\n    }\n  }, {\n    key: \'componentWillUnmount\',\n    value: function componentWillUnmount() {\n      this.context.popupContainer.off({\n        tooltipopen: this.onTooltipOpen,\n        tooltipclose: this.onTooltipClose\n      });\n      this.context.map.removeLayer(this.leafletElement);\n      _get(Tooltip.prototype.__proto__ || Object.getPrototypeOf(Tooltip.prototype), \'componentWillUnmount\', this).call(this);\n    }\n  }, {\n    key: \'render\',\n    value: function render() {\n      return null;\n    }\n  }]);\n\n  return Tooltip;\n}(_MapComponent3.default);\n\nTooltip.propTypes = {\n  children: _propTypes2.default.node\n};\nTooltip.contextTypes = {\n  map: _map2.default,\n  popupContainer: _propTypes2.default.object,\n  pane: _propTypes2.default.string\n};\nexports.default = Tooltip;',
        _name: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js' },
     meta: {},
     assets: {},
     built: true,
     _cachedSource: { source: [Object], hash: '9bfbee7a631bb2633acc8152c12fb213' },
     issuer: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/index.js',
     optional: false,
     useSourceMap: true,
     building: undefined,
     buildTimestamp: 1496061010338,
     cacheable: true },
  error:
   { Error: Cannot resolve module 'react-dom' in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib
       at innerCallback (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:91:16)
       at loggingCallbackWrapper (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/createInnerCallback.js:21:19)
       at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/tapable/lib/Tapable.js:134:6
       at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/ModulesInDirectoriesPlugin.js:54:23
       at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:191:15
       at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/ModulesInDirectoriesPlugin.js:45:26
       at loggingCallbackWrapper (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/createInnerCallback.js:21:19)
       at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/tapable/lib/Tapable.js:134:6
       at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:122:33
       at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:191:15
     details: 'resolve module react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib\n  looking for modules in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n    /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist (module as directory)\n    resolve \'file\' react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n      resolve file\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.webpack.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.web.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.json doesn\'t exist',
     missing:
      [ '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom',
        '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom',
        '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.webpack.js',
        '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.web.js',
        '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.js',
        '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.json' ] },
  dependencies:
   [ CommonJsRequireDependency {
       module: null,
       request: 'react-dom',
       userRequest: 'react-dom',
       range: [Object],
       loc: [Object],
       optional: false } ],
  origin:
   DependenciesBlock {
     dependencies:
      [ [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object],
        [Object] ],
     blocks: [],
     variables: [],
     context: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib',
     reasons: [ [Object] ],
     debugId: 1029,
     lastId: -1,
     id: 232,
     index: 232,
     index2: 228,
     chunks: [ [Object] ],
     warnings: [],
     dependenciesWarnings: [],
     errors: [],
     dependenciesErrors: [ [Circular] ],
     request: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js',
     userRequest: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js',
     rawRequest: './Tooltip',
     parser:
      Parser {
        _plugins: [Object],
        options: undefined,
        scope: undefined,
        state: undefined,
        _currentPluginApply: undefined },
     resource: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js',
     loaders: [],
     fileDependencies: [ '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js' ],
     contextDependencies: [],
     error: null,
     _source:
      OriginalSource {
        _value: '\'use strict\';\n\nObject.defineProperty(exports, "__esModule", {\n  value: true\n});\n\nvar _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();\n\nvar _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };\n\nvar _leaflet = require(\'leaflet\');\n\nvar _propTypes = require(\'prop-types\');\n\nvar _propTypes2 = _interopRequireDefault(_propTypes);\n\nvar _react = require(\'react\');\n\nvar _reactDom = require(\'react-dom\');\n\nvar _map = require(\'./propTypes/map\');\n\nvar _map2 = _interopRequireDefault(_map);\n\nvar _MapComponent2 = require(\'./MapComponent\');\n\nvar _MapComponent3 = _interopRequireDefault(_MapComponent2);\n\nfunction _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }\n\nfunction _defaults(obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; var value = Object.getOwnPropertyDescriptor(defaults, key); if (value && value.configurable && obj[key] === undefined) { Object.defineProperty(obj, key, value); } } return obj; }\n\nfunction _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }\n\nfunction _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }\n\nfunction _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn\'t been initialised - super() hasn\'t been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }\n\nfunction _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : _defaults(subClass, superClass); }\n\nvar Tooltip = function (_MapComponent) {\n  _inherits(Tooltip, _MapComponent);\n\n  function Tooltip() {\n    var _ref;\n\n    var _temp, _this, _ret;\n\n    _classCallCheck(this, Tooltip);\n\n    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {\n      args[_key] = arguments[_key];\n    }\n\n    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Tooltip.__proto__ || Object.getPrototypeOf(Tooltip)).call.apply(_ref, [this].concat(args))), _this), _this.onTooltipOpen = function (_ref2) {\n      var tooltip = _ref2.tooltip;\n\n      if (tooltip === _this.leafletElement) {\n        _this.renderTooltipContent();\n      }\n    }, _this.onTooltipClose = function (_ref3) {\n      var tooltip = _ref3.tooltip;\n\n      if (tooltip === _this.leafletElement) {\n        _this.removeTooltipContent();\n      }\n    }, _this.renderTooltipContent = function () {\n      if (_this.props.children) {\n        (0, _reactDom.render)(_react.Children.only(_this.props.children), _this.leafletElement._contentNode);\n        _this.leafletElement.update();\n      } else {\n        _this.removeTooltipContent();\n      }\n    }, _this.removeTooltipContent = function () {\n      if (_this.leafletElement._contentNode) {\n        (0, _reactDom.unmountComponentAtNode)(_this.leafletElement._contentNode);\n      }\n    }, _temp), _possibleConstructorReturn(_this, _ret);\n  }\n\n  _createClass(Tooltip, [{\n    key: \'createLeafletElement\',\n    value: function createLeafletElement(props) {\n      var _children = props.children,\n          options = _objectWithoutProperties(props, [\'children\']);\n\n      return (0, _leaflet.tooltip)(this.getOptions(options), this.context.popupContainer);\n    }\n  }, {\n    key: \'componentWillMount\',\n    value: function componentWillMount() {\n      _get(Tooltip.prototype.__proto__ || Object.getPrototypeOf(Tooltip.prototype), \'componentWillMount\', this).call(this);\n      this.leafletElement = this.createLeafletElement(this.props);\n\n      this.context.popupContainer.on({\n        tooltipopen: this.onTooltipOpen,\n        tooltipclose: this.onTooltipClose\n      });\n    }\n  }, {\n    key: \'componentDidMount\',\n    value: function componentDidMount() {\n      this.context.popupContainer.bindTooltip(this.leafletElement);\n    }\n  }, {\n    key: \'componentDidUpdate\',\n    value: function componentDidUpdate() {\n      if (this.leafletElement.isOpen()) {\n        this.renderTooltipContent();\n      }\n    }\n  }, {\n    key: \'componentWillUnmount\',\n    value: function componentWillUnmount() {\n      this.context.popupContainer.off({\n        tooltipopen: this.onTooltipOpen,\n        tooltipclose: this.onTooltipClose\n      });\n      this.context.map.removeLayer(this.leafletElement);\n      _get(Tooltip.prototype.__proto__ || Object.getPrototypeOf(Tooltip.prototype), \'componentWillUnmount\', this).call(this);\n    }\n  }, {\n    key: \'render\',\n    value: function render() {\n      return null;\n    }\n  }]);\n\n  return Tooltip;\n}(_MapComponent3.default);\n\nTooltip.propTypes = {\n  children: _propTypes2.default.node\n};\nTooltip.contextTypes = {\n  map: _map2.default,\n  popupContainer: _propTypes2.default.object,\n  pane: _propTypes2.default.string\n};\nexports.default = Tooltip;',
        _name: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js' },
     meta: {},
     assets: {},
     built: true,
     _cachedSource: { source: [Object], hash: '9bfbee7a631bb2633acc8152c12fb213' },
     issuer: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/index.js',
     optional: false,
     useSourceMap: true,
     building: undefined,
     buildTimestamp: 1496061010338,
     cacheable: true } } 1 [ { ModuleNotFoundError: Module not found: Error: Cannot resolve module 'react-dom' in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/webpack/lib/Compilation.js:229:38
      at onDoneResolving (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/webpack/lib/NormalModuleFactory.js:29:20)
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/webpack/lib/NormalModuleFactory.js:85:20
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:726:13
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:52:16
      at done (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:241:17)
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:44:16
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:723:17
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:167:37
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/UnsafeCachePlugin.js:24:19
    name: 'ModuleNotFoundError',
    message: 'Module not found: Error: Cannot resolve module \'react-dom\' in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib',
    details: 'resolve module react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib\n  looking for modules in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n    /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist (module as directory)\n    resolve \'file\' react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n      resolve file\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.webpack.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.web.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.json doesn\'t exist',
    missing:
     [ '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom',
       '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom',
       '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.webpack.js',
       '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.web.js',
       '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.js',
       '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.json' ],
    module:
     DependenciesBlock {
       dependencies: [Object],
       blocks: [],
       variables: [],
       context: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib',
       reasons: [Object],
       debugId: 1025,
       lastId: -1,
       id: 228,
       index: 228,
       index2: 224,
       chunks: [Object],
       warnings: [],
       dependenciesWarnings: [],
       errors: [],
       dependenciesErrors: [Object],
       request: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js',
       userRequest: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js',
       rawRequest: './Popup',
       parser: [Object],
       resource: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js',
       loaders: [],
       fileDependencies: [Object],
       contextDependencies: [],
       error: null,
       _source: [Object],
       meta: {},
       assets: {},
       built: true,
       _cachedSource: [Object],
       issuer: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/index.js',
       optional: false,
       useSourceMap: true,
       building: undefined,
       buildTimestamp: 1496061010337,
       cacheable: true },
    error:
     { Error: Cannot resolve module 'react-dom' in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib
         at innerCallback (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:91:16)
         at loggingCallbackWrapper (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/createInnerCallback.js:21:19)
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/tapable/lib/Tapable.js:134:6
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/ModulesInDirectoriesPlugin.js:54:23
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:191:15
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/ModulesInDirectoriesPlugin.js:45:26
         at loggingCallbackWrapper (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/createInnerCallback.js:21:19)
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/tapable/lib/Tapable.js:134:6
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:122:33
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:191:15
       details: 'resolve module react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib\n  looking for modules in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n    /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist (module as directory)\n    resolve \'file\' react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n      resolve file\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.webpack.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.web.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.json doesn\'t exist',
       missing: [Object] },
    dependencies: [ [Object] ],
    origin:
     DependenciesBlock {
       dependencies: [Object],
       blocks: [],
       variables: [],
       context: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib',
       reasons: [Object],
       debugId: 1025,
       lastId: -1,
       id: 228,
       index: 228,
       index2: 224,
       chunks: [Object],
       warnings: [],
       dependenciesWarnings: [],
       errors: [],
       dependenciesErrors: [Object],
       request: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js',
       userRequest: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js',
       rawRequest: './Popup',
       parser: [Object],
       resource: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Popup.js',
       loaders: [],
       fileDependencies: [Object],
       contextDependencies: [],
       error: null,
       _source: [Object],
       meta: {},
       assets: {},
       built: true,
       _cachedSource: [Object],
       issuer: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/index.js',
       optional: false,
       useSourceMap: true,
       building: undefined,
       buildTimestamp: 1496061010337,
       cacheable: true } },
  { ModuleNotFoundError: Module not found: Error: Cannot resolve module 'react-dom' in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/webpack/lib/Compilation.js:229:38
      at onDoneResolving (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/webpack/lib/NormalModuleFactory.js:29:20)
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/webpack/lib/NormalModuleFactory.js:85:20
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:726:13
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:52:16
      at done (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:241:17)
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:44:16
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:723:17
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/async/lib/async.js:167:37
      at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/UnsafeCachePlugin.js:24:19
    name: 'ModuleNotFoundError',
    message: 'Module not found: Error: Cannot resolve module \'react-dom\' in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib',
    details: 'resolve module react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib\n  looking for modules in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n    /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist (module as directory)\n    resolve \'file\' react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n      resolve file\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.webpack.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.web.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.json doesn\'t exist',
    missing:
     [ '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom',
       '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom',
       '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.webpack.js',
       '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.web.js',
       '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.js',
       '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.json' ],
    module:
     DependenciesBlock {
       dependencies: [Object],
       blocks: [],
       variables: [],
       context: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib',
       reasons: [Object],
       debugId: 1029,
       lastId: -1,
       id: 232,
       index: 232,
       index2: 228,
       chunks: [Object],
       warnings: [],
       dependenciesWarnings: [],
       errors: [],
       dependenciesErrors: [Object],
       request: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js',
       userRequest: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js',
       rawRequest: './Tooltip',
       parser: [Object],
       resource: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js',
       loaders: [],
       fileDependencies: [Object],
       contextDependencies: [],
       error: null,
       _source: [Object],
       meta: {},
       assets: {},
       built: true,
       _cachedSource: [Object],
       issuer: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/index.js',
       optional: false,
       useSourceMap: true,
       building: undefined,
       buildTimestamp: 1496061010338,
       cacheable: true },
    error:
     { Error: Cannot resolve module 'react-dom' in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib
         at innerCallback (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:91:16)
         at loggingCallbackWrapper (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/createInnerCallback.js:21:19)
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/tapable/lib/Tapable.js:134:6
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/ModulesInDirectoriesPlugin.js:54:23
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:191:15
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/ModulesInDirectoriesPlugin.js:45:26
         at loggingCallbackWrapper (/Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/createInnerCallback.js:21:19)
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/tapable/lib/Tapable.js:134:6
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:122:33
         at /Users/sebastian/src/neosdev_3.0/Packages/Application/Neos.Neos.Ui/node_modules/enhanced-resolve/lib/Resolver.js:191:15
       details: 'resolve module react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib\n  looking for modules in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n    /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist (module as directory)\n    resolve \'file\' react-dom in /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules\n      resolve file\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.webpack.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.web.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.js doesn\'t exist\n        /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-dom.json doesn\'t exist',
       missing: [Object] },
    dependencies: [ [Object] ],
    origin:
     DependenciesBlock {
       dependencies: [Object],
       blocks: [],
       variables: [],
       context: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib',
       reasons: [Object],
       debugId: 1029,
       lastId: -1,
       id: 232,
       index: 232,
       index2: 228,
       chunks: [Object],
       warnings: [],
       dependenciesWarnings: [],
       errors: [],
       dependenciesErrors: [Object],
       request: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js',
       userRequest: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js',
       rawRequest: './Tooltip',
       parser: [Object],
       resource: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/Tooltip.js',
       loaders: [],
       fileDependencies: [Object],
       contextDependencies: [],
       error: null,
       _source: [Object],
       meta: {},
       assets: {},
       built: true,
       _cachedSource: [Object],
       issuer: '/Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/node_modules/react-leaflet/lib/index.js',
       optional: false,
       useSourceMap: true,
       building: undefined,
       buildTimestamp: 1496061010338,
       cacheable: true } } ]

npm ERR! Darwin 16.5.0
npm ERR! argv "/Users/sebastian/.nvm/versions/node/v6.3.0/bin/node" "/Users/sebastian/.nvm/versions/node/v6.3.0/bin/npm" "run" "build"
npm ERR! node v6.3.0
npm ERR! npm  v3.10.3
npm ERR! code ELIFECYCLE
npm ERR! @ build: `neos-react-scripts build`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the @ build script 'neos-react-scripts build'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the  package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     neos-react-scripts build
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/sebastian/src/neosdev_3.0/Packages/Application/Vette.Location/Resources/Private/LocationEditor/npm-debug.log
```