### PR TITLE
FEATURE: Enable alignment options for CKEditor

### DIFF
--- a/packages/neos-ui-ckeditor-bindings/src/manifest.formattingRules.js
+++ b/packages/neos-ui-ckeditor-bindings/src/manifest.formattingRules.js
@@ -177,6 +177,34 @@ export default ckEditorRegistry => {
     });
 
     /**
+     * Alignment
+     */
+
+    // left
+    formattingRules.add('left', {
+        command: 'justifyleft',
+        config: formattingRules.config.add('JustifyLeft')
+    });
+
+    // center
+    formattingRules.add('center', {
+        command: 'justifycenter',
+        config: formattingRules.config.add('JustifyCenter')
+    });
+
+    // right
+    formattingRules.add('right', {
+        command: 'justifyright',
+        config: formattingRules.config.add('JustifyRight')
+    });
+
+    // justify
+    formattingRules.add('justify', {
+        command: 'justifyblock',
+        config: formattingRules.config.add('JustifyBlock')
+    });
+
+    /**
      * Tables
      */
     formattingRules.add('table', {

--- a/packages/neos-ui-ckeditor-bindings/src/manifest.richtextToolbar.js
+++ b/packages/neos-ui-ckeditor-bindings/src/manifest.richtextToolbar.js
@@ -231,6 +231,45 @@ export default (ckEditorRegistry, nodeTypesRegistry) => {
     });
 
     /**
+     * Alignment
+     */
+    richtextToolbar.add('alignleft', {
+        formattingRule: 'left',
+        component: IconButtonComponent,
+        callbackPropName: 'onClick',
+
+        icon: 'align-left',
+        hoverStyle: 'brand'
+    });
+
+    richtextToolbar.add('aligncenter', {
+        formattingRule: 'center',
+        component: IconButtonComponent,
+        callbackPropName: 'onClick',
+
+        icon: 'align-center',
+        hoverStyle: 'brand'
+    });
+
+    richtextToolbar.add('alignright', {
+        formattingRule: 'right',
+        component: IconButtonComponent,
+        callbackPropName: 'onClick',
+
+        icon: 'align-right',
+        hoverStyle: 'brand'
+    });
+
+    richtextToolbar.add('alignjustify', {
+        formattingRule: 'justify',
+        component: IconButtonComponent,
+        callbackPropName: 'onClick',
+
+        icon: 'align-justify',
+        hoverStyle: 'brand'
+    });
+
+    /**
      * Tables
      */
     richtextToolbar.add('table', {

--- a/packages/neos-ui-ckeditor-bindings/src/registry/RichTextToolbarRegistry.js
+++ b/packages/neos-ui-ckeditor-bindings/src/registry/RichTextToolbarRegistry.js
@@ -22,7 +22,7 @@ export default class RichTextToolbarRegistry extends SynchronousRegistry {
             .getInlineEditorOptionsForProperty(nodeTypeName, propertyName) || {};
 
         return [].concat(
-            ...['format', 'link', 'list', 'table']
+            ...['format', 'link', 'list', 'table', 'alignment']
                 .map(configurationKey => editorOptions[configurationKey])
                 .filter(i => i)
         ).filter(this.hasFormattingRule);

--- a/packages/neos-ui/src/Registry/RichTextToolbarRegistry.js
+++ b/packages/neos-ui/src/Registry/RichTextToolbarRegistry.js
@@ -15,7 +15,7 @@ export default class RichTextToolbarRegistry extends SynchronousRegistry {
 
     getEnabledFormattingRulesFromEditorOptions = memoize(
         editorOptions => [].concat(
-            ...['format', 'link', 'list', 'table']
+            ...['format', 'link', 'list', 'table', 'alignment']
                 .map(configurationKey => editorOptions[configurationKey])
                 .filter(i => i)
         ).filter(this.hasFormattingRule)


### PR DESCRIPTION
This enables the `left`, `right`, `center` and `justify` alignment options for CKEditor.

**Attention when testing:** I recognized that by default, none of the alignment options is enabled for Text nodes on the demo page - although the old UI is showing them anyway. So, when you're testing this with the Demo page, you have to explicitly enable the options via:

```yaml
  properties:
    text:
      ui:
        aloha:
          alignment:
            'left': TRUE
            'center': TRUE
            'right': TRUE
            'justify': TRUE
```

Resolves: #829