### PR TITLE
BUGFIX: display inspector tabs that have only views and no properties

### DIFF
--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
@@ -21,7 +21,7 @@ export default class TabPanel extends PureComponent {
         const tabPanel = groups => (
             <Tabs.Panel theme={{panel: style.inspectorTabPanel}}>
                 {
-                    groups.filter(g => g.properties && g.properties.length).map(group => (
+                    groups.filter(g => (g.properties && g.properties.length) || (g.views && g.views.length)).map(group => (
                         <PropertyGroup
                             key={group.id}
                             label={group.label}

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -126,7 +126,7 @@ export default class Inspector extends PureComponent {
                         // Only display tabs, that have groups and these groups have properties
                         //
                         .filter(t => t.groups && t.groups.length && t.groups.reduce((acc, group) => {
-                            return acc || group.properties.length > 0;
+                            return acc || group.properties.length > 0 || group.views.length > 0;
                         }, false))
 
                         //


### PR DESCRIPTION
Fixes #837