### PR TITLE
FEATURE: Handle access to content canvas iframe

### DIFF
--- a/packages/neos-ui-redux-store/src/UI/ContentCanvas/index.js
+++ b/packages/neos-ui-redux-store/src/UI/ContentCanvas/index.js
@@ -17,6 +17,7 @@ const START_LOADING = '@neos/neos-ui/UI/ContentCanvas/START_LOADING';
 const STOP_LOADING = '@neos/neos-ui/UI/ContentCanvas/STOP_LOADING';
 const FOCUS_PROPERTY = '@neos/neos-ui/UI/ContentCanvas/FOCUS_PROPERTY';
 const REQUEST_SCROLL_INTO_VIEW = '@neos/neos-ui/UI/ContentCanvas/REQUEST_SCROLL_INTO_VIEW';
+const REQUEST_REGAIN_CONTROL = '@neos/neos-ui/UI/ContentCanvas/REQUEST_REGAIN_CONTROL';
 
 //
 // Export the action types
@@ -30,7 +31,8 @@ export const actionTypes = {
     START_LOADING,
     STOP_LOADING,
     FOCUS_PROPERTY,
-    REQUEST_SCROLL_INTO_VIEW
+    REQUEST_SCROLL_INTO_VIEW,
+    REQUEST_REGAIN_CONTROL
 };
 
 const setContextPath = createAction(SET_CONTEXT_PATH, (contextPath, siteNode = null) => ({contextPath, siteNode}));
@@ -42,6 +44,8 @@ const startLoading = createAction(START_LOADING);
 const stopLoading = createAction(STOP_LOADING);
 // Set a flag to tell ContentCanvas to scroll the focused node into view
 const requestScrollIntoView = createAction(REQUEST_SCROLL_INTO_VIEW, activate => activate);
+// If we have lost controll over the iframe, we need to take action
+const requestRegainControl = createAction(REQUEST_REGAIN_CONTROL, (src, errorMessage) => ({src, errorMessage}));
 
 //
 // Export the actions
@@ -54,7 +58,8 @@ export const actions = {
     setCurrentlyEditedPropertyName,
     startLoading,
     stopLoading,
-    requestScrollIntoView
+    requestScrollIntoView,
+    requestRegainControl
 };
 
 //
@@ -108,7 +113,8 @@ export const reducer = handleActions({
     [SET_CURRENTLY_EDITED_PROPERTY_NAME]: ({propertyName}) => $set('ui.contentCanvas.currentlyEditedPropertyName', propertyName),
     [STOP_LOADING]: () => $set('ui.contentCanvas.isLoading', false),
     [START_LOADING]: () => $set('ui.contentCanvas.isLoading', true),
-    [REQUEST_SCROLL_INTO_VIEW]: activate => $set('ui.contentCanvas.shouldScrollIntoView', activate)
+    [REQUEST_SCROLL_INTO_VIEW]: activate => $set('ui.contentCanvas.shouldScrollIntoView', activate),
+    [REQUEST_REGAIN_CONTROL]: () => $set('ui.contentCanvas.src', '')
 });
 
 //

