### PR TITLE
BUGFIX: Simulate click after placeholder removal (CKEditor)

### DIFF
--- a/packages/neos-ui-ckeditor-bindings/src/ckeditor/neosPlaceholder.js
+++ b/packages/neos-ui-ckeditor-bindings/src/ckeditor/neosPlaceholder.js
@@ -70,6 +70,7 @@ export default CKEDITOR => {
                 const range = editor.createRange();
                 range.moveToElementEditablePosition(editable.getFirst(), true);
                 editor.getSelection().selectRanges([range]);
+                editor.editable().$.click();
             } else {
                 // if we are inside an inline editable (e.g. a span), we have to set the selection
                 // *using a timeout*, otherwise it won't be selected in Firefox and Chrome.
@@ -79,6 +80,7 @@ export default CKEDITOR => {
                     const range = editor.createRange();
                     range.moveToElementEditablePosition(editable.getFirst(), true);
                     editor.getSelection().selectRanges([range]);
+                    editor.editable().$.click();
                 }, 5);
             }
         }


### PR DESCRIPTION
This is a workaround for the focus issue that occurs, if you click on an empty inline editable.

Since it is unclear at which point the event propagation is stopped (looks like CK internals), I just simulate another click on the editable element after the neosPlaceholder is removed.

Fixes: #940