### PR TITLE
TASK: Extract z-index variables into CSS vars

### DIFF
--- a/packages/build-essentials/src/styleConfig.js
+++ b/packages/build-essentials/src/styleConfig.js
@@ -3,29 +3,89 @@ const upperFirst = require('lodash.upperfirst');
 // Global CSS variables for Neos.Ui
 const config = {
     zIndex: {
-        flashMessage: '999999',
-        linkIconButton: '1000',
-        aspectRatioDropdownContents: '10',
+        secondaryToolbar: {
+            linkIconButtonFlyout: '1'
+        },
+        flashMessageContainer: {
+            context: '1'
+        },
+        secondaryInspector: {
+            context: '1',
+            close: '2'
+        },
+        secondaryInspectorElevated: {
+            context: '1',
+            dropdownContents: '2'
+        },
+        dialog: {
+            context: '1'
+        },
+        fullScreenClose: {
+            context: '1'
+        },
+        drawer: {
+            context: '1'
+        },
+        bar: {
+            context: '1'
+        },
+        primaryToolbar: {
+            context: '1'
+        },
+        checkboxInput: {
+            context: '1'
+        },
+        dropdownContents: {
+            context: '1'
+        },
+        selectBoxContents: {
+            context: '1'
+        },
+        selectBoxLoadingIcon: {
+            context: '1'
+        },
+        selectBoxBtnDelete: {
+            context: '1'
+        },
+        notInlineEditableOverlay: {
+            context: '1'
+        },
+        calendarFakeInputMirror: {
+            context: '1'
+        },
+        rdtPicker: {
+            context: '1'
+        },
+        sideBar: {
+            dropTargetBefore: '1',
+            dropTargetAfter: '2'
+        },
+        wrapperDropdown: {
+            context: '1'
+        },
+        flashMessage: '999999', //
+        linkIconButton: '1000', //
+        aspectRatioDropdownContents: '10', // secondaryInspectorElevated.dropdownContents
         nodeToolBar: '2147483647',
-        notInlineEditableOverlay: '10000',
-        secondaryInspectorElevated: '10001',
-        secondaryInspectorClose: '10',
-        drawer: '8000',
-        fullScreenClose: '1',
-        primaryToolbar: '9999',
+        notInlineEditableOverlay: '10000', // notInlineEditableOverlay.context
+        secondaryInspectorElevated: '10001', // secondaryInspectorElevated.context
+        secondaryInspectorClose: '10', // secondaryInspector.close
+        drawer: '8000', // drawer.context
+        fullScreenClose: '1', // fullScreenClose.context
+        primaryToolbar: '9999', // primaryToolbar.context
         unappliedChangesOverlay: '10000',
-        bar: '1',
-        checkboxInput: '1',
-        calendarFakeInputMirror: '1',
-        rdtPicker: '99999 !important',
-        dialog: '999',
-        dropdownContents: '1',
-        wrapperDropdown: '1',
-        selectBoxLoadingIcon: '1',
-        selectBoxBtnDelete: '1',
-        selectBoxContents: '10',
-        dropTargetBefore: '1',
-        dropTargetAfter: '2'
+        bar: '1', // bar.context
+        checkboxInput: '1', // checkoboxInput.context
+        calendarFakeInputMirror: '1', // calendarFakeInputMirror.context
+        rdtPicker: '99999 !important', // rdtPicker.context
+        dialog: '999', // dialog.context
+        dropdownContents: '1', // dropdownContents.context
+        wrapperDropdown: '1', //
+        selectBoxLoadingIcon: '1', // selectBoxLoadingIcon.context
+        selectBoxBtnDelete: '1', //
+        selectBoxContents: '10', // selectBoxContents.context
+        dropTargetBefore: '1', // sideBar.dropTargetBefore
+        dropTargetAfter: '2' // sidebar.dropTargetAfter
     }
 };
 
