### PR TITLE
BUGFIX: make decodeLabel() in node tree more robust

### DIFF
--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -27,9 +27,12 @@ const findScrollingParent = parentElement => {
     return null;
 };
 
+const getOrDefault = defaultValue => value => value || defaultValue;
+
 const decodeLabel = flowright(
     decodeHtml,
-    stripTags
+    stripTags,
+    getOrDefault('')
 );
 
 export default class Node extends PureComponent {


### PR DESCRIPTION
Previously, if the label was not given, the decode function
crashed with a NULL value.