### PR TITLE
FEATURE: Support keyboard navigation in SelectBox

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "react-height": "^3.0.0",
     "react-image-crop": "^2.0.5",
     "react-immutable-proptypes": "^2.1.0",
+    "react-keydown": "^1.9.4",
     "react-measure": "^1.4.7",
     "react-motion": "^0.5.0",
     "react-portal": "^3.1.0",

--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -5,7 +5,9 @@ import DefaultSelectBoxOption from './defaultSelectBoxOption';
 import keydown from 'react-keydown';
 import mergeClassNames from 'classnames';
 
-@keydown
+const KEYS = ['down', 'up', 'enter'];
+
+@keydown(KEYS)
 export default class SelectBox extends PureComponent {
 
     static defaultProps = {

--- a/packages/react-ui-components/src/SelectBox/style.css
+++ b/packages/react-ui-components/src/SelectBox/style.css
@@ -163,6 +163,10 @@
     }
 }
 
+.selectBox__item--isSelectable--active {
+        background: var(--brandColorsPrimaryBlue);
+}
+
 .selectBox__itemIcon {
     composes: reset from './../reset.css';
     padding-right: .5em;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6906,6 +6906,12 @@ react-immutable-proptypes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/react-immutable-proptypes/-/react-immutable-proptypes-2.1.0.tgz#023d6f39bb15c97c071e9e60d00d136eac5fa0b4"
 
+react-keydown@^1.9.4:
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/react-keydown/-/react-keydown-1.9.4.tgz#22718ac95edb64dd840dfc4350abf7e693ea0b7f"
+  dependencies:
+    core-js "^2.5.0"
+
 react-measure@^1.4.7:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/react-measure/-/react-measure-1.4.7.tgz#a1d2ca0dcfef04978b7ac263a765dcb6a0936fdb"


### PR DESCRIPTION
In this implementation it is possible to use the arrow keys to navigate
up and down and to chose one item via the enter key.
This replicates the behaviour of the old UI.

This doesn't work for SelectBoxes with a search box currently.

closes #1036