@@ -38,12 +98,12 @@ const generateCssVarsObject = (subject = config, predicate = '') => {
         const camelKey = upperFirst(key);
         const nestedPredicate = hasPredicate ? predicate + camelKey : key;
 
-        if (typeof val === 'object') {
-            target = Object.assign(
-        {},
-        target,
-        generateCssVarsObject(val, nestedPredicate)
-      );
+        if (Array.isArray(val)) {
+            val.forEach((item, index) => {
+                target[`--${predicate}${camelKey}${upperFirst(item)}`] = `${index + 1}`;
+            });
+        } else if (typeof val === 'object') {
+            target = Object.assign({}, target, generateCssVarsObject(val, nestedPredicate));
         } else {
             target[`--${predicate}${camelKey}`] = val;
         }

--- a/packages/build-essentials/src/styleConfig.js
+++ b/packages/build-essentials/src/styleConfig.js
@@ -1,0 +1,58 @@
+const upperFirst = require('lodash.upperfirst');
+
+// Global CSS variables for Neos.Ui
+const config = {
+    zIndex: {
+        flashMessage: '999999',
+        linkIconButton: '1000',
+        aspectRatioDropdownContents: '10',
+        nodeToolBar: '2147483647',
+        notInlineEditableOverlay: '10000',
+        secondaryInspectorElevated: '10001',
+        secondaryInspectorClose: '10',
+        drawer: '8000',
+        fullScreenClose: '1',
+        primaryToolbar: '9999',
+        unappliedChangesOverlay: '10000',
+        bar: '1',
+        checkboxInput: '1',
+        calendarFakeInputMirror: '1',
+        rdtPicker: '99999 !important',
+        dialog: '999',
+        dropdownContents: '1',
+        wrapperDropdown: '1',
+        selectBoxLoadingIcon: '1',
+        selectBoxBtnDelete: '1',
+        selectBoxContents: '10',
+        dropTargetBefore: '1',
+        dropTargetAfter: '2'
+    }
+};
+
+const generateCssVarsObject = (subject = config, predicate = '') => {
+    const hasPredicate = predicate && predicate.length;
+    let target = {};
+
+    Object.keys(subject).forEach(key => {
+        const val = subject[key];
+        const camelKey = upperFirst(key);
+        const nestedPredicate = hasPredicate ? predicate + camelKey : key;
+
+        if (typeof val === 'object') {
+            target = Object.assign(
+        {},
+        target,
+        generateCssVarsObject(val, nestedPredicate)
+      );
+        } else {
+            target[`--${predicate}${camelKey}`] = val;
+        }
+    });
+
+    return target;
+};
+
+module.exports = {
+    config,
+    generateCssVarsObject
+};

--- a/packages/build-essentials/src/styleConfig.js
+++ b/packages/build-essentials/src/styleConfig.js
@@ -3,89 +3,27 @@ const upperFirst = require('lodash.upperfirst');
 // Global CSS variables for Neos.Ui
 const config = {
     zIndex: {
-        secondaryToolbar: {
-            linkIconButtonFlyout: '1'
-        },
-        flashMessageContainer: {
-            context: '1'
-        },
-        secondaryInspector: {
-            context: '1',
-            close: '2'
-        },
-        secondaryInspectorElevated: {
-            context: '1',
-            dropdownContents: '2'
-        },
-        dialog: {
-            context: '1'
-        },
-        fullScreenClose: {
-            context: '1'
-        },
-        drawer: {
-            context: '1'
-        },
-        bar: {
-            context: '1'
-        },
-        primaryToolbar: {
-            context: '1'
-        },
-        checkboxInput: {
-            context: '1'
-        },
-        dropdownContents: {
-            context: '1'
-        },
-        selectBoxContents: {
-            context: '1'
-        },
-        selectBoxLoadingIcon: {
-            context: '1'
-        },
-        selectBoxBtnDelete: {
-            context: '1'
-        },
-        notInlineEditableOverlay: {
-            context: '1'
-        },
-        calendarFakeInputMirror: {
-            context: '1'
-        },
-        rdtPicker: {
-            context: '1'
-        },
-        sideBar: {
-            dropTargetBefore: '1',
-            dropTargetAfter: '2'
-        },
-        wrapperDropdown: {
-            context: '1'
-        },
-        flashMessage: '999999', //
-        linkIconButton: '1000', //
-        aspectRatioDropdownContents: '10', // secondaryInspectorElevated.dropdownContents
-        nodeToolBar: '2147483647',
-        notInlineEditableOverlay: '10000', // notInlineEditableOverlay.context
-        secondaryInspectorElevated: '10001', // secondaryInspectorElevated.context
-        secondaryInspectorClose: '10', // secondaryInspector.close
-        drawer: '8000', // drawer.context
-        fullScreenClose: '1', // fullScreenClose.context
-        primaryToolbar: '9999', // primaryToolbar.context
-        unappliedChangesOverlay: '10000',
-        bar: '1', // bar.context
-        checkboxInput: '1', // checkoboxInput.context
-        calendarFakeInputMirror: '1', // calendarFakeInputMirror.context
-        rdtPicker: '99999 !important', // rdtPicker.context
-        dialog: '999', // dialog.context
-        dropdownContents: '1', // dropdownContents.context
-        wrapperDropdown: '1', //
-        selectBoxLoadingIcon: '1', // selectBoxLoadingIcon.context
-        selectBoxBtnDelete: '1', //
-        selectBoxContents: '10', // selectBoxContents.context
-        dropTargetBefore: '1', // sideBar.dropTargetBefore
-        dropTargetAfter: '2' // sidebar.dropTargetAfter
+        secondaryToolbar: ['linkIconButtonFlyout'],
+        flashMessageContainer: ['context'],
+        secondaryInspector: ['context', 'close'],
+        secondaryInspectorElevated: ['context', 'dropdownContents'],
+        dialog: ['context'],
+        fullScreenClose: ['context'],
+        drawer: ['context'],
+        bar: ['context'],
+        primaryToolbar: ['context'],
+        checkboxInput: ['context'],
+        dropdownContents: ['context'],
+        selectBoxContents: ['context'],
+        selectBoxLoadingIcon: ['context'],
+        selectBoxBtnDelete: ['context'],
+        notInlineEditableOverlay: ['context'],
+        calendarFakeInputMirror: ['context'],
+        rdtPicker: ['context'],
+        sideBar: ['dropTargetBefore', 'dropTargetAfter'],
+        wrapperDropdown: ['context'],
+        unappliedChangesOverlay: ['context'],
+        nodeToolBar: '2147483647'
     }
 };
 

--- a/packages/build-essentials/src/styleConfig.js
+++ b/packages/build-essentials/src/styleConfig.js
@@ -38,12 +38,12 @@ const generateCssVarsObject = (subject = config, predicate = '') => {
 
         if (Array.isArray(val)) {
             val.forEach((item, index) => {
-                target[`--${predicate}${camelKey}${upperFirst(item)}`] = `${index + 1}`;
+                target[`--${predicate}-${camelKey}-${upperFirst(item)}`] = `${index + 1}`;
             });
         } else if (typeof val === 'object') {
             target = Object.assign({}, target, generateCssVarsObject(val, nestedPredicate));
         } else {
-            target[`--${predicate}${camelKey}`] = val;
+            target[`--${predicate}-${camelKey}`] = val;
         }
     });
 

--- a/packages/build-essentials/src/webpack.config.js
+++ b/packages/build-essentials/src/webpack.config.js
@@ -4,7 +4,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const LiveReloadPlugin = require('webpack-livereload-plugin');
 const env = require('./environment');
 const brand = require('@neos-project/brand');
-
+const styles = require('./styleConfig');
 //
 // Prevent from failing, when NEOS_BUILD_ROOT env variable isn't set
 // (e.g. when extending this config from storybook)
@@ -12,10 +12,13 @@ const brand = require('@neos-project/brand');
 const rootPath = env.rootPath || __dirname;
 
 //
-// Create the vars object for brand vars like colors and font settings
+// Create the vars object for:
+//    - brand vars like colors and font settings
+//    - global css variables for Neos.Ui
 // for the `postcss-css-variables` plugin.
 //
 const brandVars = brand.generateCssVarsObject(brand.config, 'brand');
+const styleVars = styles.generateCssVarsObject(styles.config);
 
 const webpackConfig = {
     // https://github.com/webpack/docs/wiki/build-performance#sourcemaps
@@ -70,7 +73,7 @@ const webpackConfig = {
                 // Font sizes
                 //
                 '--baseFontSize': '14px'
-            }, brandVars)
+            }, styleVars, brandVars)
         }),
         require('postcss-import')(),
         require('postcss-nested')(),

