### PR TITLE
TASK: Add option disabled to the CheckBox component

### DIFF
--- a/packages/neos-ui-editors/src/Boolean/index.js
+++ b/packages/neos-ui-editors/src/Boolean/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {$get} from 'plow-js';
 
 import CheckBox from '@neos-project/react-ui-components/src/CheckBox/';
 import Label from '@neos-project/react-ui-components/src/Label/';
@@ -23,11 +24,12 @@ const toBoolean = val => {
 
 const BooleanEditor = props => {
     const {value, label, identifier, commit} = props;
+    const disabled = $get('options.disabled', props) || false;
 
     return (
         <div>
             <Label htmlFor={identifier}>
-                <CheckBox id={identifier} isChecked={toBoolean(value)} onChange={commit}/>
+                <CheckBox id={identifier} isChecked={toBoolean(value)} isDisabled={disabled} onChange={commit}/>
                 <I18n id={label}/>
             </Label>
         </div>
@@ -37,7 +39,8 @@ BooleanEditor.propTypes = {
     identifier: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
     value: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-    commit: PropTypes.func.isRequired
+    commit: PropTypes.func.isRequired,
+    isDisabled: PropTypes.bool
 };
 
 export default BooleanEditor;

--- a/packages/neos-ui-editors/src/Boolean/index.js
+++ b/packages/neos-ui-editors/src/Boolean/index.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import mergeClassNames from 'classnames';
 import {$get} from 'plow-js';
 
 import CheckBox from '@neos-project/react-ui-components/src/CheckBox/';
 import Label from '@neos-project/react-ui-components/src/Label/';
 import I18n from '@neos-project/neos-ui-i18n';
+
+import style from './style.css';
 
 const toBoolean = val => {
     if (typeof val === 'string') {
@@ -26,9 +29,13 @@ const BooleanEditor = props => {
     const {value, label, identifier, commit} = props;
     const disabled = $get('options.disabled', props) || false;
 
+    const finalClassName = mergeClassNames({
+        [style.boolean__disabled]: disabled
+    });
+
     return (
         <div>
-            <Label htmlFor={identifier}>
+            <Label htmlFor={identifier} className={finalClassName}>
                 <CheckBox id={identifier} isChecked={toBoolean(value)} isDisabled={disabled} onChange={commit}/>
                 <I18n id={label}/>
             </Label>

--- a/packages/neos-ui-editors/src/Boolean/style.css
+++ b/packages/neos-ui-editors/src/Boolean/style.css
@@ -1,0 +1,4 @@
+.boolean__disabled {
+    opacity: .65;
+    cursor: not-allowed;
+}

--- a/packages/react-ui-components/src/CheckBox/checkBox.js
+++ b/packages/react-ui-components/src/CheckBox/checkBox.js
@@ -10,6 +10,11 @@ class CheckBox extends PureComponent {
         isChecked: PropTypes.bool.isRequired,
 
         /**
+         * This prop controls if the CheckBox is disabled or not.
+         */
+        isDisabled: PropTypes.bool,
+
+        /**
          * An optional `className` to attach to the wrapper.
          */
         className: PropTypes.string,
@@ -39,13 +44,15 @@ class CheckBox extends PureComponent {
     render() {
         const {
             isChecked,
+            isDisabled,
             className,
             theme,
             ...rest
         } = this.props;
         const finalClassName = mergeClassNames({
             [className]: className && className.length,
-            [theme.checkbox]: true
+            [theme.checkbox]: true,
+            [theme.checkbox__disabled]: isDisabled
         });
         const mirrorClassNames = mergeClassNames({
             [theme.checkbox__inputMirror]: true,
@@ -62,6 +69,7 @@ class CheckBox extends PureComponent {
                     checked={isChecked}
                     aria-checked={isChecked}
                     onChange={this.handleChange}
+                    disabled={isDisabled}
                     />
                 <div className={mirrorClassNames}/>
             </div>

--- a/packages/react-ui-components/src/CheckBox/style.css
+++ b/packages/react-ui-components/src/CheckBox/style.css
@@ -43,3 +43,11 @@
         transform: translateX(-50%) translateY(-50%);
     }
 }
+.checkbox__disabled {
+    opacity: .65;
+    cursor: not-allowed;
+
+    .checkbox__input {
+        cursor: not-allowed;
+    }
+}


### PR DESCRIPTION
A boolean property can be set to disabled [Documentation](http://neos.readthedocs.io/en/3.1.3/References/PropertyEditorReference.html#property-type-boolean-booleaneditor-checkbox-editor)