### PR TITLE
BUGFIX: force dev-master version of Neos.Demo

### DIFF
--- a/Build/TravisCi/composer.json
+++ b/Build/TravisCi/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "neos/neos-development-collection": "@dev",
         "neos/flow-development-collection": "@dev",
-        "neos/demo": "@dev",
+        "neos/demo": "dev-master@dev",
 
         "neos/neos-ui": "@dev",
         "neos/neos-ui-compiled": "@dev",


### PR DESCRIPTION
For some reason currently it's installing the wrong branch.