### PR TITLE
BUGFIX: replace history instead of pushing new entry

### DIFF
--- a/packages/neos-ui/src/Sagas/Browser/index.js
+++ b/packages/neos-ui/src/Sagas/Browser/index.js
@@ -6,7 +6,7 @@ function * watchContentURIChange() {
     yield * takeEvery(actionTypes.UI.ContentCanvas.SET_CONTEXT_PATH, function * reflectChangeInAddressBar(action) {
         const {contextPath} = action.payload;
 
-        yield history.pushState({}, '', `?node=${contextPath}`);
+        yield history.replaceState({}, '', `?node=${contextPath}`);
     });
 }
 

--- a/packages/neos-ui/src/Sagas/Browser/index.js
+++ b/packages/neos-ui/src/Sagas/Browser/index.js
@@ -1,0 +1,15 @@
+import {takeEvery} from 'redux-saga';
+
+import {actionTypes} from '@neos-project/neos-ui-redux-store';
+
+function * watchContentURIChange() {
+    yield * takeEvery(actionTypes.UI.ContentCanvas.SET_CONTEXT_PATH, function * reflectChangeInAddressBar(action) {
+        const {contextPath} = action.payload;
+
+        yield history.pushState({}, '', `?node=${contextPath}`);
+    });
+}
+
+export const sagas = [
+    watchContentURIChange
+];

--- a/packages/neos-ui/src/Sagas/Browser/index.spec.js
+++ b/packages/neos-ui/src/Sagas/Browser/index.spec.js
@@ -1,0 +1,3 @@
+test(`write tests`, () => {
+    expect(true).toBe(true);
+});

--- a/packages/neos-ui/src/Sagas/index.js
+++ b/packages/neos-ui/src/Sagas/index.js
@@ -1,3 +1,4 @@
+import {sagas as BrowserSagas} from './Browser/index';
 import {sagas as ChangesSagas} from './Changes/index';
 import {sagas as CRSagas} from './CR/index';
 import {sagas as PublishSagas} from './Publish/index';
@@ -5,6 +6,7 @@ import {sagas as ServerFeedbackSagas} from './ServerFeedback/index';
 import {sagas as UISagas} from './UI/index';
 
 export default [
+    ...BrowserSagas,
     ...ChangesSagas,
     ...CRSagas,
     ...PublishSagas,


### PR DESCRIPTION
History is written on ifame url changes, so setting it again would cause
duplicate entries.

My previous attempt to fix it removed the url handling altogether...