### PR TITLE
TASK: Enable custom styles

### DIFF
--- a/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/Helpers/renderToolbarComponents.js
+++ b/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/Helpers/renderToolbarComponents.js
@@ -24,7 +24,11 @@ export default richtextToolbarRegistry => {
             .map((componentDefinition, index) => {
                 const {component, formattingRule, callbackPropName, ...props} = componentDefinition;
                 const restProps = omit(props, ['isVisibleWhen']);
-                const isActive = formattingRule && $get(formattingRule, formattingUnderCursor) === richtextToolbarRegistry.TRISTATE_ON;
+                const isActive = formattingRule && (
+                    $get(formattingRule, formattingUnderCursor) === true ||
+                    $get(formattingRule, formattingUnderCursor) === richtextToolbarRegistry.TRISTATE_ON
+                );
+
                 const finalProps = {
                     ...restProps,
                     formattingRule,

--- a/packages/neos-ui-ckeditor-bindings/src/registry/CkEditorFormattingRulesRegistry.js
+++ b/packages/neos-ui-ckeditor-bindings/src/registry/CkEditorFormattingRulesRegistry.js
@@ -54,6 +54,20 @@ export default class CkEditorFormattingRulesRegistry extends SynchronousRegistry
 
                     return config;
                 },
+
+            /**
+             * create a new `format_*` configuration key and add it to `format_tags`
+             * to enable custom styles
+             */
+            addCustomFormat: (name, styleDefinition) =>
+                config => {
+                    config[`format_${name}`] = styleDefinition;
+
+                    config = this.config.addToFormatTags(name)(config);
+
+                    return config;
+                },
+
             /**
              * adds the given "buttonName" to the list of enabled buttons, i.e. configuring ACF for them correctly
              */
@@ -78,9 +92,18 @@ export default class CkEditorFormattingRulesRegistry extends SynchronousRegistry
                     } else {
                         config.extraAllowedContent = extraExpression;
                     }
-
                     return config;
                 }
         };
+    }
+
+    /**
+     * Shorthand add* method to ease creation of custom styles
+     */
+    addCustomStyle(name, styleDefinition) {
+        this.add(name, {
+            config: this.config.addCustomFormat(name, styleDefinition),
+            style: styleDefinition
+        });
     }
 }


### PR DESCRIPTION
This fixes 2 problems that are currently preventing our CKEditor integration to allow custom style definitions.

1. When `formattingUnderCursor` for a custom formattingRule evaluates to `true`, the corresponding Element in the Toolbar is now considered active. Before this only applied for `TRISTATE_ON`, although `true` is a perfectly valid answer as well.

2. Defining styles like this:

```js
formattingRules.add('red', {
  style: {
     element: 'span',
     attributes: {
         style: 'color: red;'
     }
  }
});
```
appearently is not sufficient. It'll work, as long as the editor doesn't re-initialize. So at the next reload, the formatting is gone. The given methods to whitelist elements for ACF did not help. After a while of research, I stumbled upon this: https://stackoverflow.com/a/13194812 - and it works.

So, I included a helper method for the `CkEditorFormattingRulesRegistry`, to take care of the configuration.