--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -136,7 +136,6 @@ export default class ContentCanvas extends PureComponent {
 
     handleFrameAccess = iframe => {
         const {startLoading, requestRegainControl} = this.props;
-        const {isVisible} = this.state;
 
         try {
             if (iframe) {

--- a/packages/neos-ui/src/Containers/ContentCanvas/style.css
+++ b/packages/neos-ui/src/Containers/ContentCanvas/style.css
@@ -1,4 +1,5 @@
 .contentCanvas {
+    position: relative;
     float: left;
     height: 100%;
     width: 100%;
@@ -6,6 +7,11 @@
     transition: .2s ease padding;
     will-change: padding;
     background-color: var(--brandColorsContrastDarker);
+
+    &::after {
+        content: '';
+        position: absolute;
+    }
 }
 .contentCanvas--isFringeLeft {
     padding-left: 0;
@@ -18,6 +24,15 @@
 }
 .contentCanvas--isFullScreen {
     padding: 0;
+}
+.contentCanvas--isHidden {
+    &::after {
+        top: 0;
+        left: 0;
+        bottom: 0;
+        right: 0;
+        background-color: white;
+    }
 }
 .contentCanvas__itemWrapper {
     width: 100%;

--- a/packages/neos-ui/src/Sagas/UI/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Sagas/UI/ContentCanvas/index.js
@@ -1,5 +1,5 @@
-import {takeLatest} from 'redux-saga';
-import {put, select} from 'redux-saga/effects';
+import {takeLatest, delay} from 'redux-saga';
+import {put, select, take, race} from 'redux-saga/effects';
 import {$get} from 'plow-js';
 import {getGuestFrameDocument} from '@neos-project/neos-ui-guest-frame/src/dom';
 
@@ -47,9 +47,33 @@ function * watchStopLoading({globalRegistry, store}) {
     );
 }
 
+function * watchControlOverIFrame() {
+    yield take(actionTypes.System.READY);
+
+    while (true) { //eslint-disable-line
+        const src = yield select($get('ui.contentCanvas.src'));
+        const waitForNextAction = yield race([
+            take(actionTypes.UI.ContentCanvas.SET_SRC),
+            take(actionTypes.UI.ContentCanvas.REQUEST_REGAIN_CONTROL)
+        ]);
+        const nextAction = Object.keys(waitForNextAction).map(k => waitForNextAction[k])[0];
+
+        if (nextAction.type === actionTypes.UI.ContentCanvas.REQUEST_REGAIN_CONTROL) {
+            yield put(actions.UI.FlashMessages.add('iframe access', nextAction.payload.errorMessage, 'error', 5000));
+
+            //
+            // We need to delay, so that the iframe gets cleared before we load a new src
+            //
+            yield delay(0);
+            yield put(actions.UI.ContentCanvas.setSrc(nextAction.payload.src || src));
+        }
+    }
+}
+
 export const sagas = [
     watchNodeCreate,
     watchNodeCreated,
     watchCanvasUpdateToChangeTitle,
-    watchStopLoading
+    watchStopLoading,
+    watchControlOverIFrame
 ];

--- a/packages/react-ui-components/src/Frame/frame.js
+++ b/packages/react-ui-components/src/Frame/frame.js
@@ -7,21 +7,34 @@ export default class Frame extends PureComponent {
     static propTypes = {
         mountTarget: PropTypes.string.isRequired,
         contentDidUpdate: PropTypes.func.isRequired,
+        onLoad: PropTypes.func,
         children: PropTypes.node
     };
+
+    handleReference = ref => {
+        this.ref = ref;
+    }
 
     render() {
         const rest = omit(this.props, [
             'mountTarget',
             'contentDidUpdate',
             'theme',
-            'children'
+            'children',
+            'onLoad'
         ]);
 
-        return <iframe {...rest}/>;
+        return <iframe ref={this.handleReference} onLoad={this.handleLoad} {...rest}/>;
     }
     componentWillMount() {
         document.addEventListener('Neos.Neos.Ui.ContentReady', this.renderFrameContents);
+    }
+    handleLoad = () => {
+        const {onLoad} = this.props;
+
+        if (typeof onLoad === 'function') {
+            onLoad(this.ref);
+        }
     }
     renderFrameContents = () => {
         const doc = ReactDOM.findDOMNode(this).contentDocument; // eslint-disable-line react/no-find-dom-node


### PR DESCRIPTION
As described in #811 it is currently possible, that our UI loses access to the content canvas iframe, when its location changes to some external URI.

This change prevents this scenario, by testing the access to the frame after it has been loaded and, if it fails, seamlessly reloading the previous page and printing an error message that informs the user, that his/her navigation attempt failed.

To the user, this looks like this:
![peek 2017-09-29 16-25](https://user-images.githubusercontent.com/2522299/31020322-f4c17d1a-a532-11e7-92cd-6c963f42b087.gif)
