### PR TITLE
FEATURE: Enable polling for file watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ In order to start contributing, follow the following steps:
 | `yarn build:ui`  | Builds the ui via webpack. |
 | `yarn build` |  Runs `build:dev` optimised for production. |
 | `yarn build:ui:watch` | Watches the source files for changes and runs a build:ui in case. |
+| `yarn build:ui:watch-poll` | Watches (and polls) the source files on a file share. Should preferably be used when working an a VM for example. |
 | `yarn start-storybook` | Starts the storybook server. |
 | `yarn lint`  | Lints all source files. |
 | `yarn test`  | Executes `yarn lint` to trigger tests via ava. |

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "postinstall": "lerna bootstrap",
     "build:ui": "NEOS_BUILD_ROOT=$(pwd) webpack --progress --colors",
     "build:ui:watch": "npm run build:ui -- --watch",
+    "build:ui:watch-poll": "npm run build:ui -- --watch-poll --watch",
     "build:components": "echo 'Not needed anymore, just use build:ui'",
     "build:components:watch": "echo 'Not needed anymore, just use build:ui:watch'",
     "build": "cross-env NODE_ENV=production npm run build:ui",


### PR DESCRIPTION
When a file share is used (for example when developing on an VM), the webpack file watcher might not work reliable because of issues connected with inotify and Samba.

This command adds the `watch-poll` flag to the `npm run build:ui -- --watch`. The issue is resolved through the polling mechanism and the performance impact seems to be negligible.