### PR TITLE
!!! BUGFIX: Do not flush the full content cache when switching UIs

### DIFF
--- a/Classes/Neos/Neos/Ui/Aspects/BackendRedirectionServiceAspect.php
+++ b/Classes/Neos/Neos/Ui/Aspects/BackendRedirectionServiceAspect.php
@@ -10,7 +10,6 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Aop\JoinPointInterface;
 use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\Flow\Session\SessionInterface;
-use Neos\Fusion\Core\Cache\ContentCache;
 use Neos\Neos\Service\UserService;
 
 /**
@@ -32,12 +31,6 @@ class BackendRedirectionServiceAspect
      * @var SessionInterface
      */
     protected $session;
-
-    /**
-     * @Flow\Inject
-     * @var ContentCache
-     */
-    protected $contentCache;
 
     /**
      * @Flow\Around("method(Neos\Neos\Service\BackendRedirectionService->getAfterLoginRedirectionUri())")

--- a/Classes/Neos/Neos/Ui/Cache/ContentCacheStringFrontend.php
+++ b/Classes/Neos/Neos/Ui/Cache/ContentCacheStringFrontend.php
@@ -23,6 +23,8 @@ use Neos\Flow\Session\SessionInterface;
  *
  * Class ContentCacheStringFrontend
  * @package Neos\Neos\Ui\Cache
+ * @internal
+ * @deprecated - get rid as soon as the old UI is no longer delivered with Neos.
  */
 class ContentCacheStringFrontend extends StringFrontend
 {
@@ -66,5 +68,4 @@ class ContentCacheStringFrontend extends StringFrontend
 
         return $entryIdentifier;
     }
-
 }

--- a/Classes/Neos/Neos/Ui/Cache/ContentCacheStringFrontend.php
+++ b/Classes/Neos/Neos/Ui/Cache/ContentCacheStringFrontend.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Neos\Neos\Ui\Cache;
+
+/*                                                                        *
+ * This script belongs to the Neos Flow package "Neos.Neos.Ui".           *
+ *                                                                        *
+ *                                                                        */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Cache\Frontend\StringFrontend;
+use Neos\Flow\Session\SessionInterface;
+
+/**
+ * When logged into the backend, the old and new UI have different rendering behavior - the old UI renders
+ * the node metadata in a different way than the new UI. That's why we cannot let the new UI run on cached
+ * segments which were generated on the old UI (happens when switching between old and new UI), and vice versa.
+ *
+ * This class prepends the cache entries with "neos-ui" if we are in the new UI, to prevent clashes.
+ *
+ * NOTE: Cache flushing still works properly in *both* UIs (when modifying content), because tags are not
+ * touched or namespaced at all.
+ *
+ * Class ContentCacheStringFrontend
+ * @package Neos\Neos\Ui\Cache
+ */
+class ContentCacheStringFrontend extends StringFrontend
+{
+
+    /**
+     * @Flow\Inject
+     * @var SessionInterface
+     */
+    protected $session;
+
+    public function set($entryIdentifier, $string, array $tags = [], $lifetime = null)
+    {
+        $entryIdentifier = $this->preprocessEntryIdentifier($entryIdentifier);
+        parent::set($entryIdentifier, $string, $tags, $lifetime);
+    }
+
+    public function get($entryIdentifier)
+    {
+        $entryIdentifier = $this->preprocessEntryIdentifier($entryIdentifier);
+        return parent::get($entryIdentifier);
+    }
+
+    public function has($entryIdentifier): bool
+    {
+        $entryIdentifier = $this->preprocessEntryIdentifier($entryIdentifier);
+        return parent::has($entryIdentifier);
+    }
+
+    public function remove($entryIdentifier): bool
+    {
+        $entryIdentifier = $this->preprocessEntryIdentifier($entryIdentifier);
+        return parent::remove($entryIdentifier);
+    }
+
+    protected function preprocessEntryIdentifier($entryIdentifier)
+    {
+        // It might be we do not have a session yet; that's why we are extremely conservative in this check here.
+        if ($this->session !== null && $this->session->isStarted() && $this->session->getData('__neosEnabled__')) {
+            return 'neos-ui-' . $entryIdentifier;
+        }
+
+        return $entryIdentifier;
+    }
+
+}

--- a/Classes/Neos/Neos/Ui/Controller/BackendController.php
+++ b/Classes/Neos/Neos/Ui/Controller/BackendController.php
@@ -17,10 +17,7 @@ use Neos\Neos\Domain\Repository\DomainRepository;
 use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Domain\Service\ContentContext;
 use Neos\Neos\Service\UserService;
-use Neos\Neos\Service\NodeTypeSchemaBuilder;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
-use Neos\Flow\I18n\Locale;
-use Neos\Fusion\Core\Cache\ContentCache;
 use Neos\Fusion\View\FusionView;
 use Neos\Flow\Mvc\View\ViewInterface;
 use Neos\Neos\Ui\Domain\Service\StyleAndJavascriptInclusionService;
@@ -82,12 +79,6 @@ class BackendController extends ActionController
 
     /**
      * @Flow\Inject
-     * @var ContentCache
-     */
-    protected $contentCache;
-
-    /**
-     * @Flow\Inject
      * @var MenuHelper
      */
     protected $menuHelper;
@@ -111,7 +102,6 @@ class BackendController extends ActionController
      */
     public function indexAction(NodeInterface $node = null)
     {
-        $this->contentCache->flush();
         $this->session->start();
         $this->session->putData('__neosEnabled__', true);
 
@@ -149,7 +139,6 @@ class BackendController extends ActionController
      */
     public function deactivateAction()
     {
-        $this->contentCache->flush();
         $this->session->start();
         $this->session->putData('__neosEnabled__', false);
 

--- a/Configuration/Caches.yaml
+++ b/Configuration/Caches.yaml
@@ -1,0 +1,2 @@
+Neos_Fusion_Content:
+  frontend: Neos\Neos\Ui\Cache\ContentCacheStringFrontend


### PR DESCRIPTION
When logged into the backend, the old and new UI have different rendering
behavior - the old UI renders the node metadata in a different way than
the new UI. That's why we cannot let the new UI run on cached segments
which were generated on the old UI (happens when switching between old
and new UI), and vice versa.

We now prepend the content cache entries with "neos-ui" if we are in the
new UI, to prevent clashes.

NOTE: Cache flushing still works properly in *both* UIs (when modifying 
content), because tags are not touched or namespaced at all.