### PR TITLE
BUGFIX: scroll inline node into view only when requested from the tree

### DIFF
--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
@@ -34,7 +34,9 @@ export default class NodeToolbar extends PureComponent {
     static propTypes = {
         contextPath: PropTypes.string,
         fusionPath: PropTypes.string,
+        // Flag triggered by content tree that tells inlineUI that it should scroll into view
         shouldScrollIntoView: PropTypes.bool.isRequired,
+        // Unsets the flag
         requestScrollIntoView: PropTypes.func.isRequired
     };
 
@@ -48,6 +50,7 @@ export default class NodeToolbar extends PureComponent {
     }
 
     componentDidUpdate() {
+        // Only scroll into view when triggered from content tree (on focus change)
         if (this.props.shouldScrollIntoView) {
             this.scrollIntoView();
             this.props.requestScrollIntoView(false);

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
@@ -33,7 +33,9 @@ export const position = nodeElement => {
 export default class NodeToolbar extends PureComponent {
     static propTypes = {
         contextPath: PropTypes.string,
-        fusionPath: PropTypes.string
+        fusionPath: PropTypes.string,
+        shouldScrollIntoView: PropTypes.bool.isRequired,
+        requestScrollIntoView: PropTypes.func.isRequired
     };
 
     constructor() {
@@ -46,7 +48,10 @@ export default class NodeToolbar extends PureComponent {
     }
 
     componentDidUpdate() {
-        this.scrollIntoView();
+        if (this.props.shouldScrollIntoView) {
+            this.scrollIntoView();
+            this.props.requestScrollIntoView(false);
+        }
     }
 
     scrollIntoView() {

--- a/packages/neos-ui-guest-frame/src/InlineUI/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/index.js
@@ -2,25 +2,36 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {$transform, $get} from 'plow-js';
+import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 
 import NodeToolbar from './NodeToolbar/index';
 
 import style from './style.css';
 
 @connect($transform({
-    focused: $get('cr.nodes.focused')
-}))
+    focused: $get('cr.nodes.focused'),
+    shouldScrollIntoView: selectors.UI.ContentCanvas.shouldScrollIntoView
+}), {
+    requestScrollIntoView: actions.UI.ContentCanvas.requestScrollIntoView
+})
 export default class InlineUI extends PureComponent {
     static propTypes = {
-        focused: PropTypes.object
+        focused: PropTypes.object,
+        requestScrollIntoView: PropTypes.func.isRequired,
+        shouldScrollIntoView: PropTypes.bool.isRequired
     };
 
     render() {
         const focused = this.props.focused.toJS();
+        const {shouldScrollIntoView, requestScrollIntoView} = this.props;
 
         return (
             <div className={style.inlineUi} data-__neos__inlineUI="TRUE">
-                <NodeToolbar {...focused}/>
+                <NodeToolbar
+                    shouldScrollIntoView={shouldScrollIntoView}
+                    requestScrollIntoView={requestScrollIntoView}
+                    {...focused}
+                    />
             </div>
         );
     }

--- a/packages/neos-ui-redux-store/src/UI/ContentCanvas/index.js
+++ b/packages/neos-ui-redux-store/src/UI/ContentCanvas/index.js
@@ -40,6 +40,7 @@ const setFormattingUnderCursor = createAction(FORMATTING_UNDER_CURSOR, formattin
 const setCurrentlyEditedPropertyName = createAction(SET_CURRENTLY_EDITED_PROPERTY_NAME, propertyName => ({propertyName}));
 const startLoading = createAction(START_LOADING);
 const stopLoading = createAction(STOP_LOADING);
+// Set a flag to tell ContentCanvas to scroll the focused node into view
 const requestScrollIntoView = createAction(REQUEST_SCROLL_INTO_VIEW, activate => activate);
 
 //

--- a/packages/neos-ui-redux-store/src/UI/ContentCanvas/index.js
+++ b/packages/neos-ui-redux-store/src/UI/ContentCanvas/index.js
@@ -16,6 +16,7 @@ const SET_CURRENTLY_EDITED_PROPERTY_NAME = '@neos/neos-ui/UI/ContentCanvas/SET_C
 const START_LOADING = '@neos/neos-ui/UI/ContentCanvas/START_LOADING';
 const STOP_LOADING = '@neos/neos-ui/UI/ContentCanvas/STOP_LOADING';
 const FOCUS_PROPERTY = '@neos/neos-ui/UI/ContentCanvas/FOCUS_PROPERTY';
+const REQUEST_SCROLL_INTO_VIEW = '@neos/neos-ui/UI/ContentCanvas/REQUEST_SCROLL_INTO_VIEW';
 
 //
 // Export the action types
@@ -28,7 +29,8 @@ export const actionTypes = {
     SET_CURRENTLY_EDITED_PROPERTY_NAME,
     START_LOADING,
     STOP_LOADING,
-    FOCUS_PROPERTY
+    FOCUS_PROPERTY,
+    REQUEST_SCROLL_INTO_VIEW
 };
 
 const setContextPath = createAction(SET_CONTEXT_PATH, (contextPath, siteNode = null) => ({contextPath, siteNode}));
@@ -38,6 +40,7 @@ const setFormattingUnderCursor = createAction(FORMATTING_UNDER_CURSOR, formattin
 const setCurrentlyEditedPropertyName = createAction(SET_CURRENTLY_EDITED_PROPERTY_NAME, propertyName => ({propertyName}));
 const startLoading = createAction(START_LOADING);
 const stopLoading = createAction(STOP_LOADING);
+const requestScrollIntoView = createAction(REQUEST_SCROLL_INTO_VIEW, activate => activate);
 
 //
 // Export the actions
@@ -49,7 +52,8 @@ export const actions = {
     setFormattingUnderCursor,
     setCurrentlyEditedPropertyName,
     startLoading,
-    stopLoading
+    stopLoading,
+    requestScrollIntoView
 };
 
 //
@@ -65,7 +69,8 @@ export const reducer = handleActions({
             formattingUnderCursor: new Map(),
             currentlyEditedPropertyName: '',
             isLoading: true,
-            focusedProperty: ''
+            focusedProperty: '',
+            shouldScrollIntoView: false
         })
     ),
     [SET_CONTEXT_PATH]: ({contextPath, siteNode}) => state => {
@@ -100,7 +105,8 @@ export const reducer = handleActions({
     [FORMATTING_UNDER_CURSOR]: ({formatting}) => $set('ui.contentCanvas.formattingUnderCursor', new Map(formatting)),
     [SET_CURRENTLY_EDITED_PROPERTY_NAME]: ({propertyName}) => $set('ui.contentCanvas.currentlyEditedPropertyName', propertyName),
     [STOP_LOADING]: () => $set('ui.contentCanvas.isLoading', false),
-    [START_LOADING]: () => $set('ui.contentCanvas.isLoading', true)
+    [START_LOADING]: () => $set('ui.contentCanvas.isLoading', true),
+    [REQUEST_SCROLL_INTO_VIEW]: activate => $set('ui.contentCanvas.shouldScrollIntoView', activate)
 });
 
 //

--- a/packages/neos-ui-redux-store/src/UI/ContentCanvas/selectors.js
+++ b/packages/neos-ui-redux-store/src/UI/ContentCanvas/selectors.js
@@ -1,6 +1,7 @@
 import {createSelector} from 'reselect';
 import {$get} from 'plow-js';
 
+export const shouldScrollIntoView = $get('ui.contentCanvas.shouldScrollIntoView');
 export const getCurrentContentCanvasContextPath = $get('ui.contentCanvas.contextPath');
 export const currentlyEditedPropertyName = $get('ui.contentCanvas.currentlyEditedPropertyName');
 

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
@@ -43,6 +43,7 @@ export default class NodeTree extends PureComponent {
 
     handleClick = (src, contextPath) => {
         const {setActiveContentCanvasSrc, setActiveContentCanvasContextPath, requestScrollIntoView} = this.props;
+        // Set a flag that will imperatively tell ContentCanvas to scroll to focused node
         requestScrollIntoView(true);
         if (setActiveContentCanvasSrc && setActiveContentCanvasContextPath) {
             setActiveContentCanvasSrc(src);

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
@@ -20,6 +20,7 @@ export default class NodeTree extends PureComponent {
         nodeTypeRole: PropTypes.string,
         toggle: PropTypes.func,
         focus: PropTypes.func,
+        requestScrollIntoView: PropTypes.func.isRequired,
         setActiveContentCanvasSrc: PropTypes.func,
         setActiveContentCanvasContextPath: PropTypes.func,
         moveNode: PropTypes.func
@@ -37,13 +38,12 @@ export default class NodeTree extends PureComponent {
 
     handleFocus = contextPath => {
         const {focus} = this.props;
-
         focus(contextPath);
     }
 
     handleClick = (src, contextPath) => {
-        const {setActiveContentCanvasSrc, setActiveContentCanvasContextPath} = this.props;
-
+        const {setActiveContentCanvasSrc, setActiveContentCanvasContextPath, requestScrollIntoView} = this.props;
+        requestScrollIntoView(true);
         if (setActiveContentCanvasSrc && setActiveContentCanvasContextPath) {
             setActiveContentCanvasSrc(src);
             setActiveContentCanvasContextPath(contextPath);
@@ -103,7 +103,8 @@ export const PageTree = connect(state => ({
     focus: actions.UI.PageTree.focus,
     setActiveContentCanvasSrc: actions.UI.ContentCanvas.setSrc,
     setActiveContentCanvasContextPath: actions.UI.ContentCanvas.setContextPath,
-    moveNode: actions.CR.Nodes.move
+    moveNode: actions.CR.Nodes.move,
+    requestScrollIntoView: () => {}
 })(NodeTree);
 
 export const ContentTree = connect(state => ({
@@ -112,5 +113,6 @@ export const ContentTree = connect(state => ({
 }), {
     toggle: actions.UI.ContentTree.toggle,
     focus: actions.CR.Nodes.focus,
-    moveNode: actions.CR.Nodes.move
+    moveNode: actions.CR.Nodes.move,
+    requestScrollIntoView: actions.UI.ContentCanvas.requestScrollIntoView
 })(NodeTree);


### PR DESCRIPTION
Fixes #835.

I couldn't think of a nicer way to do it. We imperatively request to scroll the node into view when selecting a node from the tree.