### PR TITLE
BUGFIX: limit height for the cropped image

### DIFF
--- a/packages/neos-ui-editors/src/Image/Components/Secondary/ImageCropper/index.js
+++ b/packages/neos-ui-editors/src/Image/Components/Secondary/ImageCropper/index.js
@@ -91,6 +91,21 @@ export default class ImageCropper extends PureComponent {
         this.handleSetCustomAspectRatioDimensions = this.setCustomAspectRatioDimensions.bind(this);
     }
 
+    componentDidMount() {
+        //
+        // Calculate and set maximum height for the cropped image
+        const containerHeight = this.containerNode.clientHeight;
+        const toolbarStyles = getComputedStyle(this.toolbarNode);
+        const toolbarFullHeight = parseInt(toolbarStyles.height, 10) + parseInt(toolbarStyles['margin-top'], 10) + parseInt(toolbarStyles['margin-bottom'], 10);
+        const spacing = 32;
+        const topOffset = 82;
+        const height = (containerHeight - toolbarFullHeight - spacing - topOffset) + 'px';
+        const imageNode = this.containerNode.querySelector('.ReactCrop__image');
+        const imageCopyNode = this.containerNode.querySelector('.ReactCrop__image-copy');
+        imageNode.style.height = height;
+        imageCopyNode.style.height = height;
+    }
+
     componentWillReceiveProps(nextProps) {
         const {cropConfiguration} = this.state;
 
@@ -142,9 +157,15 @@ export default class ImageCropper extends PureComponent {
             cropConfiguration.aspectRatioStrategy.__width = width;
         }
 
+        const toolbarRef = el => {
+            this.toolbarNode = el;
+        };
+        const containerRef = el => {
+            this.containerNode = el;
+        };
         return (
-            <div style={{textAlign: 'center'}}>
-                <div className={style.tools}>
+            <div style={{textAlign: 'center'}} ref={containerRef}>
+                <div ref={toolbarRef} className={style.tools}>
                     <div className={style.aspectRatioIndicator}>
                         {
                             cropConfiguration.aspectRatioReducedLabel.map((label, index) => (

--- a/packages/neos-ui-editors/src/Image/Components/Secondary/ImageCropper/index.js
+++ b/packages/neos-ui-editors/src/Image/Components/Secondary/ImageCropper/index.js
@@ -94,12 +94,11 @@ export default class ImageCropper extends PureComponent {
     componentDidMount() {
         //
         // Calculate and set maximum height for the cropped image
-        const containerHeight = this.containerNode.clientHeight;
+        const containerHeight = this.containerNode.parentElement.clientHeight;
         const toolbarStyles = getComputedStyle(this.toolbarNode);
         const toolbarFullHeight = parseInt(toolbarStyles.height, 10) + parseInt(toolbarStyles['margin-top'], 10) + parseInt(toolbarStyles['margin-bottom'], 10);
         const spacing = 32;
-        const topOffset = 82;
-        const height = (containerHeight - toolbarFullHeight - spacing - topOffset) + 'px';
+        const height = (containerHeight - toolbarFullHeight - spacing) + 'px';
         const imageNode = this.containerNode.querySelector('.ReactCrop__image');
         const imageCopyNode = this.containerNode.querySelector('.ReactCrop__image-copy');
         imageNode.style.height = height;


### PR DESCRIPTION
Fixes: #917 

I didn't find a way to fix it in CSS: `max-height` won't work within absolute div; `object-fit: contain` breaks the cropper. 
So I fixed it via direct DOM manipulations.