### PR TITLE
TASK: use new fontawesome declaration for contentcollection-icon

### DIFF
--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -14,3 +14,6 @@
     nodeCreationHandlers:
       documentTitle:
         nodeCreationHandler: 'Neos\Neos\Ui\NodeCreationHandler\DocumentTitleNodeCreationHandler'
+'Neos.Neos:ContentCollection':
+  ui:
+    icon: 'icon-folder-open'


### PR DESCRIPTION
to prevent error message for unknown icon

Related: #