### PR TITLE
FEATURE: Set background color for the content canvas

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -35,6 +35,9 @@ Neos:
             resource: '${"resource://" + Neos.Ui.StaticResources.compiledResourcePackage() + "/Public/Styles/HostOnlyStyles.css"}'
             position: 'start 900'
 
+      contentCanvas:
+        backgroundColor: '#ffffff'
+
       #################################
       # INTERNAL CONFIG (no API)
       #################################
@@ -86,6 +89,7 @@ Neos:
             contentCanvas:
               src: '${Neos.Ui.NodeInfo.uri(documentNode, controllerContext)}'
               contextPath: '${q(documentNode).property(''_contextPath'')}'
+              backgroundColor: '${Configuration.setting(''Neos.Neos.Ui.contentCanvas.backgroundColor'')}'
             debugMode: false
             editPreviewMode: '${q(user).property("preferences.preferences")["contentEditing.editPreviewMode"] || Configuration.setting(''Neos.Neos.userInterface.defaultEditPreviewMode'')}'
             fullScreen:

--- a/Resources/Private/Fusion/Backend/Root.fusion
+++ b/Resources/Private/Fusion/Backend/Root.fusion
@@ -14,7 +14,6 @@ backend = Neos.Fusion:Template {
         nodeTree = ${Configuration.setting('Neos.Neos.userInterface.navigateComponent.nodeTree')}
         structureTree = ${Configuration.setting('Neos.Neos.userInterface.navigateComponent.structureTree')}
         allowedTargetWorkspaces = ${Neos.Ui.Workspace.getAllowedTargetWorkspaces()}
-        contentCanvas = ${Configuration.setting('Neos.Neos.Ui.contentCanvas')}
         endpoints = Neos.Fusion:RawArray {
             nodeTypeSchema = Neos.Fusion:UriBuilder {
                 package = 'Neos.Neos'

--- a/Resources/Private/Fusion/Backend/Root.fusion
+++ b/Resources/Private/Fusion/Backend/Root.fusion
@@ -14,6 +14,7 @@ backend = Neos.Fusion:Template {
         nodeTree = ${Configuration.setting('Neos.Neos.userInterface.navigateComponent.nodeTree')}
         structureTree = ${Configuration.setting('Neos.Neos.userInterface.navigateComponent.structureTree')}
         allowedTargetWorkspaces = ${Neos.Ui.Workspace.getAllowedTargetWorkspaces()}
+        contentCanvas = ${Configuration.setting('Neos.Neos.Ui.contentCanvas')}
         endpoints = Neos.Fusion:RawArray {
             nodeTypeSchema = Neos.Fusion:UriBuilder {
                 package = 'Neos.Neos'

--- a/packages/neos-ui-redux-store/src/UI/ContentCanvas/index.js
+++ b/packages/neos-ui-redux-store/src/UI/ContentCanvas/index.js
@@ -71,6 +71,7 @@ export const reducer = handleActions({
             currentlyEditedPropertyName: '',
             isLoading: true,
             focusedProperty: '',
+            backgroundColor: $get('ui.contentCanvas.backgroundColor', state),
             shouldScrollIntoView: false
         })
     ),

--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -16,6 +16,7 @@ import style from './style.css';
     isFringeRight: $get('ui.rightSideBar.isHidden'),
     isFullScreen: $get('ui.fullScreen.isFullScreen'),
     isEditModePanelHidden: $get('ui.editModePanel.isHidden'),
+    backgroundColor: $get('ui.contentCanvas.backgroundColor'),
     src: $get('ui.contentCanvas.src'),
     currentEditPreviewMode: selectors.UI.EditPreviewMode.currentEditPreviewMode
 }), {
@@ -31,6 +32,7 @@ export default class ContentCanvas extends PureComponent {
         isFringeRight: PropTypes.bool.isRequired,
         isEditModePanelHidden: PropTypes.bool.isRequired,
         isFullScreen: PropTypes.bool.isRequired,
+        backgroundColor: PropTypes.string,
         src: PropTypes.string.isRequired,
         stopLoading: PropTypes.func.isRequired,
         currentEditPreviewMode: PropTypes.string.isRequired,
@@ -54,7 +56,8 @@ export default class ContentCanvas extends PureComponent {
             src,
             currentEditPreviewMode,
             editPreviewModesRegistry,
-            guestFrameRegistry
+            guestFrameRegistry,
+            backgroundColor
         } = this.props;
         const classNames = mergeClassNames({
             [style.contentCanvas]: true,
@@ -76,6 +79,11 @@ export default class ContentCanvas extends PureComponent {
             inlineStyles.height = height;
         }
 
+        const canvasContentStyle = {};
+        if (backgroundColor) {
+            canvasContentStyle.background = backgroundColor;
+        }
+
         // ToDo: Is the `[data-__neos__hook]` attr used?
         return (
             <div className={classNames}>
@@ -86,6 +94,7 @@ export default class ContentCanvas extends PureComponent {
                         frameBorder="0"
                         name="neos-content-main"
                         className={style.contentCanvas__contents}
+                        style={canvasContentStyle}
                         mountTarget="#neos-new-backend-container"
                         contentDidUpdate={this.onFrameChange}
                         >


### PR DESCRIPTION
This feature introduces a new Setting `Neos.Neos.Ui.configuration.contentCanvas.backgroundColor`. It can be set to any valid string for the css property `background` and defaults to a white color. With this setting set the background of the content canvas can be set to prevent it flickering on a page load.

Resolves #863