### PR TITLE
BUGFIX: ensure node info is only updated non-recursively in most cases

### DIFF
--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractStructuralChange.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractStructuralChange.php
@@ -147,6 +147,7 @@ abstract class AbstractStructuralChange extends AbstractChange
 
         $updateNodeInfo = new UpdateNodeInfo();
         $updateNodeInfo->setNode($node);
+        $updateNodeInfo->recursive();
 
         $updateParentNodeInfo = new UpdateNodeInfo();
         $updateParentNodeInfo->setNode($node->getParent());

--- a/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
@@ -20,6 +20,8 @@ class UpdateNodeInfo implements FeedbackInterface
      */
     protected $nodeInfoHelper;
 
+    protected $isRecursive = false;
+
     /**
      * Set the node
      *
@@ -29,6 +31,15 @@ class UpdateNodeInfo implements FeedbackInterface
     public function setNode(NodeInterface $node)
     {
         $this->node = $node;
+    }
+
+    /**
+     * Update node infos recursively
+     *
+     * @return void
+     */
+    public function recursive() {
+        $this->isRecursive = true;
     }
 
     /**
@@ -101,8 +112,10 @@ class UpdateNodeInfo implements FeedbackInterface
             $node->getContextPath() => $this->nodeInfoHelper->renderNode($node, $controllerContext)
         ];
 
-        foreach ($node->getChildNodes() as $childNode) {
-            $result = array_merge($result, $this->serializeNodeRecursively($childNode, $controllerContext));
+        if ($this->isRecursive === true) {
+            foreach ($node->getChildNodes() as $childNode) {
+                $result = array_merge($result, $this->serializeNodeRecursively($childNode, $controllerContext));
+            }
         }
 
         return $result;


### PR DESCRIPTION
This quick-fixes a pretty bad performance regression when inserting nodes on
top levels of the tree; leading to the problem that the full node tree
was sent to the client.

Generally, we still send way too much nodes to the client as the result
of a change operation; but that should be optimized in separate steps.