### PR TITLE
FEATURE: Make inline toolbar sticky while scrolling over large elements

### DIFF
--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
@@ -42,13 +42,31 @@ export default class NodeToolbar extends PureComponent {
         requestScrollIntoView: PropTypes.func.isRequired
     };
 
+    state = {
+        isSticky: false
+    };
+
     constructor() {
         super();
         this.iframeWindow = document.getElementsByName('neos-content-main')[0].contentWindow;
     }
 
+    updateStickyness = () => {
+        const nodeElement = findNodeInGuestFrame(this.props.contextPath, this.props.fusionPath);
+        if (nodeElement) {
+            const {isSticky} = this.state;
+            const {top, bottom} = nodeElement.getBoundingClientRect();
+            const shouldBeSticky = top < 50 && bottom > 0;
+
+            if (isSticky !== shouldBeSticky) {
+                this.setState({isSticky: shouldBeSticky});
+            }
+        }
+    };
+
     componentDidMount() {
         this.iframeWindow.addEventListener('resize', debounce(() => this.forceUpdate(), 20));
+        this.iframeWindow.addEventListener('scroll', debounce(this.updateStickyness, 5));
     }
 
     componentDidUpdate() {
@@ -57,6 +75,8 @@ export default class NodeToolbar extends PureComponent {
             this.scrollIntoView();
             this.props.requestScrollIntoView(false);
         }
+
+        this.updateStickyness();
     }
 
     scrollIntoView() {
@@ -93,8 +113,10 @@ export default class NodeToolbar extends PureComponent {
         const nodeElement = findNodeInGuestFrame(contextPath, fusionPath);
         const {top, right} = position(nodeElement);
 
+        const {isSticky} = this.state;
         const classNames = mergeClassNames({
-            [style.toolBar]: true
+            [style.toolBar]: true,
+            [style['toolBar--isSticky']]: isSticky
         });
 
         return (

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/style.css
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/style.css
@@ -24,6 +24,11 @@
     display: none;
 }
 
+.toolBar--isSticky {
+    position: fixed;
+    top: 0!important;
+}
+
 .toolBar--isBlurred {
     display: none;
 }


### PR DESCRIPTION
![screenshot_2017-09-24_17-20-23](https://user-images.githubusercontent.com/2522299/30783972-b6f7fdea-a14c-11e7-9bf2-9f5099fae36c.png)

Here's another nice-to-have feature. With this change, the inline toolbar becomes sticky, before it scrolls off-screen. This helps to improve usability if you have to deal with large content elements (like the Text Nodes in the Chapter documents on the demo page).