### PR TITLE
BUGFIX: Make e2e section helper function async

### DIFF
--- a/Classes/Neos/Neos/Ui/ContentRepository/Service/NodeService.php
+++ b/Classes/Neos/Neos/Ui/ContentRepository/Service/NodeService.php
@@ -6,6 +6,7 @@ use Neos\Error\Messages\Error;
 use Neos\Flow\Annotations as Flow;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\ContentRepository\Domain\Utility\NodePaths;
 use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 use Neos\Neos\Domain\Model\Site;
@@ -105,6 +106,21 @@ class NodeService
         }
 
         return $context->getNode($nodePath);
+    }
+
+    /**
+     * Checks if the given node exists in the given workspace
+     *
+     * @param NodeInterface $node
+     * @param Workspace $workspace
+     * @return boolean
+     */
+    public function nodeExistsInWorkspace(NodeInterface $node, Workspace $workspace)
+    {
+        $context = ['workspaceName' => $workspace->getName()];
+        $flowQuery = new FlowQuery([$node]);
+
+        return $flowQuery->context($context)->count() > 0;
     }
 
     /**

--- a/Classes/Neos/Neos/Ui/Controller/BackendServiceController.php
+++ b/Classes/Neos/Neos/Ui/Controller/BackendServiceController.php
@@ -206,12 +206,13 @@ class BackendServiceController extends ActionController
                         $reloadDocument = new ReloadDocument();
                         $this->feedbackCollection->add($reloadDocument);
                     }
-                } else {
-                    // The node could either be created, moved, or have properties changed
-                    // To not have to account for all that, just reload the document...
-                    $reloadDocument = new ReloadDocument();
-                    $this->feedbackCollection->add($reloadDocument);
+                } elseif (!$this->nodeService->nodeExistsInWorkspace($node, $node->getWorkSpace()->getBaseWorkspace())) {
+                    // If the node doesn't exist in the target workspace, tell the UI to remove it
+                    $removeNode = new RemoveNode();
+                    $removeNode->setNode($node);
+                    $this->feedbackCollection->add($removeNode);
                 }
+
                 $this->publishingService->discardNode($node);
             }
 

--- a/Tests/IntegrationTests/contentModule.js
+++ b/Tests/IntegrationTests/contentModule.js
@@ -3,9 +3,9 @@ import ReactSelector from 'testcafe-react-selectors';
 
 import Page from './pageModel';
 
-const section = (name, testFunc) => {
+const section = async (name, testFunc) => {
     console.log('\x1b[44m%s\x1b[0m', name);
-    testFunc();
+    await testFunc();
 };
 const subSection = name => console.log('\x1b[33m%s\x1b[0m', ' - ' + name);
 
@@ -29,7 +29,7 @@ fixture `Content Module`
     });
 
 test('All tests at once', async t => {
-    section('Discarding: create a document node and then discard it', async () => {
+    await section('Discarding: create a document node and then discard it', async () => {
         const pageTitleToCreate = 'DiscardTest';
         subSection('Create a document node');
         await t
@@ -56,7 +56,7 @@ test('All tests at once', async t => {
             .switchToMainWindow();
     });
 
-    section('Discarding: delete a document node and then discard deletion', async () => {
+    await section('Discarding: delete a document node and then discard deletion', async () => {
         const pageTitleToDelete = 'Try me';
         subSection('Navigate via the page tree');
         await t
@@ -77,7 +77,7 @@ test('All tests at once', async t => {
             .expect(page.treeNode.withText(pageTitleToDelete).exists).ok('Deleted node reappeared in the tree');
     });
 
-    section('Discarding: create a content node and then discard it', async () => {
+    await section('Discarding: create a content node and then discard it', async () => {
         const defaultHeadlineTitle = 'Enter headline here';
         subSection('Create a content node');
         await t
@@ -107,8 +107,7 @@ test('All tests at once', async t => {
             .switchToMainWindow();
     });
 
-
-    section('Discarding: delete a content node and then discard deletion', async () => {
+    await section('Discarding: delete a content node and then discard deletion', async () => {
         const headlineToDelete = 'Imagine this...';
         subSection('Delete this headline');
         await t
@@ -129,7 +128,7 @@ test('All tests at once', async t => {
             .switchToMainWindow();
     });
 
-    section('PageTree search and filter', async () => {
+    await section('PageTree search and filter', async () => {
         subSection('Search the page tree');
         const nodeTreeSearchInput = ReactSelector('NodeTreeSearchInput');
         const nodeTreeFilter = ReactSelector('NodeTreeFilter');
@@ -158,7 +157,7 @@ test('All tests at once', async t => {
             .expect(page.treeNode.withText('Try me').exists).ok('Top level "Try me" page should shown again');
     });
 
-    section('Can toggle sidebars', async () => {
+    await section('Can toggle sidebars', async () => {
         subSection('LeftSideBar');
         const leftSideBarToggler = ReactSelector('LeftSideBarToggler Button');
         const leftSideBar = ReactSelector('LeftSideBar');
@@ -180,7 +179,7 @@ test('All tests at once', async t => {
         .expect(rightSideBar.getReact(({props}) => props.isHidden)).eql(false);
     });
 
-    section('Can create a new page', async () => {
+    await section('Can create a new page', async () => {
         const newPageTitle = 'TestPage';
         const SelectNodeTypeModal = ReactSelector('SelectNodeType');
         await t
@@ -200,7 +199,7 @@ test('All tests at once', async t => {
             .switchToMainWindow();
     });
 
-    section('Can create content node from inside InlineUI', async () => {
+    await section('Can create content node from inside InlineUI', async () => {
         const headlineTitle = 'Helloworld!';
         await t
             .switchToIframe('[name="neos-content-main"]')

--- a/packages/neos-ui-redux-store/src/UI/PageTree/selectors.js
+++ b/packages/neos-ui-redux-store/src/UI/PageTree/selectors.js
@@ -1,6 +1,9 @@
 import {$get} from 'plow-js';
 import {createSelector} from 'reselect';
 
+import {siteNodeSelector} from '../../CR/Nodes/selectors';
+import {isNodeCollapsed} from '../../CR/Nodes/helpers';
+
 export const getFocused = $get('ui.pageTree.isFocused');
 export const getToggled = $get('ui.pageTree.toggled');
 export const getLoading = $get('ui.pageTree.loading');
@@ -13,4 +16,23 @@ export const getIsLoading = createSelector(
         getLoading
     ],
     list => Boolean(list.size)
+);
+
+export const getUncollapsed = createSelector(
+    [
+        getToggled,
+        $get('cr.nodes.byContextPath'),
+        siteNodeSelector,
+        (_, {loadingDepth = 0}) => loadingDepth
+    ],
+    (toggleTreeNodeContextPaths, nodesByContextPath, siteNode, loadingDepth) => {
+        return nodesByContextPath.filter(
+            node => !isNodeCollapsed(
+                node,
+                toggleTreeNodeContextPaths.includes($get('contextPath', node)),
+                siteNode,
+                loadingDepth
+            )
+        ).map($get('contextPath')).toArray();
+    }
 );

--- a/packages/neos-ui-redux-store/src/UI/PageTree/selectors.js
+++ b/packages/neos-ui-redux-store/src/UI/PageTree/selectors.js
@@ -1,4 +1,4 @@
-import {$get, $count} from 'plow-js';
+import {$get} from 'plow-js';
 import {createSelector} from 'reselect';
 
 import {siteNodeSelector} from '../../CR/Nodes/selectors';

--- a/packages/neos-ui-redux-store/src/UI/PageTree/selectors.js
+++ b/packages/neos-ui-redux-store/src/UI/PageTree/selectors.js
@@ -1,4 +1,4 @@
-import {$get} from 'plow-js';
+import {$get, $count} from 'plow-js';
 import {createSelector} from 'reselect';
 
 import {siteNodeSelector} from '../../CR/Nodes/selectors';

--- a/packages/neos-ui-redux-store/src/UI/PageTree/selectors.spec.js
+++ b/packages/neos-ui-redux-store/src/UI/PageTree/selectors.spec.js
@@ -1,0 +1,58 @@
+import Immutable from 'immutable';
+import {$all, $set} from 'plow-js';
+
+import {getUncollapsed} from './selectors';
+
+test('getUncollapsed should return the context paths of manually toggled nodes', () => {
+    const state = Immutable.fromJS($all(
+        $set('cr.nodes.siteNode', '/sites/site@some-user'),
+        $set('cr.nodes.byContextPath', {
+            '/sites/site@some-user': {contextPath: '/sites/site@some-user', depth: 1},
+            '/sites/site/context-path-1@some-user': {contextPath: '/sites/site/context-path-1@some-user', depth: 2},
+            '/sites/site/context-path-2@some-user': {contextPath: '/sites/site/context-path-2@some-user', depth: 2},
+            '/sites/site/context-path-3@some-user': {contextPath: '/sites/site/context-path-3@some-user', depth: 2}
+        }),
+        $set('ui.pageTree.toggled', [
+            '/sites/site/context-path-1@some-user',
+            '/sites/site/context-path-2@some-user'
+        ]),
+        {}
+    ));
+
+    const result = getUncollapsed(state, {loadingDepth: 1});
+
+    expect(result.includes('/sites/site/context-path-1@some-user')).toBe(true);
+    expect(result.includes('/sites/site/context-path-2@some-user')).toBe(true);
+    expect(result.includes('/sites/site/context-path-3@some-user')).toBe(false);
+});
+
+test('getUncollapsed should return the context paths of nodes within the loading depth that have not been toggled', () => {
+    const state = Immutable.fromJS($all(
+        $set('cr.nodes.siteNode', '/sites/site@some-user'),
+        $set('cr.nodes.byContextPath', {
+            '/sites/site@some-user': {contextPath: '/sites/site@some-user', depth: 1},
+            '/sites/site/context-path-1@some-user': {contextPath: '/sites/site/context-path-1@some-user', depth: 2},
+            '/sites/site/context-path-2@some-user': {contextPath: '/sites/site/context-path-2@some-user', depth: 2},
+            '/sites/site/context-path-3@some-user': {contextPath: '/sites/site/context-path-3@some-user', depth: 2},
+            '/sites/site/deeper/context-path-1@some-user': {contextPath: '/sites/site/deeper/context-path-1@some-user', depth: 3},
+            '/sites/site/deeper/context-path-2@some-user': {contextPath: '/sites/site/deeper/context-path-2@some-user', depth: 3}
+        }),
+        $set('ui.pageTree.toggled', [
+            // should be collapsed
+            '/sites/site/context-path-1@some-user',
+            '/sites/site/context-path-2@some-user',
+
+            // should be uncollapsed
+            '/sites/site/deeper/context-path-2@some-user'
+        ]),
+        {}
+    ));
+
+    const result = getUncollapsed(state, {loadingDepth: 2});
+
+    expect(result.includes('/sites/site/context-path-1@some-user')).toBe(false);
+    expect(result.includes('/sites/site/context-path-2@some-user')).toBe(false);
+
+    expect(result.includes('/sites/site/context-path-3@some-user')).toBe(true);
+    expect(result.includes('/sites/site/deeper/context-path-2@some-user')).toBe(true);
+});

--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -204,12 +204,19 @@ manifest('main', {}, globalRegistry => {
     // When the server advices to reload the document, just reload it
     //
     serverFeedbackHandlers.add('Neos.Neos.Ui:ReloadDocument', (feedbackPayload, {store}) => {
+        const currentPreviewUrl = $get('ui.contentCanvas.previewUrl', store.getState());
+
         [].slice.call(document.querySelectorAll(`iframe[name=neos-content-main]`)).forEach(iframe => {
             const iframeWindow = iframe.contentWindow || iframe;
 
-            iframeWindow.location.href = iframeWindow.location.href;
+            //
+            // Make sure href is still consistent before reloading - if not, some other process
+            // might be already handling this
+            //
+            if (iframeWindow.location.href === currentPreviewUrl) {
+                iframeWindow.location.href = iframeWindow.location.href;
+            }
         });
-        store.dispatch(actions.UI.PageTree.reloadTree());
     });
 
     //


### PR DESCRIPTION
I recognized that the e2e-Tests are currently false-positive. All of the test-scenarios run through immediately without executing any assertions, because the `section` function itself is not asynchronous.

I fixed that and immediately found this one thanks to the tests: #999

**Update**

This now includes a fix for #999, so that the e2e tests should be green now.

Fixes: #999