### PR TITLE
BUGFIX: misc cut/paste logic fixes

### DIFF
--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/CopySelectedNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/CopySelectedNode/index.js
@@ -14,6 +14,7 @@ export default class CopySelectedNode extends PureComponent {
         className: PropTypes.string,
         contextPath: PropTypes.string,
         destructiveOperationsAreDisabled: PropTypes.bool.isRequired,
+        isActive: PropTypes.bool.isRequired,
         copyNode: PropTypes.func.isRequired
     };
 
@@ -24,12 +25,13 @@ export default class CopySelectedNode extends PureComponent {
     }
 
     render() {
-        const {destructiveOperationsAreDisabled, className} = this.props;
+        const {destructiveOperationsAreDisabled, className, isActive} = this.props;
 
         return (
             <IconButton
                 className={className}
                 isDisabled={destructiveOperationsAreDisabled}
+                isActive={isActive}
                 onClick={this.handleCopySelectedNodeClick}
                 icon="copy"
                 hoverStyle="clean"

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/CutSelectedNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/CutSelectedNode/index.js
@@ -14,6 +14,7 @@ export default class CutSelectedNode extends PureComponent {
         className: PropTypes.string,
         contextPath: PropTypes.string,
         destructiveOperationsAreDisabled: PropTypes.bool.isRequired,
+        isActive: PropTypes.bool.isRequired,
         cutNode: PropTypes.func.isRequired
     };
 
@@ -26,12 +27,14 @@ export default class CutSelectedNode extends PureComponent {
     render() {
         const {
             destructiveOperationsAreDisabled,
+            isActive,
             className
         } = this.props;
 
         return (
             <IconButton
                 className={className}
+                isActive={isActive}
                 isDisabled={destructiveOperationsAreDisabled}
                 onClick={this.handleCutSelectedNodeClick}
                 icon="cut"

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/PasteClipBoardNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/PasteClipBoardNode/index.js
@@ -11,11 +11,11 @@ import {selectors, actions} from '@neos-project/neos-ui-redux-store';
     nodeTypesRegistry: globalRegistry.get('@neos-project/neos-ui-contentrepository')
 }))
 @connect((state, {nodeTypesRegistry}) => {
-    const canBeInsertedSelector = selectors.CR.Nodes.makeCanBeInsertedSelector(nodeTypesRegistry);
+    const canBePastedSelector = selectors.CR.Nodes.makeCanBePastedSelector(nodeTypesRegistry);
 
     return (state, {contextPath}) => {
         const clipboardNodeContextPath = selectors.CR.Nodes.clipboardNodeContextPathSelector(state);
-        const canBePasted = canBeInsertedSelector(state, {
+        const canBePasted = canBePastedSelector(state, {
             subject: clipboardNodeContextPath,
             reference: contextPath
         });

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
@@ -27,6 +27,8 @@ export default class NodeToolbar extends PureComponent {
         destructiveOperationsAreDisabled: PropTypes.bool.isRequired,
         // Flag triggered by content tree that tells inlineUI that it should scroll into view
         shouldScrollIntoView: PropTypes.bool.isRequired,
+        isCut: PropTypes.bool.isRequired,
+        isCopied: PropTypes.bool.isRequired,
         // Unsets the flag
         requestScrollIntoView: PropTypes.func.isRequired
     };
@@ -77,7 +79,7 @@ export default class NodeToolbar extends PureComponent {
     }
 
     render() {
-        const {contextPath, fusionPath, destructiveOperationsAreDisabled} = this.props;
+        const {contextPath, fusionPath, destructiveOperationsAreDisabled, isCut, isCopied} = this.props;
 
         if (!contextPath) {
             return null;
@@ -104,8 +106,8 @@ export default class NodeToolbar extends PureComponent {
                 <div className={style.toolBar__btnGroup}>
                     <AddNode {...props}/>
                     <HideSelectedNode {...props}/>
-                    <CopySelectedNode {...props}/>
-                    <CutSelectedNode {...props}/>
+                    <CopySelectedNode {...props} isActive={isCopied}/>
+                    <CutSelectedNode {...props} isActive={isCut}/>
                     <PasteClipBoardNode {...props}/>
                     <DeleteSelectedNode {...props}/>
                 </div>

--- a/packages/neos-ui-guest-frame/src/InlineUI/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/index.js
@@ -11,7 +11,9 @@ import style from './style.css';
 @connect($transform({
     focused: $get('cr.nodes.focused'),
     shouldScrollIntoView: selectors.UI.ContentCanvas.shouldScrollIntoView,
-    destructiveOperationsAreDisabled: selectors.CR.Nodes.destructiveOperationsAreDisabledSelector
+    destructiveOperationsAreDisabled: selectors.CR.Nodes.destructiveOperationsAreDisabledSelector,
+    clipboardMode: $get('cr.nodes.clipboardMode'),
+    clipboardNodeContextPath: selectors.CR.Nodes.clipboardNodeContextPathSelector
 }), {
     requestScrollIntoView: actions.UI.ContentCanvas.requestScrollIntoView
 })
@@ -20,12 +22,17 @@ export default class InlineUI extends PureComponent {
         focused: PropTypes.object,
         destructiveOperationsAreDisabled: PropTypes.bool.isRequired,
         requestScrollIntoView: PropTypes.func.isRequired,
-        shouldScrollIntoView: PropTypes.bool.isRequired
+        shouldScrollIntoView: PropTypes.bool.isRequired,
+        clipboardMode: PropTypes.string.isRequired,
+        clipboardNodeContextPath: PropTypes.string
     };
 
     render() {
         const focused = this.props.focused.toJS();
-        const {shouldScrollIntoView, requestScrollIntoView, destructiveOperationsAreDisabled} = this.props;
+        const focusedNodeContextPath = focused.contextPath;
+        const {shouldScrollIntoView, requestScrollIntoView, destructiveOperationsAreDisabled, clipboardMode, clipboardNodeContextPath} = this.props;
+        const isCut = focusedNodeContextPath === clipboardNodeContextPath && clipboardMode === 'Move';
+        const isCopied = focusedNodeContextPath === clipboardNodeContextPath && clipboardMode === 'Copy';
 
         return (
             <div className={style.inlineUi} data-__neos__inlineUI="TRUE">
@@ -33,6 +40,8 @@ export default class InlineUI extends PureComponent {
                     shouldScrollIntoView={shouldScrollIntoView}
                     requestScrollIntoView={requestScrollIntoView}
                     destructiveOperationsAreDisabled={destructiveOperationsAreDisabled}
+                    isCut={isCut}
+                    isCopied={isCopied}
                     {...focused}
                     />
             </div>

--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.js
@@ -217,7 +217,8 @@ export const reducer = handleActions({
                 fusionPath: ''
             }),
             toBeRemoved: '',
-            clipboard: ''
+            clipboard: '',
+            clipboardMode: ''
         })
     ),
     [ADD]: ({nodeMap}) => $all(
@@ -314,8 +315,14 @@ export const reducer = handleActions({
         })),
         $merge('cr.nodes.byContextPath', Immutable.fromJS(nodes))
     ),
-    [COPY]: contextPath => $set('cr.nodes.clipboard', contextPath),
-    [CUT]: contextPath => $set('cr.nodes.clipboard', contextPath),
+    [COPY]: contextPath => $all(
+        $set('cr.nodes.clipboard', contextPath),
+        $set('cr.nodes.clipboardMode', 'Copy')
+    ),
+    [CUT]: contextPath => $all(
+        $set('cr.nodes.clipboard', contextPath),
+        $set('cr.nodes.clipboardMode', 'Move')
+    ),
     [PASTE]: () => $set('cr.nodes.clipboard', ''),
     [HIDE]: contextPath => $set(['cr', 'nodes', 'byContextPath', contextPath, 'properties', '_hidden'], true),
     [SHOW]: contextPath => $set(['cr', 'nodes', 'byContextPath', contextPath, 'properties', '_hidden'], false),

--- a/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
@@ -207,7 +207,7 @@ export const makeIsAllowedToAddChildOrSiblingNodes = nodeTypesRegistry => create
         Boolean(allowedChildNodeTypes.length + allowedSiblingNodeTypes.length)
 );
 
-export const makeCanBeInsertedAlongsideSelector = nodeTypesRegistry => createSelector(
+export const makeCanBeCopiedAlongsideSelector = nodeTypesRegistry => createSelector(
     [
         (state, {subject}) => getPathInNode(state, subject, 'nodeType'),
         makeGetAllowedSiblingNodeTypesSelector(nodeTypesRegistry)
@@ -215,7 +215,7 @@ export const makeCanBeInsertedAlongsideSelector = nodeTypesRegistry => createSel
     (subjectNodeType, allowedNodeTypes) => allowedNodeTypes.includes(subjectNodeType)
 );
 
-export const makeCanBeInsertedIntoSelector = nodeTypesRegistry => createSelector(
+export const makeCanBeCopiedIntoSelector = nodeTypesRegistry => createSelector(
     [
         (state, {subject}) => getPathInNode(state, subject, 'nodeType'),
         makeGetAllowedChildNodeTypesSelector(nodeTypesRegistry)
@@ -225,10 +225,10 @@ export const makeCanBeInsertedIntoSelector = nodeTypesRegistry => createSelector
 
 export const makeCanBeMovedIntoSelector = nodeTypesRegistry => createSelector(
     [
-        makeCanBeInsertedIntoSelector(nodeTypesRegistry),
+        makeCanBeCopiedIntoSelector(nodeTypesRegistry),
         (state, {subject, reference}) => {
             const subjectPath = subject && subject.split('@')[0];
-            return reference.indexOf(subjectPath) === 0;
+            return subjectPath ? reference.indexOf(subjectPath) === 0 : false;
         }
     ],
     (canBeInsertedInto, referenceIsDescendantOfSubject) => canBeInsertedInto && !referenceIsDescendantOfSubject
@@ -236,19 +236,19 @@ export const makeCanBeMovedIntoSelector = nodeTypesRegistry => createSelector(
 
 export const makeCanBeMovedAlongsideSelector = nodeTypesRegistry => createSelector(
     [
-        makeCanBeInsertedIntoSelector(nodeTypesRegistry),
+        makeCanBeCopiedAlongsideSelector(nodeTypesRegistry),
         (state, {subject, reference}) => {
             const subjectPath = subject && subject.split('@')[0];
-            return parentNodeContextPath(reference).indexOf(subjectPath) === 0;
+            return subjectPath ? parentNodeContextPath(reference).indexOf(subjectPath) === 0 : false;
         }
     ],
     (canBeInsertedInto, referenceIsDescendantOfSubject) => canBeInsertedInto && !referenceIsDescendantOfSubject
 );
 
-export const makeCanBeInsertedSelector = nodeTypesRegistry => createSelector(
+export const makeCanBeCopiedSelector = nodeTypesRegistry => createSelector(
     [
-        makeCanBeInsertedAlongsideSelector(nodeTypesRegistry),
-        makeCanBeInsertedIntoSelector(nodeTypesRegistry)
+        makeCanBeCopiedAlongsideSelector(nodeTypesRegistry),
+        makeCanBeCopiedIntoSelector(nodeTypesRegistry)
     ],
     (canBeInsertedAlongside, canBeInsertedInto) => (canBeInsertedAlongside || canBeInsertedInto)
 );
@@ -264,10 +264,10 @@ export const makeCanBeMovedSelector = nodeTypesRegistry => createSelector(
 export const makeCanBePastedSelector = nodeTypesRegistry => createSelector(
     [
         makeCanBeMovedSelector(nodeTypesRegistry),
-        makeCanBeInsertedSelector(nodeTypesRegistry),
+        makeCanBeCopiedSelector(nodeTypesRegistry),
         $get('cr.nodes.clipboardMode')
     ],
-    (canBeMoved, canBePasted, mode) => mode === 'Copy' ? canBePasted : canBeMoved
+    (canBeMoved, canBeCopied, mode) => mode === 'Copy' ? canBeCopied : canBeMoved
 );
 
 export const destructiveOperationsAreDisabledSelector = createSelector(

--- a/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
@@ -223,12 +223,51 @@ export const makeCanBeInsertedIntoSelector = nodeTypesRegistry => createSelector
     (subjectNodeType, allowedNodeTypes) => allowedNodeTypes.includes(subjectNodeType)
 );
 
+export const makeCanBeMovedIntoSelector = nodeTypesRegistry => createSelector(
+    [
+        makeCanBeInsertedIntoSelector(nodeTypesRegistry),
+        (state, {subject, reference}) => {
+            const subjectPath = subject && subject.split('@')[0];
+            return reference.indexOf(subjectPath) === 0;
+        }
+    ],
+    (canBeInsertedInto, referenceIsDescendantOfSubject) => canBeInsertedInto && !referenceIsDescendantOfSubject
+);
+
+export const makeCanBeMovedAlongsideSelector = nodeTypesRegistry => createSelector(
+    [
+        makeCanBeInsertedIntoSelector(nodeTypesRegistry),
+        (state, {subject, reference}) => {
+            const subjectPath = subject && subject.split('@')[0];
+            return parentNodeContextPath(reference).indexOf(subjectPath) === 0;
+        }
+    ],
+    (canBeInsertedInto, referenceIsDescendantOfSubject) => canBeInsertedInto && !referenceIsDescendantOfSubject
+);
+
 export const makeCanBeInsertedSelector = nodeTypesRegistry => createSelector(
     [
         makeCanBeInsertedAlongsideSelector(nodeTypesRegistry),
         makeCanBeInsertedIntoSelector(nodeTypesRegistry)
     ],
     (canBeInsertedAlongside, canBeInsertedInto) => (canBeInsertedAlongside || canBeInsertedInto)
+);
+
+export const makeCanBeMovedSelector = nodeTypesRegistry => createSelector(
+    [
+        makeCanBeMovedAlongsideSelector(nodeTypesRegistry),
+        makeCanBeMovedIntoSelector(nodeTypesRegistry)
+    ],
+    (canBeMovedAlongside, canBeMovedInto) => (canBeMovedAlongside || canBeMovedInto)
+);
+
+export const makeCanBePastedSelector = nodeTypesRegistry => createSelector(
+    [
+        makeCanBeMovedSelector(nodeTypesRegistry),
+        makeCanBeInsertedSelector(nodeTypesRegistry),
+        $get('cr.nodes.clipboardMode')
+    ],
+    (canBeMoved, canBePasted, mode) => mode === 'Copy' ? canBePasted : canBeMoved
 );
 
 export const destructiveOperationsAreDisabledSelector = createSelector(

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -252,6 +252,7 @@ export default class Node extends PureComponent {
                     onToggle={this.handleNodeToggle}
                     onClick={this.handleNodeClick}
                     dragAndDropContext={this.getDragAndDropContext()}
+                    dragForbidden={$get('isAutoCreated', node)}
                     />
                 {this.isCollapsed() ? null : (
                     <Tree.Node.Contents>

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -300,8 +300,8 @@ export const PageTreeNode = withNodeTypeRegistry(connect(
 
         const childrenOfSelector = selectors.CR.Nodes.makeChildrenOfSelector(allowedNodeTypes);
         const hasChildrenSelector = selectors.CR.Nodes.makeHasChildrenSelector(allowedNodeTypes);
-        const canBeInsertedAlongsideSelector = selectors.CR.Nodes.makeCanBeInsertedAlongsideSelector(nodeTypesRegistry);
-        const canBeInsertedIntoSelector = selectors.CR.Nodes.makeCanBeInsertedIntoSelector(nodeTypesRegistry);
+        const canBeMovedAlongsideSelector = selectors.CR.Nodes.makeCanBeMovedAlongsideSelector(nodeTypesRegistry);
+        const canBeMovedIntoSelector = selectors.CR.Nodes.makeCanBeMovedIntoSelector(nodeTypesRegistry);
         const isDocumentNodeDirtySelector = selectors.CR.Workspaces.makeIsDocumentNodeDirtySelector();
 
         return (state, {node, currentlyDraggedNode}) => ({
@@ -319,11 +319,11 @@ export const PageTreeNode = withNodeTypeRegistry(connect(
             loadingNodeContextPaths: selectors.UI.PageTree.getLoading(state),
             errorNodeContextPaths: selectors.UI.PageTree.getErrors(state),
             isNodeDirty: isDocumentNodeDirtySelector(state, $get('contextPath', node)),
-            canBeInsertedAlongside: canBeInsertedAlongsideSelector(state, {
+            canBeInsertedAlongside: canBeMovedAlongsideSelector(state, {
                 subject: getContextPath(currentlyDraggedNode),
                 reference: getContextPath(node)
             }),
-            canBeInsertedInto: canBeInsertedIntoSelector(state, {
+            canBeInsertedInto: canBeMovedIntoSelector(state, {
                 subject: getContextPath(currentlyDraggedNode),
                 reference: getContextPath(node)
             })
@@ -342,8 +342,8 @@ export const ContentTreeNode = withNodeTypeRegistry(connect(
 
         const childrenOfSelector = selectors.CR.Nodes.makeChildrenOfSelector(allowedNodeTypes);
         const hasChildrenSelector = selectors.CR.Nodes.makeHasChildrenSelector(allowedNodeTypes);
-        const canBeInsertedAlongsideSelector = selectors.CR.Nodes.makeCanBeInsertedAlongsideSelector(nodeTypesRegistry);
-        const canBeInsertedIntoSelector = selectors.CR.Nodes.makeCanBeInsertedIntoSelector(nodeTypesRegistry);
+        const canBeMovedAlongsideSelector = selectors.CR.Nodes.makeCanBeMovedAlongsideSelector(nodeTypesRegistry);
+        const canBeMovedIntoSelector = selectors.CR.Nodes.makeCanBeMovedIntoSelector(nodeTypesRegistry);
         const isContentNodeDirtySelector = selectors.CR.Workspaces.makeIsContentNodeDirtySelector();
 
         return (state, {node, currentlyDraggedNode}) => ({
@@ -357,11 +357,11 @@ export const ContentTreeNode = withNodeTypeRegistry(connect(
             focusedNodeContextPath: $get('cr.nodes.focused.contextPath', state),
             toggledNodeContextPaths: selectors.UI.ContentTree.getToggled(state),
             isNodeDirty: isContentNodeDirtySelector(state, $get('contextPath', node)),
-            canBeInsertedAlongside: canBeInsertedAlongsideSelector(state, {
+            canBeInsertedAlongside: canBeMovedAlongsideSelector(state, {
                 subject: getContextPath(currentlyDraggedNode),
                 reference: getContextPath(node)
             }),
-            canBeInsertedInto: canBeInsertedIntoSelector(state, {
+            canBeInsertedInto: canBeMovedIntoSelector(state, {
                 subject: getContextPath(currentlyDraggedNode),
                 reference: getContextPath(node)
             })

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/CopySelectedNode/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/CopySelectedNode/index.js
@@ -11,7 +11,9 @@ export default class CopySelectedNode extends PureComponent {
 
         onClick: PropTypes.func.isRequired,
 
-        isDisabled: PropTypes.bool
+        isDisabled: PropTypes.bool,
+
+        isActive: PropTypes.bool
     };
 
     handleClick = () => {
@@ -23,13 +25,15 @@ export default class CopySelectedNode extends PureComponent {
     render() {
         const {
             className,
-            isDisabled
+            isDisabled,
+            isActive
         } = this.props;
 
         return (
             <IconButton
                 className={className}
                 isDisabled={isDisabled}
+                isActive={isActive}
                 onClick={this.handleClick}
                 icon="copy"
                 hoverStyle="clean"

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/CutSelectedNode/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/CutSelectedNode/index.js
@@ -8,6 +8,7 @@ export default class CutSelectedNode extends PureComponent {
 
         focusedNodeContextPath: PropTypes.string,
         isDisabled: PropTypes.bool.isRequired,
+        isActive: PropTypes.bool.isRequired,
 
         onClick: PropTypes.func.isRequired
     };
@@ -19,12 +20,13 @@ export default class CutSelectedNode extends PureComponent {
     }
 
     render() {
-        const {className, isDisabled} = this.props;
+        const {className, isDisabled, isActive} = this.props;
 
         return (
             <IconButton
                 className={className}
                 isDisabled={isDisabled}
+                isActive={isActive}
                 onClick={this.handleClick}
                 icon="cut"
                 hoverStyle="clean"

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
@@ -24,6 +24,8 @@ export default class NodeTreeToolBar extends PureComponent {
         canBePasted: PropTypes.bool.isRequired,
         isLoading: PropTypes.bool.isRequired,
         isHidden: PropTypes.bool.isRequired,
+        isCut: PropTypes.bool.isRequired,
+        isCopied: PropTypes.bool.isRequired,
         destructiveOperationsAreDisabled: PropTypes.bool.isRequired,
         isAllowedToAddChildOrSiblingNodes: PropTypes.bool.isRequired,
 
@@ -94,6 +96,8 @@ export default class NodeTreeToolBar extends PureComponent {
             focusedNodeContextPath,
             canBePasted,
             isHidden,
+            isCut,
+            isCopied,
             isLoading,
             destructiveOperationsAreDisabled,
             isAllowedToAddChildOrSiblingNodes
@@ -120,11 +124,13 @@ export default class NodeTreeToolBar extends PureComponent {
                         className={style.toolBar__btnGroup__btn}
                         focusedNodeContextPath={focusedNodeContextPath}
                         onClick={this.handleCopyNode}
+                        isActive={isCopied}
                         isDisabled={destructiveOperationsAreDisabled}
                         />
                     <CutSelectedNode
                         className={style.toolBar__btnGroup__btn}
                         focusedNodeContextPath={focusedNodeContextPath}
+                        isActive={isCut}
                         isDisabled={destructiveOperationsAreDisabled}
                         onClick={this.handleCutNode}
                         />
@@ -171,6 +177,9 @@ export const PageTreeToolbar = withNodeTypesRegistry(connect(
                 subject: clipboardNodeContextPath,
                 reference: focusedNodeContextPath
             });
+            const clipboardMode = $get('cr.nodes.clipboardMode', state);
+            const isCut = focusedNodeContextPath === clipboardNodeContextPath && clipboardMode === 'Move';
+            const isCopied = focusedNodeContextPath === clipboardNodeContextPath && clipboardMode === 'Copy';
             const isLoading = selectors.UI.PageTree.getIsLoading(state);
             const isHidden = $get('properties._hidden', focusedNode);
             const destructiveOperationsAreDisabled = (
@@ -188,7 +197,9 @@ export const PageTreeToolbar = withNodeTypesRegistry(connect(
                 isLoading,
                 isHidden,
                 destructiveOperationsAreDisabled,
-                isAllowedToAddChildOrSiblingNodes
+                isAllowedToAddChildOrSiblingNodes,
+                isCut,
+                isCopied
             };
         };
     }, {
@@ -217,6 +228,9 @@ export const ContentTreeToolbar = withNodeTypesRegistry(connect(
                 subject: clipboardNodeContextPath,
                 reference: focusedNodeContextPath
             });
+            const clipboardMode = $get('cr.nodes.clipboardMode', state);
+            const isCut = focusedNodeContextPath === clipboardNodeContextPath && clipboardMode === 'Move';
+            const isCopied = focusedNodeContextPath === clipboardNodeContextPath && clipboardMode === 'Copy';
             const isLoading = selectors.UI.ContentTree.getIsLoading(state);
             const isHidden = $get('properties._hidden', focusedNode);
             const destructiveOperationsAreDisabled = selectors.CR.Nodes.destructiveOperationsAreDisabledSelector(state);
@@ -230,7 +244,9 @@ export const ContentTreeToolbar = withNodeTypesRegistry(connect(
                 isLoading,
                 isHidden,
                 destructiveOperationsAreDisabled,
-                isAllowedToAddChildOrSiblingNodes
+                isAllowedToAddChildOrSiblingNodes,
+                isCut,
+                isCopied
             };
         };
     }, {

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
@@ -164,7 +164,7 @@ const withNodeTypesRegistry = neos(globalRegistry => ({
 
 export const PageTreeToolbar = withNodeTypesRegistry(connect(
     (state, {nodeTypesRegistry}) => {
-        const canBePastedSelector = selectors.CR.Nodes.makeCanBeInsertedSelector(nodeTypesRegistry);
+        const canBePastedSelector = selectors.CR.Nodes.makeCanBePastedSelector(nodeTypesRegistry);
         const isAllowedToAddChildOrSiblingNodesSelector = selectors.CR.Nodes.makeIsAllowedToAddChildOrSiblingNodes(nodeTypesRegistry);
 
         return state => {
@@ -216,7 +216,7 @@ export const PageTreeToolbar = withNodeTypesRegistry(connect(
 
 export const ContentTreeToolbar = withNodeTypesRegistry(connect(
     (state, {nodeTypesRegistry}) => {
-        const canBePastedSelector = selectors.CR.Nodes.makeCanBeInsertedSelector(nodeTypesRegistry);
+        const canBePastedSelector = selectors.CR.Nodes.makeCanBePastedSelector(nodeTypesRegistry);
         const isAllowedToAddChildOrSiblingNodesSelector = selectors.CR.Nodes.makeIsAllowedToAddChildOrSiblingNodes(nodeTypesRegistry);
 
         return state => {

--- a/packages/neos-ui/src/Sagas/CR/NodeOperations/copyAndPasteNode.js
+++ b/packages/neos-ui/src/Sagas/CR/NodeOperations/copyAndPasteNode.js
@@ -9,8 +9,8 @@ import {calculateChangeTypeFromMode, calculateDomAddressesFromMode} from './help
 
 export default function * copyAndPasteNode({globalRegistry}) {
     const nodeTypesRegistry = globalRegistry.get('@neos-project/neos-ui-contentrepository');
-    const canBeInsertedAlongsideSelector = selectors.CR.Nodes.makeCanBeInsertedAlongsideSelector(nodeTypesRegistry);
-    const canBeInsertedIntoSelector = selectors.CR.Nodes.makeCanBeInsertedIntoSelector(nodeTypesRegistry);
+    const canBeInsertedAlongsideSelector = selectors.CR.Nodes.makeCanBeCopiedAlongsideSelector(nodeTypesRegistry);
+    const canBeInsertedIntoSelector = selectors.CR.Nodes.makeCanBeCopiedIntoSelector(nodeTypesRegistry);
 
     yield * takeEvery(actionTypes.CR.Nodes.COPY, function * waitForPaste() {
         const subject = yield select($get('cr.nodes.clipboard'));

--- a/packages/neos-ui/src/Sagas/CR/NodeOperations/cutAndPasteNode.js
+++ b/packages/neos-ui/src/Sagas/CR/NodeOperations/cutAndPasteNode.js
@@ -9,8 +9,8 @@ import {calculateChangeTypeFromMode, calculateDomAddressesFromMode} from './help
 
 export default function * cutAndPasteNode({globalRegistry}) {
     const nodeTypesRegistry = globalRegistry.get('@neos-project/neos-ui-contentrepository');
-    const canBeInsertedAlongsideSelector = selectors.CR.Nodes.makeCanBeInsertedAlongsideSelector(nodeTypesRegistry);
-    const canBeInsertedIntoSelector = selectors.CR.Nodes.makeCanBeInsertedIntoSelector(nodeTypesRegistry);
+    const canBeMovedAlongsideSelector = selectors.CR.Nodes.makeCanBeMovedAlongsideSelector(nodeTypesRegistry);
+    const canBeMovedIntoSelector = selectors.CR.Nodes.makeCanBeMovedIntoSelector(nodeTypesRegistry);
 
     yield * takeEvery(actionTypes.CR.Nodes.CUT, function * waitForPaste() {
         const subject = yield select($get('cr.nodes.clipboard'));
@@ -32,15 +32,15 @@ export default function * cutAndPasteNode({globalRegistry}) {
 
         if (nextAction.type === actionTypes.CR.Nodes.PASTE) {
             const {contextPath: reference, fusionPath} = nextAction.payload;
-            const canBeInsertedAlongside = yield select(canBeInsertedAlongsideSelector, {subject, reference});
-            const canBeInsertedInto = yield select(canBeInsertedIntoSelector, {subject, reference});
+            const canBeMovedAlongside = yield select(canBeMovedAlongsideSelector, {subject, reference});
+            const canBeMovedInto = yield select(canBeMovedIntoSelector, {subject, reference});
 
             const mode = yield call(
                 determineInsertMode,
                 subject,
                 reference,
-                canBeInsertedAlongside,
-                canBeInsertedInto,
+                canBeMovedAlongside,
+                canBeMovedInto,
                 actionTypes.CR.Nodes.CUT
             );
 

--- a/packages/react-ui-components/src/Tree/node.js
+++ b/packages/react-ui-components/src/Tree/node.js
@@ -47,7 +47,7 @@ class NodeDropTarget extends PureComponent {
         mode: PropTypes.string.isRequired
     };
     render() {
-        const {connectDropTarget, isOver, mode, theme} = this.props;
+        const {connectDropTarget, isOver, canDrop, mode, theme} = this.props;
         const classNames = mergeClassNames({
             [theme.dropTarget]: true,
             [theme['dropTarget--before']]: mode === 'before',
@@ -55,7 +55,7 @@ class NodeDropTarget extends PureComponent {
         });
         const classNamesInner = mergeClassNames({
             [theme.dropTarget__inner]: true,
-            [theme['dropTarget__inner--acceptsDrop']]: isOver
+            [theme['dropTarget__inner--acceptsDrop']]: isOver && canDrop
         });
         return connectDropTarget(
             <div className={classNames}>

--- a/packages/react-ui-components/src/Tree/node.js
+++ b/packages/react-ui-components/src/Tree/node.js
@@ -71,6 +71,9 @@ class NodeDropTarget extends PureComponent {
         return {
             contextPath: props.id
         };
+    },
+    canDrag({dragForbidden}) {
+        return !dragForbidden;
     }
 }, (connect, monitor) => ({
     connectDragSource: connect.dragSource(),
@@ -103,6 +106,7 @@ export class Header extends PureComponent {
         canDrop: PropTypes.bool.isRequired,
         isDragging: PropTypes.bool,
         isOver: PropTypes.bool,
+        dragForbidden: PropTypes.bool,
 
         onToggle: PropTypes.func,
         onClick: PropTypes.func,
@@ -153,7 +157,7 @@ export class Header extends PureComponent {
             canDrop,
             ...restProps
         } = this.props;
-        const rest = omit(restProps, ['onToggle', 'isCollapsed', 'isLoading', 'hasError', 'isDragging']);
+        const rest = omit(restProps, ['onToggle', 'isCollapsed', 'isLoading', 'hasError', 'isDragging', 'dragForbidden']);
         const dataClassNames = mergeClassNames({
             [theme.header__data]: true,
             [theme['header__data--isActive']]: isActive,


### PR DESCRIPTION
Fixes: #1075
Fixes: #1092
Fixes: #817

Fix multiple bugs related to the logic of moving nodes:
- DragAndDrop of autoCreated nodes should be disallowed
- Moving into descendants of the node itself should be disallowed
- Before and after dropzones should not be highlighted when can't drop into them
- Cut/Copy buttons should reflect their state