### PR TITLE
BUGFIX: Replace node state on dimension switch

### DIFF
--- a/Classes/Neos/Neos/Ui/FlowQueryOperations/NeosUiDefaultNodesOperation.php
+++ b/Classes/Neos/Neos/Ui/FlowQueryOperations/NeosUiDefaultNodesOperation.php
@@ -1,0 +1,83 @@
+<?php
+namespace Neos\Neos\Ui\FlowQueryOperations;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Eel\FlowQuery\FlowQuery;
+use Neos\Eel\FlowQuery\Operations\AbstractOperation;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+
+/**
+ * Renders nodes that are initially required by the user interface
+ */
+class NeosUiDefaultNodesOperation extends AbstractOperation
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @var string
+     */
+    protected static $shortName = 'neosUiDefaultNodes';
+
+    /**
+     * {@inheritdoc}
+     *
+     * @var integer
+     */
+    protected static $priority = 100;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param array (or array-like object) $context onto which this operation should be applied
+     * @return boolean TRUE if the operation can be applied onto the $context, FALSE otherwise
+     */
+    public function canEvaluate($context)
+    {
+        return isset($context[0]) && ($context[0] instanceof NodeInterface);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param FlowQuery $flowQuery the FlowQuery object
+     * @param array $arguments the arguments for this operation
+     * @return void
+     */
+    public function evaluate(FlowQuery $flowQuery, array $arguments)
+    {
+        list($site, $documentNode) = $flowQuery->getContext();
+        list($baseNodeType, $loadingDepth) = array_replace([
+            '',
+            0
+        ], $arguments);
+
+        $nodes = [];
+        if ($site !== $documentNode) {
+            $nodes[] = $site;
+        }
+
+        $gatherNodesRecursively = function (&$nodes, $baseNode, $level = 0) use (&$gatherNodesRecursively, $baseNodeType, $loadingDepth) {
+            if ($level < $loadingDepth || $loadingDepth === 0) {
+                foreach ($baseNode->getChildNodes($baseNodeType) as $childNode) {
+                    $nodes[] = $childNode;
+                    $gatherNodesRecursively($nodes, $childNode, $level + 1);
+                }
+            }
+        };
+        $gatherNodesRecursively($nodes, $site);
+
+        $nodes[] = $documentNode;
+
+        $flowQuery->setContext($nodes);
+    }
+}

