### PR TITLE
TASK: uncollapse content tree rootline when a node is focused

### DIFF
--- a/packages/neos-ui-redux-store/src/CR/Nodes/helpers.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/helpers.js
@@ -20,3 +20,13 @@ export const getAllowedNodeTypesTakingAutoCreatedIntoAccount = (baseNode, parent
     // not auto created
     return nodeTypesRegistry.getAllowedChildNodeTypes($get('nodeType', baseNode));
 };
+
+export const parentNodeContextPath = contextPath => {
+    if (typeof contextPath !== 'string') {
+        return null;
+    }
+
+    const [path, context] = contextPath.split('@');
+
+    return `${path.substr(0, path.lastIndexOf('/'))}@${context}`;
+};

--- a/packages/neos-ui/src/Sagas/UI/ContentTree/index.js
+++ b/packages/neos-ui/src/Sagas/UI/ContentTree/index.js
@@ -37,17 +37,15 @@ function * watchNodeFocus() {
         const {contextPath} = action.payload;
         const documentNodeContextPath = yield select($get('ui.contentCanvas.contextPath'));
 
-        if (contextPath !== documentNodeContextPath) {
-            let parentContextPath = contextPath;
+        let parentContextPath = contextPath;
 
-            while (parentContextPath !== documentNodeContextPath) {
-                parentContextPath = parentNodeContextPath(parentContextPath);
-                const isInStore = yield select($get(['cr', 'nodes', 'byContextPath', parentContextPath]));
-                const isUnCollapsed = yield select($contains(parentContextPath, 'ui.contentTree.uncollapsed'));
+        while (parentContextPath !== documentNodeContextPath) {
+            parentContextPath = parentNodeContextPath(parentContextPath);
+            const isInStore = yield select($get(['cr', 'nodes', 'byContextPath', parentContextPath]));
+            const isUnCollapsed = yield select($contains(parentContextPath, 'ui.contentTree.uncollapsed'));
 
-                if (!isInStore || !isUnCollapsed) {
-                    yield put(actions.UI.ContentTree.uncollapse(parentContextPath));
-                }
+            if (!isInStore || !isUnCollapsed) {
+                yield put(actions.UI.ContentTree.uncollapse(parentContextPath));
             }
         }
     });

--- a/packages/neos-ui/src/Sagas/UI/PageTree/index.js
+++ b/packages/neos-ui/src/Sagas/UI/PageTree/index.js
@@ -121,33 +121,31 @@ function * watchCurrentDocument() {
         const siteNodeContextPath = yield select($get('cr.nodes.siteNode'));
         const {q} = backend.get();
 
-        if (contextPath !== siteNodeContextPath) {
-            let parentContextPath = contextPath;
+        let parentContextPath = contextPath;
 
-            while (parentContextPath !== siteNodeContextPath) {
-                parentContextPath = parentNodeContextPath(parentContextPath);
-                const isInStore = yield select($get(['cr', 'nodes', 'byContextPath', parentContextPath]));
-                const isUnCollapsed = yield select($contains(parentContextPath, 'ui.pageTree.uncollapsed'));
+        while (parentContextPath !== siteNodeContextPath) {
+            parentContextPath = parentNodeContextPath(parentContextPath);
+            const isInStore = yield select($get(['cr', 'nodes', 'byContextPath', parentContextPath]));
+            const isUnCollapsed = yield select($contains(parentContextPath, 'ui.pageTree.uncollapsed'));
 
-                if (!isInStore || !isUnCollapsed) {
-                    yield put(actions.UI.PageTree.setAsLoading(siteNodeContextPath));
-                }
-
-                if (!isInStore) {
-                    const nodes = yield q(parentContextPath).get();
-                    yield put(actions.CR.Nodes.add(nodes.reduce((nodeMap, node) => {
-                        nodeMap[$get('contextPath', node)] = node;
-                        return nodeMap;
-                    }, {})));
-                }
-
-                if (!isUnCollapsed) {
-                    yield put(actions.UI.PageTree.commenceUncollapse(parentContextPath));
-                }
+            if (!isInStore || !isUnCollapsed) {
+                yield put(actions.UI.PageTree.setAsLoading(siteNodeContextPath));
             }
 
-            yield put(actions.UI.PageTree.setAsLoaded(siteNodeContextPath));
+            if (!isInStore) {
+                const nodes = yield q(parentContextPath).get();
+                yield put(actions.CR.Nodes.add(nodes.reduce((nodeMap, node) => {
+                    nodeMap[$get('contextPath', node)] = node;
+                    return nodeMap;
+                }, {})));
+            }
+
+            if (!isUnCollapsed) {
+                yield put(actions.UI.PageTree.commenceUncollapse(parentContextPath));
+            }
         }
+
+        yield put(actions.UI.PageTree.setAsLoaded(siteNodeContextPath));
     });
 }
 

--- a/packages/neos-ui/src/Sagas/UI/PageTree/index.js
+++ b/packages/neos-ui/src/Sagas/UI/PageTree/index.js
@@ -5,15 +5,7 @@ import {$get, $contains} from 'plow-js';
 import {actionTypes, actions, selectors} from '@neos-project/neos-ui-redux-store';
 import backend from '@neos-project/neos-ui-backend-connector';
 
-const parentNodeContextPath = contextPath => {
-    if (typeof contextPath !== 'string') {
-        return null;
-    }
-
-    const [path, context] = contextPath.split('@');
-
-    return `${path.substr(0, path.lastIndexOf('/'))}@${context}`;
-};
+import {parentNodeContextPath} from '@neos-project/neos-ui-redux-store/src/CR/Nodes/helpers';
 
 function * watchToggle() {
     yield * takeLatest(actionTypes.UI.PageTree.TOGGLE, function * toggleTreeNode(action) {
@@ -132,7 +124,7 @@ function * watchCurrentDocument() {
         if (contextPath !== siteNodeContextPath) {
             let parentContextPath = contextPath;
 
-            do {
+            while (parentContextPath !== siteNodeContextPath) {
                 parentContextPath = parentNodeContextPath(parentContextPath);
                 const isInStore = yield select($get(['cr', 'nodes', 'byContextPath', parentContextPath]));
                 const isUnCollapsed = yield select($contains(parentContextPath, 'ui.pageTree.uncollapsed'));
@@ -152,11 +144,7 @@ function * watchCurrentDocument() {
                 if (!isUnCollapsed) {
                     yield put(actions.UI.PageTree.commenceUncollapse(parentContextPath));
                 }
-
-                if (parentContextPath === siteNodeContextPath) {
-                    break;
-                }
-            } while (parentContextPath !== siteNodeContextPath);
+            }
 
             yield put(actions.UI.PageTree.setAsLoaded(siteNodeContextPath));
         }


### PR DESCRIPTION
When selecting a content node within a page that node should be auto expanded and revealed in the content tree.