### PR TITLE
BUGFIX: Let the userdropdown be over the codemirror editor

### DIFF
--- a/packages/neos-ui/src/Containers/PrimaryToolbar/style.css
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/style.css
@@ -7,6 +7,8 @@
     &:after {
         clear: both;
     }
+
+    z-index: 9999;
 }
 .primaryToolbar--isHidden {
     display: none;
@@ -16,7 +18,6 @@
     right: 0;
     top: 0;
 }
-
 .primaryToolbar__btn {
     border-right: 1px solid var(--brandColorsContrastDark);
 }


### PR DESCRIPTION
![screenshot_2017-08-01_10-48-15](https://user-images.githubusercontent.com/12071529/28822094-4640f0de-76b8-11e7-9e03-38ce5ffd31ce.png)

Because Codemirror does something with it's z-index to do some stuff this is necessary