### PR TITLE
TASK: make scrollable dropdown taller

### DIFF
--- a/packages/react-ui-components/src/DropDown/style.css
+++ b/packages/react-ui-components/src/DropDown/style.css
@@ -50,7 +50,7 @@
     background: var(--brandColorsContrastNeutral);
 }
 .dropDown__contents--scrollable {
-    max-height: 320px;
+    max-height: 80vh;
     overflow-y: auto;
 }
 .dropDown__contents--isOpen {


### PR DESCRIPTION
I propose to make scrollable dropdowns to take up 80% of viewport. E.g. for links editor 320px is not enough.