### PR TITLE
TASK: addEmptyContentCollectionOverlay should use the full width of the container

### DIFF
--- a/packages/neos-ui-guest-frame/src/style.css
+++ b/packages/neos-ui-guest-frame/src/style.css
@@ -8,6 +8,7 @@
 
 .addEmptyContentCollectionOverlay {
     height: 20px;
+    width: 100%;
     outline: 2px solid var(--brandColorsContrastBrighter);
 }
 


### PR DESCRIPTION
This change add width 100% for the class addEmptyContentCollectionOverlay
in certain situation, like if the parent node has display flex, the overlay
can collapse to a one pixel wide block on the left (or right) of the parent