### PR TITLE
BUGFIX: use UI locale when rendering nodes via getNonRenderedContentNodeMetadata

### DIFF
--- a/Classes/Neos/Neos/Ui/Aspects/AugmentationAspect.php
+++ b/Classes/Neos/Neos/Ui/Aspects/AugmentationAspect.php
@@ -262,7 +262,7 @@ class AugmentationAspect
      */
     protected function switchToUILocale($reset = false)
     {
-        if ($reset === TRUE) {
+        if ($reset === true) {
             // Reset the locale
             $this->i18nService->getConfiguration()->setCurrentLocale($this->rememberedContentLocale);
         } else {


### PR DESCRIPTION
Steps to reproduce: e.g. go to Multiple columns page in demo site. Switch language to Latvian. Label for content collection that is not rendered (footer) will be rendered in Larvian.