### PR TITLE
FEATURE: Frontend configuration API

### DIFF
--- a/Classes/Neos/Neos/Ui/Domain/Service/ConfigurationRenderingService.php
+++ b/Classes/Neos/Neos/Ui/Domain/Service/ConfigurationRenderingService.php
@@ -9,7 +9,7 @@ use Neos\Flow\Annotations as Flow;
 /**
  * @Flow\Scope("singleton")
  */
-class StateRenderingService
+class ConfigurationRenderingService
 {
 
     /**
@@ -19,24 +19,24 @@ class StateRenderingService
     protected $eelEvaluator;
 
     /**
-     * @Flow\InjectConfiguration(path="state.defaultEelContext")
+     * @Flow\InjectConfiguration(path="configurationDefaultEelContext")
      * @var array
      */
     protected $defaultContext;
 
-    public function computeState(array $state, $context)
+    public function computeConfiguration(array $configuration, $context)
     {
-        $adjustedState = $state;
-        $this->computeStateInternally($adjustedState, $context);
+        $adjustedConfiguration = $configuration;
+        $this->computeConfigurationInternally($adjustedConfiguration, $context);
 
-        return $adjustedState;
+        return $adjustedConfiguration;
     }
 
-    protected function computeStateInternally(&$adjustedState, $context)
+    protected function computeConfigurationInternally(&$adjustedConfiguration, $context)
     {
-        foreach ($adjustedState as $key => &$value) {
+        foreach ($adjustedConfiguration as $key => &$value) {
             if (is_array($value)) {
-                $this->computeStateInternally($value, $context);
+                $this->computeConfigurationInternally($value, $context);
             } elseif (is_string($value) && substr($value, 0, 2) === '${' && substr($value, -1) === '}') {
                 $value = Utility::evaluateEelExpression($value, $this->eelEvaluator, $context, $this->defaultContext);
             }

--- a/Classes/Neos/Neos/Ui/Domain/Service/StyleAndJavascriptInclusionService.php
+++ b/Classes/Neos/Neos/Ui/Domain/Service/StyleAndJavascriptInclusionService.php
@@ -27,7 +27,7 @@ class StyleAndJavascriptInclusionService
     protected $eelEvaluator;
 
     /**
-     * @Flow\InjectConfiguration(path="state.defaultEelContext")
+     * @Flow\InjectConfiguration(path="configurationDefaultEelContext")
      * @var array
      */
     protected $defaultContext;

--- a/Classes/Neos/Neos/Ui/Fusion/RenderConfigurationImplementation.php
+++ b/Classes/Neos/Neos/Ui/Fusion/RenderConfigurationImplementation.php
@@ -1,19 +1,19 @@
 <?php
 namespace Neos\Neos\Ui\Fusion;
 
-use Neos\Neos\Ui\Domain\Service\StateRenderingService;
+use Neos\Neos\Ui\Domain\Service\ConfigurationRenderingService;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Exception;
 use Neos\Fusion\FusionObjects\AbstractFusionObject;
 
-class RenderStateImplementation extends AbstractFusionObject
+class RenderConfigurationImplementation extends AbstractFusionObject
 {
 
     /**
      * @Flow\Inject
-     * @var StateRenderingService
+     * @var ConfigurationRenderingService
      */
-    protected $stateRenderingService;
+    protected $configurationRenderingService;
 
     /**
      * @Flow\InjectConfiguration()
@@ -48,6 +48,6 @@ class RenderStateImplementation extends AbstractFusionObject
             throw new Exception('The path "Neos.Neos.Ui.' . $pathToRender . '" was not found in the settings.', 1458814468);
         }
 
-        return $this->stateRenderingService->computeState($this->settings[$pathToRender], $context);
+        return $this->configurationRenderingService->computeConfiguration($this->settings[$pathToRender], $context);
     }
 }

--- a/Classes/Neos/Neos/Ui/Fusion/RenderStateImplementation.php
+++ b/Classes/Neos/Neos/Ui/Fusion/RenderStateImplementation.php
@@ -16,19 +16,19 @@ class RenderStateImplementation extends AbstractFusionObject
     protected $stateRenderingService;
 
     /**
-     * @Flow\InjectConfiguration(path="state")
+     * @Flow\InjectConfiguration()
      * @var array
      */
-    protected $stateInSettings;
+    protected $settings;
 
     protected function getContext()
     {
         return $this->fusionValue('context');
     }
 
-    protected function getState()
+    protected function getPath()
     {
-        return $this->fusionValue('state');
+        return $this->fusionValue('path');
     }
 
 
@@ -41,13 +41,13 @@ class RenderStateImplementation extends AbstractFusionObject
     public function evaluate()
     {
         $context = $this->getContext();
-        $stateNameToRender = $this->getState();
+        $pathToRender = $this->getPath();
         $context['controllerContext'] = $this->getruntime()->getControllerContext();
 
-        if (!isset($this->stateInSettings[$stateNameToRender])) {
-            throw new Exception('The state "Neos.Neos.Ui.state.' . $stateNameToRender . '" was not found in the settings.', 1458814468);
+        if (!isset($this->settings[$pathToRender])) {
+            throw new Exception('The path "Neos.Neos.Ui.' . $pathToRender . '" was not found in the settings.', 1458814468);
         }
 
-        return $this->stateRenderingService->computeState($this->stateInSettings[$stateNameToRender], $context);
+        return $this->stateRenderingService->computeState($this->settings[$pathToRender], $context);
     }
 }

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -38,6 +38,12 @@ Neos:
       contentCanvas:
         backgroundColor: '#ffffff'
 
+      frontendConfiguration:
+        editPreviewModes: '${Configuration.setting(''Neos.Neos.userInterface.editPreviewModes'')}'
+        # You may use this place to deliver some configuration to your custom UI components, e.g.:
+        # 'Your.Own:Package':
+        #   someKey: someValue
+
       #################################
       # INTERNAL CONFIG (no API)
       #################################
@@ -46,24 +52,18 @@ Neos:
         document: 'Neos.Neos:Document'
         content: 'Neos.Neos:Content'
         contentCollection: 'Neos.Neos:ContentCollection'
-      state:
-        defaultEelContext:
-          String: Neos\Eel\Helper\StringHelper
-          Array: Neos\Eel\Helper\ArrayHelper
-          Date: Neos\Eel\Helper\DateHelper
-          Configuration: Neos\Eel\Helper\ConfigurationHelper
-          Math: Neos\Eel\Helper\MathHelper
-          Json: Neos\Eel\Helper\JsonHelper
-          I18n: Neos\Flow\I18n\EelHelper\TranslationHelper
-          Neos.Ui.Workspace: Neos\Neos\Ui\Fusion\Helper\WorkspaceHelper
-          Neos.Ui.NodeInfo: Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper
-          Neos.Ui.ContentDimensions: Neos\Neos\Ui\Fusion\Helper\ContentDimensionsHelper
-          Neos.Ui.StaticResources: Neos\Neos\Ui\Fusion\Helper\StaticResourcesHelper
-      frontendConfiguration:
-        editPreviewModes: '${Configuration.setting(''Neos.Neos.userInterface.editPreviewModes'')}'
-        # You may use this place to deliver some configuration to your custom UI components, e.g.:
-        # 'Your.Own:Package':
-        #   someKey: someValue
+      configurationDefaultEelContext:
+        String: Neos\Eel\Helper\StringHelper
+        Array: Neos\Eel\Helper\ArrayHelper
+        Date: Neos\Eel\Helper\DateHelper
+        Configuration: Neos\Eel\Helper\ConfigurationHelper
+        Math: Neos\Eel\Helper\MathHelper
+        Json: Neos\Eel\Helper\JsonHelper
+        I18n: Neos\Flow\I18n\EelHelper\TranslationHelper
+        Neos.Ui.Workspace: Neos\Neos\Ui\Fusion\Helper\WorkspaceHelper
+        Neos.Ui.NodeInfo: Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper
+        Neos.Ui.ContentDimensions: Neos\Neos\Ui\Fusion\Helper\ContentDimensionsHelper
+        Neos.Ui.StaticResources: Neos\Neos\Ui\Fusion\Helper\StaticResourcesHelper
       documentNodeInformation:
         metaData:
           contextPath: '${q(documentNode).property("_contextPath")}'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -59,72 +59,72 @@ Neos:
           Neos.Ui.NodeInfo: Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper
           Neos.Ui.ContentDimensions: Neos\Neos\Ui\Fusion\Helper\ContentDimensionsHelper
           Neos.Ui.StaticResources: Neos\Neos\Ui\Fusion\Helper\StaticResourcesHelper
-        frontendConfiguration:
-          editPreviewModes: '${Configuration.setting(''Neos.Neos.userInterface.editPreviewModes'')}'
-        documentNode:
-          metaData:
-            contextPath: '${q(documentNode).property("_contextPath")}'
+      frontendConfiguration:
+        editPreviewModes: '${Configuration.setting(''Neos.Neos.userInterface.editPreviewModes'')}'
+      documentNodeInformation:
+        metaData:
+          contextPath: '${q(documentNode).property("_contextPath")}'
+          siteNode: '${q(site).property(''_contextPath'')}'
+          previewUrl: '${Neos.Ui.NodeInfo.uri(q(documentNode).context({workspaceName: "live"}).get(0), controllerContext)}'
+          contentDimensions:
+            active: '${documentNode.context.dimensions}'
+            allowedPresets: '${Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.context.dimensions)}'
+          documentNodeSerialization: '${Neos.Ui.NodeInfo.renderNode(documentNode, controllerContext)}'
+      initialState:
+        changes:
+          pending: {  }
+          processing: {  }
+          failed: {  }
+        cr:
+          nodes:
+            byContextPath: '${Neos.Ui.NodeInfo.defaultNodesForBackend(site, documentNode, controllerContext)}'
             siteNode: '${q(site).property(''_contextPath'')}'
-            previewUrl: '${Neos.Ui.NodeInfo.uri(q(documentNode).context({workspaceName: "live"}).get(0), controllerContext)}'
-            contentDimensions:
-              active: '${documentNode.context.dimensions}'
-              allowedPresets: '${Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.context.dimensions)}'
-            documentNodeSerialization: '${Neos.Ui.NodeInfo.renderNode(documentNode, controllerContext)}'
-        backend:
-          changes:
-            pending: {  }
-            processing: {  }
-            failed: {  }
-          cr:
-            nodes:
-              byContextPath: '${Neos.Ui.NodeInfo.defaultNodesForBackend(site, documentNode, controllerContext)}'
-              siteNode: '${q(site).property(''_contextPath'')}'
-            contentDimensions:
-              byName: '${Neos.Ui.ContentDimensions.contentDimensionsByName()}'
-              active: '${documentNode.context.dimensions}'
-              allowedPresets: '${Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.context.dimensions)}'
-            workspaces:
-              personalWorkspace: '${Neos.Ui.Workspace.getPersonalWorkspace()}'
-          ui:
-            contentCanvas:
-              src: '${Neos.Ui.NodeInfo.uri(documentNode, controllerContext)}'
-              contextPath: '${q(documentNode).property(''_contextPath'')}'
-              backgroundColor: '${Configuration.setting(''Neos.Neos.Ui.contentCanvas.backgroundColor'')}'
-            debugMode: false
-            editPreviewMode: '${q(user).property("preferences.preferences")["contentEditing.editPreviewMode"] || Configuration.setting(''Neos.Neos.userInterface.defaultEditPreviewMode'')}'
-            fullScreen:
-              isFullScreen: false
-            editModePanel:
-              isHidden: true
-            leftSideBar:
-              isHidden: false
-            rightSideBar:
-              isHidden: false
-            addNodeModal:
-              referenceNode: ''
-              mode: insert
-            drawer:
-              isHidden: true
-            pageTree:
-              isLoading: false
-              hasError: false
-              focused: '${q(documentNode).property(''_contextPath'')}'
-              active: '${q(documentNode).property(''_contextPath'')}'
-            remote:
-              isSaving: false
-              isPublishing: false
-              isDiscarding: false
-          user:
-            name:
-              title: '${q(user).property(''name.title'')}'
-              firstName: '${q(user).property(''name.firstName'')}'
-              middleName: '${q(user).property(''name.middleName'')}'
-              lastName: '${q(user).property(''name.lastName'')}'
-              otherName: '${q(user).property(''name.otherName'')}'
-              fullName: '${q(user).property(''name.fullName'')}'
-            settings:
-              isAutoPublishingEnabled: false
-              targetWorkspace: 'live'
+          contentDimensions:
+            byName: '${Neos.Ui.ContentDimensions.contentDimensionsByName()}'
+            active: '${documentNode.context.dimensions}'
+            allowedPresets: '${Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.context.dimensions)}'
+          workspaces:
+            personalWorkspace: '${Neos.Ui.Workspace.getPersonalWorkspace()}'
+        ui:
+          contentCanvas:
+            src: '${Neos.Ui.NodeInfo.uri(documentNode, controllerContext)}'
+            contextPath: '${q(documentNode).property(''_contextPath'')}'
+            backgroundColor: '${Configuration.setting(''Neos.Neos.Ui.contentCanvas.backgroundColor'')}'
+          debugMode: false
+          editPreviewMode: '${q(user).property("preferences.preferences")["contentEditing.editPreviewMode"] || Configuration.setting(''Neos.Neos.userInterface.defaultEditPreviewMode'')}'
+          fullScreen:
+            isFullScreen: false
+          editModePanel:
+            isHidden: true
+          leftSideBar:
+            isHidden: false
+          rightSideBar:
+            isHidden: false
+          addNodeModal:
+            referenceNode: ''
+            mode: insert
+          drawer:
+            isHidden: true
+          pageTree:
+            isLoading: false
+            hasError: false
+            focused: '${q(documentNode).property(''_contextPath'')}'
+            active: '${q(documentNode).property(''_contextPath'')}'
+          remote:
+            isSaving: false
+            isPublishing: false
+            isDiscarding: false
+        user:
+          name:
+            title: '${q(user).property(''name.title'')}'
+            firstName: '${q(user).property(''name.firstName'')}'
+            middleName: '${q(user).property(''name.middleName'')}'
+            lastName: '${q(user).property(''name.lastName'')}'
+            otherName: '${q(user).property(''name.otherName'')}'
+            fullName: '${q(user).property(''name.fullName'')}'
+          settings:
+            isAutoPublishingEnabled: false
+            targetWorkspace: 'live'
       changes:
         types:
           'Neos.Neos.Ui:Property': Neos\Neos\Ui\Domain\Model\Changes\Property

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -61,6 +61,9 @@ Neos:
           Neos.Ui.StaticResources: Neos\Neos\Ui\Fusion\Helper\StaticResourcesHelper
       frontendConfiguration:
         editPreviewModes: '${Configuration.setting(''Neos.Neos.userInterface.editPreviewModes'')}'
+        # You may use this place to deliver some configuration to your custom UI components, e.g.:
+        # 'Your.Own:Package':
+        #   someKey: someValue
       documentNodeInformation:
         metaData:
           contextPath: '${q(documentNode).property("_contextPath")}'

--- a/Resources/Private/Fusion/Backend/Root.fusion
+++ b/Resources/Private/Fusion/Backend/Root.fusion
@@ -1,6 +1,6 @@
 include: resource://Neos.Fusion/Private/Fusion/Root.fusion
 include: resource://Neos.Neos/Private/Fusion/Prototypes/NodeUri.fusion
-include: resource://Neos.Neos.Ui/Private/Fusion/Prototypes/RenderState.fusion
+include: resource://Neos.Neos.Ui/Private/Fusion/Prototypes/RenderConfiguration.fusion
 include: resource://Neos.Neos.Ui/Private/Fusion/Prototypes/ArrayCollection.fusion
 include: resource://Neos.Neos.Ui/Private/Fusion/Prototypes/AppendAllToCollection.fusion
 
@@ -41,7 +41,7 @@ backend = Neos.Fusion:Template {
         @process.json = ${Json.stringify(value)}
     }
 
-    frontendConfiguration = Neos.Neos.Ui:RenderState {
+    frontendConfiguration = Neos.Neos.Ui:RenderConfiguration {
         path = 'frontendConfiguration'
         @process.json = ${Json.stringify(value)}
     }
@@ -130,7 +130,7 @@ backend = Neos.Fusion:Template {
         @process.json = ${Json.stringify(value)}
     }
 
-    initialState = Neos.Neos.Ui:RenderState {
+    initialState = Neos.Neos.Ui:RenderConfiguration {
         path = 'initialState'
         context {
             documentNode = ${documentNode}

--- a/Resources/Private/Fusion/Backend/Root.fusion
+++ b/Resources/Private/Fusion/Backend/Root.fusion
@@ -42,7 +42,7 @@ backend = Neos.Fusion:Template {
     }
 
     frontendConfiguration = Neos.Neos.Ui:RenderState {
-        state = 'frontendConfiguration'
+        path = 'frontendConfiguration'
         @process.json = ${Json.stringify(value)}
     }
 
@@ -131,7 +131,7 @@ backend = Neos.Fusion:Template {
     }
 
     initialState = Neos.Neos.Ui:RenderState {
-        state = 'backend'
+        path = 'initialState'
         context {
             documentNode = ${documentNode}
             site = ${site}

--- a/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -21,7 +21,7 @@ prototype(Neos.Neos:Page) {
         neosBackendHeader.@if.oldBackend = ${!Neos.Ui.Activation.enableNewBackend()}
         neosBackendEndpoints.@if.oldBackend = ${!Neos.Ui.Activation.enableNewBackend()}
 
-        javascriptBackendInformation = Neos.Neos.Ui:RenderState {
+        javascriptBackendInformation = Neos.Neos.Ui:RenderConfiguration {
             path = 'documentNodeInformation'
             context {
                 documentNode = ${documentNode}

--- a/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -22,7 +22,7 @@ prototype(Neos.Neos:Page) {
         neosBackendEndpoints.@if.oldBackend = ${!Neos.Ui.Activation.enableNewBackend()}
 
         javascriptBackendInformation = Neos.Neos.Ui:RenderState {
-            state = 'documentNode'
+            path = 'documentNodeInformation'
             context {
                 documentNode = ${documentNode}
                 site = ${site}

--- a/Resources/Private/Fusion/Prototypes/RenderConfiguration.fusion
+++ b/Resources/Private/Fusion/Prototypes/RenderConfiguration.fusion
@@ -1,0 +1,5 @@
+prototype(Neos.Neos.Ui:RenderConfiguration) {
+    @class = 'Neos\\Neos\\Ui\\Fusion\\RenderConfigurationImplementation'
+
+    context = Neos.Fusion:RawArray
+}

--- a/Resources/Private/Fusion/Prototypes/RenderState.fusion
+++ b/Resources/Private/Fusion/Prototypes/RenderState.fusion
@@ -1,5 +1,0 @@
-prototype(Neos.Neos.Ui:RenderState) {
-    @class = 'Neos\\Neos\\Ui\\Fusion\\RenderStateImplementation'
-
-    context = Neos.Fusion:RawArray
-}

--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -25,7 +25,7 @@ import style from './style.css';
     requestRegainControl: actions.UI.ContentCanvas.requestRegainControl
 })
 @neos(globalRegistry => ({
-    editPreviewModesRegistry: globalRegistry.get('editPreviewModes'),
+    editPreviewModes: globalRegistry.get('frontendConfiguration').get('editPreviewModes'),
     guestFrameRegistry: globalRegistry.get('@neos-project/neos-ui-guest-frame')
 }))
 export default class ContentCanvas extends PureComponent {
@@ -41,7 +41,7 @@ export default class ContentCanvas extends PureComponent {
         requestRegainControl: PropTypes.func.isRequired,
         currentEditPreviewMode: PropTypes.string.isRequired,
 
-        editPreviewModesRegistry: PropTypes.object.isRequired,
+        editPreviewModes: PropTypes.object.isRequired,
         guestFrameRegistry: PropTypes.object.isRequired
     };
 
@@ -64,7 +64,7 @@ export default class ContentCanvas extends PureComponent {
             isEditModePanelHidden,
             src,
             currentEditPreviewMode,
-            editPreviewModesRegistry,
+            editPreviewModes,
             guestFrameRegistry,
             backgroundColor
         } = this.props;
@@ -78,7 +78,7 @@ export default class ContentCanvas extends PureComponent {
             [style['contentCanvas--isHidden']]: !isVisible
         });
         const InlineUI = guestFrameRegistry.get('InlineUIComponent');
-        const currentEditPreviewModeConfiguration = editPreviewModesRegistry.get(currentEditPreviewMode);
+        const currentEditPreviewModeConfiguration = editPreviewModes[currentEditPreviewMode];
 
         const inlineStyles = {};
         const width = $get('width', currentEditPreviewModeConfiguration);

--- a/packages/neos-ui/src/Containers/EditModePanel/index.js
+++ b/packages/neos-ui/src/Containers/EditModePanel/index.js
@@ -23,7 +23,7 @@ import style from './style.css';
     setEditPreviewMode: actions.UI.EditPreviewMode.set
 })
 @neos(globalRegistry => ({
-    editPreviewModesRegistry: globalRegistry.get('editPreviewModes')
+    editPreviewModes: globalRegistry.get('frontendConfiguration').get('editPreviewModes')
 }))
 export default class EditModePanel extends PureComponent {
     static propTypes = {
@@ -33,7 +33,7 @@ export default class EditModePanel extends PureComponent {
         isHidden: PropTypes.bool.isRequired,
         setEditPreviewMode: PropTypes.func.isRequired,
 
-        editPreviewModesRegistry: PropTypes.object.isRequired
+        editPreviewModes: PropTypes.object.isRequired
     };
 
     handleEditPreviewModeClick = memoize(mode => () => {
@@ -48,7 +48,7 @@ export default class EditModePanel extends PureComponent {
             isFringedRight,
             editPreviewMode,
             isHidden,
-            editPreviewModesRegistry
+            editPreviewModes
         } = this.props;
         const classNames = mergeClassNames({
             [style.editModePanel]: true,
@@ -57,7 +57,13 @@ export default class EditModePanel extends PureComponent {
             [style['editModePanel--isHidden']]: isHidden
         });
 
-        const currentEditMode = editPreviewModesRegistry.get(editPreviewMode);
+        const currentEditMode = editPreviewModes[editPreviewMode];
+
+        const editPreviewModesList = Object.keys(editPreviewModes).map(key => {
+            const element = editPreviewModes[key];
+            element.id = key;
+            return element;
+        });
 
         return (
             <div className={classNames}>
@@ -65,7 +71,7 @@ export default class EditModePanel extends PureComponent {
                     <Panel
                         title="Editing Mode"
                         className={style.editModePanel__editingModes}
-                        modes={editPreviewModesRegistry.getAllAsList().filter(editPreviewMode => editPreviewMode.isEditingMode && editPreviewMode.id !== editPreviewMode)}
+                        modes={editPreviewModesList.filter(editPreviewMode => editPreviewMode.isEditingMode && editPreviewMode.id !== editPreviewMode)}
                         current={editPreviewMode}
                         currentMode={currentEditMode.isEditingMode ? currentEditMode : null}
                         style={style}
@@ -74,7 +80,7 @@ export default class EditModePanel extends PureComponent {
                     <Panel
                         title="Preview Central"
                         className={style.editModePanel__previewModes}
-                        modes={editPreviewModesRegistry.getAllAsList().filter(editPreviewMode => editPreviewMode.isPreviewMode && editPreviewMode.id !== editPreviewMode)}
+                        modes={editPreviewModesList.filter(editPreviewMode => editPreviewMode.isPreviewMode && editPreviewMode.id !== editPreviewMode)}
                         current={editPreviewMode}
                         currentMode={currentEditMode.isPreviewMode ? currentEditMode : null}
                         style={style}

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/EditModePanelToggler/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/EditModePanelToggler/index.js
@@ -16,7 +16,7 @@ import {actions, selectors} from '@neos-project/neos-ui-redux-store';
     toggleEditModePanel: actions.UI.EditModePanel.toggle
 })
 @neos(globalRegistry => ({
-    editPreviewModesRegistry: globalRegistry.get('editPreviewModes')
+    editPreviewModes: globalRegistry.get('frontendConfiguration').get('editPreviewModes')
 }))
 export default class EditModePanelToggler extends PureComponent {
     static propTypes = {
@@ -27,7 +27,7 @@ export default class EditModePanelToggler extends PureComponent {
 
         toggleEditModePanel: PropTypes.func.isRequired,
 
-        editPreviewModesRegistry: PropTypes.object.isRequired
+        editPreviewModes: PropTypes.object.isRequired
     };
 
     handleToggle = () => {
@@ -37,14 +37,14 @@ export default class EditModePanelToggler extends PureComponent {
     };
 
     render() {
-        const {className, isEditModePanelHidden, editPreviewMode, editPreviewModesRegistry} = this.props;
+        const {className, isEditModePanelHidden, editPreviewMode, editPreviewModes} = this.props;
         const isActive = !isEditModePanelHidden;
         const classNames = mergeClassNames({
             [className]: true,
             [style['btn--isActive']]: isActive
         });
 
-        const currentEditMode = editPreviewModesRegistry.get(editPreviewMode);
+        const currentEditMode = editPreviewModes[editPreviewMode];
 
         let editLabel = <I18n id="edit" fallback="Edit"/>;
         let previewLabel = <I18n id="preview" fallback="Preview"/>;

--- a/packages/neos-ui/src/index.js
+++ b/packages/neos-ui/src/index.js
@@ -114,11 +114,11 @@ function * application() {
     // Load frontend configuration (edit/preview modes)
     //
     const frontendConfiguration = yield system.getFrontendConfiguration;
-    const editPreviewModesRegistry = globalRegistry.get('editPreviewModes');
+    const frontendConfigurationRegistry = globalRegistry.get('frontendConfiguration');
 
-    Object.keys(frontendConfiguration.editPreviewModes).forEach(editPreviewModeName => {
-        editPreviewModesRegistry.set(editPreviewModeName, {
-            ...frontendConfiguration.editPreviewModes[editPreviewModeName]
+    Object.keys(frontendConfiguration).forEach(key => {
+        frontendConfigurationRegistry.set(key, {
+            ...frontendConfiguration[key]
         });
     });
 

--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -24,8 +24,23 @@ manifest('main', {}, globalRegistry => {
     //
     // Create edit preview mode registry
     //
-    globalRegistry.set('editPreviewModes', new SynchronousRegistry(`
-        # Edit/Preview Mode specific registry
+    globalRegistry.set('frontendConfiguration', new SynchronousRegistry(`
+        # Frontend configuration registry
+
+        Any settings under 'Neos.Neos.Ui.frontendConfiguration' would be available here.
+        Might be used also for third parth packages to deliver own settings to the UI, but this is still experimental.
+        Settings from each package should be prefixed to avoid collisions (unprefixed settings are reserved for the core UI itself), e.g.:
+
+        Neos:
+          Neos:
+            Ui:
+              frontendConfiguration:
+                'Your.Own:Package':
+                  someKey: someValue
+
+        Then it may be accessed as:
+
+        globalRegistry.get('frontendConfiguration').get('Your.Own:Package').someKey
     `));
 
     //

--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -32,11 +32,11 @@ manifest('main', {}, globalRegistry => {
         Settings from each package should be prefixed to avoid collisions (unprefixed settings are reserved for the core UI itself), e.g.:
 
         Neos:
-          Neos:
-            Ui:
-              frontendConfiguration:
-                'Your.Own:Package':
-                  someKey: someValue
+            Neos:
+                Ui:
+                    frontendConfiguration:
+                        'Your.Own:Package':
+                            someKey: someValue
 
         Then it may be accessed as:
 


### PR DESCRIPTION
This change introduces a place in settings which allows to transfer some configuration to UI components, including 3rd-party components.

E.g.:
```
Neos:
  Neos:
    Ui:
      frontendConfiguration:
        'Your.Own:Package':
          someKey: someValue
```

Then it may be accessed as:
```js
globalRegistry.get('frontendConfiguration').get('Your.Own:Package').someKey
```

I guess we should declare it as an experimental API that may change in the future in a breaking way.

TODO:

- [x] rename RenderState object to smth like RenderConfiguration

