### PR TITLE
FEATURE: Filter nodetypes in SelectNodeTypeDialog

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
@@ -62,9 +62,8 @@ export default class SelectNodeType extends PureComponent {
     };
 
     componentDidMount() {
-        const {filterSearchTerm} = this.state || {};
         this.setState({
-            filterSearchTerm: filterSearchTerm || '',
+            filterSearchTerm: '',
             insertMode: calculateInitialMode(
                 this.props.allowedSiblingNodeTypes,
                 this.props.allowedChildNodeTypes
@@ -72,10 +71,19 @@ export default class SelectNodeType extends PureComponent {
         });
     }
 
+    updateInsertMode() {
+        this.setState({
+            insertMode: calculateInitialMode(
+                this.props.allowedSiblingNodeTypes,
+              this.props.allowedChildNodeTypes
+            )
+        });
+    }
+
     componentDidUpdate(prevProps) {
         if (prevProps.allowedSiblingNodeTypes !== this.props.allowedSiblingNodeTypes ||
             prevProps.allowedChildNodeTypes !== this.props.allowedChildNodeTypes) {
-            this.componentDidMount();
+            this.updateInsertMode();
         }
     }
 

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
@@ -12,6 +12,8 @@ import I18n from '@neos-project/neos-ui-i18n';
 
 import {InsertModeSelector} from '@neos-project/neos-ui-containers';
 import NodeTypeGroupPanel from './nodeTypeGroupPanel';
+import NodeTypeFilter from './nodeTypeFilter';
+import style from './style.css';
 
 const calculateInitialMode = (allowedSiblingNodeTypes, allowedChildNodeTypes) => {
     if (allowedSiblingNodeTypes.length) {
@@ -61,6 +63,7 @@ export default class SelectNodeType extends PureComponent {
 
     componentDidMount() {
         this.setState({
+            filterSearchTerm: '',
             insertMode: calculateInitialMode(
                 this.props.allowedSiblingNodeTypes,
                 this.props.allowedChildNodeTypes
@@ -79,7 +82,9 @@ export default class SelectNodeType extends PureComponent {
 
     handleCancel = () => {
         const {cancel} = this.props;
-
+        this.setState({
+            filterSearchTerm: ''
+        });
         cancel();
     }
 
@@ -107,20 +112,6 @@ export default class SelectNodeType extends PureComponent {
         }
     }
 
-    renderInsertModeSelector() {
-        const {insertMode} = this.state;
-        const {allowedSiblingNodeTypes, allowedChildNodeTypes} = this.props;
-
-        return (
-            <InsertModeSelector
-                mode={insertMode}
-                onSelect={this.handleModeChange}
-                enableAlongsideModes={Boolean(allowedSiblingNodeTypes.length)}
-                enableIntoMode={Boolean(allowedChildNodeTypes.length)}
-                />
-        );
-    }
-
     renderCancelAction() {
         return (
             <Button
@@ -134,6 +125,27 @@ export default class SelectNodeType extends PureComponent {
         );
     }
 
+    renderSelectNodeTypeDialogHeader() {
+        const {insertMode} = this.state;
+        const {allowedSiblingNodeTypes, allowedChildNodeTypes} = this.props;
+
+        return (
+            <div className={style.nodeTypeDialogHeader} key="nodeTypeDialogHeader">
+                <InsertModeSelector
+                    mode={insertMode}
+                    onSelect={this.handleModeChange}
+                    enableAlongsideModes={Boolean(allowedSiblingNodeTypes.length)}
+                    enableIntoMode={Boolean(allowedChildNodeTypes.length)}
+                    />
+                <NodeTypeFilter
+                    onChange={this.handleNodeTypeFilterChange}
+                    />
+            </div>
+        );
+    }
+
+    handleNodeTypeFilterChange = filterSearchTerm => this.setState({filterSearchTerm});
+
     render() {
         const {isOpen} = this.props;
 
@@ -144,7 +156,7 @@ export default class SelectNodeType extends PureComponent {
         return (
             <Dialog
                 actions={[this.renderCancelAction()]}
-                title={this.renderInsertModeSelector()}
+                title={[this.renderSelectNodeTypeDialogHeader()]}
                 onRequestClose={this.handleCancel}
                 isOpen
                 style="wide"
@@ -153,6 +165,7 @@ export default class SelectNodeType extends PureComponent {
                     <div key={key}>
                         <NodeTypeGroupPanel
                             group={group}
+                            filterSearchTerm={this.state.filterSearchTerm}
                             onSelect={this.handleApply}
                             />
                     </div>

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
@@ -61,29 +61,27 @@ export default class SelectNodeType extends PureComponent {
         apply: PropTypes.func.isRequired
     };
 
-    componentDidMount() {
-        this.setState({
+    constructor(props) {
+        super(props);
+
+        this.state = {
             filterSearchTerm: '',
             insertMode: calculateInitialMode(
                 this.props.allowedSiblingNodeTypes,
                 this.props.allowedChildNodeTypes
             )
-        });
+        };
     }
 
-    updateInsertMode() {
-        this.setState({
-            insertMode: calculateInitialMode(
-                this.props.allowedSiblingNodeTypes,
-              this.props.allowedChildNodeTypes
-            )
-        });
-    }
-
-    componentDidUpdate(prevProps) {
-        if (prevProps.allowedSiblingNodeTypes !== this.props.allowedSiblingNodeTypes ||
-            prevProps.allowedChildNodeTypes !== this.props.allowedChildNodeTypes) {
-            this.updateInsertMode();
+    componentWillReceiveProps(nextProps) {
+        if (this.props.allowedSiblingNodeTypes !== nextProps.allowedSiblingNodeTypes ||
+            this.props.allowedChildNodeTypes !== nextProps.allowedChildNodeTypes) {
+            this.setState({
+                insertMode: calculateInitialMode(
+                    nextProps.allowedSiblingNodeTypes,
+                    nextProps.allowedChildNodeTypes
+                )
+            });
         }
     }
 

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
@@ -133,7 +133,7 @@ export default class SelectNodeType extends PureComponent {
     }
 
     renderSelectNodeTypeDialogHeader() {
-        const {insertMode} = this.state;
+        const {insertMode, filterSearchTerm} = this.state;
         const {allowedSiblingNodeTypes, allowedChildNodeTypes} = this.props;
 
         return (
@@ -145,6 +145,7 @@ export default class SelectNodeType extends PureComponent {
                     enableIntoMode={Boolean(allowedChildNodeTypes.length)}
                     />
                 <NodeTypeFilter
+                    filterSearchTerm={filterSearchTerm}
                     onChange={this.handleNodeTypeFilterChange}
                     />
             </div>

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
@@ -62,8 +62,9 @@ export default class SelectNodeType extends PureComponent {
     };
 
     componentDidMount() {
+        const {filterSearchTerm} = this.state || {};
         this.setState({
-            filterSearchTerm: '',
+            filterSearchTerm: filterSearchTerm || '',
             insertMode: calculateInitialMode(
                 this.props.allowedSiblingNodeTypes,
                 this.props.allowedChildNodeTypes

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeFilter.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeFilter.js
@@ -1,11 +1,17 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import TextInput from '@neos-project/react-ui-components/src/TextInput/';
+import Icon from '@neos-project/react-ui-components/src/Icon/';
+import {neos} from '@neos-project/neos-ui-decorators';
 import style from './style.css';
 
+@neos(globalRegistry => ({
+    i18nRegistry: globalRegistry.get('i18n')
+}))
 class NodeTypeFilter extends PureComponent {
     static propTypes = {
-        onChange: PropTypes.func.isRequired
+        onChange: PropTypes.func.isRequired,
+        i18nRegistry: PropTypes.object.isRequired
     };
 
     constructor(props) {
@@ -15,11 +21,15 @@ class NodeTypeFilter extends PureComponent {
     }
 
     render() {
+        const {i18nRegistry} = this.props;
+        const label = i18nRegistry.translate('filter', 'Filter', {}, 'Neos.Neos', 'Main');
+
         return (
             <div className={style.nodeTypeDialogHeader__filter}>
-                <span className={style.nodeTypeFilter__label}>Filter:</span>
+                <Icon icon="filter" padded="right"/>
                 <TextInput
                     onChange={this.handleValueChange}
+                    placeholder={label}
                     />
             </div>
         );

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeFilter.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeFilter.js
@@ -1,0 +1,34 @@
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+import TextInput from '@neos-project/react-ui-components/src/TextInput/';
+import style from './style.css';
+
+class NodeTypeFilter extends PureComponent {
+    static propTypes = {
+        onChange: PropTypes.func.isRequired
+    };
+
+    constructor(props) {
+        super(props);
+
+        this.handleValueChange = this.handleValueChange.bind(this);
+    }
+
+    render() {
+        return (
+            <div className={style.nodeTypeDialogHeader__filter}>
+                <span className={style.nodeTypeFilter__label}>Filter:</span>
+                <TextInput
+                    onChange={this.handleValueChange}
+                    />
+            </div>
+        );
+    }
+
+    handleValueChange(filterSearchTerm) {
+        const {onChange} = this.props;
+        onChange(filterSearchTerm);
+    }
+}
+
+export default NodeTypeFilter;

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeFilter.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeFilter.js
@@ -1,4 +1,4 @@
-import React, {PureComponent} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import TextInput from '@neos-project/react-ui-components/src/TextInput/';
 import IconButton from '@neos-project/react-ui-components/src/IconButton/';
@@ -6,54 +6,40 @@ import Icon from '@neos-project/react-ui-components/src/Icon/';
 import {neos} from '@neos-project/neos-ui-decorators';
 import style from './style.css';
 
-@neos(globalRegistry => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}))
-class NodeTypeFilter extends PureComponent {
-    static propTypes = {
-        onChange: PropTypes.func.isRequired,
-        filterSearchTerm: PropTypes.string,
-        i18nRegistry: PropTypes.object.isRequired
+const NodeTypeFilter = ({onChange, filterSearchTerm, i18nRegistry}) => {
+    const handleResetFilter = () => {
+        onChange('');
     };
 
-    constructor(props) {
-        super(props);
-
-        this.handleValueChange = this.handleValueChange.bind(this);
-        this.handleResetFilter = this.handleResetFilter.bind(this);
-    }
-
-    render() {
-        const {i18nRegistry, filterSearchTerm} = this.props;
-        const label = i18nRegistry.translate('filter', 'Filter', {}, 'Neos.Neos', 'Main');
-
-        return (
-            <div className={style.nodeTypeDialogHeader__filter}>
-
-                {filterSearchTerm ? (
-                    <IconButton icon="close" onClick={this.handleResetFilter}/>
-                ) : (
-                    <Icon icon="filter" padded="right"/>
-                ) }
-
-                <TextInput
-                    value={filterSearchTerm}
-                    onChange={this.handleValueChange}
-                    placeholder={label}
-                    />
-            </div>
-        );
-    }
-
-    handleResetFilter() {
-        const {onChange} = this.props;
-        onChange('');
-    }
-
-    handleValueChange(filterSearchTerm) {
-        const {onChange} = this.props;
+    const handleValueChange = filterSearchTerm => {
         onChange(filterSearchTerm);
-    }
-}
+    };
 
-export default NodeTypeFilter;
+    const label = i18nRegistry.translate('filter', 'Filter', {}, 'Neos.Neos', 'Main');
+
+    return (
+        <div className={style.nodeTypeDialogHeader__filter}>
+            {filterSearchTerm ? (
+                <IconButton icon="close" onClick={handleResetFilter}/>
+            ) : (
+                <Icon icon="filter" padded="right"/>
+            ) }
+
+            <TextInput
+                value={filterSearchTerm}
+                onChange={handleValueChange}
+                placeholder={label}
+                />
+        </div>
+    );
+};
+
+NodeTypeFilter.propTypes = {
+    onChange: PropTypes.func.isRequired,
+    filterSearchTerm: PropTypes.string,
+    i18nRegistry: PropTypes.object.isRequired
+};
+
+export default neos(globalRegistry => ({
+    i18nRegistry: globalRegistry.get('i18n')
+}))(NodeTypeFilter);

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeFilter.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeFilter.js
@@ -1,6 +1,7 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import TextInput from '@neos-project/react-ui-components/src/TextInput/';
+import IconButton from '@neos-project/react-ui-components/src/IconButton/';
 import Icon from '@neos-project/react-ui-components/src/Icon/';
 import {neos} from '@neos-project/neos-ui-decorators';
 import style from './style.css';
@@ -11,6 +12,7 @@ import style from './style.css';
 class NodeTypeFilter extends PureComponent {
     static propTypes = {
         onChange: PropTypes.func.isRequired,
+        filterSearchTerm: PropTypes.string,
         i18nRegistry: PropTypes.object.isRequired
     };
 
@@ -18,21 +20,34 @@ class NodeTypeFilter extends PureComponent {
         super(props);
 
         this.handleValueChange = this.handleValueChange.bind(this);
+        this.handleResetFilter = this.handleResetFilter.bind(this);
     }
 
     render() {
-        const {i18nRegistry} = this.props;
+        const {i18nRegistry, filterSearchTerm} = this.props;
         const label = i18nRegistry.translate('filter', 'Filter', {}, 'Neos.Neos', 'Main');
 
         return (
             <div className={style.nodeTypeDialogHeader__filter}>
-                <Icon icon="filter" padded="right"/>
+
+                {filterSearchTerm ? (
+                    <IconButton icon="close" onClick={this.handleResetFilter}/>
+                ) : (
+                    <Icon icon="filter" padded="right"/>
+                ) }
+
                 <TextInput
+                    value={filterSearchTerm}
                     onChange={this.handleValueChange}
                     placeholder={label}
                     />
             </div>
         );
+    }
+
+    handleResetFilter() {
+        const {onChange} = this.props;
+        onChange('');
     }
 
     handleValueChange(filterSearchTerm) {

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeGroupPanel.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeGroupPanel.js
@@ -5,7 +5,7 @@ import {$transform, $get} from 'plow-js';
 import ToggablePanel from '@neos-project/react-ui-components/src/ToggablePanel/';
 import Grid from '@neos-project/react-ui-components/src/Grid/';
 import {neos} from '@neos-project/neos-ui-decorators';
-
+import escaperegexp from 'lodash.escaperegexp';
 import {actions} from '@neos-project/neos-ui-redux-store';
 
 import I18n from '@neos-project/neos-ui-i18n';
@@ -56,7 +56,7 @@ class NodeTypeGroupPanel extends PureComponent {
         const filteredNodeTypes = (nodeTypes || [])
             .filter(nodeType => {
                 const label = i18nRegistry.translate(nodeType.label, nodeType.label);
-                if (label.toLowerCase().search(filterSearchTerm.toLowerCase()) !== -1) {
+                if (label.toLowerCase().search(escaperegexp(filterSearchTerm.toLowerCase())) !== -1) {
                     return true;
                 }
                 return false;

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeGroupPanel.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeGroupPanel.js
@@ -4,6 +4,7 @@ import {connect} from 'react-redux';
 import {$transform, $get} from 'plow-js';
 import ToggablePanel from '@neos-project/react-ui-components/src/ToggablePanel/';
 import Grid from '@neos-project/react-ui-components/src/Grid/';
+import {neos} from '@neos-project/neos-ui-decorators';
 
 import {actions} from '@neos-project/neos-ui-redux-store';
 
@@ -12,6 +13,9 @@ import I18n from '@neos-project/neos-ui-i18n';
 import NodeTypeItem from './nodeTypeItem';
 import style from './style.css';
 
+@neos(globalRegistry => ({
+    i18nRegistry: globalRegistry.get('i18n')
+}))
 @connect($transform({
     collapsedGroups: $get('ui.addNodeModal.collapsedGroups')
 }), {
@@ -21,13 +25,16 @@ class NodeTypeGroupPanel extends PureComponent {
     static propTypes = {
         toggleNodeTypeGroup: PropTypes.func.isRequired,
         collapsedGroups: PropTypes.array.isRequired,
+        filterSearchTerm: PropTypes.string,
 
         group: PropTypes.shape({
             name: PropTypes.string.isRequired,
             label: PropTypes.string.isRequired,
             nodeTypes: PropTypes.array.isRequired
         }).isRequired,
-        onSelect: PropTypes.func.isRequired
+        onSelect: PropTypes.func.isRequired,
+
+        i18nRegistry: PropTypes.object.isRequired
     };
 
     constructor(props) {
@@ -40,9 +47,20 @@ class NodeTypeGroupPanel extends PureComponent {
         const {
             group,
             collapsedGroups,
-            onSelect
+            onSelect,
+            filterSearchTerm,
+            i18nRegistry
         } = this.props;
         const {name, label, nodeTypes} = group;
+
+        const filteredNodeTypes = (nodeTypes || [])
+            .filter(nodeType => {
+                const label = i18nRegistry.translate(nodeType.label, nodeType.label);
+                if (label.toLowerCase().search(filterSearchTerm.toLowerCase()) !== -1) {
+                    return true;
+                }
+                return false;
+            });
 
         return (
             <ToggablePanel
@@ -54,7 +72,7 @@ class NodeTypeGroupPanel extends PureComponent {
                 </ToggablePanel.Header>
                 <ToggablePanel.Contents className={style.groupContents}>
                     <Grid className={style.grid}>
-                        {nodeTypes.map((nodeType, key) => <NodeTypeItem nodeType={nodeType} key={key} onSelect={onSelect}/>)}
+                        {filteredNodeTypes.map((nodeType, key) => <NodeTypeItem nodeType={nodeType} key={key} onSelect={onSelect}/>)}
                     </Grid>
                 </ToggablePanel.Contents>
             </ToggablePanel>

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/style.css
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/style.css
@@ -35,11 +35,11 @@
 }
 
 .nodeTypeDialogHeader__filter {
-    margin-right: 40px;
+    margin-right: var(--goldenUnit);
     display: flex;
     align-items: center;
 }
 
 .nodeTypeFilter__label {
-    margin-right: 10px;
+    margin-right: var(--halfSpacing);
 }

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/style.css
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/style.css
@@ -28,3 +28,18 @@
 .gridItem {
     padding: 0;
 }
+
+.nodeTypeDialogHeader {
+    display: flex;
+    justify-content: space-between;
+}
+
+.nodeTypeDialogHeader__filter {
+    margin-right: 40px;
+    display: flex;
+    align-items: center;
+}
+
+.nodeTypeFilter__label {
+    margin-right: 10px;
+}

--- a/packages/react-ui-components/package.json
+++ b/packages/react-ui-components/package.json
@@ -36,6 +36,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.isfunction": "^3.0.8",
     "lodash.omit": "^4.3.0",
+    "lodash.escaperegexp": "^4.1.0",
     "moment": "^2.14.1",
     "object-assign": "^4.1.0",
     "prop-types": "^15.5.10",

--- a/packages/react-ui-components/package.json
+++ b/packages/react-ui-components/package.json
@@ -36,7 +36,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.isfunction": "^3.0.8",
     "lodash.omit": "^4.3.0",
-    "lodash.escaperegexp": "^4.1.0",
+    "lodash.escaperegexp": "^4.1.2",
     "moment": "^2.14.1",
     "object-assign": "^4.1.0",
     "prop-types": "^15.5.10",


### PR DESCRIPTION
If you have a lot of content nodetypes it can be complex to find the correct nodetype in our new node dialog. Therefore this change adds a possibility to filter nodetypes.