### PR TITLE
BUGFIX: Use empty object to assign options to

### DIFF
--- a/packages/neos-ui-editors/src/Boolean/index.js
+++ b/packages/neos-ui-editors/src/Boolean/index.js
@@ -30,7 +30,7 @@ const defaultOptions = {
 
 const BooleanEditor = props => {
     const {value, label, identifier, commit, options} = props;
-    const finalOptions = Object.assign(defaultOptions, options);
+    const finalOptions = Object.assign({}, defaultOptions, options);
 
     const finalClassName = mergeClassNames({
         [style.boolean__disabled]: finalOptions.disabled

--- a/packages/neos-ui-editors/src/TextArea/index.js
+++ b/packages/neos-ui-editors/src/TextArea/index.js
@@ -11,7 +11,7 @@ const defaultOptions = {
 const TextAreaEditor = props => {
     const {value, commit, highlight, options} = props;
 
-    const finalOptions = Object.assign(defaultOptions, options);
+    const finalOptions = Object.assign({}, defaultOptions, options);
 
     return (<TextArea
         value={value}

--- a/packages/neos-ui-editors/src/TextField/index.js
+++ b/packages/neos-ui-editors/src/TextField/index.js
@@ -36,7 +36,7 @@ export default class TextField extends PureComponent {
 
         // Placeholder text must be unescaped in case html entities were used
         const placeholder = options && options.placeholder && i18nRegistry.translate(unescape(options.placeholder));
-        const finalOptions = Object.assign(defaultOptions, options);
+        const finalOptions = Object.assign({}, defaultOptions, options);
 
         return (<TextInput
             autoFocus={finalOptions.autoFocus}


### PR DESCRIPTION
to eliminate sideeffects

like mentioned in #787 