### PR TITLE
TASK: Expose prop-types package via extensibility

### DIFF
--- a/packages/neos-ui-extensibility/scripts/helpers/webpack.config.js
+++ b/packages/neos-ui-extensibility/scripts/helpers/webpack.config.js
@@ -2,8 +2,7 @@ const sharedWebPackConfig = require('@neos-project/build-essentials/src/webpack.
 const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
-module.exports = function(neosPackageJson) {
-
+module.exports = function (neosPackageJson) {
     return Object.assign({}, sharedWebPackConfig, {
         module: {
             loaders: sharedWebPackConfig.module.loaders.map(loaderConfig => {
@@ -11,13 +10,13 @@ module.exports = function(neosPackageJson) {
                     loaderConfig.query = {
                         babelrc: false,
                         presets: [
-                            require.resolve("babel-preset-react"),
-                            require.resolve("babel-preset-es2015"),
-                            require.resolve("babel-preset-stage-0")
+                            require.resolve('babel-preset-react'),
+                            require.resolve('babel-preset-es2015'),
+                            require.resolve('babel-preset-stage-0')
                         ],
                         plugins: [
-                            require.resolve("babel-plugin-transform-decorators-legacy"),
-                            require.resolve("babel-plugin-transform-object-rest-spread")
+                            require.resolve('babel-plugin-transform-decorators-legacy'),
+                            require.resolve('babel-plugin-transform-object-rest-spread')
                         ]
                     };
                 }
@@ -48,6 +47,7 @@ module.exports = function(neosPackageJson) {
             alias: {
                 'react': '@neos-project/neos-ui-extensibility/src/shims/vendor/react/index',
                 'react-dom': '@neos-project/neos-ui-extensibility/src/shims/vendor/react-dom/index',
+                'prop-types': '@neos-project/neos-ui-extensibility/src/shims/vendor/prop-types/index',
                 'immutable': '@neos-project/neos-ui-extensibility/src/shims/vendor/immutable/index',
                 'plow-js': '@neos-project/neos-ui-extensibility/src/shims/vendor/plow-js/index',
                 'classnames': '@neos-project/neos-ui-extensibility/src/shims/vendor/classnames/index',

--- a/packages/neos-ui-extensibility/src/shims/vendor/prop-types/index.js
+++ b/packages/neos-ui-extensibility/src/shims/vendor/prop-types/index.js
@@ -1,0 +1,3 @@
+import readFromConsumerApi from '../../../readFromConsumerApi';
+
+module.exports = readFromConsumerApi('vendor')().PropTypes;

--- a/packages/neos-ui/src/apiExposureMap.js
+++ b/packages/neos-ui/src/apiExposureMap.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 import Immutable from 'immutable';
 import * as plow from 'plow-js';
 import classnames from 'classnames';
@@ -20,6 +21,7 @@ export default {
     '@vendor': () => ({
         React,
         ReactDOM,
+        PropTypes,
         Immutable,
         plow,
         classnames,


### PR DESCRIPTION
Since it has been split from the react main package and we've adopted the change, the prop-types package should be exposed as a shim via our extensibility package.