### PR TITLE
BUGFIX: don't scroll the tree unless focused node has changed

### DIFF
--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -67,7 +67,7 @@ export default class Node extends PureComponent {
         super(props);
 
         this.state = {
-            shoulScrollIntoView: false
+            shouldScrollIntoView: false
         };
 
         this.handleNodeToggle = this.handleNodeToggle.bind(this);
@@ -82,7 +82,7 @@ export default class Node extends PureComponent {
             if (nextProps.focusedNodeContextPath === $get('contextPath', nextProps.node)) {
                 // Request scrolling itself into view
                 this.setState({
-                    shoulScrollIntoView: true
+                    shouldScrollIntoView: true
                 });
             }
         }
@@ -93,7 +93,7 @@ export default class Node extends PureComponent {
     }
 
     scrollFocusedNodeIntoView() {
-        if (this.state.shoulScrollIntoView && this.domNode) {
+        if (this.state.shouldScrollIntoView && this.domNode) {
             const scrollingElement = findScrollingParent(this.domNode);
             if (scrollingElement) {
                 const nodeTopPosition = this.domNode.getBoundingClientRect().top;
@@ -105,7 +105,7 @@ export default class Node extends PureComponent {
                     animate(scrollingElement, {scrollTop});
                 }
                 this.setState({
-                    shoulScrollIntoView: false
+                    shouldScrollIntoView: false
                 });
             }
         }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -66,9 +66,26 @@ export default class Node extends PureComponent {
     constructor(props) {
         super(props);
 
+        this.state = {
+            shoulScrollIntoView: false
+        };
+
         this.handleNodeToggle = this.handleNodeToggle.bind(this);
         this.handleNodeClick = this.handleNodeClick.bind(this);
         this.handleNodeLabelClick = this.handleNodeLabelClick.bind(this);
+    }
+
+    componentWillReceiveProps(nextProps) {
+        // If focused node changed
+        if (this.props.focusedNodeContextPath !== nextProps.focusedNodeContextPath) {
+            // And it is the current node
+            if (nextProps.focusedNodeContextPath === $get('contextPath', nextProps.node)) {
+                // Request scrolling itself into view
+                this.setState({
+                    shoulScrollIntoView: true
+                });
+            }
+        }
     }
 
     componentDidUpdate() {
@@ -76,7 +93,7 @@ export default class Node extends PureComponent {
     }
 
     scrollFocusedNodeIntoView() {
-        if (this.isFocused() && this.domNode) {
+        if (this.state.shoulScrollIntoView && this.domNode) {
             const scrollingElement = findScrollingParent(this.domNode);
             if (scrollingElement) {
                 const nodeTopPosition = this.domNode.getBoundingClientRect().top;
@@ -87,6 +104,9 @@ export default class Node extends PureComponent {
                     const scrollTop = nodeTopPosition - scrollingElement.firstElementChild.getBoundingClientRect().top - offset;
                     animate(scrollingElement, {scrollTop});
                 }
+                this.setState({
+                    shoulScrollIntoView: false
+                });
             }
         }
     }


### PR DESCRIPTION
Without this fix, if you clicked on expanding a tree node, the tree would rewind to the focused node.