### PR TITLE
BUGFIX: set height of codemirror instance with ref callback

### DIFF
--- a/packages/neos-ui-editors/src/SecondaryEditors/CodeMirrorWrap/index.js
+++ b/packages/neos-ui-editors/src/SecondaryEditors/CodeMirrorWrap/index.js
@@ -26,13 +26,16 @@ export default class CodeMirrorWrap extends PureComponent {
         this.handleChange = this.handleChange.bind(this);
     }
 
-    componentDidMount() {
-        const codeMirrorDomElement = document.querySelector('div.ReactCodeMirror > .CodeMirror');
-        const offsetTop = codeMirrorDomElement.getBoundingClientRect().top;
+    editorRefCallback = ref => {
+        if (!ref) {
+            return;
+        }
+        const codeMirrorRef = ref.getCodeMirror();
+        const codeMirrorWrapperDomElement = codeMirrorRef.display.wrapper;
+        const offsetTop = codeMirrorWrapperDomElement.getBoundingClientRect().top;
         const clientHeight = window.innerHeight || document.clientHeight || document.getElementByTagName('body').clientHeight;
         const height = clientHeight - offsetTop;
-
-        codeMirrorDomElement.style.height = `${height}px`;
+        codeMirrorRef.setSize(null, height);
     }
 
     render() {
@@ -46,7 +49,7 @@ export default class CodeMirrorWrap extends PureComponent {
         };
 
         return (
-            <CodeMirror value={this.props.value} onChange={this.handleChange} options={options}/>
+            <CodeMirror value={this.props.value} onChange={this.handleChange} options={options} ref={this.editorRefCallback}/>
         );
     }
 


### PR DESCRIPTION
Fixes: #832 
Before, sometimes not all lines were rendered in the editor because the setting the height manually did not trigger a rerender of the lines.
When setting the height with the [`setSize()`-method from codemirror](https://github.com/codemirror/CodeMirror/blob/0ea666fe3db9cd68dd951cc9178944cccdd9276d/src/edit/methods.js#L392), the number of displayed lines is newly calculated.

Setting the height this way seems to be advised with codemirror, as it mentioned here:
https://github.com/JedWatson/react-codemirror/issues/57#issuecomment-274236854

