### PR TITLE
BUGFIX: refresh workspace info when adopting a node to other dimension

### DIFF
--- a/Classes/Neos/Neos/Ui/Controller/BackendServiceController.php
+++ b/Classes/Neos/Neos/Ui/Controller/BackendServiceController.php
@@ -276,7 +276,8 @@ class BackendServiceController extends ActionController
         $this->view->assign('value', $this->feedbackCollection);
     }
 
-    public function getWorkspaceInfoAction() {
+    public function getWorkspaceInfoAction()
+    {
         $workspaceHelper = new WorkspaceHelper();
         $personalWorkspaceInfo = $workspaceHelper->getPersonalWorkspace();
         $this->view->assign('value', $personalWorkspaceInfo);

--- a/Classes/Neos/Neos/Ui/Controller/BackendServiceController.php
+++ b/Classes/Neos/Neos/Ui/Controller/BackendServiceController.php
@@ -8,6 +8,7 @@ namespace Neos\Neos\Ui\Controller;
 
 use Neos\Flow\Mvc\View\JsonView;
 use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
+use Neos\Neos\Ui\Fusion\Helper\WorkspaceHelper;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Mvc\RequestInterface;
@@ -273,6 +274,12 @@ class BackendServiceController extends ActionController
         }
 
         $this->view->assign('value', $this->feedbackCollection);
+    }
+
+    public function getWorkspaceInfoAction() {
+        $workspaceHelper = new WorkspaceHelper();
+        $personalWorkspaceInfo = $workspaceHelper->getPersonalWorkspace();
+        $this->view->assign('value', $personalWorkspaceInfo);
     }
 
     public function initializeLoadTreeAction()

--- a/Configuration/Routes.Service.yaml
+++ b/Configuration/Routes.Service.yaml
@@ -45,3 +45,11 @@
     '@controller': 'BackendService'
     '@action': 'flowQuery'
   httpMethods: ['POST']
+
+-
+  name: 'Get Workspace Info'
+  uriPattern: 'get-workspace-info'
+  defaults:
+    '@controller': 'BackendService'
+    '@action': 'getWorkspaceInfo'
+  httpMethods: ['GET']

--- a/Tests/IntegrationTests/contentModule.js
+++ b/Tests/IntegrationTests/contentModule.js
@@ -61,7 +61,7 @@ test('Switching dimensions', async t => {
         })).ok('Loading stopped and dimension switched to Latvian')
         .expect(ReactSelector('Provider').getReact(({props}) => {
             const reduxState = props.store.getState().toJS();
-            return reduxState.cr.workspaces.publishableNodes;
+            return reduxState.cr.workspaces.personalWorkspace.publishableNodes.length;
         })).gt(0, 'There are some unpublished nodes after adoption')
         .expect(page.treeNode.withText('Navigation elements').exists).notOk('Untranslated node gone from the tree');
 

--- a/Tests/IntegrationTests/contentModule.js
+++ b/Tests/IntegrationTests/contentModule.js
@@ -59,6 +59,10 @@ test('Switching dimensions', async t => {
             const activeDimension = reduxState.cr.contentDimensions.active.language[0];
             return !isLoading && activeDimension === 'lv';
         })).ok('Loading stopped and dimension switched to Latvian')
+        .expect(ReactSelector('Provider').getReact(({props}) => {
+            const reduxState = props.store.getState().toJS();
+            return reduxState.cr.workspaces.publishableNodes;
+        })).gt(0, 'There are some unpublished nodes after adoption')
         .expect(page.treeNode.withText('Navigation elements').exists).notOk('Untranslated node gone from the tree');
 
     subSection('Switch back to original dimension');

--- a/packages/neos-ui-backend-connector/src/Endpoints/index.js
+++ b/packages/neos-ui-backend-connector/src/Endpoints/index.js
@@ -228,6 +228,15 @@ const setUserPreferences = (key, value) => fetchWithErrorHandling.withCsrfToken(
     };
 });
 
+const getWorkspaceInfo = () => fetchWithErrorHandling.withCsrfToken(() => ({
+    url: `neos!/service/get-workspace-info`,
+    method: 'GET',
+    credentials: 'include',
+    headers: {
+        'Content-Type': 'application/json'
+    }
+})).then(response => response.json());
+
 const dataSource = (dataSourceIdentifier, dataSourceUri, params = {}) => fetchWithErrorHandling.withCsrfToken(() => ({
     url: urlWithParams(dataSourceUri || '/neos/service/data-source/' + dataSourceIdentifier, params),
 
@@ -273,5 +282,6 @@ export default () => ({
     setUserPreferences,
     dataSource,
     getJsonResource,
+    getWorkspaceInfo,
     tryLogin
 });

--- a/packages/neos-ui/src/Sagas/CR/ContentDimensions/index.js
+++ b/packages/neos-ui/src/Sagas/CR/ContentDimensions/index.js
@@ -67,6 +67,7 @@ function * watchSelectPreset({configuration}) {
  * If not: Ask the user to either create an empty node or to copy the given node.
  */
 function * ensureNodeInSelectedDimension({nodeIdentifier, sourceDimensions, targetDimensions}) {
+    const {getWorkspaceInfo} = backend.get().endpoints;
     const {
         getSingleNode,
         adoptNodeToOtherDimension
@@ -97,6 +98,9 @@ function * ensureNodeInSelectedDimension({nodeIdentifier, sourceDimensions, targ
     const nextAction = Object.values(waitForNextAction)[0];
 
     if (nextAction.type !== actionTypes.UI.NodeVariantCreationDialog.CANCEL) {
+        const workspaceInfo = yield call(getWorkspaceInfo);
+        yield put(actions.CR.Workspaces.update(workspaceInfo));
+
         const copyContent = nextAction.type === actionTypes.UI.NodeVariantCreationDialog.CREATE_AND_COPY;
         const {nodeFrontendUri, nodeContextPath} = yield adoptNodeToOtherDimension({
             identifier: nodeIdentifier,

--- a/packages/neos-ui/src/Sagas/CR/ContentDimensions/index.js
+++ b/packages/neos-ui/src/Sagas/CR/ContentDimensions/index.js
@@ -98,9 +98,6 @@ function * ensureNodeInSelectedDimension({nodeIdentifier, sourceDimensions, targ
     const nextAction = Object.values(waitForNextAction)[0];
 
     if (nextAction.type !== actionTypes.UI.NodeVariantCreationDialog.CANCEL) {
-        const workspaceInfo = yield call(getWorkspaceInfo);
-        yield put(actions.CR.Workspaces.update(workspaceInfo));
-
         const copyContent = nextAction.type === actionTypes.UI.NodeVariantCreationDialog.CREATE_AND_COPY;
         const {nodeFrontendUri, nodeContextPath} = yield adoptNodeToOtherDimension({
             identifier: nodeIdentifier,
@@ -109,6 +106,9 @@ function * ensureNodeInSelectedDimension({nodeIdentifier, sourceDimensions, targ
             sourceDimensions: sourceDimensions.toJS(),
             copyContent
         });
+
+        const workspaceInfo = yield call(getWorkspaceInfo);
+        yield put(actions.CR.Workspaces.update(workspaceInfo));
 
         return {nodeFrontendUri, nodeContextPath};
     }


### PR DESCRIPTION
Fixes: #1114 

I'm not happy about how this is fixed architecture-wise, but I couldn't think of anything better without spending too much time redesigning the whole thing.
Besides being ugly and ad-hoc, it requires an extra ajax request when adopting a node.

In the future I see such data fetching needs be put in order via the upcoming GraphQL integration.