### PR TITLE
TASK: respect loadingDepth in the trees

### DIFF
--- a/Classes/Neos/Neos/Ui/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Neos/Neos/Ui/Fusion/Helper/NodeInfoHelper.php
@@ -122,7 +122,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
         }
 
         $renderNodesRecursively = function (&$nodes, $baseNode, $level = 0) use (&$renderNodesRecursively, $controllerContext) {
-            if ($level < $this->loadingDepth) {
+            if ($level < $this->loadingDepth || $this->loadingDepth === 0) {
                 foreach ($baseNode->getChildNodes($this->baseNodeType) as $childNode) {
                     $this->renderNodeToList($nodes, $childNode, $controllerContext);
                     $renderNodesRecursively($nodes, $childNode, $level + 1);

--- a/Resources/Private/Fusion/Backend/Root.fusion
+++ b/Resources/Private/Fusion/Backend/Root.fusion
@@ -12,6 +12,7 @@ backend = Neos.Fusion:Template {
 
     configuration = Neos.Fusion:RawArray {
         nodeTree = ${Configuration.setting('Neos.Neos.userInterface.navigateComponent.nodeTree')}
+        structureTree = ${Configuration.setting('Neos.Neos.userInterface.navigateComponent.structureTree')}
         allowedTargetWorkspaces = ${Neos.Ui.Workspace.getAllowedTargetWorkspaces()}
         @process.json = ${Json.stringify(value)}
     }

--- a/packages/neos-ui-redux-store/src/CR/Nodes/helpers.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/helpers.js
@@ -21,6 +21,9 @@ export const getAllowedNodeTypesTakingAutoCreatedIntoAccount = (baseNode, parent
     return nodeTypesRegistry.getAllowedChildNodeTypes($get('nodeType', baseNode));
 };
 
+//
+// Helper function to get parent contextPath from current contextPath
+//
 export const parentNodeContextPath = contextPath => {
     if (typeof contextPath !== 'string') {
         return null;
@@ -29,4 +32,12 @@ export const parentNodeContextPath = contextPath => {
     const [path, context] = contextPath.split('@');
 
     return `${path.substr(0, path.lastIndexOf('/'))}@${context}`;
+};
+
+//
+// Helper function to check if the node is collapsed
+//
+export const isNodeCollapsed = (node, isToggled, rootNode, loadingDepth) => {
+    const isCollapsedByDefault = $get('depth', node) - $get('depth', rootNode) >= loadingDepth;
+    return (isCollapsedByDefault && !isToggled) || (!isCollapsedByDefault && isToggled);
 };

--- a/packages/neos-ui-redux-store/src/CR/Nodes/helpers.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/helpers.js
@@ -38,6 +38,6 @@ export const parentNodeContextPath = contextPath => {
 // Helper function to check if the node is collapsed
 //
 export const isNodeCollapsed = (node, isToggled, rootNode, loadingDepth) => {
-    const isCollapsedByDefault = $get('depth', node) - $get('depth', rootNode) >= loadingDepth;
+    const isCollapsedByDefault = loadingDepth === 0 ? false : $get('depth', node) - $get('depth', rootNode) >= loadingDepth;
     return (isCollapsedByDefault && !isToggled) || (!isCollapsedByDefault && isToggled);
 };

--- a/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
@@ -42,9 +42,9 @@ export const makeGetDocumentNodes = nodeTypesRegistry => createSelector(
     }
 );
 
-export const makeGetNodeByContextPathSelector = () => createSelector(
+export const makeGetNodeByContextPathSelector = contextPath => createSelector(
     [
-        (state, contextPath) => $get(['cr', 'nodes', 'byContextPath', contextPath], state)
+        state => $get(['cr', 'nodes', 'byContextPath', contextPath], state)
     ],
     node => node
 );

--- a/packages/neos-ui-redux-store/src/UI/ContentTree/index.js
+++ b/packages/neos-ui-redux-store/src/UI/ContentTree/index.js
@@ -1,15 +1,12 @@
 import {createAction} from 'redux-actions';
 import {Map, Set} from 'immutable';
-import {$toggle, $set, $remove, $add} from 'plow-js';
+import {$toggle, $set} from 'plow-js';
 
 import {handleActions} from '@neos-project/utils-redux';
 import {actionTypes as system} from '../../System/index';
-import {actionTypes as contentCanvas} from '../ContentCanvas/index';
 
 import * as selectors from './selectors';
 
-const UNCOLLAPSE = '@neos/neos-ui/UI/ContentTree/UNCOLLAPSE';
-const COLLAPSE = '@neos/neos-ui/UI/ContentTree/COLLAPSE';
 const TOGGLE = '@neos/neos-ui/UI/ContentTree/TOGGLE';
 const START_LOADING = '@neos/neos-ui/UI/ContentTree/START_LOADING';
 const STOP_LOADING = '@neos/neos-ui/UI/ContentTree/STOP_LOADING';
@@ -19,16 +16,12 @@ const RELOAD_TREE = '@neos/neos-ui/UI/ContentTree/RELOAD_TREE';
 // Export the action types
 //
 export const actionTypes = {
-    UNCOLLAPSE,
-    COLLAPSE,
     TOGGLE,
     START_LOADING,
     STOP_LOADING,
     RELOAD_TREE
 };
 
-const uncollapse = createAction(UNCOLLAPSE, contextPath => ({contextPath}));
-const collapse = createAction(COLLAPSE, contextPath => ({contextPath}));
 const toggle = createAction(TOGGLE, contextPath => ({contextPath}));
 const startLoading = createAction(START_LOADING);
 const stopLoading = createAction(STOP_LOADING);
@@ -38,8 +31,6 @@ const reloadTree = createAction(RELOAD_TREE);
 // Export the actions
 //
 export const actions = {
-    uncollapse,
-    collapse,
     toggle,
     startLoading,
     stopLoading,
@@ -53,16 +44,13 @@ export const reducer = handleActions({
     [system.INIT]: () => $set(
         'ui.contentTree',
         new Map({
-            uncollapsed: new Set(),
+            toggled: new Set(),
             isLoading: false
         })
     ),
-    [contentCanvas.SET_CONTEXT_PATH]: ({contextPath}) => $add('ui.contentTree.uncollapsed', contextPath),
-    [UNCOLLAPSE]: ({contextPath}) => $add('ui.contentTree.uncollapsed', contextPath),
-    [COLLAPSE]: ({contextPath}) => $remove('ui.contentTree.uncollapsed', contextPath),
     [START_LOADING]: () => $set('ui.contentTree.isLoading', true),
     [STOP_LOADING]: () => $set('ui.contentTree.isLoading', false),
-    [TOGGLE]: ({contextPath}) => $toggle('ui.contentTree.uncollapsed', contextPath)
+    [TOGGLE]: ({contextPath}) => $toggle('ui.contentTree.toggled', contextPath)
 });
 
 //

--- a/packages/neos-ui-redux-store/src/UI/ContentTree/index.spec.js
+++ b/packages/neos-ui-redux-store/src/UI/ContentTree/index.spec.js
@@ -1,4 +1,4 @@
-import Immutable, {Map} from 'immutable';
+import {Map} from 'immutable';
 
 import {actionTypes, actions, reducer} from './index.js';
 
@@ -6,16 +6,12 @@ import {actionTypes as system} from '../../System/index';
 
 test(`should export actionTypes`, () => {
     expect(actionTypes).not.toBe(undefined);
-    expect(typeof (actionTypes.UNCOLLAPSE)).toBe('string');
-    expect(typeof (actionTypes.COLLAPSE)).toBe('string');
     expect(typeof (actionTypes.TOGGLE)).toBe('string');
     expect(typeof (actionTypes.RELOAD_TREE)).toBe('string');
 });
 
 test(`should export action creators`, () => {
     expect(actions).not.toBe(undefined);
-    expect(typeof (actions.uncollapse)).toBe('function');
-    expect(typeof (actions.collapse)).toBe('function');
     expect(typeof (actions.toggle)).toBe('function');
     expect(typeof (actions.reloadTree)).toBe('function');
 });
@@ -32,40 +28,4 @@ test(`The reducer should return an Immutable.Map as the initial state.`, () => {
     });
 
     expect(nextState.get('ui').get('contentTree') instanceof Map).toBe(true);
-});
-
-test(`The "uncollapse" action should add the given node to uncollapsed state`, () => {
-    const state = Immutable.fromJS({
-        ui: {
-            contentTree: {
-                uncollapsed: []
-            }
-        }
-    });
-    const nextState1 = reducer(state, actions.uncollapse('someContextPath'));
-    const nextState2 = reducer(state, actions.uncollapse('someOtherContextPath'));
-    const nextState3 = reducer(nextState1, actions.uncollapse('someOtherContextPath'));
-
-    expect(nextState1.get('ui').get('contentTree').get('uncollapsed').toJS()).toEqual(['someContextPath']);
-    expect(nextState2.get('ui').get('contentTree').get('uncollapsed').toJS()).toEqual(['someOtherContextPath']);
-    expect(nextState3.get('ui').get('contentTree').get('uncollapsed').toJS()).toEqual(['someContextPath', 'someOtherContextPath']);
-});
-
-test(`The "collapse" action should remove the given node from uncollapsed state`, () => {
-    const state = Immutable.fromJS({
-        ui: {
-            contentTree: {
-                loading: [],
-                errors: [],
-                uncollapsed: ['someContextPath', 'someOtherContextPath']
-            }
-        }
-    });
-    const nextState1 = reducer(state, actions.collapse('someContextPath'));
-    const nextState2 = reducer(state, actions.collapse('someOtherContextPath'));
-    const nextState3 = reducer(nextState1, actions.collapse('someOtherContextPath'));
-
-    expect(nextState1.get('ui').get('contentTree').get('uncollapsed').toJS()).toEqual(['someOtherContextPath']);
-    expect(nextState2.get('ui').get('contentTree').get('uncollapsed').toJS()).toEqual(['someContextPath']);
-    expect(nextState3.get('ui').get('contentTree').get('uncollapsed').toJS()).toEqual([]);
 });

--- a/packages/neos-ui-redux-store/src/UI/ContentTree/selectors.js
+++ b/packages/neos-ui-redux-store/src/UI/ContentTree/selectors.js
@@ -1,4 +1,4 @@
 import {$get} from 'plow-js';
 
-export const getUncollapsed = $get('ui.contentTree.uncollapsed');
+export const getToggled = $get('ui.contentTree.toggled');
 export const getIsLoading = $get('ui.contentTree.isLoading');

--- a/packages/neos-ui-redux-store/src/UI/PageTree/index.js
+++ b/packages/neos-ui-redux-store/src/UI/PageTree/index.js
@@ -1,6 +1,6 @@
 import {createAction} from 'redux-actions';
 import {Map, Set} from 'immutable';
-import {$all, $get, $set, $remove, $add} from 'plow-js';
+import {$all, $get, $set, $remove, $add, $toggle} from 'plow-js';
 
 import {handleActions} from '@neos-project/utils-redux';
 import {actionTypes as system} from '../../System/index';
@@ -8,9 +8,6 @@ import {actionTypes as system} from '../../System/index';
 import * as selectors from './selectors';
 
 const FOCUS = '@neos/neos-ui/UI/PageTree/FOCUS';
-const COMMENCE_UNCOLLAPSE = '@neos/neos-ui/UI/PageTree/COMMENCE_UNCOLLAPSE';
-const UNCOLLAPSE = '@neos/neos-ui/UI/PageTree/UNCOLLAPSE';
-const COLLAPSE = '@neos/neos-ui/UI/PageTree/COLLAPSE';
 const TOGGLE = '@neos/neos-ui/UI/PageTree/TOGGLE';
 const INVALIDATE = '@neos/neos-ui/UI/PageTree/INVALIDATE';
 const SET_AS_LOADING = '@neos/neos-ui/UI/PageTree/SET_AS_LOADING';
@@ -23,9 +20,6 @@ const RELOAD_TREE = '@neos/neos-ui/UI/PageTree/RELOAD_TREE';
 //
 export const actionTypes = {
     FOCUS,
-    COMMENCE_UNCOLLAPSE,
-    UNCOLLAPSE,
-    COLLAPSE,
     TOGGLE,
     INVALIDATE,
     SET_AS_LOADING,
@@ -35,9 +29,6 @@ export const actionTypes = {
 };
 
 const focus = createAction(FOCUS, contextPath => ({contextPath}));
-const commenceUncollapse = createAction(COMMENCE_UNCOLLAPSE, contextPath => ({contextPath}));
-const uncollapse = createAction(UNCOLLAPSE, contextPath => ({contextPath}));
-const collapse = createAction(COLLAPSE, contextPath => ({contextPath}));
 const toggle = createAction(TOGGLE, contextPath => ({contextPath}));
 const invalidate = createAction(INVALIDATE, contextPath => ({contextPath}));
 const requestChildren = createAction(REQUEST_CHILDREN, (contextPath, {unCollapse = true, activate = false} = {}) => ({contextPath, opts: {unCollapse, activate}}));
@@ -50,9 +41,6 @@ const reloadTree = createAction(RELOAD_TREE);
 //
 export const actions = {
     focus,
-    commenceUncollapse,
-    uncollapse,
-    collapse,
     toggle,
     invalidate,
     setAsLoading,
@@ -69,24 +57,15 @@ export const reducer = handleActions({
         'ui.pageTree',
         new Map({
             isFocused: $get('ui.contentCanvas.contextPath', state) || $get('cr.nodes.siteNode', state),
-            uncollapsed: new Set([$get('cr.nodes.siteNode', state)]),
+            toggled: new Set(),
             loading: new Set(),
             errors: new Set()
         })
     ),
     [FOCUS]: ({contextPath}) => $set('ui.pageTree.isFocused', contextPath),
-    [UNCOLLAPSE]: ({contextPath}) => $all(
-        $remove('ui.pageTree.errors', contextPath),
-        $remove('ui.pageTree.loading', contextPath),
-        $add('ui.pageTree.uncollapsed', contextPath)
-    ),
-    [COLLAPSE]: ({contextPath}) => $all(
-        $remove('ui.pageTree.errors', contextPath),
-        $remove('ui.pageTree.loading', contextPath),
-        $remove('ui.pageTree.uncollapsed', contextPath)
-    ),
+    [TOGGLE]: ({contextPath}) => $toggle('ui.pageTree.toggled', contextPath),
     [INVALIDATE]: ({contextPath}) => $all(
-        $remove('ui.pageTree.uncollapsed', contextPath),
+        $remove('ui.pageTree.toggled', contextPath),
         $remove('ui.pageTree.loading', contextPath),
         $add('ui.pageTree.errors', contextPath)
     ),

--- a/packages/neos-ui-redux-store/src/UI/PageTree/index.spec.js
+++ b/packages/neos-ui-redux-store/src/UI/PageTree/index.spec.js
@@ -7,9 +7,6 @@ import {actionTypes as system} from '../../System/index';
 test(`should export actionTypes`, () => {
     expect(actionTypes).not.toBe(undefined);
     expect(typeof (actionTypes.FOCUS)).toBe('string');
-    expect(typeof (actionTypes.COMMENCE_UNCOLLAPSE)).toBe('string');
-    expect(typeof (actionTypes.UNCOLLAPSE)).toBe('string');
-    expect(typeof (actionTypes.COLLAPSE)).toBe('string');
     expect(typeof (actionTypes.TOGGLE)).toBe('string');
     expect(typeof (actionTypes.INVALIDATE)).toBe('string');
     expect(typeof (actionTypes.REQUEST_CHILDREN)).toBe('string');
@@ -18,9 +15,6 @@ test(`should export actionTypes`, () => {
 test(`should export action creators`, () => {
     expect(actions).not.toBe(undefined);
     expect(typeof (actions.focus)).toBe('function');
-    expect(typeof (actions.commenceUncollapse)).toBe('function');
-    expect(typeof (actions.uncollapse)).toBe('function');
-    expect(typeof (actions.collapse)).toBe('function');
     expect(typeof (actions.toggle)).toBe('function');
     expect(typeof (actions.invalidate)).toBe('function');
     expect(typeof (actions.requestChildren)).toBe('function');
@@ -54,127 +48,13 @@ test(`The "focus" action should set the focused node context path.`, () => {
     expect(nextState.get('ui').get('pageTree').get('isFocused')).toBe('someOtherContextPath');
 });
 
-test(`The "uncollapse" action should remove the given node from error state`, () => {
-    const state = Immutable.fromJS({
-        ui: {
-            pageTree: {
-                uncollapsed: [],
-                loading: [],
-                errors: ['someContextPath', 'someOtherContextPath']
-            }
-        }
-    });
-    const nextState1 = reducer(state, actions.uncollapse('someContextPath'));
-    const nextState2 = reducer(state, actions.uncollapse('someOtherContextPath'));
-    const nextState3 = reducer(nextState1, actions.uncollapse('someOtherContextPath'));
-
-    expect(nextState1.get('ui').get('pageTree').get('errors').toJS()).toEqual(['someOtherContextPath']);
-    expect(nextState2.get('ui').get('pageTree').get('errors').toJS()).toEqual(['someContextPath']);
-    expect(nextState3.get('ui').get('pageTree').get('errors').toJS()).toEqual([]);
-});
-
-test(`The "uncollapse" action should remove the given node from loading state`, () => {
-    const state = Immutable.fromJS({
-        ui: {
-            pageTree: {
-                uncollapsed: [],
-                errors: [],
-                loading: ['someContextPath', 'someOtherContextPath']
-            }
-        }
-    });
-    const nextState1 = reducer(state, actions.uncollapse('someContextPath'));
-    const nextState2 = reducer(state, actions.uncollapse('someOtherContextPath'));
-    const nextState3 = reducer(nextState1, actions.uncollapse('someOtherContextPath'));
-
-    expect(nextState1.get('ui').get('pageTree').get('loading').toJS()).toEqual(['someOtherContextPath']);
-    expect(nextState2.get('ui').get('pageTree').get('loading').toJS()).toEqual(['someContextPath']);
-    expect(nextState3.get('ui').get('pageTree').get('loading').toJS()).toEqual([]);
-});
-
-test(`The "uncollapse" action should add the given node to uncollapsed state`, () => {
+test(`The "invalidate" action should remove the given node from toggled state`, () => {
     const state = Immutable.fromJS({
         ui: {
             pageTree: {
                 loading: [],
                 errors: [],
-                uncollapsed: []
-            }
-        }
-    });
-    const nextState1 = reducer(state, actions.uncollapse('someContextPath'));
-    const nextState2 = reducer(state, actions.uncollapse('someOtherContextPath'));
-    const nextState3 = reducer(nextState1, actions.uncollapse('someOtherContextPath'));
-
-    expect(nextState1.get('ui').get('pageTree').get('uncollapsed').toJS()).toEqual(['someContextPath']);
-    expect(nextState2.get('ui').get('pageTree').get('uncollapsed').toJS()).toEqual(['someOtherContextPath']);
-    expect(nextState3.get('ui').get('pageTree').get('uncollapsed').toJS()).toEqual(['someContextPath', 'someOtherContextPath']);
-});
-
-test(`The "collapse" action should remove the given node from error state`, () => {
-    const state = Immutable.fromJS({
-        ui: {
-            pageTree: {
-                uncollapsed: [],
-                loading: [],
-                errors: ['someContextPath', 'someOtherContextPath']
-            }
-        }
-    });
-    const nextState1 = reducer(state, actions.collapse('someContextPath'));
-    const nextState2 = reducer(state, actions.collapse('someOtherContextPath'));
-    const nextState3 = reducer(nextState1, actions.collapse('someOtherContextPath'));
-
-    expect(nextState1.get('ui').get('pageTree').get('errors').toJS()).toEqual(['someOtherContextPath']);
-    expect(nextState2.get('ui').get('pageTree').get('errors').toJS()).toEqual(['someContextPath']);
-    expect(nextState3.get('ui').get('pageTree').get('errors').toJS()).toEqual([]);
-});
-
-test(`The "collapse" action should remove the given node from loading state`, () => {
-    const state = Immutable.fromJS({
-        ui: {
-            pageTree: {
-                uncollapsed: [],
-                errors: [],
-                loading: ['someContextPath', 'someOtherContextPath']
-            }
-        }
-    });
-    const nextState1 = reducer(state, actions.collapse('someContextPath'));
-    const nextState2 = reducer(state, actions.collapse('someOtherContextPath'));
-    const nextState3 = reducer(nextState1, actions.collapse('someOtherContextPath'));
-
-    expect(nextState1.get('ui').get('pageTree').get('loading').toJS()).toEqual(['someOtherContextPath']);
-    expect(nextState2.get('ui').get('pageTree').get('loading').toJS()).toEqual(['someContextPath']);
-    expect(nextState3.get('ui').get('pageTree').get('loading').toJS()).toEqual([]);
-});
-
-test(`The "collapse" action should remove the given node from uncollapsed state`, () => {
-    const state = Immutable.fromJS({
-        ui: {
-            pageTree: {
-                loading: [],
-                errors: [],
-                uncollapsed: ['someContextPath', 'someOtherContextPath']
-            }
-        }
-    });
-    const nextState1 = reducer(state, actions.collapse('someContextPath'));
-    const nextState2 = reducer(state, actions.collapse('someOtherContextPath'));
-    const nextState3 = reducer(nextState1, actions.collapse('someOtherContextPath'));
-
-    expect(nextState1.get('ui').get('pageTree').get('uncollapsed').toJS()).toEqual(['someOtherContextPath']);
-    expect(nextState2.get('ui').get('pageTree').get('uncollapsed').toJS()).toEqual(['someContextPath']);
-    expect(nextState3.get('ui').get('pageTree').get('uncollapsed').toJS()).toEqual([]);
-});
-
-test(`The "invalidate" action should remove the given node from uncollapsed state`, () => {
-    const state = Immutable.fromJS({
-        ui: {
-            pageTree: {
-                loading: [],
-                errors: [],
-                uncollapsed: ['someContextPath', 'someOtherContextPath']
+                toggled: ['someContextPath', 'someOtherContextPath']
             }
         }
     });
@@ -182,16 +62,16 @@ test(`The "invalidate" action should remove the given node from uncollapsed stat
     const nextState2 = reducer(state, actions.invalidate('someOtherContextPath'));
     const nextState3 = reducer(nextState1, actions.invalidate('someOtherContextPath'));
 
-    expect(nextState1.get('ui').get('pageTree').get('uncollapsed').toJS()).toEqual(['someOtherContextPath']);
-    expect(nextState2.get('ui').get('pageTree').get('uncollapsed').toJS()).toEqual(['someContextPath']);
-    expect(nextState3.get('ui').get('pageTree').get('uncollapsed').toJS()).toEqual([]);
+    expect(nextState1.get('ui').get('pageTree').get('toggled').toJS()).toEqual(['someOtherContextPath']);
+    expect(nextState2.get('ui').get('pageTree').get('toggled').toJS()).toEqual(['someContextPath']);
+    expect(nextState3.get('ui').get('pageTree').get('toggled').toJS()).toEqual([]);
 });
 
 test(`The "invalidate" action should remove the given node from loading state`, () => {
     const state = Immutable.fromJS({
         ui: {
             pageTree: {
-                uncollapsed: [],
+                toggled: [],
                 errors: [],
                 loading: ['someContextPath', 'someOtherContextPath']
             }
@@ -210,7 +90,7 @@ test(`The "invalidate" action should add the given node to error state`, () => {
     const state = Immutable.fromJS({
         ui: {
             pageTree: {
-                uncollapsed: [],
+                toggled: [],
                 loading: [],
                 errors: []
             }
@@ -229,7 +109,7 @@ test(`The "setAsLoading" action should remove the given node from error state`, 
     const state = Immutable.fromJS({
         ui: {
             pageTree: {
-                uncollapsed: [],
+                toggled: [],
                 loading: [],
                 errors: ['someContextPath', 'someOtherContextPath']
             }
@@ -248,7 +128,7 @@ test(`The "setAsLoading" action should add the given node to loading state`, () 
     const state = Immutable.fromJS({
         ui: {
             pageTree: {
-                uncollapsed: [],
+                toggled: [],
                 errors: [],
                 loading: []
             }
@@ -267,7 +147,7 @@ test(`The "setAsLoaded" action should remove the given node to loading state`, (
     const state = Immutable.fromJS({
         ui: {
             pageTree: {
-                uncollapsed: [],
+                toggled: [],
                 errors: [],
                 loading: ['someContextPath', 'someOtherContextPath']
             }

--- a/packages/neos-ui-redux-store/src/UI/PageTree/selectors.js
+++ b/packages/neos-ui-redux-store/src/UI/PageTree/selectors.js
@@ -2,7 +2,7 @@ import {$get} from 'plow-js';
 import {createSelector} from 'reselect';
 
 export const getFocused = $get('ui.pageTree.isFocused');
-export const getUncollapsed = $get('ui.pageTree.uncollapsed');
+export const getToggled = $get('ui.pageTree.toggled');
 export const getLoading = $get('ui.pageTree.loading');
 export const getErrors = $get('ui.pageTree.errors');
 

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -7,12 +7,15 @@ import Tree from '@neos-project/react-ui-components/src/Tree/';
 import {stripTags} from '@neos-project/utils-helpers';
 
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
+import {isNodeCollapsed} from '@neos-project/neos-ui-redux-store/src/CR/Nodes/helpers';
 import {neos} from '@neos-project/neos-ui-decorators';
 
 const getContextPath = $get('contextPath');
 
 export default class Node extends PureComponent {
     static propTypes = {
+        rootNode: PropTypes.object,
+        loadingDepth: PropTypes.number,
         ChildRenderer: PropTypes.func.isRequired,
         node: PropTypes.object,
         nodeTypeRole: PropTypes.string,
@@ -21,7 +24,7 @@ export default class Node extends PureComponent {
         childNodes: PropTypes.object,
         currentDocumentNodeContextPath: PropTypes.string,
         focusedNodeContextPath: PropTypes.string,
-        uncollapsedNodeContextPaths: PropTypes.object,
+        toggledNodeContextPaths: PropTypes.object,
         loadingNodeContextPaths: PropTypes.object,
         errorNodeContextPaths: PropTypes.object,
         canBeInserted: PropTypes.bool,
@@ -82,9 +85,10 @@ export default class Node extends PureComponent {
     }
 
     isCollapsed() {
-        const {node, uncollapsedNodeContextPaths} = this.props;
+        const {node, toggledNodeContextPaths, rootNode, loadingDepth} = this.props;
 
-        return !uncollapsedNodeContextPaths.includes($get('contextPath', node));
+        const isToggled = toggledNodeContextPaths.includes($get('contextPath', node));
+        return isNodeCollapsed(node, isToggled, rootNode, loadingDepth);
     }
 
     isLoading() {
@@ -185,7 +189,7 @@ const withNodeTypeRegistry = neos(globalRegistry => ({
 }));
 
 export const PageTreeNode = withNodeTypeRegistry(connect(
-    (state, {nodeTypesRegistry}) => {
+    (state, {neos, nodeTypesRegistry}) => {
         const allowedNodeTypes = nodeTypesRegistry.getSubTypesOf(nodeTypesRegistry.getRole('document'));
 
         const childrenOfSelector = selectors.CR.Nodes.makeChildrenOfSelector(allowedNodeTypes);
@@ -193,11 +197,14 @@ export const PageTreeNode = withNodeTypeRegistry(connect(
         const canBeInsertedSelector = selectors.CR.Nodes.makeCanBeInsertedSelector(nodeTypesRegistry);
 
         return (state, {node, currentlyDraggedNode}) => ({
+            rootNode: selectors.CR.Nodes.siteNodeSelector(state),
+            loadingDepth: neos.configuration.nodeTree.loadingDepth,
             childNodes: childrenOfSelector(state, getContextPath(node)),
             hasChildren: hasChildrenSelector(state, getContextPath(node)),
             currentDocumentNodeContextPath: selectors.UI.ContentCanvas.getCurrentContentCanvasContextPath(state),
+            currentDocumentNode: selectors.UI.ContentCanvas.documentNodeSelector(state),
             focusedNodeContextPath: selectors.UI.PageTree.getFocused(state),
-            uncollapsedNodeContextPaths: selectors.UI.PageTree.getUncollapsed(state),
+            toggledNodeContextPaths: selectors.UI.PageTree.getToggled(state),
             loadingNodeContextPaths: selectors.UI.PageTree.getLoading(state),
             errorNodeContextPaths: selectors.UI.PageTree.getErrors(state),
             canBeInserted: canBeInsertedSelector(state, {
@@ -211,7 +218,7 @@ export const PageTreeNode = withNodeTypeRegistry(connect(
 )(Node));
 
 export const ContentTreeNode = withNodeTypeRegistry(connect(
-    (state, {nodeTypesRegistry}) => {
+    (state, {neos, nodeTypesRegistry}) => {
         const allowedNodeTypes = [].concat(
             nodeTypesRegistry.getSubTypesOf(nodeTypesRegistry.getRole('content')),
             nodeTypesRegistry.getSubTypesOf(nodeTypesRegistry.getRole('contentCollection'))
@@ -220,13 +227,15 @@ export const ContentTreeNode = withNodeTypeRegistry(connect(
         const childrenOfSelector = selectors.CR.Nodes.makeChildrenOfSelector(allowedNodeTypes);
         const hasChildrenSelector = selectors.CR.Nodes.makeHasChildrenSelector(allowedNodeTypes);
         const canBeInsertedSelector = selectors.CR.Nodes.makeCanBeInsertedSelector(nodeTypesRegistry);
-
         return (state, {node, currentlyDraggedNode}) => ({
+            rootNode: selectors.UI.ContentCanvas.documentNodeSelector(state),
+            loadingDepth: neos.configuration.structureTree.loadingDepth,
             childNodes: childrenOfSelector(state, getContextPath(node)),
             hasChildren: hasChildrenSelector(state, getContextPath(node)),
-            currentDocumentNodeContextPath: $get('cr.nodes.focused.contextPath', state),
+            currentDocumentNodeContextPath: selectors.UI.ContentCanvas.getCurrentContentCanvasContextPath(state),
+            currentDocumentNode: selectors.UI.ContentCanvas.documentNodeSelector(state),
             focusedNodeContextPath: $get('cr.nodes.focused.contextPath', state),
-            uncollapsedNodeContextPaths: selectors.UI.ContentTree.getUncollapsed(state),
+            toggledNodeContextPaths: selectors.UI.ContentTree.getToggled(state),
             canBeInserted: canBeInsertedSelector(state, {
                 subject: getContextPath(currentlyDraggedNode),
                 reference: getContextPath(node)

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
@@ -155,12 +155,12 @@ const withNodeTypesRegistry = neos(globalRegistry => ({
 export const PageTreeToolbar = withNodeTypesRegistry(connect(
     (state, {nodeTypesRegistry}) => {
         const canBePastedSelector = selectors.CR.Nodes.makeCanBeInsertedSelector(nodeTypesRegistry);
-        const getNodeByContextPathSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector();
 
         return state => {
             const siteNodeContextPath = $get('cr.nodes.siteNode', state);
             const focusedNodeContextPath = selectors.UI.PageTree.getFocused(state);
-            const focusedNode = getNodeByContextPathSelector(state, focusedNodeContextPath);
+            const getNodeByContextPathSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector(focusedNodeContextPath);
+            const focusedNode = getNodeByContextPathSelector(state);
             const clipboardNodeContextPath = selectors.CR.Nodes.clipboardNodeContextPathSelector(state);
             const canBePasted = canBePastedSelector(state, {
                 subject: clipboardNodeContextPath,
@@ -197,12 +197,12 @@ export const PageTreeToolbar = withNodeTypesRegistry(connect(
 export const ContentTreeToolbar = withNodeTypesRegistry(connect(
     (state, {nodeTypesRegistry}) => {
         const canBePastedSelector = selectors.CR.Nodes.makeCanBeInsertedSelector(nodeTypesRegistry);
-        const getNodeByContextPathSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector();
 
         return state => {
             const documentNodeContextPath = $get('ui.contentCanvas.contextPath', state);
             const focusedNodeContextPath = $get('cr.nodes.focused.contextPath', state);
-            const focusedNode = getNodeByContextPathSelector(state, focusedNodeContextPath);
+            const getNodeByContextPathSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector(focusedNodeContextPath);
+            const focusedNode = getNodeByContextPathSelector(state);
             const clipboardNodeContextPath = selectors.CR.Nodes.clipboardNodeContextPathSelector(state);
             const canBePasted = canBePastedSelector(state, {
                 subject: clipboardNodeContextPath,

--- a/packages/neos-ui/src/Sagas/UI/ContentTree/index.js
+++ b/packages/neos-ui/src/Sagas/UI/ContentTree/index.js
@@ -2,8 +2,8 @@ import {takeLatest} from 'redux-saga';
 import {put, select} from 'redux-saga/effects';
 import {$get, $contains} from 'plow-js';
 
-import {actionTypes, actions} from '@neos-project/neos-ui-redux-store';
-import {parentNodeContextPath} from '@neos-project/neos-ui-redux-store/src/CR/Nodes/helpers';
+import {actionTypes, actions, selectors} from '@neos-project/neos-ui-redux-store';
+import {parentNodeContextPath, isNodeCollapsed} from '@neos-project/neos-ui-redux-store/src/CR/Nodes/helpers';
 
 import backend from '@neos-project/neos-ui-backend-connector';
 
@@ -32,20 +32,24 @@ function * watchReloadTree({globalRegistry}) {
     });
 }
 
-function * watchNodeFocus() {
+function * watchNodeFocus({configuration}) {
     yield * takeLatest(actionTypes.CR.Nodes.FOCUS, function * loadContentNodeRootLine(action) {
         const {contextPath} = action.payload;
         const documentNodeContextPath = yield select($get('ui.contentCanvas.contextPath'));
 
         let parentContextPath = contextPath;
 
+        const documentNode = yield select(selectors.UI.ContentCanvas.documentNodeSelector);
+        const loadingDepth = configuration.structureTree.loadingDepth;
         while (parentContextPath !== documentNodeContextPath) {
             parentContextPath = parentNodeContextPath(parentContextPath);
-            const isInStore = yield select($get(['cr', 'nodes', 'byContextPath', parentContextPath]));
-            const isUnCollapsed = yield select($contains(parentContextPath, 'ui.contentTree.uncollapsed'));
+            const getNodeByContextPathSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector(parentContextPath);
+            const node = yield select(getNodeByContextPathSelector);
+            const isToggled = yield select($contains(parentContextPath, 'ui.contentTree.toggled'));
+            const isCollapsed = isNodeCollapsed(node, isToggled, documentNode, loadingDepth);
 
-            if (!isInStore || !isUnCollapsed) {
-                yield put(actions.UI.ContentTree.uncollapse(parentContextPath));
+            if (!node || isCollapsed) {
+                yield put(actions.UI.ContentTree.toggle(parentContextPath));
             }
         }
     });

--- a/packages/neos-ui/src/Sagas/UI/ContentTree/index.js
+++ b/packages/neos-ui/src/Sagas/UI/ContentTree/index.js
@@ -37,17 +37,15 @@ function * watchNodeFocus() {
         const {contextPath} = action.payload;
         const documentNodeContextPath = yield select($get('ui.contentCanvas.contextPath'));
 
-        if (contextPath !== documentNodeContextPath) {
-            let parentContextPath = contextPath;
+        let parentContextPath = contextPath;
 
-            while (parentContextPath !== documentNodeContextPath) {
-                parentContextPath = parentNodeContextPath(parentContextPath);
-                const isInStore = yield select($get(['cr', 'nodes', 'byContextPath', parentContextPath]));
-                const isUnCollapsed = yield select($contains(parentContextPath, 'ui.contentTree.uncollapsed'));
+        while (parentContextPath !== documentNodeContextPath) {
+            parentContextPath = parentNodeContextPath(parentContextPath);
+            const isInStore = yield select($get(['cr', 'nodes', 'byContextPath', parentContextPath]));
+            const isUnCollapsed = yield select($contains(parentContextPath, 'ui.contentTree.uncollapsed'));
 
-                if (!isInStore || !isUnCollapsed) {
-                    yield put(actions.UI.ContentTree.uncollapse(parentContextPath));
-                }
+            if (!isInStore || !isUnCollapsed) {
+                yield put(actions.UI.ContentTree.uncollapse(parentContextPath));
             }
         }
     });

--- a/packages/neos-ui/src/Sagas/UI/PageTree/index.js
+++ b/packages/neos-ui/src/Sagas/UI/PageTree/index.js
@@ -121,33 +121,31 @@ function * watchCurrentDocument() {
         const siteNodeContextPath = yield select($get('cr.nodes.siteNode'));
         const {q} = backend.get();
 
-        if (contextPath !== siteNodeContextPath) {
-            let parentContextPath = contextPath;
+        let parentContextPath = contextPath;
 
-            while (parentContextPath !== siteNodeContextPath) {
-                parentContextPath = parentNodeContextPath(parentContextPath);
-                const isInStore = yield select($get(['cr', 'nodes', 'byContextPath', parentContextPath]));
-                const isUnCollapsed = yield select($contains(parentContextPath, 'ui.pageTree.uncollapsed'));
+        while (parentContextPath !== siteNodeContextPath) {
+            parentContextPath = parentNodeContextPath(parentContextPath);
+            const isInStore = yield select($get(['cr', 'nodes', 'byContextPath', parentContextPath]));
+            const isUnCollapsed = yield select($contains(parentContextPath, 'ui.pageTree.uncollapsed'));
 
-                if (!isInStore || !isUnCollapsed) {
-                    yield put(actions.UI.PageTree.setAsLoading(siteNodeContextPath));
-                }
-
-                if (!isInStore) {
-                    const nodes = yield q(parentContextPath).get();
-                    yield put(actions.CR.Nodes.add(nodes.reduce((nodeMap, node) => {
-                        nodeMap[$get('contextPath', node)] = node;
-                        return nodeMap;
-                    }, {})));
-                }
-
-                if (!isUnCollapsed) {
-                    yield put(actions.UI.PageTree.commenceUncollapse(parentContextPath));
-                }
+            if (!isInStore || !isUnCollapsed) {
+                yield put(actions.UI.PageTree.setAsLoading(siteNodeContextPath));
             }
 
-            yield put(actions.UI.PageTree.setAsLoaded(siteNodeContextPath));
+            if (!isInStore) {
+                const nodes = yield q(parentContextPath).get();
+                yield put(actions.CR.Nodes.add(nodes.reduce((nodeMap, node) => {
+                    nodeMap[$get('contextPath', node)] = node;
+                    return nodeMap;
+                }, {})));
+            }
+
+            if (!isUnCollapsed) {
+                yield put(actions.UI.PageTree.commenceUncollapse(parentContextPath));
+            }
         }
+
+        yield put(actions.UI.PageTree.setAsLoaded(siteNodeContextPath));
     });
 }
 

--- a/packages/neos-ui/src/Sagas/UI/PageTree/index.js
+++ b/packages/neos-ui/src/Sagas/UI/PageTree/index.js
@@ -5,18 +5,22 @@ import {$get, $contains} from 'plow-js';
 import {actionTypes, actions, selectors} from '@neos-project/neos-ui-redux-store';
 import backend from '@neos-project/neos-ui-backend-connector';
 
-import {parentNodeContextPath} from '@neos-project/neos-ui-redux-store/src/CR/Nodes/helpers';
+import {parentNodeContextPath, isNodeCollapsed} from '@neos-project/neos-ui-redux-store/src/CR/Nodes/helpers';
 
-function * watchToggle() {
+function * watchToggle({globalRegistry}) {
+    const nodeTypesRegistry = globalRegistry.get('@neos-project/neos-ui-contentrepository');
     yield * takeLatest(actionTypes.UI.PageTree.TOGGLE, function * toggleTreeNode(action) {
         const state = yield select();
         const {contextPath} = action.payload;
-        const isCollapsed = !$contains(contextPath, 'ui.pageTree.uncollapsed', state);
 
-        if (isCollapsed) {
-            yield put(actions.UI.PageTree.commenceUncollapse(contextPath));
-        } else {
-            yield put(actions.UI.PageTree.collapse(contextPath));
+        const childrenAreFullyLoaded = $get(['cr', 'nodes', 'byContextPath', contextPath, 'children'], state).toJS()
+            .filter(childEnvelope => nodeTypesRegistry.hasRole(childEnvelope.nodeType, 'document'))
+            .every(
+                childEnvelope => Boolean($get(['cr', 'nodes', 'byContextPath', $get('contextPath', childEnvelope)], state))
+            );
+
+        if (!childrenAreFullyLoaded) {
+            yield put(actions.UI.PageTree.requestChildren(contextPath));
         }
     });
 }
@@ -25,7 +29,7 @@ function * watchRequestChildrenForContextPath({configuration}) {
     yield * takeEvery(actionTypes.UI.PageTree.REQUEST_CHILDREN, function * requestChildrenForContextPath(action) {
         // ToDo Call yield put(actions.UI.PageTree.requestChildren(contextPath));
         const {contextPath, opts} = action.payload;
-        const {unCollapse, activate} = opts;
+        const {activate} = opts;
         const {q} = backend.get();
         let parentNodes;
         let childNodes;
@@ -57,10 +61,6 @@ function * watchRequestChildrenForContextPath({configuration}) {
             // the data which the nodes already in the system; and not override them completely.
             yield put(actions.CR.Nodes.merge(nodes));
 
-            if (unCollapse) {
-                yield put(actions.UI.PageTree.uncollapse(contextPath));
-            }
-
             //
             // ToDo: Set the ContentCanvas src / contextPath
             //
@@ -79,32 +79,12 @@ function * watchNodeCreated() {
     });
 }
 
-function * watchCommenceUncollapse({globalRegistry}) {
-    const nodeTypesRegistry = globalRegistry.get('@neos-project/neos-ui-contentrepository');
-
-    yield * takeLatest(actionTypes.UI.PageTree.COMMENCE_UNCOLLAPSE, function * uncollapseNode(action) {
-        const state = yield select();
-        const {contextPath} = action.payload;
-        const childrenAreFullyLoaded = $get(['cr', 'nodes', 'byContextPath', contextPath, 'children'], state).toJS()
-            .filter(childEnvelope => nodeTypesRegistry.hasRole(childEnvelope.nodeType, 'document'))
-            .every(
-                childEnvelope => Boolean($get(['cr', 'nodes', 'byContextPath', $get('contextPath', childEnvelope)], state))
-            );
-
-        if (childrenAreFullyLoaded) {
-            yield put(actions.UI.PageTree.uncollapse(contextPath));
-        } else {
-            yield put(actions.UI.PageTree.requestChildren(contextPath));
-        }
-    });
-}
-
 function * watchReloadTree({globalRegistry}) {
     const nodeTypesRegistry = globalRegistry.get('@neos-project/neos-ui-contentrepository');
     yield * takeLatest(actionTypes.UI.PageTree.RELOAD_TREE, function * reloadTree() {
         const documentNodes = yield select(selectors.CR.Nodes.makeGetDocumentNodes(nodeTypesRegistry));
-        const uncollapsedContextPaths = yield select(selectors.UI.PageTree.getUncollapsed);
-        const nodesToReload = documentNodes.toArray().filter(node => uncollapsedContextPaths.includes(node.get('contextPath')));
+        const toggledContextPaths = yield select(selectors.UI.PageTree.getToggled);
+        const nodesToReload = documentNodes.toArray().filter(node => toggledContextPaths.includes(node.get('contextPath')));
 
         for (let i = 0; i < nodesToReload.length; i++) {
             const node = nodesToReload[i];
@@ -115,7 +95,7 @@ function * watchReloadTree({globalRegistry}) {
     });
 }
 
-function * watchCurrentDocument() {
+function * watchCurrentDocument({configuration}) {
     yield * takeLatest(actionTypes.UI.ContentCanvas.SET_CONTEXT_PATH, function * loadDocumentRootLine(action) {
         const {contextPath} = action.payload;
         const siteNodeContextPath = yield select($get('cr.nodes.siteNode'));
@@ -123,16 +103,17 @@ function * watchCurrentDocument() {
 
         let parentContextPath = contextPath;
 
+        const siteNode = yield select(selectors.CR.Nodes.siteNodeSelector);
+        const loadingDepth = configuration.nodeTree.loadingDepth;
         while (parentContextPath !== siteNodeContextPath) {
             parentContextPath = parentNodeContextPath(parentContextPath);
-            const isInStore = yield select($get(['cr', 'nodes', 'byContextPath', parentContextPath]));
-            const isUnCollapsed = yield select($contains(parentContextPath, 'ui.pageTree.uncollapsed'));
+            const getNodeByContextPathSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector(parentContextPath);
+            const node = yield select(getNodeByContextPathSelector);
+            const isToggled = yield select($contains(parentContextPath, 'ui.pageTree.toggled'));
+            const isCollapsed = isNodeCollapsed(node, isToggled, siteNode, loadingDepth);
 
-            if (!isInStore || !isUnCollapsed) {
+            if (!node) {
                 yield put(actions.UI.PageTree.setAsLoading(siteNodeContextPath));
-            }
-
-            if (!isInStore) {
                 const nodes = yield q(parentContextPath).get();
                 yield put(actions.CR.Nodes.add(nodes.reduce((nodeMap, node) => {
                     nodeMap[$get('contextPath', node)] = node;
@@ -140,8 +121,8 @@ function * watchCurrentDocument() {
                 }, {})));
             }
 
-            if (!isUnCollapsed) {
-                yield put(actions.UI.PageTree.commenceUncollapse(parentContextPath));
+            if (isCollapsed) {
+                yield put(actions.UI.PageTree.toggle(parentContextPath));
             }
         }
 
@@ -151,7 +132,6 @@ function * watchCurrentDocument() {
 
 export const sagas = [
     watchToggle,
-    watchCommenceUncollapse,
     watchRequestChildrenForContextPath,
     watchNodeCreated,
     watchReloadTree,


### PR DESCRIPTION
This PR switches from keeping track of uncollapsed nodes to tracking toggled nodes and XOR'ing them with the default collapsed state based on the loadingDepth configuration from the settings.