### PR TITLE
BUGFIX: scroll tree into view on first render

### DIFF
--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -80,6 +80,13 @@ export default class Node extends PureComponent {
         this.handleNodeClick = this.handleNodeClick.bind(this);
     }
 
+    componentDidMount() {
+        // Always request scroll on first render
+        this.setState({
+            shouldScrollIntoView: true
+        });
+    }
+
     componentWillReceiveProps(nextProps) {
         // If focused node changed
         if (this.props.focusedNodeContextPath !== nextProps.focusedNodeContextPath) {


### PR DESCRIPTION
Currently on first render the tree is not scrolled to reveal the focused node. This fixes it.