--- a/packages/neos-ui-backend-connector/src/Endpoints/index.js
+++ b/packages/neos-ui-backend-connector/src/Endpoints/index.js
@@ -152,9 +152,13 @@ const parseGetSingleNodeResult = requestPromise => {
 
             const nodeFrontendUri = d.querySelector('.node-frontend-uri').getAttribute('href');
 
+            // TODO: Temporary hack due to missing contextPath in the API response
+            const nodeContextPath = `${d.querySelector('.node-path').innerHTML}@${nodeFrontendUri.split('@')[1]}`;
+
             return {
                 nodeFound: true,
-                nodeFrontendUri
+                nodeFrontendUri,
+                nodeContextPath
             };
         } else if (result.status === 404) {
             const nodeExistsInOtherDimensions = Boolean(result.headers.get('X-Neos-Node-Exists-In-Other-Dimensions'));

--- a/packages/neos-ui-backend-connector/src/FlowQuery/Operations/NeosUiDefaultNodes/index.js
+++ b/packages/neos-ui-backend-connector/src/FlowQuery/Operations/NeosUiDefaultNodes/index.js
@@ -1,0 +1,4 @@
+export default () => (baseNodeType, loadingDepth) => ({
+    type: 'neosUiDefaultNodes',
+    payload: [baseNodeType, loadingDepth]
+});

--- a/packages/neos-ui-backend-connector/src/FlowQuery/Operations/index.js
+++ b/packages/neos-ui-backend-connector/src/FlowQuery/Operations/index.js
@@ -1,5 +1,6 @@
 import children from './Children/index';
 import filter from './Filter/index';
+import neosUiDefaultNodes from './NeosUiDefaultNodes/index';
 import neosUiFilteredChildren from './NeosUiFilteredChildren/index';
 import find from './Find/index';
 import context from './Context/index';
@@ -10,6 +11,7 @@ import getForTreeWithParents from './GetForTreeWithParents/index';
 
 export {
     children,
+    neosUiDefaultNodes,
     neosUiFilteredChildren,
     filter,
     find,

--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.js
@@ -17,6 +17,7 @@ const COMMENCE_REMOVAL = '@neos/neos-ui/CR/Nodes/COMMENCE_REMOVAL';
 const REMOVAL_ABORTED = '@neos/neos-ui/CR/Nodes/REMOVAL_ABORTED';
 const REMOVAL_CONFIRMED = '@neos/neos-ui/CR/Nodes/REMOVAL_CONFIRMED';
 const REMOVE = '@neos/neos-ui/CR/Nodes/REMOVE';
+const REPLACE = '@neos/neos-ui/CR/Nodes/REPLACE';
 const COPY = '@neos/neos-ui/CR/Nodes/COPY';
 const CUT = '@neos/neos-ui/CR/Nodes/CUT';
 const MOVE = '@neos/neos-ui/CR/Nodes/MOVE';
@@ -38,6 +39,7 @@ export const actionTypes = {
     REMOVAL_ABORTED,
     REMOVAL_CONFIRMED,
     REMOVE,
+    REPLACE,
     COPY,
     CUT,
     MOVE,
@@ -113,6 +115,11 @@ const confirmRemoval = createAction(REMOVAL_CONFIRMED);
 const remove = createAction(REMOVE, contextPath => contextPath);
 
 /**
+ * Remove all nodes from the store
+ */
+const replace = createAction(REPLACE, ({siteNode, documentNode, nodes}) => ({siteNode, documentNode, nodes}));
+
+/**
  * Mark a node for copy on paste
  *
  * @param {String} contextPath The context path of the node to be copied
@@ -179,6 +186,7 @@ export const actions = {
     abortRemoval,
     confirmRemoval,
     remove,
+    replace,
     copy,
     cut,
     move,
@@ -279,6 +287,15 @@ export const reducer = handleActions({
     [REMOVAL_ABORTED]: () => $set('cr.nodes.toBeRemoved', ''),
     [REMOVAL_CONFIRMED]: () => $set('cr.nodes.toBeRemoved', ''),
     [REMOVE]: contextPath => $drop(['cr', 'nodes', 'byContextPath', contextPath]),
+    [REPLACE]: ({siteNode, documentNode, nodes}) => $all(
+        $set('cr.nodes.siteNode', siteNode),
+        $set('ui.contentCanvas.contextPath', documentNode),
+        $set('cr.nodes.focused', new Map({
+            contextPath: '',
+            fusionPath: ''
+        })),
+        $set('cr.nodes.byContextPath', Immutable.fromJS(nodes))
+    ),
     [COPY]: contextPath => $set('cr.nodes.clipboard', contextPath),
     [CUT]: contextPath => $set('cr.nodes.clipboard', contextPath),
     [PASTE]: () => $set('cr.nodes.clipboard', ''),

--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.js
@@ -17,7 +17,7 @@ const COMMENCE_REMOVAL = '@neos/neos-ui/CR/Nodes/COMMENCE_REMOVAL';
 const REMOVAL_ABORTED = '@neos/neos-ui/CR/Nodes/REMOVAL_ABORTED';
 const REMOVAL_CONFIRMED = '@neos/neos-ui/CR/Nodes/REMOVAL_CONFIRMED';
 const REMOVE = '@neos/neos-ui/CR/Nodes/REMOVE';
-const REPLACE = '@neos/neos-ui/CR/Nodes/REPLACE';
+const SWITCH_DIMENSION = '@neos/neos-ui/CR/Nodes/SWITCH_DIMENSION';
 const COPY = '@neos/neos-ui/CR/Nodes/COPY';
 const CUT = '@neos/neos-ui/CR/Nodes/CUT';
 const MOVE = '@neos/neos-ui/CR/Nodes/MOVE';
@@ -39,7 +39,7 @@ export const actionTypes = {
     REMOVAL_ABORTED,
     REMOVAL_CONFIRMED,
     REMOVE,
-    REPLACE,
+    SWITCH_DIMENSION,
     COPY,
     CUT,
     MOVE,
@@ -115,9 +115,16 @@ const confirmRemoval = createAction(REMOVAL_CONFIRMED);
 const remove = createAction(REMOVE, contextPath => contextPath);
 
 /**
- * Remove all nodes from the store
+ * Switch to new site- and documentNodes, add initial nodes for the new dimension
  */
-const replace = createAction(REPLACE, ({siteNode, documentNode, nodes}) => ({siteNode, documentNode, nodes}));
+const switchDimension = createAction(
+    SWITCH_DIMENSION,
+    ({siteNodeContextPath, documentNodeContextPath, nodes}) => ({
+        siteNodeContextPath,
+        documentNodeContextPath,
+        nodes
+    })
+);
 
 /**
  * Mark a node for copy on paste
@@ -186,7 +193,7 @@ export const actions = {
     abortRemoval,
     confirmRemoval,
     remove,
-    replace,
+    switchDimension,
     copy,
     cut,
     move,
@@ -287,14 +294,14 @@ export const reducer = handleActions({
     [REMOVAL_ABORTED]: () => $set('cr.nodes.toBeRemoved', ''),
     [REMOVAL_CONFIRMED]: () => $set('cr.nodes.toBeRemoved', ''),
     [REMOVE]: contextPath => $drop(['cr', 'nodes', 'byContextPath', contextPath]),
-    [REPLACE]: ({siteNode, documentNode, nodes}) => $all(
-        $set('cr.nodes.siteNode', siteNode),
-        $set('ui.contentCanvas.contextPath', documentNode),
+    [SWITCH_DIMENSION]: ({siteNodeContextPath, documentNodeContextPath, nodes}) => $all(
+        $set('cr.nodes.siteNode', siteNodeContextPath),
+        $set('ui.contentCanvas.contextPath', documentNodeContextPath),
         $set('cr.nodes.focused', new Map({
             contextPath: '',
             fusionPath: ''
         })),
-        $set('cr.nodes.byContextPath', Immutable.fromJS(nodes))
+        $merge('cr.nodes.byContextPath', Immutable.fromJS(nodes))
     ),
     [COPY]: contextPath => $set('cr.nodes.clipboard', contextPath),
     [CUT]: contextPath => $set('cr.nodes.clipboard', contextPath),

--- a/packages/neos-ui/src/Sagas/CR/ContentDimensions/index.js
+++ b/packages/neos-ui/src/Sagas/CR/ContentDimensions/index.js
@@ -87,7 +87,6 @@ function * ensureNodeInSelectedDimension({nodeIdentifier, sourceDimensions, targ
         return {nodeFrontendUri, nodeContextPath};
     }
 
-    console.log('Open NodeVariantCreationDialog');
     yield put(actions.UI.NodeVariantCreationDialog.open(numberOfNodesMissingOnRootline));
 
     const waitForNextAction = yield race([

--- a/packages/neos-ui/src/Sagas/CR/ContentDimensions/index.js
+++ b/packages/neos-ui/src/Sagas/CR/ContentDimensions/index.js
@@ -4,6 +4,16 @@ import {$get} from 'plow-js';
 import {actions, actionTypes, selectors} from '@neos-project/neos-ui-redux-store';
 import backend from '@neos-project/neos-ui-backend-connector';
 
+/**
+ * Watch for the user's request to change a dimension. And then:
+ *
+ * 1. Make sure, the current content canvas node exists in the target dimension
+ * by either loading it or offer the user a workflow to create it.
+ *
+ * 2. Load the node in the target dimension into the content canvas.
+ *
+ * 3. Load all default nodes needed for the tree
+ */
 function * watchSelectPreset({configuration}) {
     yield take(actionTypes.System.READY);
 
@@ -52,6 +62,10 @@ function * watchSelectPreset({configuration}) {
     }
 }
 
+/**
+ * Make sure, that the given nodeidentifier has a representation in the target dimension.
+ * If not: Ask the user to either create an empty node or to copy the given node.
+ */
 function * ensureNodeInSelectedDimension({nodeIdentifier, sourceDimensions, targetDimensions}) {
     const {
         getSingleNode,

--- a/packages/neos-ui/src/Sagas/CR/ContentDimensions/index.js
+++ b/packages/neos-ui/src/Sagas/CR/ContentDimensions/index.js
@@ -1,66 +1,99 @@
-import {takeLatest} from 'redux-saga';
-import {put, select, race, take} from 'redux-saga/effects';
+import {put, select, race, take, call} from 'redux-saga/effects';
 import {$get} from 'plow-js';
 
 import {actions, actionTypes, selectors} from '@neos-project/neos-ui-redux-store';
 import backend from '@neos-project/neos-ui-backend-connector';
-function * watchSelectPreset() {
-    // Only process the latest selection and cancel previous ones
-    yield * takeLatest(actionTypes.CR.ContentDimensions.SELECT_PRESET, updateContentCanvasSrc);
-}
-function * updateContentCanvasSrc(action) {
-    const previousPresetName = action.payload.previousPresetName;
-    const changedDimensionName = action.payload.name;
 
-    const activeDimensions = yield select(selectors.CR.ContentDimensions.active);
+function * watchSelectPreset({configuration}) {
+    yield take(actionTypes.System.READY);
+
+    let sourceDimensions = yield select(selectors.CR.ContentDimensions.active);
+
+    while (true) { // eslint-disable-line no-constant-condition
+        yield take(actionTypes.CR.ContentDimensions.SELECT_PRESET);
+        const targetDimensions = yield select(selectors.CR.ContentDimensions.active);
+        const currentContentCanvasNode = yield select(selectors.CR.Nodes.currentContentCanvasNodeSelector);
+        const currentContentCanvasNodeIdentifier = $get('identifier', currentContentCanvasNode);
+
+        const informationAboutNodeInTargetDimension = yield call(ensureNodeInSelectedDimension, {
+            nodeIdentifier: currentContentCanvasNodeIdentifier,
+            sourceDimensions,
+            targetDimensions
+        });
+
+        if (!informationAboutNodeInTargetDimension) {
+            yield put(actions.CR.ContentDimensions.setActive(sourceDimensions));
+            continue;
+        }
+
+        const {nodeFrontendUri, nodeContextPath} = informationAboutNodeInTargetDimension;
+
+        const {q} = backend.get();
+        const siteNode = yield select(selectors.CR.Nodes.siteNodeSelector);
+        const siteNodeContextPath = $get('contextPath', siteNode);
+        const targetSiteNodeContextPath = `${siteNodeContextPath.split('@')[0]}@${nodeContextPath.split('@')[1]}`;
+
+        const nodes = yield q([targetSiteNodeContextPath, nodeContextPath]).neosUiDefaultNodes(
+            configuration.nodeTree.presets.default.baseNodeType,
+            configuration.nodeTree.loadingDepth
+        ).get();
+
+        yield put(actions.CR.Nodes.replace({
+            siteNode: targetSiteNodeContextPath,
+            documentNode: nodeContextPath,
+            nodes: nodes.reduce((nodes, node) => {
+                nodes[node.contextPath] = node;
+                return nodes;
+            }, {})
+        }));
+        yield put(actions.UI.ContentCanvas.setSrc(nodeFrontendUri));
+
+        sourceDimensions = targetDimensions;
+    }
+}
+
+function * ensureNodeInSelectedDimension({nodeIdentifier, sourceDimensions, targetDimensions}) {
+    const {
+        getSingleNode,
+        adoptNodeToOtherDimension
+    } = backend.get().endpoints;
     const currentWorkspaceName = yield select($get('cr.workspaces.personalWorkspace.name'));
 
-    const currentContentCanvasNode = yield select(selectors.CR.Nodes.currentContentCanvasNodeSelector);
-    const currentContentCanvasNodeIdentifier = $get('identifier', currentContentCanvasNode);
-
-    const result = yield backend.get().endpoints.getSingleNode(currentContentCanvasNodeIdentifier, {
-        dimensions: activeDimensions.toJS(),
+    const {
+        nodeFound,
+        nodeFrontendUri,
+        nodeContextPath,
+        numberOfNodesMissingOnRootline
+    } = yield getSingleNode(nodeIdentifier, {
+        dimensions: targetDimensions.toJS(),
         workspaceName: currentWorkspaceName
     });
 
-    if (result.nodeFound) {
-        yield put(actions.UI.ContentCanvas.setSrc(result.nodeFrontendUri));
-    } else {
-        yield put(actions.UI.NodeVariantCreationDialog.open(result.numberOfNodesMissingOnRootline));
+    if (nodeFound) {
+        return {nodeFrontendUri, nodeContextPath};
+    }
 
-        const sourceDimensions = activeDimensions.toJS();
-        const dimensionsByName = yield select(selectors.CR.ContentDimensions.byName);
-        sourceDimensions[changedDimensionName] = $get([changedDimensionName, 'presets', previousPresetName, 'values'], dimensionsByName).toJS();
+    console.log('Open NodeVariantCreationDialog');
+    yield put(actions.UI.NodeVariantCreationDialog.open(numberOfNodesMissingOnRootline));
 
-        const waitForNextAction = yield race([
-            take(actionTypes.UI.NodeVariantCreationDialog.CANCEL),
-            take(actionTypes.UI.NodeVariantCreationDialog.CREATE_EMPTY),
-            take(actionTypes.UI.NodeVariantCreationDialog.CREATE_AND_COPY)
-        ]);
-        const nextAction = Object.values(waitForNextAction)[0];
+    const waitForNextAction = yield race([
+        take(actionTypes.UI.NodeVariantCreationDialog.CANCEL),
+        take(actionTypes.UI.NodeVariantCreationDialog.CREATE_EMPTY),
+        take(actionTypes.UI.NodeVariantCreationDialog.CREATE_AND_COPY)
+    ]);
+    const nextAction = Object.values(waitForNextAction)[0];
 
-        if (nextAction.type === actionTypes.UI.NodeVariantCreationDialog.CREATE_EMPTY) {
-            const result = yield backend.get().endpoints.adoptNodeToOtherDimension({
-                identifier: currentContentCanvasNodeIdentifier,
-                targetDimensions: activeDimensions.toJS(),
-                sourceDimensions,
-                workspaceName: currentWorkspaceName,
-                copyContent: false
-            });
-            yield put(actions.UI.ContentCanvas.setSrc(result.nodeFrontendUri));
-        } else if (nextAction.type === actionTypes.UI.NodeVariantCreationDialog.CREATE_AND_COPY) {
-            const result = yield backend.get().endpoints.adoptNodeToOtherDimension({
-                identifier: currentContentCanvasNodeIdentifier,
-                targetDimensions: activeDimensions.toJS(),
-                sourceDimensions,
-                workspaceName: currentWorkspaceName,
-                copyContent: true
-            });
-            yield put(actions.UI.ContentCanvas.setSrc(result.nodeFrontendUri));
-        } else if (nextAction.type === actionTypes.UI.NodeVariantCreationDialog.CANCEL) {
-            // Select old dimensions again if user cancelled
-            yield put(actions.CR.ContentDimensions.setActive(sourceDimensions));
-        }
+    if (nextAction.type !== actionTypes.UI.NodeVariantCreationDialog.CANCEL) {
+        const copyContent = nextAction.type === actionTypes.UI.NodeVariantCreationDialog.CREATE_AND_COPY;
+        const {nodeFrontendUri, nodeContextPath} = yield adoptNodeToOtherDimension({
+            identifier: nodeIdentifier,
+            workspaceName: currentWorkspaceName,
+            targetDimensions,
+            sourceDimensions,
+            copyContent
+        });
+
+        return {nodeFrontendUri, nodeContextPath};
     }
 }
 

--- a/packages/neos-ui/src/Sagas/CR/ContentDimensions/index.js
+++ b/packages/neos-ui/src/Sagas/CR/ContentDimensions/index.js
@@ -38,9 +38,9 @@ function * watchSelectPreset({configuration}) {
             configuration.nodeTree.loadingDepth
         ).get();
 
-        yield put(actions.CR.Nodes.replace({
-            siteNode: targetSiteNodeContextPath,
-            documentNode: nodeContextPath,
+        yield put(actions.CR.Nodes.switchDimension({
+            siteNodeContextPath: targetSiteNodeContextPath,
+            documentNodeContextPath: nodeContextPath,
             nodes: nodes.reduce((nodes, node) => {
                 nodes[node.contextPath] = node;
                 return nodes;

--- a/packages/neos-ui/src/Sagas/CR/ContentDimensions/index.js
+++ b/packages/neos-ui/src/Sagas/CR/ContentDimensions/index.js
@@ -33,6 +33,7 @@ function * watchSelectPreset({configuration}) {
         const siteNodeContextPath = $get('contextPath', siteNode);
         const targetSiteNodeContextPath = `${siteNodeContextPath.split('@')[0]}@${nodeContextPath.split('@')[1]}`;
 
+        yield put(actions.UI.ContentCanvas.setSrc(nodeFrontendUri));
         const nodes = yield q([targetSiteNodeContextPath, nodeContextPath]).neosUiDefaultNodes(
             configuration.nodeTree.presets.default.baseNodeType,
             configuration.nodeTree.loadingDepth
@@ -46,7 +47,6 @@ function * watchSelectPreset({configuration}) {
                 return nodes;
             }, {})
         }));
-        yield put(actions.UI.ContentCanvas.setSrc(nodeFrontendUri));
 
         sourceDimensions = targetDimensions;
     }


### PR DESCRIPTION
So, this is a larger change.

Basically what it does is:

* Creating a new FlowQuery operation that allows to load the default nodes for the backend
* Exposing that FlowQuery operation to the UI
* <s>Replace the entire node state, whenever a dimension is switched, before the content canvas loads the new document state.</s>
* Load all default nodes of the target dimension into the store

<s>This is still crazy slow, but at least it works.</s>
I was able to parallelize loading the default nodes and the guest frame. Now it feels quite fast.

Fixes: #1042 