### PR TITLE
BUGFIX: correctly redirect on removal of nested nodes

### DIFF
--- a/Tests/IntegrationTests/contentModule.js
+++ b/Tests/IntegrationTests/contentModule.js
@@ -36,7 +36,10 @@ test('Discarding: create multiple nodes nested within each other and then discar
         .expect(ReactSelector('Provider').getReact(({props}) => {
             const reduxState = props.store.getState().toJS();
             return !reduxState.ui.contentCanvas.isLoading;
-        })).ok('Loading stopped')
+        })).ok('Loading stopped');
+
+    subSection('Create another node inside it');
+    await t
         .click(ReactSelector('AddNode Button'))
         .click(ReactSelector('InsertModeSelector').find('#into'))
         .click(ReactSelector('NodeTypeItem'))
@@ -45,14 +48,16 @@ test('Discarding: create multiple nodes nested within each other and then discar
         .expect(ReactSelector('Provider').getReact(({props}) => {
             const reduxState = props.store.getState().toJS();
             return !reduxState.ui.contentCanvas.isLoading;
-        })).ok('Loading stopped')
+        })).ok('Loading stopped');
+
+    subSection('Discard all nodes and hope to be redirected to root');
+    await t
         .click(ReactSelector('PublishDropDown ContextDropDownHeader'))
         .click(ReactSelector('PublishDropDown ShallowDropDownContents').find('button').withText('Discard All'))
         .expect(ReactSelector('Provider').getReact(({props}) => {
             const reduxState = props.store.getState().toJS();
             return !reduxState.ui.contentCanvas.isLoading && reduxState.ui.contentCanvas.contextPath === '/sites/neosdemo@user-admin;language=en_US';
         })).ok('After discarding we are back to the main page');
-    subSection('Discard that node');
 });
 
 test('Discarding: create a document node and then discard it', async t => {

--- a/Tests/IntegrationTests/contentModule.js
+++ b/Tests/IntegrationTests/contentModule.js
@@ -232,6 +232,7 @@ test('Can create a new page', async t => {
 
 test('Can create content node from inside InlineUI', async t => {
     const headlineTitle = 'Helloworld!';
+    subSection('Create a headline node');
     await t
         .switchToIframe('[name="neos-content-main"]')
         .click(Selector('.neos-contentcollection'))
@@ -240,9 +241,19 @@ test('Can create content node from inside InlineUI', async t => {
         .click(Selector('button#into'))
         // TODO: this selector will only work with English translation.
         // Change to `withProps` when implemented: https://github.com/DevExpress/testcafe-react-selectors/issues/14
-        .click(ReactSelector('NodeTypeItem').find('button').withText('Headline'))
+        .click(ReactSelector('NodeTypeItem').find('button').withText('Headline'));
+    subSection('Type something inside of it');
+    await t
         .switchToIframe('[name="neos-content-main"]')
         .typeText(Selector('.neos-inline-editable h1'), headlineTitle)
         .expect(Selector('.neos-contentcollection').withText(headlineTitle).exists).ok()
         .switchToMainWindow();
+    subSection('Discard all at the end');
+    await t
+        .click(ReactSelector('PublishDropDown ContextDropDownHeader'))
+        .click(ReactSelector('PublishDropDown ShallowDropDownContents').find('button').withText('Discard All'))
+        .expect(ReactSelector('Provider').getReact(({props}) => {
+            const reduxState = props.store.getState().toJS();
+            return !reduxState.ui.contentCanvas.isLoading && reduxState.ui.contentCanvas.contextPath === '/sites/neosdemo@user-admin;language=en_US';
+        })).ok('After discarding we are back to the main page');
 });

--- a/Tests/IntegrationTests/contentModule.js
+++ b/Tests/IntegrationTests/contentModule.js
@@ -24,6 +24,37 @@ fixture `Content Module`
         await t.useRole(adminUser);
     });
 
+test('Discarding: create multiple nodes nested within each other and then discard them', async t => {
+    const pageTitleToCreate = 'DiscardTest';
+    subSection('Create a document node');
+    await t
+        .click(ReactSelector('AddNode Button'))
+        .click(ReactSelector('InsertModeSelector').find('#into'))
+        .click(ReactSelector('NodeTypeItem'))
+        .typeText(Selector('#neos-nodeCreationDialog-body input'), pageTitleToCreate)
+        .click(Selector('#neos-nodeCreationDialog-createNew'))
+        .expect(ReactSelector('Provider').getReact(({props}) => {
+            const reduxState = props.store.getState().toJS();
+            return !reduxState.ui.contentCanvas.isLoading;
+        })).ok('Loading stopped')
+        .click(ReactSelector('AddNode Button'))
+        .click(ReactSelector('InsertModeSelector').find('#into'))
+        .click(ReactSelector('NodeTypeItem'))
+        .typeText(Selector('#neos-nodeCreationDialog-body input'), pageTitleToCreate)
+        .click(Selector('#neos-nodeCreationDialog-createNew'))
+        .expect(ReactSelector('Provider').getReact(({props}) => {
+            const reduxState = props.store.getState().toJS();
+            return !reduxState.ui.contentCanvas.isLoading;
+        })).ok('Loading stopped')
+        .click(ReactSelector('PublishDropDown ContextDropDownHeader'))
+        .click(ReactSelector('PublishDropDown ShallowDropDownContents').find('button').withText('Discard All'))
+        .expect(ReactSelector('Provider').getReact(({props}) => {
+            const reduxState = props.store.getState().toJS();
+            return !reduxState.ui.contentCanvas.isLoading && reduxState.ui.contentCanvas.contextPath === '/sites/neosdemo@user-admin;language=en_US';
+        })).ok('After discarding we are back to the main page');
+    subSection('Discard that node');
+});
+
 test('Discarding: create a document node and then discard it', async t => {
     const pageTitleToCreate = 'DiscardTest';
     subSection('Create a document node');

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:ui:watch-poll": "yarn run build:ui -- --watch-poll --watch",
     "start-storybook": "lerna run --scope @neos-project/react-ui-components start",
     "test": "lerna run test --concurrency 1",
-    "test:e2e": "yarn run testcafe -- chrome:headless Tests/IntegrationTests/* --selector-timeout 30000 --assertion-timeout 30000",
+    "test:e2e": "yarn run testcafe -- chrome:headless Tests/IntegrationTests/* --selector-timeout=30000 --assertion-timeout=30000",
     "lint": "lerna run lint --concurrency 1",
     "lint:editorconfig": "editorconfig-checker --exclude-regexp 'LICENSE|\\.vanilla\\-css$|banner\\.js$' --exclude-pattern './{README.md,**/*{fontAwesome,Resources}/**/*}'"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:ui:watch-poll": "yarn run build:ui -- --watch-poll --watch",
     "start-storybook": "lerna run --scope @neos-project/react-ui-components start",
     "test": "lerna run test --concurrency 1",
-    "test:e2e": "yarn run testcafe chrome:headless Tests/IntegrationTests/* --selector-timeout 20000",
+    "test:e2e": "yarn run testcafe -- chrome:headless Tests/IntegrationTests/* --selector-timeout 30000 --assertion-timeout 30000",
     "lint": "lerna run lint --concurrency 1",
     "lint:editorconfig": "editorconfig-checker --exclude-regexp 'LICENSE|\\.vanilla\\-css$|banner\\.js$' --exclude-pattern './{README.md,**/*{fontAwesome,Resources}/**/*}'"
   },


### PR DESCRIPTION
Steps to reproduce: Create a document node. Create another document node inside of it. Discard all and see all sorts of errors.

This change recursively looks for the parent node that still exists, and redirects to it.