### PR TITLE
FEATURE: indicate inline editable elements

### DIFF
--- a/packages/neos-ui-guest-frame/src/style.css
+++ b/packages/neos-ui-guest-frame/src/style.css
@@ -21,6 +21,11 @@
     outline: none;
 }
 
+:global(.neos-inline-editable:hover) {
+    outline-offset: .5em;
+    outline: 2px dashed var(--brandColorsPrimaryBlue);
+}
+
 .notInlineEditableOverlay {
     position: absolute;
     top: 0;


### PR DESCRIPTION
Fixes #1064: Highlight inline editable elements on hover by adding a dashed border.

On inline editable elements the classes `neos-inline-editable cke_editable cke_editable_inline` (and some other ones) are applied. By choosing `neos-inline-editable:hover` instead of the `cke`-prefixed ones, the CSS is independent of the text editor.

