### PR TITLE
BUGFIX: fix performance of trees by fixing makeChildrenOfSelector

### DIFF
--- a/packages/debug-reason-for-rendering/package.json
+++ b/packages/debug-reason-for-rendering/package.json
@@ -3,5 +3,8 @@
   "version": "1.0.0-beta3",
   "description": "React Performance Optimization Utility - Why does a component re-render?",
   "main": "./src/index.js",
-  "license": "MIT"
+  "license": "MIT",
+  "peerDependencies": {
+    "react": "^15.5.0"
+  }
 }

--- a/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
@@ -73,6 +73,7 @@ export const makeChildrenOfSelector = allowedNodeTypes => createSelector(
     .map(
         contextPath => $get(contextPath, nodesByContextPath)
     )
+    .filter(node => node)
 );
 
 export const siteNodeSelector = createSelector(


### PR DESCRIPTION
Also fixes the `debug-reason-for-rendering` helper to support pure components by refactoring to HOC. 
It drastically improves performance! Before all nodes were rerendered on each update.

Before it used inheritance, which didn't work and in general is not a good idea with React components.