### PR TITLE
BUGFIX: Fix positioning of inline node toolbar

### DIFF
--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
@@ -2,9 +2,13 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import mergeClassNames from 'classnames';
 import debounce from 'lodash.debounce';
-import animate from 'amator';
 
-import {getGuestFrameBody, findNodeInGuestFrame} from '@neos-project/neos-ui-guest-frame/src/dom';
+import {
+    findNodeInGuestFrame,
+    getAbsolutePositionOfElementInGuestFrame,
+    isElementVisibleInGuestFrame,
+    animateScrollToElementInGuestFrame
+} from '@neos-project/neos-ui-guest-frame/src/dom';
 
 import {
     AddNode,
@@ -15,21 +19,6 @@ import {
     PasteClipBoardNode
 } from './Buttons/index';
 import style from './style.css';
-
-export const position = nodeElement => {
-    if (nodeElement && nodeElement.getBoundingClientRect) {
-        const bodyBounds = getGuestFrameBody().getBoundingClientRect();
-        const domBounds = nodeElement.getBoundingClientRect();
-
-        return {
-            top: domBounds.top - bodyBounds.top,
-            right: bodyBounds.right - domBounds.right,
-            bottom: bodyBounds.bottom - domBounds.bottom
-        };
-    }
-
-    return {top: 0, right: 0, bottom: 0};
-};
 
 export default class NodeToolbar extends PureComponent {
     static propTypes = {
@@ -60,22 +49,10 @@ export default class NodeToolbar extends PureComponent {
     }
 
     scrollIntoView() {
-        const iframeDocument = this.iframeWindow.document;
-        const currentScrollY = this.iframeWindow.scrollY || this.iframeWindow.pageYOffset || iframeDocument.body.scrollTop;
         const nodeElement = findNodeInGuestFrame(this.props.contextPath, this.props.fusionPath);
 
-        if (nodeElement) {
-            const nodeAbsolutePosition = position(nodeElement);
-            const nodeRelativePosition = nodeElement.getBoundingClientRect();
-            const offset = 100;
-            const elementIsNotInView = nodeRelativePosition.top < offset || nodeRelativePosition.bottom + offset > this.iframeWindow.innerHeight;
-            if (elementIsNotInView) {
-                const scrollY = nodeAbsolutePosition.top - offset;
-
-                animate({scrollY: currentScrollY}, {scrollY}, {
-                    step: ({scrollY}) => this.iframeWindow.scrollTo(0, scrollY)
-                });
-            }
+        if (nodeElement && !isElementVisibleInGuestFrame(nodeElement)) {
+            animateScrollToElementInGuestFrame(nodeElement, 100);
         }
     }
 
@@ -94,7 +71,7 @@ export default class NodeToolbar extends PureComponent {
         };
 
         const nodeElement = findNodeInGuestFrame(contextPath, fusionPath);
-        const {top, right} = position(nodeElement);
+        const {top, right} = getAbsolutePositionOfElementInGuestFrame(nodeElement);
 
         const classNames = mergeClassNames({
             [style.toolBar]: true


### PR DESCRIPTION
This also comes with an abstraction of the determination of guest frame elements' positioning, as well as an abstraction for the scroll animation to have all of it in a central place.

Fixes: #1017