### PR TITLE
BUGFIX: fix scrollIntoView in the trees

### DIFF
--- a/Classes/Neos/Neos/Ui/ContentRepository/Service/WorkspaceService.php
+++ b/Classes/Neos/Neos/Ui/ContentRepository/Service/WorkspaceService.php
@@ -56,7 +56,6 @@ class WorkspaceService
         $publishableNodes = $this->publishingService->getUnpublishedNodes($workspace);
 
         $publishableNodes = array_map(function ($node) {
-
             if ($documentNode = $this->nodeService->getClosestDocument($node)) {
                 return [
                     'contextPath' => $node->getContextPath(),

--- a/Classes/Neos/Neos/Ui/View/BackendFusionView.php
+++ b/Classes/Neos/Neos/Ui/View/BackendFusionView.php
@@ -10,7 +10,6 @@ use Neos\Fusion\View\FusionView;
 
 class BackendFusionView extends FusionView
 {
-
     public function __construct(array $options = array())
     {
         parent::__construct($options);

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -81,10 +81,12 @@ export default class Node extends PureComponent {
     }
 
     componentDidMount() {
-        // Always request scroll on first render
-        this.setState({
-            shouldScrollIntoView: true
-        });
+        // Always request scroll on first render if given node is focused
+        if (this.props.focusedNodeContextPath === $get('contextPath', this.props.node)) {
+            this.setState({
+                shouldScrollIntoView: true
+            });
+        }
     }
 
     componentWillReceiveProps(nextProps) {

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -116,7 +116,11 @@ export default class Node extends PureComponent {
                 const nodeIsNotInView = nodeTopPosition < scrollingElementPosition.top + offset || nodeTopPosition > scrollingElementPosition.bottom - offset;
                 if (nodeIsNotInView) {
                     const scrollTop = nodeTopPosition - scrollingElement.firstElementChild.getBoundingClientRect().top - offset;
-                    animate(scrollingElement, {scrollTop});
+                    animate({scrollTop: scrollingElement.scrollTop}, {scrollTop}, {
+                        step: ({scrollTop}) => {
+                            scrollingElement.scrollTop = scrollTop;
+                        }
+                    });
                 }
                 this.setState({
                     shouldScrollIntoView: false


### PR DESCRIPTION
Every node has been asked to be scrolled into view on initial render, which caused the page tree to scroll till the last node on first load.

Fixes: #1027 