### PR TITLE
BUGFIX: load metadata for all direct children of document node

### DIFF
--- a/Classes/Neos/Neos/Ui/Aspects/AugmentationAspect.php
+++ b/Classes/Neos/Neos/Ui/Aspects/AugmentationAspect.php
@@ -197,7 +197,7 @@ class AugmentationAspect
     protected function appendNonRenderedContentNodeMetadata(NodeInterface $documentNode)
     {
         foreach ($documentNode->getChildNodes() as $node) {
-            if ($documentNode->getNodeType()->isOfType('Neos.Neos:Document') === true) {
+            if ($node->getNodeType()->isOfType('Neos.Neos:Document') === true) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes #824 