### PR TITLE
BUGFIX: Reintroduce backward compatible icons

### DIFF
--- a/packages/react-ui-components/src/_lib/fontAwesome.js
+++ b/packages/react-ui-components/src/_lib/fontAwesome.js
@@ -3,9 +3,18 @@ export function makeValidateId(icons = {}) {
 
     return function validateId(id = '') {
         //
+        // A list of backward compatible icons
+        //
+        const backwardCompatibleIcons = {
+            'icon-folder-open-alt': 'fa-folder-open-o'
+        };
+
+        const tempName = id in backwardCompatibleIcons ? backwardCompatibleIcons[id] :
+            (id.startsWith('fa-') ? id : (id.startsWith('icon-') ? id.replace(/^icon/, 'fa') : `fa-${id}`));
+
+        //
         // Automatically prefix the passed id with fa regardless which prefix was passed
         //
-        const tempName = id.startsWith('fa-') ? id : (id.startsWith('icon-') ? id.replace(/^icon/, 'fa') : `fa-${id}`);
 
         //
         // becuase e.g. picture is called picture-o in FA

--- a/packages/react-ui-components/src/_lib/fontAwesome.spec.js
+++ b/packages/react-ui-components/src/_lib/fontAwesome.spec.js
@@ -2,7 +2,8 @@ import {makeValidateId, makeGetClassName} from './fontAwesome.js';
 
 const icons = {
     'fa-foo': 'fooIconClassName',
-    'fa-glass': 'glassIconClassName'
+    'fa-glass': 'glassIconClassName',
+    'icon-folder-open-alt': 'fa-folder-open-o'
 };
 const validateId = makeValidateId(icons);
 const getClassName = makeGetClassName(icons);


### PR DESCRIPTION
Introduce a list of backward compatible icons to allow using icons from the old FontAwesome versions that the old UI still uses.