### PR TITLE
BUGFIX: focus editors on label click

### DIFF
--- a/packages/neos-ui-editors/src/DateTime/index.js
+++ b/packages/neos-ui-editors/src/DateTime/index.js
@@ -14,11 +14,13 @@ class DateTime extends PureComponent {
         commit: PropTypes.func.isRequired,
         highlight: PropTypes.bool,
         placeholder: PropTypes.string,
+        id: PropTypes.string,
         i18nRegistry: PropTypes.object
     }
 
     render() {
         const {
+            id,
             value,
             commit,
             placeholder,
@@ -33,6 +35,7 @@ class DateTime extends PureComponent {
 
         return (
             <DateInput
+                id={id}
                 value={mappedValue}
                 onChange={onChange}
                 highlight={highlight}

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -35,6 +35,7 @@ export default class EditorEnvelope extends PureComponent {
             return (
                 <EditorComponent
                     {...this.props}
+                    id={this.generateIdentifier()}
                     />
             );
         }

--- a/packages/neos-ui-editors/src/TextArea/index.js
+++ b/packages/neos-ui-editors/src/TextArea/index.js
@@ -9,11 +9,12 @@ const defaultOptions = {
 };
 
 const TextAreaEditor = props => {
-    const {value, commit, highlight, options} = props;
+    const {id, value, commit, highlight, options} = props;
 
     const finalOptions = Object.assign({}, defaultOptions, options);
 
     return (<TextArea
+        id={id}
         value={value}
         onChange={commit}
         highlight={highlight}
@@ -24,6 +25,7 @@ const TextAreaEditor = props => {
     );
 };
 TextAreaEditor.propTypes = {
+    id: PropTypes.string,
     value: PropTypes.string,
     highlight: PropTypes.bool,
     commit: PropTypes.func.isRequired,

--- a/packages/neos-ui-editors/src/TextField/index.js
+++ b/packages/neos-ui-editors/src/TextField/index.js
@@ -23,6 +23,7 @@ export default class TextField extends PureComponent {
         highlight: PropTypes.bool,
         options: PropTypes.object,
         onKeyPress: PropTypes.func,
+        id: PropTypes.string,
 
         i18nRegistry: PropTypes.object.isRequired
     };
@@ -32,13 +33,14 @@ export default class TextField extends PureComponent {
     };
 
     render() {
-        const {value, commit, validationErrors, options, i18nRegistry, highlight, onKeyPress} = this.props;
+        const {id, value, commit, validationErrors, options, i18nRegistry, highlight, onKeyPress} = this.props;
 
         // Placeholder text must be unescaped in case html entities were used
         const placeholder = options && options.placeholder && i18nRegistry.translate(unescape(options.placeholder));
         const finalOptions = Object.assign({}, defaultOptions, options);
 
         return (<TextInput
+            id={id}
             autoFocus={finalOptions.autoFocus}
             value={value}
             onChange={commit}

--- a/packages/react-ui-components/src/DateInput/dateInput.js
+++ b/packages/react-ui-components/src/DateInput/dateInput.js
@@ -17,6 +17,11 @@ export class DateInput extends PureComponent {
         placeholder: PropTypes.string,
 
         /**
+         * An optional id for the input.
+         */
+        id: PropTypes.string,
+
+        /**
          * The label which will be displayed within the `Select Today` btn.
          */
         todayLabel: PropTypes.string,
@@ -91,6 +96,7 @@ export class DateInput extends PureComponent {
             placeholder,
             theme,
             value,
+            id,
             applyLabel,
             todayLabel,
             labelFormat,
@@ -119,6 +125,7 @@ export class DateInput extends PureComponent {
                             className={theme.calendarFakeInputMirror}
                             />
                         <input
+                            id={id}
                             onFocus={this.handleInputClick}
                             type="datetime"
                             placeholder={placeholder}


### PR DESCRIPTION
Fixes: #1026 

Doesn't work with SelectBox-derived editors since they have no native input inside, but it never worked in the old ui either.