### PR TITLE
BUGFIX: override children in merge action, instead of deep merging

### DIFF
--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.js
@@ -283,7 +283,18 @@ export const reducer = handleActions({
                 //
                 JSON.parse(JSON.stringify(nodeMap[contextPath]))
             )
-        ))
+        )),
+        ...Object.keys(nodeMap).map(contextPath => $set(
+            ['cr', 'nodes', 'byContextPath', contextPath, 'children'],
+            Immutable.fromJS(
+                //
+                // the data is passed from *the guest iFrame*. Because of this, at least in Chrome, Immutable.fromJS() does not do anything;
+                // as the object has a different prototype than the default "Object". For this reason, we need to JSON-encode-and-decode
+                // the data, to scope it relative to *this* frame.
+                //
+                JSON.parse(JSON.stringify(nodeMap[contextPath].children))
+            )
+        )),
     ),
     [FOCUS]: ({contextPath, fusionPath}) => $set('cr.nodes.focused', new Map({contextPath, fusionPath})),
     [UNFOCUS]: () => $set('cr.nodes.focused', new Map({


### PR DESCRIPTION
Imagine what happens when children would change from these:
```
[0: {contextPath: 'a'}, 1: {contextPath: 'b'}, 2: {contextPath: 'c'}]
```
Into these:
```
[0: {contextPath: 'a'}, 2: {contextPath: 'c'}]
```
Currently our deep merge would just merge them like this:
```
[0: {contextPath: 'a'}, 1: {contextPath: 'c'}, 2: {contextPath: 'c'}]
```
Which causes a duplicate child, and React would complain about it.

Even better solution would be to create a new kind of deep $merge, that
would only deep merge objects, but override the arrays. But I'm scared to touch @grebaldi's Plow and just need to fix the tests right now.