### PR TITLE
BUGFIX: forbid publishing to read-only workspaces

### DIFF
--- a/Classes/Neos/Neos/Ui/Fusion/Helper/WorkspaceHelper.php
+++ b/Classes/Neos/Neos/Ui/Fusion/Helper/WorkspaceHelper.php
@@ -5,6 +5,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\Neos\Service\UserService;
+use Neos\Neos\Domain\Service\UserService as DomainUserService;
 use Neos\Neos\Ui\ContentRepository\Service\WorkspaceService;
 
 class WorkspaceHelper implements ProtectedContextAwareInterface
@@ -14,6 +15,12 @@ class WorkspaceHelper implements ProtectedContextAwareInterface
      * @var WorkspaceService
      */
     protected $workspaceService;
+
+    /**
+     * @Flow\Inject
+     * @var DomainUserService
+     */
+    protected $domainUserService;
 
     /**
      * @Flow\Inject
@@ -30,10 +37,12 @@ class WorkspaceHelper implements ProtectedContextAwareInterface
     public function getPersonalWorkspace()
     {
         $personalWorkspace = $this->userService->getPersonalWorkspace();
+        $baseWorkspace = $personalWorkspace->getBaseWorkspace();
         return [
             'name' => $personalWorkspace->getName(),
             'publishableNodes' => $this->getPublishableNodeInfo($personalWorkspace),
-            'baseWorkspace' => $personalWorkspace->getBaseWorkspace()->getName()
+            'baseWorkspace' => $baseWorkspace->getName(),
+            'readOnly' => !$this->domainUserService->currentUserCanPublishToWorkspace($baseWorkspace)
         ];
     }
 

--- a/packages/neos-ui-redux-store/src/CR/Workspaces/selectors.js
+++ b/packages/neos-ui-redux-store/src/CR/Workspaces/selectors.js
@@ -5,6 +5,8 @@ export const activeDocumentContextPathSelector = $get('ui.contentCanvas.contextP
 
 export const baseWorkspaceSelector = $get('cr.workspaces.personalWorkspace.baseWorkspace');
 
+export const isWorkspaceReadOnlySelector = $get('cr.workspaces.personalWorkspace.readOnly');
+
 export const publishableNodesSelector = $get('cr.workspaces.personalWorkspace.publishableNodes');
 
 export const publishableNodesInDocumentSelector = createSelector(

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -15,7 +15,7 @@ import I18n from '@neos-project/neos-ui-i18n';
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {neos} from '@neos-project/neos-ui-decorators';
 
-const {publishableNodesSelector, publishableNodesInDocumentSelector, baseWorkspaceSelector} = selectors.CR.Workspaces;
+const {publishableNodesSelector, publishableNodesInDocumentSelector, baseWorkspaceSelector, isWorkspaceReadOnlySelector} = selectors.CR.Workspaces;
 
 import AbstractButton from './AbstractButton/index';
 import WorkspaceSelector from './WorkspaceSelector/index';
@@ -28,6 +28,7 @@ import style from './style.css';
     publishableNodes: publishableNodesSelector,
     publishableNodesInDocument: publishableNodesInDocumentSelector,
     baseWorkspace: baseWorkspaceSelector,
+    isWorkspaceReadOnly: isWorkspaceReadOnlySelector,
     isAutoPublishingEnabled: $get('user.settings.isAutoPublishingEnabled')
 }), {
     toggleAutoPublishing: actions.User.Settings.toggleAutoPublishing,
@@ -41,6 +42,7 @@ export default class PublishDropDown extends PureComponent {
         isSaving: PropTypes.bool,
         isPublishing: PropTypes.bool,
         isDiscarding: PropTypes.bool,
+        isWorkspaceReadOnly: PropTypes.bool,
         publishableNodes: ImmutablePropTypes.list,
         publishableNodesInDocument: ImmutablePropTypes.list,
         baseWorkspace: PropTypes.string.isRequired,
@@ -82,6 +84,7 @@ export default class PublishDropDown extends PureComponent {
             publishableNodesInDocument,
             isSaving,
             isAutoPublishingEnabled,
+            isWorkspaceReadOnly,
             toggleAutoPublishing,
             baseWorkspace,
             changeBaseWorkspaceAction,
@@ -109,11 +112,11 @@ export default class PublishDropDown extends PureComponent {
             <div className={style.wrapper}>
                 <AbstractButton
                     className={style.publishBtn}
-                    isEnabled={canPublishLocally || isSaving}
+                    isEnabled={!isWorkspaceReadOnly && (canPublishLocally || isSaving)}
                     isHighlighted={canPublishLocally || isSaving}
                     onClick={this.handlePublishClick}
                     >
-                    <I18n fallback={mainButtonTarget} id={mainButtonLabel}/> <I18n id="to"/> {baseWorkspaceTitle}
+                    <I18n fallback={mainButtonTarget} id={mainButtonLabel}/> <I18n id="to"/> {isWorkspaceReadOnly ? (<Icon icon="lock"/>) : ''} {baseWorkspaceTitle}
                     {publishableNodesInDocumentCount > 0 && <Badge className={style.badge} label={String(publishableNodesInDocumentCount)}/>}
                 </AbstractButton>
 
@@ -135,7 +138,7 @@ export default class PublishDropDown extends PureComponent {
                         </li>
                         <li className={style.dropDown__item}>
                             <AbstractButton
-                                isEnabled={canPublishGlobally}
+                                isEnabled={!isWorkspaceReadOnly && canPublishGlobally}
                                 isHighlighted={false}
                                 onClick={this.handlePublishAllClick}
                                 >


### PR DESCRIPTION
Before it was possible to publish to live workspace for restricted editors, which would lead to an exception.
This change forbids publishing and indicates early on that the workspace is locked.