### PR TITLE
BUGFIX: Add 'load' eventListener to NodeToolbar

### DIFF
--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
@@ -58,6 +58,7 @@ export default class NodeToolbar extends PureComponent {
     componentDidMount() {
         this.iframeWindow.addEventListener('resize', debounce(() => this.forceUpdate(), 20));
         this.iframeWindow.addEventListener('scroll', debounce(this.updateStickyness, 5));
+        this.iframeWindow.addEventListener('load', debounce(() => this.forceUpdate(), 5));
     }
 
     componentDidUpdate() {


### PR DESCRIPTION
to fix top position of toolbar after the page reloads

Fixes: #1073