### PR TITLE
BUGFIX: Relogin Submit on Enter

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/ReloginDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/ReloginDialog/index.js
@@ -84,8 +84,22 @@ export default class ReloginDialog extends PureComponent {
                 isOpen
                 >
                 <div className={style.modalContents}>
-                    <TextInput className={style.inputField} value={this.state.username} placeholder={i18nRegistry.translate('Neos.Neos:Main:username', 'Username')} onChange={this.handleUsernameChange}/>
-                    <TextInput type="password" className={style.inputField} value={this.state.password} placeholder={i18nRegistry.translate('Neos.Neos:Main:password', 'Password')} onChange={this.handlePasswordChange}/>
+                    <TextInput
+                        className={style.inputField}
+                        value={this.state.username}
+                        placeholder={i18nRegistry.translate('Neos.Neos:Main:username', 'Username')}
+                        onChange={this.handleUsernameChange}
+                        onEnterKey={this.handleTryLogin}
+                        setFocus={true}
+                        />
+                    <TextInput
+                        type="password"
+                        className={style.inputField}
+                        value={this.state.password}
+                        placeholder={i18nRegistry.translate('Neos.Neos:Main:password', 'Password')}
+                        onChange={this.handlePasswordChange}
+                        onEnterKey={this.handleTryLogin}
+                        />
                     <Button
                         key="login"
                         style="brand"

--- a/packages/react-ui-components/src/TextInput/textInput.js
+++ b/packages/react-ui-components/src/TextInput/textInput.js
@@ -1,6 +1,7 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import mergeClassNames from 'classnames';
+import omit from 'lodash.omit';
 
 class TextInput extends PureComponent {
     static propTypes = {
@@ -50,6 +51,21 @@ class TextInput extends PureComponent {
         disabled: PropTypes.bool,
 
         /**
+         * This prob controls what function is triggered when the enter key is pressed
+         */
+        onEnterKey: PropTypes.func,
+
+        /**
+         * A prop of which type this input field is eg password
+         */
+        type: PropTypes.string,
+
+        /**
+         * Set the focus to this input element after mount
+         */
+        setFocus: PropTypes.bool,
+
+        /**
          * An optional css theme to be injected.
          */
         theme: PropTypes.shape({
@@ -68,6 +84,13 @@ class TextInput extends PureComponent {
         super(props);
 
         this.handleValueChange = this.handleValueChange.bind(this);
+        this.handleKeyPress = this.handleKeyPress.bind(this);
+    }
+
+    componentDidMount() {
+        if (this.props.setFocus) {
+            this.inputRef.focus();
+        }
     }
 
     render() {
@@ -80,8 +103,11 @@ class TextInput extends PureComponent {
             highlight,
             containerClassName,
             disabled,
-            ...rest
+            type,
+            ...restProps
         } = this.props;
+
+        const rest = omit(...restProps, ['onEnterKey']);
         const classNames = mergeClassNames({
             [className]: className && className.length,
             [theme.textInput]: true,
@@ -94,19 +120,35 @@ class TextInput extends PureComponent {
             return <div key={key}>{validationError}</div>;
         });
 
+        const inputRef = el => {
+            this.inputRef = el;
+        };
+
         return (
             <div className={containerClassName}>
                 <input
                     {...rest}
                     className={classNames}
                     role="textbox"
+                    type={type}
                     placeholder={placeholder}
                     disabled={disabled}
                     onChange={this.handleValueChange}
+                    onKeyPress={this.handleKeyPress}
+                    ref={inputRef}
                     />
                 {renderedErrors && <TooltipComponent>{renderedErrors}</TooltipComponent>}
             </div>
         );
+    }
+
+    handleKeyPress(e) {
+        const enterKeyCode = 13;
+        const keyCode = e.keyCode || e.which;
+        const {onEnterKey} = this.props;
+        if (keyCode === enterKeyCode) {
+            onEnterKey();
+        }
     }
 
     handleValueChange(e) {

--- a/packages/react-ui-components/src/TextInput/textInput.js
+++ b/packages/react-ui-components/src/TextInput/textInput.js
@@ -107,7 +107,7 @@ class TextInput extends PureComponent {
             ...restProps
         } = this.props;
 
-        const rest = omit(...restProps, ['onEnterKey']);
+        const rest = omit(restProps, ['onEnterKey', 'setFocus']);
         const classNames = mergeClassNames({
             [className]: className && className.length,
             [theme.textInput]: true,
@@ -146,7 +146,7 @@ class TextInput extends PureComponent {
         const enterKeyCode = 13;
         const keyCode = e.keyCode || e.which;
         const {onEnterKey} = this.props;
-        if (keyCode === enterKeyCode) {
+        if (keyCode === enterKeyCode && typeof onEnterKey === 'function') {
             onEnterKey();
         }
     }


### PR DESCRIPTION
This makes it possible to trigger submit via the enter key.
It also enables the textinput to receive 3 new props.
onEnterKey - which triggers a function when enter is pressed
type - like password
setFocus = to focus this input element when it is mounted.

I get a console warning: `Warning: Unknown prop `0` on <input> tag.` even I am omitting the `onEnterKey` prop. The warning is triggered from the searchinput. If anyone know why this happens please ping me.

fixes #1011