--- a/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/style.css
+++ b/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/style.css
@@ -17,7 +17,7 @@
 
 .linkIconButton__flyout {
     position: fixed;
-    z-index: var(--zIndexLinkIconButton);
+    z-index: var(--zIndexSecondaryToolbarLinkIconButtonFlyout);
     width: 460px;
     border: var(--halfSpacing) solid var(--brandColorsContrastDarker);
 }

--- a/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/style.css
+++ b/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/style.css
@@ -17,7 +17,7 @@
 
 .linkIconButton__flyout {
     position: fixed;
-    z-index: var(--zIndexSecondaryToolbarLinkIconButtonFlyout);
+    z-index: var(--zIndex-SecondaryToolbar-LinkIconButtonFlyout);
     width: 460px;
     border: var(--halfSpacing) solid var(--brandColorsContrastDarker);
 }

--- a/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/style.css
+++ b/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/style.css
@@ -17,7 +17,7 @@
 
 .linkIconButton__flyout {
     position: fixed;
-    z-index: 1000;
+    z-index: var(--zIndexLinkIconButton);
     width: 460px;
     border: var(--halfSpacing) solid var(--brandColorsContrastDarker);
 }

--- a/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/AspectRatioDropDown/style.css
+++ b/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/AspectRatioDropDown/style.css
@@ -33,7 +33,7 @@
 .dropDown__contents {
     min-width: 160px;
     box-shadow: 0 5px 10px rgba(#000, .2);
-    z-index: var(--zIndexAspectRatioDropdownContents);
+    z-index: var(--zIndexSecondaryInspectorElevatedDropdownContents);
 }
 .dropDown__item {
     height: 40px;

--- a/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/AspectRatioDropDown/style.css
+++ b/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/AspectRatioDropDown/style.css
@@ -33,7 +33,7 @@
 .dropDown__contents {
     min-width: 160px;
     box-shadow: 0 5px 10px rgba(#000, .2);
-    z-index: 10;
+    z-index: var(--zIndexAspectRatioDropdownContents);
 }
 .dropDown__item {
     height: 40px;

--- a/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/AspectRatioDropDown/style.css
+++ b/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/AspectRatioDropDown/style.css
@@ -33,7 +33,7 @@
 .dropDown__contents {
     min-width: 160px;
     box-shadow: 0 5px 10px rgba(#000, .2);
-    z-index: var(--zIndexSecondaryInspectorElevatedDropdownContents);
+    z-index: var(--zIndex-SecondaryInspectorElevated-DropdownContents);
 }
 .dropDown__item {
     height: 40px;

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/style.css
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/style.css
@@ -2,7 +2,7 @@
     position: absolute;
     border-bottom: 1px solid var(--brandColorsContrastDark);
     background: #222;
-    z-index: 2147483647;
+    z-index: var(--zIndexNodeToolBar);
 }
 .toolBar__btnGroup {
     border-bottom: 1px solid var(--brandColorsContrastDark);

--- a/packages/neos-ui-guest-frame/src/style.css
+++ b/packages/neos-ui-guest-frame/src/style.css
@@ -27,7 +27,7 @@
     left: 0;
     bottom: 0;
     right: 0;
-    z-index: var(--zIndexNotInlineEditableOverlayContext);
+    z-index: var(--zIndex-NotInlineEditableOverlay-Context);
     background-size: 100%;
     background-image: linear-gradient(to bottom, rgba(50, 50, 50, .1), rgba(50, 50, 50, .2), rgba(50, 50, 50, .1));
 }

--- a/packages/neos-ui-guest-frame/src/style.css
+++ b/packages/neos-ui-guest-frame/src/style.css
@@ -27,7 +27,7 @@
     left: 0;
     bottom: 0;
     right: 0;
-    z-index: var(--zIndexNotInlineEditableOverlay);
+    z-index: var(--zIndexNotInlineEditableOverlayContext);
     background-size: 100%;
     background-image: linear-gradient(to bottom, rgba(50, 50, 50, .1), rgba(50, 50, 50, .2), rgba(50, 50, 50, .1));
 }

--- a/packages/neos-ui-guest-frame/src/style.css
+++ b/packages/neos-ui-guest-frame/src/style.css
@@ -27,7 +27,7 @@
     left: 0;
     bottom: 0;
     right: 0;
-    z-index: 10000;
+    z-index: var(--zIndexNotInlineEditableOverlay);
     background-size: 100%;
     background-image: linear-gradient(to bottom, rgba(50, 50, 50, .1), rgba(50, 50, 50, .2), rgba(50, 50, 50, .1));
 }

--- a/packages/neos-ui-inspector/src/SecondaryInspector/style.css
+++ b/packages/neos-ui-inspector/src/SecondaryInspector/style.css
@@ -17,7 +17,7 @@
     right: 0;
 }
 .secondaryInspector--isElevated {
-    z-index: var(--zIndexSecondaryInspectorElevatedContext);
+    z-index: var(--zIndex-SecondaryInspectorElevated-Context);
 }
 .secondaryInspector .close {
     position: absolute;

--- a/packages/neos-ui-inspector/src/SecondaryInspector/style.css
+++ b/packages/neos-ui-inspector/src/SecondaryInspector/style.css
@@ -17,7 +17,7 @@
     right: 0;
 }
 .secondaryInspector--isElevated {
-    z-index: var(--zIndexSecondaryInspectorElevated);
+    z-index: var(--zIndexSecondaryInspectorElevatedContext);
 }
 .secondaryInspector .close {
     position: absolute;

--- a/packages/neos-ui-inspector/src/SecondaryInspector/style.css
+++ b/packages/neos-ui-inspector/src/SecondaryInspector/style.css
@@ -29,5 +29,5 @@
     font-size: 18px;
     border-right-width: 0;
     border-top-width: 0;
-    z-index: var(--zIndexSecondaryInspectorClose);
+    z-index: var(--zIndex-SecondaryInspector-Close);
 }

--- a/packages/neos-ui-inspector/src/SecondaryInspector/style.css
+++ b/packages/neos-ui-inspector/src/SecondaryInspector/style.css
@@ -17,7 +17,7 @@
     right: 0;
 }
 .secondaryInspector--isElevated {
-    z-index: 10001;
+    z-index: var(--zIndexSecondaryInspectorElevated);
 }
 .secondaryInspector .close {
     position: absolute;
@@ -29,5 +29,5 @@
     font-size: 18px;
     border-right-width: 0;
     border-top-width: 0;
-    z-index: 10;
+    z-index: var(--zIndexSecondaryInspectorClose);
 }

--- a/packages/neos-ui/src/Containers/Drawer/style.css
+++ b/packages/neos-ui/src/Containers/Drawer/style.css
@@ -2,7 +2,7 @@
     position: fixed;
     top: 41px;
     left: 0;
-    z-index: 8000;
+    z-index: var(--zIndexDrawer);
     height: 100%;
     width: var(--sidebarWidth);
     background: var(--brandColorsContrastDarker);

--- a/packages/neos-ui/src/Containers/Drawer/style.css
+++ b/packages/neos-ui/src/Containers/Drawer/style.css
@@ -2,7 +2,7 @@
     position: fixed;
     top: 41px;
     left: 0;
-    z-index: var(--zIndexDrawerContext);
+    z-index: var(--zIndex-Drawer-Context);
     height: 100%;
     width: var(--sidebarWidth);
     background: var(--brandColorsContrastDarker);

--- a/packages/neos-ui/src/Containers/Drawer/style.css
+++ b/packages/neos-ui/src/Containers/Drawer/style.css
@@ -2,7 +2,7 @@
     position: fixed;
     top: 41px;
     left: 0;
-    z-index: var(--zIndexDrawer);
+    z-index: var(--zIndexDrawerContext);
     height: 100%;
     width: var(--sidebarWidth);
     background: var(--brandColorsContrastDarker);

--- a/packages/neos-ui/src/Containers/FlashMessages/style.css
+++ b/packages/neos-ui/src/Containers/FlashMessages/style.css
@@ -1,6 +1,6 @@
 .flashMessageContainer {
     position: fixed;
-    z-index: 999999;
+    z-index: var(--zIndexFlashMessage);
     top: 0;
     left: 50%;
     width: 512px;

--- a/packages/neos-ui/src/Containers/FlashMessages/style.css
+++ b/packages/neos-ui/src/Containers/FlashMessages/style.css
@@ -1,6 +1,6 @@
 .flashMessageContainer {
     position: fixed;
-    z-index: var(--zIndexFlashMessage);
+    z-index: var(--zIndexFlashMessageContainerContext);
     top: 0;
     left: 50%;
     width: 512px;

--- a/packages/neos-ui/src/Containers/FlashMessages/style.css
+++ b/packages/neos-ui/src/Containers/FlashMessages/style.css
@@ -1,6 +1,6 @@
 .flashMessageContainer {
     position: fixed;
-    z-index: var(--zIndexFlashMessageContainerContext);
+    z-index: var(--zIndex-FlashMessageContainer-Context);
     top: 0;
     left: 50%;
     width: 512px;

--- a/packages/neos-ui/src/Containers/FullScreen/style.css
+++ b/packages/neos-ui/src/Containers/FullScreen/style.css
@@ -2,7 +2,7 @@
     position: fixed;
     top: var(--spacing);
     right: calc(2 * var(--spacing));
-    z-index: 1;
+    z-index: var(--zIndexFullScreenClose);
     background-color: var(--brandColorsPrimaryBlue);
     box-shadow: 0 0 8px rgba(#000, .25);
 }

--- a/packages/neos-ui/src/Containers/FullScreen/style.css
+++ b/packages/neos-ui/src/Containers/FullScreen/style.css
@@ -2,7 +2,7 @@
     position: fixed;
     top: var(--spacing);
     right: calc(2 * var(--spacing));
-    z-index: var(--zIndexFullScreenClose);
+    z-index: var(--zIndexFullScreenCloseContext);
     background-color: var(--brandColorsPrimaryBlue);
     box-shadow: 0 0 8px rgba(#000, .25);
 }

--- a/packages/neos-ui/src/Containers/FullScreen/style.css
+++ b/packages/neos-ui/src/Containers/FullScreen/style.css
@@ -2,7 +2,7 @@
     position: fixed;
     top: var(--spacing);
     right: calc(2 * var(--spacing));
-    z-index: var(--zIndexFullScreenCloseContext);
+    z-index: var(--zIndex-FlashMessageContainer-Context);
     background-color: var(--brandColorsPrimaryBlue);
     box-shadow: 0 0 8px rgba(#000, .25);
 }

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/style.css
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/style.css
@@ -8,7 +8,7 @@
         clear: both;
     }
 
-    z-index: 9999;
+    z-index: var(--zIndexPrimaryToolbar);
 }
 .primaryToolbar--isHidden {
     display: none;

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/style.css
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/style.css
@@ -8,7 +8,7 @@
         clear: both;
     }
 
-    z-index: var(--zIndexPrimaryToolbarContext);
+    z-index: var(--zIndex-PrimaryToolbar-Context);
 }
 .primaryToolbar--isHidden {
     display: none;

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/style.css
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/style.css
@@ -8,7 +8,7 @@
         clear: both;
     }
 
-    z-index: var(--zIndexPrimaryToolbar);
+    z-index: var(--zIndexPrimaryToolbarContext);
 }
 .primaryToolbar--isHidden {
     display: none;

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/style.css
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/style.css
@@ -19,7 +19,7 @@
     left: 0;
     width: calc(100% - var(--sidebarWidth));
     height: 100%;
-    z-index: 10000;
+    z-index: var(--zIndexUnappliedChangesOverlay);
     &,
     &::after {
         position: fixed;

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/style.css
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/style.css
@@ -19,7 +19,7 @@
     left: 0;
     width: calc(100% - var(--sidebarWidth));
     height: 100%;
-    z-index: var(--zIndexUnappliedChangesOverlay);
+    z-index: var(--zIndex-UnappliedChangesOverlay-Context);
     &,
     &::after {
         position: fixed;

--- a/packages/react-ui-components/src/Bar/style.css
+++ b/packages/react-ui-components/src/Bar/style.css
@@ -2,7 +2,7 @@
     composes: reset from './../reset.css';
     position: absolute;
     left: 0;
-    z-index: var(--zIndexBar);
+    z-index: var(--zIndexBarContext);
     width: 100%;
     background-color: var(--brandColorsContrastDarker);
     height: 41px;

--- a/packages/react-ui-components/src/Bar/style.css
+++ b/packages/react-ui-components/src/Bar/style.css
@@ -2,7 +2,7 @@
     composes: reset from './../reset.css';
     position: absolute;
     left: 0;
-    z-index: 1;
+    z-index: var(--zIndexBar);
     width: 100%;
     background-color: var(--brandColorsContrastDarker);
     height: 41px;

--- a/packages/react-ui-components/src/Bar/style.css
+++ b/packages/react-ui-components/src/Bar/style.css
@@ -2,7 +2,7 @@
     composes: reset from './../reset.css';
     position: absolute;
     left: 0;
-    z-index: var(--zIndexBarContext);
+    z-index: var(--zIndex-CheckboxInput-Context);
     width: 100%;
     background-color: var(--brandColorsContrastDarker);
     height: 41px;

--- a/packages/react-ui-components/src/CheckBox/style.css
+++ b/packages/react-ui-components/src/CheckBox/style.css
@@ -10,7 +10,7 @@
     position: absolute;
     top: 50%;
     left: 0;
-    z-index: var(--zIndexCheckboxInputContext);
+    z-index: var(--zIndex-CheckboxInput-Context);
     transform: translateY(-50%);
     width: 20px;
     height: 20px;

--- a/packages/react-ui-components/src/CheckBox/style.css
+++ b/packages/react-ui-components/src/CheckBox/style.css
@@ -10,7 +10,7 @@
     position: absolute;
     top: 50%;
     left: 0;
-    z-index: var(--zIndexCheckboxInput);
+    z-index: var(--zIndexCheckboxInputContext);
     transform: translateY(-50%);
     width: 20px;
     height: 20px;

--- a/packages/react-ui-components/src/CheckBox/style.css
+++ b/packages/react-ui-components/src/CheckBox/style.css
@@ -10,7 +10,7 @@
     position: absolute;
     top: 50%;
     left: 0;
-    z-index: 1;
+    z-index: var(--zIndexCheckboxInput);
     transform: translateY(-50%);
     width: 20px;
     height: 20px;

--- a/packages/react-ui-components/src/DateInput/style.css
+++ b/packages/react-ui-components/src/DateInput/style.css
@@ -43,7 +43,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: 1;
+    z-index: var(--zIndexCalendarFakeInputMirror);
     cursor: pointer;
 }
 .calendarFakeInput {
@@ -118,7 +118,7 @@
             width: 250px;
             padding: 4px;
             margin-top: 1px;
-            z-index: 99999 !important;
+            z-index: var(--zIndexRdtPicker);
             background: #fff;
             box-shadow: 0 1px 3px rgba(0, 0, 0, .1);
             border: 1px solid var(--brandColorsContrastNeutral);

--- a/packages/react-ui-components/src/DateInput/style.css
+++ b/packages/react-ui-components/src/DateInput/style.css
@@ -43,7 +43,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: var(--zIndexCalendarFakeInputMirrorContext);
+    z-index: var(--zIndex-CalendarFakeInputMirror-Context);
     cursor: pointer;
 }
 .calendarFakeInput {
@@ -118,7 +118,7 @@
             width: 250px;
             padding: 4px;
             margin-top: 1px;
-            z-index: var(--zIndexRdtPickerContext);
+            z-index: var(--zIndex-RdtPicker-Context);
             background: #fff;
             box-shadow: 0 1px 3px rgba(0, 0, 0, .1);
             border: 1px solid var(--brandColorsContrastNeutral);

--- a/packages/react-ui-components/src/DateInput/style.css
+++ b/packages/react-ui-components/src/DateInput/style.css
@@ -43,7 +43,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: var(--zIndexCalendarFakeInputMirror);
+    z-index: var(--zIndexCalendarFakeInputMirrorContext);
     cursor: pointer;
 }
 .calendarFakeInput {
@@ -118,7 +118,7 @@
             width: 250px;
             padding: 4px;
             margin-top: 1px;
-            z-index: var(--zIndexRdtPicker);
+            z-index: var(--zIndexRdtPickerContext);
             background: #fff;
             box-shadow: 0 1px 3px rgba(0, 0, 0, .1);
             border: 1px solid var(--brandColorsContrastNeutral);

--- a/packages/react-ui-components/src/Dialog/style.css
+++ b/packages/react-ui-components/src/Dialog/style.css
@@ -3,7 +3,7 @@
     position: fixed;
     top: 0;
     left: 0;
-    z-index: var(--zIndexDialogContext);
+    z-index: var(--zIndex-Dialog-Context);
     width: 100vw;
     height: 100vh;
     background: rgba(#000, .35);

--- a/packages/react-ui-components/src/Dialog/style.css
+++ b/packages/react-ui-components/src/Dialog/style.css
@@ -3,7 +3,7 @@
     position: fixed;
     top: 0;
     left: 0;
-    z-index: var(--zIndexDialog);
+    z-index: var(--zIndexDialogContext);
     width: 100vw;
     height: 100vh;
     background: rgba(#000, .35);

--- a/packages/react-ui-components/src/Dialog/style.css
+++ b/packages/react-ui-components/src/Dialog/style.css
@@ -3,7 +3,7 @@
     position: fixed;
     top: 0;
     left: 0;
-    z-index: 999;
+    z-index: var(--zIndexDialog);
     width: 100vw;
     height: 100vh;
     background: rgba(#000, .35);

--- a/packages/react-ui-components/src/DropDown/style.css
+++ b/packages/react-ui-components/src/DropDown/style.css
@@ -41,7 +41,7 @@
     position: absolute;
     top: 100%;
     left: 0;
-    z-index: 1;
+    z-index: var(--zIndexDropdownContents);
     display: none;
     width: 100%;
     padding: 0;

--- a/packages/react-ui-components/src/DropDown/style.css
+++ b/packages/react-ui-components/src/DropDown/style.css
@@ -41,7 +41,7 @@
     position: absolute;
     top: 100%;
     left: 0;
-    z-index: var(--zIndexDropdownContents);
+    z-index: var(--zIndexDropdownContentsContext);
     display: none;
     width: 100%;
     padding: 0;

--- a/packages/react-ui-components/src/DropDown/style.css
+++ b/packages/react-ui-components/src/DropDown/style.css
@@ -41,7 +41,7 @@
     position: absolute;
     top: 100%;
     left: 0;
-    z-index: var(--zIndexDropdownContentsContext);
+    z-index: var(--zIndex-DropdownContents-Context);
     display: none;
     width: 100%;
     padding: 0;

--- a/packages/react-ui-components/src/IconButtonDropDown/style.css
+++ b/packages/react-ui-components/src/IconButtonDropDown/style.css
@@ -27,7 +27,7 @@
     position: absolute;
     top: 100%;
     left: 0;
-    z-index: 1;
+    z-index: var(--zIndexWrapperDropdown);
     display: none;
     background: var(--brandColorsContrastDarker);
     border: 1px solid var(--brandColorsContrastDark);

--- a/packages/react-ui-components/src/IconButtonDropDown/style.css
+++ b/packages/react-ui-components/src/IconButtonDropDown/style.css
@@ -27,7 +27,7 @@
     position: absolute;
     top: 100%;
     left: 0;
-    z-index: var(--zIndexWrapperDropdown);
+    z-index: var(--zIndexWrapperDropdownContext);
     display: none;
     background: var(--brandColorsContrastDarker);
     border: 1px solid var(--brandColorsContrastDark);

--- a/packages/react-ui-components/src/IconButtonDropDown/style.css
+++ b/packages/react-ui-components/src/IconButtonDropDown/style.css
@@ -27,7 +27,7 @@
     position: absolute;
     top: 100%;
     left: 0;
-    z-index: var(--zIndexWrapperDropdownContext);
+    z-index: var(--zIndex-WrapperDropdown-Context);
     display: none;
     background: var(--brandColorsContrastDarker);
     border: 1px solid var(--brandColorsContrastDark);

--- a/packages/react-ui-components/src/SelectBox/style.css
+++ b/packages/react-ui-components/src/SelectBox/style.css
@@ -77,7 +77,7 @@
     position: absolute;
     top: 0;
     right: 0;
-    z-index: var(--zIndexSelectBoxLoadingIcon);
+    z-index: var(--zIndexSelectBoxLoadingIconContext);
     display: block;
     width: var(--goldenUnit);
     height: var(--goldenUnit);
@@ -97,7 +97,7 @@
     position: absolute;
     top: 0;
     right: 0;
-    z-index: var(--zIndexSelectBoxBtnDelete);
+    z-index: var(--zIndexSelectBoxBtnDeleteContext);
     display: block;
     width: var(--goldenUnit);
     height: var(--goldenUnit);
@@ -115,7 +115,7 @@
     composes: reset from './../reset.css';
     min-width: 160px;
     box-shadow: 0 5px 10px rgba(#000, .2);
-    z-index: var(--zIndexSelectBoxContents);
+    z-index: var(--zIndexSelectBoxContentsContext);
 }
 
 

--- a/packages/react-ui-components/src/SelectBox/style.css
+++ b/packages/react-ui-components/src/SelectBox/style.css
@@ -77,7 +77,7 @@
     position: absolute;
     top: 0;
     right: 0;
-    z-index: 1;
+    z-index: var(--zIndexSelectBoxLoadingIcon);
     display: block;
     width: var(--goldenUnit);
     height: var(--goldenUnit);
@@ -97,7 +97,7 @@
     position: absolute;
     top: 0;
     right: 0;
-    z-index: 1;
+    z-index: var(--zIndexSelectBoxBtnDelete);
     display: block;
     width: var(--goldenUnit);
     height: var(--goldenUnit);
@@ -115,7 +115,7 @@
     composes: reset from './../reset.css';
     min-width: 160px;
     box-shadow: 0 5px 10px rgba(#000, .2);
-    z-index: 10;
+    z-index: var(--zIndexSelectBoxContents);
 }
 
 

--- a/packages/react-ui-components/src/SelectBox/style.css
+++ b/packages/react-ui-components/src/SelectBox/style.css
@@ -77,7 +77,7 @@
     position: absolute;
     top: 0;
     right: 0;
-    z-index: var(--zIndexSelectBoxLoadingIconContext);
+    z-index: var(--zIndex-SelectBoxLoadingIcon-Context);
     display: block;
     width: var(--goldenUnit);
     height: var(--goldenUnit);
@@ -97,7 +97,7 @@
     position: absolute;
     top: 0;
     right: 0;
-    z-index: var(--zIndexSelectBoxBtnDeleteContext);
+    z-index: var(--zIndex-SelectBoxBtnDelete-Context);
     display: block;
     width: var(--goldenUnit);
     height: var(--goldenUnit);
@@ -115,7 +115,7 @@
     composes: reset from './../reset.css';
     min-width: 160px;
     box-shadow: 0 5px 10px rgba(#000, .2);
-    z-index: var(--zIndexSelectBoxContentsContext);
+    z-index: var(--zIndex-SelectBoxContents-Context);
 }
 
 

--- a/packages/react-ui-components/src/Tree/node.css
+++ b/packages/react-ui-components/src/Tree/node.css
@@ -107,13 +107,13 @@
 }
 .dropTarget--before {
     top: -5px;
-    z-index: var(--zIndexDropTargetBefore);
+    z-index: var(--zIndexSideBarDropTargetBefore);
     padding-top: 4px;
     padding-bottom: 4px;
 }
 .dropTarget--after {
     bottom: 0;
-    z-index: var(--zIndexDropTargetAfter);
+    z-index: var(--zIndexSideBarDropTargetAfter);
     padding-top: 6px;
     padding-bottom: 0;
 }

--- a/packages/react-ui-components/src/Tree/node.css
+++ b/packages/react-ui-components/src/Tree/node.css
@@ -107,13 +107,13 @@
 }
 .dropTarget--before {
     top: -5px;
-    z-index: var(--zIndexSideBarDropTargetBefore);
+    z-index: var(--zIndex-SideBar-DropTargetBefore);
     padding-top: 4px;
     padding-bottom: 4px;
 }
 .dropTarget--after {
     bottom: 0;
-    z-index: var(--zIndexSideBarDropTargetAfter);
+    z-index: var(--zIndex-SideBar-DropTargetAfter);
     padding-top: 6px;
     padding-bottom: 0;
 }

--- a/packages/react-ui-components/src/Tree/node.css
+++ b/packages/react-ui-components/src/Tree/node.css
@@ -107,13 +107,13 @@
 }
 .dropTarget--before {
     top: -5px;
-    z-index: 1;
+    z-index: var(--zIndexDropTargetBefore);
     padding-top: 4px;
     padding-bottom: 4px;
 }
 .dropTarget--after {
     bottom: 0;
-    z-index: 2;
+    z-index: var(--zIndexDropTargetAfter);
     padding-top: 6px;
     padding-bottom: 0;
 }


### PR DESCRIPTION
This PR is a first draft on how to move the z-indices to CSS vars as discussed in #793.
It reveals some issues which need to be solved:

- [x]  find a proper naming for the z-index-variables, e.g. scope the name to the corresponding component
- [x]  find a proper structure for the style config object
- [x]  refactor the existing [CSS vars](https://github.com/neos/neos-ui/blob/master/packages/build-essentials/src/webpack.config.js#L55) which are currently directly set in the webpack config. Maybe this out of scope of this PR which should deal with z-indices only.