### PR TITLE
TASK: Wrap button inslide slider to prevent slick-slider to override the style property

### DIFF
--- a/packages/neos-ui/src/Containers/EditModePanel/Panel/index.js
+++ b/packages/neos-ui/src/Containers/EditModePanel/Panel/index.js
@@ -37,14 +37,14 @@ export default class Panel extends PureComponent {
                 <p>{title} {currentMode && <b className={style.editModePanel__current}><I18n id={currentMode.title}/></b>}</p>
                 <Slider {...sliderSettings}>
                     {modes.map(previewMode => (
-                        <Button
-                            key={previewMode.id}
-                            onClick={onPreviewModeClick(previewMode.id)}
-                            style={previewMode.id === current ? 'brand' : null}
-                            className={style.editModePanel__button}
-                            >
-                            <I18n id={previewMode.title}/>
-                        </Button>
+                        <div key={previewMode.id} className={style.editModePanel__buttonWrapper}>
+                            <Button
+                                onClick={onPreviewModeClick(previewMode.id)}
+                                style={previewMode.id === current ? 'brand' : null}
+                                >
+                                <I18n id={previewMode.title}/>
+                            </Button>
+                        </div>
                     ))}
                 </Slider>
             </div>

--- a/packages/neos-ui/src/Containers/EditModePanel/style.css
+++ b/packages/neos-ui/src/Containers/EditModePanel/style.css
@@ -34,7 +34,7 @@
     margin-right: 2rem;
 }
 
-.editModePanel__button {
+.editModePanel__buttonWrapper {
     margin-right: 1rem;
     white-space: nowrap;
 


### PR DESCRIPTION
Currently the slider component produces a lot of property validation errors by overriding the style property of its children. Wrapping the buttons inside the slider prevents those errors.