### PR TITLE
BUGFIX: fix loading of node with dimensions, use lastVisitedNode logic

### DIFF
--- a/Classes/Neos/Neos/Ui/Controller/BackendController.php
+++ b/Classes/Neos/Neos/Ui/Controller/BackendController.php
@@ -16,6 +16,7 @@ use Neos\Neos\Controller\Backend\MenuHelper;
 use Neos\Neos\Domain\Repository\DomainRepository;
 use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Domain\Service\ContentContext;
+use Neos\Neos\Service\BackendRedirectionService;
 use Neos\Neos\Service\UserService;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Fusion\View\FusionView;
@@ -84,6 +85,12 @@ class BackendController extends ActionController
     protected $menuHelper;
 
     /**
+     * @Flow\Inject(lazy=false)
+     * @var BackendRedirectionService
+     */
+    protected $backendRedirectionService;
+
+    /**
      * @Flow\Inject
      * @var StyleAndJavascriptInclusionService
      */
@@ -107,6 +114,12 @@ class BackendController extends ActionController
 
         if ($user = $this->userService->getBackendUser()) {
             $workspaceName = $this->userService->getPersonalWorkspaceName();
+            if ($node === null) {
+                $reflectionMethod = new \ReflectionMethod($this->backendRedirectionService, 'getLastVisitedNode');
+                $reflectionMethod->setAccessible(true);
+                $node = $reflectionMethod->invoke($this->backendRedirectionService, $workspaceName);
+            }
+
             $contentContext = ($node ? $node->getContext() : $this->createContext($workspaceName));
 
             $contentContext->getWorkspace();

--- a/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -67,11 +67,6 @@ prototype(Neos.Neos:Page) {
     newNeosBackendWrappingElement.@if.newBackend = ${Neos.Ui.Activation.enableNewBackend()}
 
     //
-    // Disable memorizing last visited node
-    //
-    lastVisitedNodeScript.@if.oldBackend = ${!Neos.Ui.Activation.enableNewBackend()}
-
-    //
     // Do not render the Neos backend footer
     //
     neosBackendFooter.@if.oldBackend = ${!Neos.Ui.Activation.enableNewBackend()}


### PR DESCRIPTION
The loading error occurred exactly if the *standard* dimension contained multiple
dimension values. That's what is fixed here.

Resolves: #755

## How to test

Important: After applying this patch, clear your caches and start by visiting the FRONTEND (such that the last-visited node can be properly memoized ,*including* dimension infos)