### PR TITLE
BUGFIX: Disable drawer menu items that have no uri

### DIFF
--- a/packages/neos-ui/src/Containers/Drawer/MenuItem/index.js
+++ b/packages/neos-ui/src/Containers/Drawer/MenuItem/index.js
@@ -12,7 +12,7 @@ export default class MenuItem extends PureComponent {
     static propTypes = {
         icon: PropTypes.string,
         label: PropTypes.string.isRequired,
-        uri: PropTypes.string.isRequired,
+        uri: PropTypes.string,
         target: PropTypes.string,
         isActive: PropTypes.bool.isRequired,
         skipI18n: PropTypes.bool,
@@ -27,7 +27,7 @@ export default class MenuItem extends PureComponent {
     }
 
     render() {
-        const {skipI18n, label, icon} = this.props;
+        const {skipI18n, label, icon, uri} = this.props;
 
         return (
             <Button
@@ -35,6 +35,7 @@ export default class MenuItem extends PureComponent {
                 onClick={this.handleClick}
                 style="transparent"
                 hoverStyle="clean"
+                disabled={!uri}
                 >
                 {icon && <Icon icon={icon} size="medium" padded="right"/>}
                 {skipI18n ? label : <I18n id={label} fallback={label}/>}

--- a/packages/neos-ui/src/Containers/Drawer/MenuItemGroup/index.js
+++ b/packages/neos-ui/src/Containers/Drawer/MenuItemGroup/index.js
@@ -21,7 +21,7 @@ export default class MenuItemGroup extends PureComponent {
             PropTypes.shape({
                 icon: PropTypes.string,
                 label: PropTypes.string.isRequired,
-                uri: PropTypes.string.isRequired,
+                uri: PropTypes.string,
                 target: PropTypes.string,
                 isActive: PropTypes.bool.isReqired,
                 skipI18n: PropTypes.bool

--- a/packages/neos-ui/src/Containers/Drawer/index.js
+++ b/packages/neos-ui/src/Containers/Drawer/index.js
@@ -36,7 +36,7 @@ export default class Drawer extends PureComponent {
                     PropTypes.shape({
                         icon: PropTypes.string,
                         label: PropTypes.string.isRequired,
-                        uri: PropTypes.string.isRequired,
+                        uri: PropTypes.string,
                         target: PropTypes.string,
                         isActive: PropTypes.bool.isReqired,
                         skipI18n: PropTypes.bool.isReqired


### PR DESCRIPTION
Currently URIs  for menu items are required, but in some cases these can be `null`. The old UI would just disable the item in that case. 

This PR replicates that behavior.