### PR TITLE
TASK: Adjust proptype validation for ReferenceEditor

### DIFF
--- a/packages/neos-ui-editors/src/Reference/index.js
+++ b/packages/neos-ui-editors/src/Reference/index.js
@@ -18,7 +18,7 @@ export default class ReferenceEditor extends PureComponent {
         value: PropTypes.string,
         commit: PropTypes.func.isRequired,
         options: PropTypes.shape({
-            nodeTypes: PropTypes.arrayOf(PropTypes.string),
+            nodeTypes: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
             placeholder: PropTypes.string,
             threshold: PropTypes.number
         }),

--- a/packages/neos-ui-editors/src/References/index.js
+++ b/packages/neos-ui-editors/src/References/index.js
@@ -18,7 +18,7 @@ export default class ReferencesEditor extends PureComponent {
         value: PropTypes.arrayOf(PropTypes.string),
         commit: PropTypes.func.isRequired,
         options: PropTypes.shape({
-            nodeTypes: PropTypes.arrayOf(PropTypes.string),
+            nodeTypes: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
             placeholder: PropTypes.string,
             threshold: PropTypes.number
         }),


### PR DESCRIPTION
The nodetpye option in ReferenceEditor props can be a strig with a
single nodetype as well as an array