### PR TITLE
BUGFIX: multiple styling improvements

### DIFF
--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -92,4 +92,12 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
             }
         }
     });
+
+    yield takeEvery(actionTypes.CR.Nodes.UNFOCUS, () => {
+        const node = findInGuestFrame(`.${style['markActiveNodeAsFocused--focusedNode']}`);
+
+        if (node) {
+            node.classList.remove(style['markActiveNodeAsFocused--focusedNode']);
+        }
+    });
 };

--- a/packages/neos-ui-guest-frame/src/style.css
+++ b/packages/neos-ui-guest-frame/src/style.css
@@ -6,10 +6,6 @@
     opacity: .5;
 }
 
-.editable:focus {
-    outline: none;
-}
-
 .addEmptyContentCollectionOverlay {
     height: 20px;
     outline: 2px solid var(--brandColorsContrastBrighter);
@@ -18,4 +14,8 @@
 .markActiveNodeAsFocused--focusedNode {
     outline-offset: .5em;
     outline: 2px solid var(--brandColorsPrimaryBlue);
+}
+
+:global(.neos-inline-editable:focus) {
+    outline: none;
 }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -28,6 +28,7 @@ const findScrollingParent = parentElement => {
 
 export default class Node extends PureComponent {
     static propTypes = {
+        isContentTreeNode: PropTypes.bool,
         rootNode: PropTypes.object,
         loadingDepth: PropTypes.number,
         ChildRenderer: PropTypes.func.isRequired,
@@ -115,8 +116,10 @@ export default class Node extends PureComponent {
     }
 
     isActive() {
-        const {node, currentDocumentNodeContextPath} = this.props;
-
+        const {node, currentDocumentNodeContextPath, isContentTreeNode} = this.props;
+        if (isContentTreeNode) {
+            return this.isFocused();
+        }
         return currentDocumentNodeContextPath === $get('contextPath', node);
     }
 
@@ -250,6 +253,7 @@ export const PageTreeNode = withNodeTypeRegistry(connect(
         const canBeInsertedSelector = selectors.CR.Nodes.makeCanBeInsertedSelector(nodeTypesRegistry);
 
         return (state, {node, currentlyDraggedNode}) => ({
+            isContentTreeNode: false,
             rootNode: selectors.CR.Nodes.siteNodeSelector(state),
             loadingDepth: neos.configuration.nodeTree.loadingDepth,
             childNodes: childrenOfSelector(state, getContextPath(node)),
@@ -283,6 +287,7 @@ export const ContentTreeNode = withNodeTypeRegistry(connect(
         const hasChildrenSelector = selectors.CR.Nodes.makeHasChildrenSelector(allowedNodeTypes);
         const canBeInsertedSelector = selectors.CR.Nodes.makeCanBeInsertedSelector(nodeTypesRegistry);
         return (state, {node, currentlyDraggedNode}) => ({
+            isContentTreeNode: true,
             rootNode: selectors.UI.ContentCanvas.documentNodeSelector(state),
             loadingDepth: neos.configuration.structureTree.loadingDepth,
             childNodes: childrenOfSelector(state, getContextPath(node)),


### PR DESCRIPTION
What to test:
- select any editable, there should be no additional tiny blue outline
- when you unfocus, the main blue outline should be removed
- focused node in content tree should always be active