### PR TITLE
BUGFIX: open SelectBox on searchTerm change

### DIFF
--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -181,6 +181,11 @@ export default class SelectBox extends PureComponent {
         this.setState({isOpen: false});
     }
 
+    handleSearchTermChange = (...args) => {
+        this.setState({isOpen: true});
+        this.props.onSearchTermChange(...args);
+    }
+
     render() {
         const {
             options,
@@ -194,7 +199,6 @@ export default class SelectBox extends PureComponent {
             placeholderIcon,
             displaySearchBox,
             searchTerm,
-            onSearchTermChange,
             scrollable,
             TextInputComponent,
             IconButtonComponent,
@@ -249,7 +253,7 @@ export default class SelectBox extends PureComponent {
                             <TextInputComponent
                                 placeholder={placeholder}
                                 value={searchTerm}
-                                onChange={onSearchTermChange}
+                                onChange={this.handleSearchTermChange}
                                 className={theme.selectBox__searchInput}
                                 setFocus={setFocus}
                                 containerClassName={theme.selectBox__searchInputContainer}


### PR DESCRIPTION
Steps to reproduce:
1. Create a link in CKE. Start typing something to find a node.
2. Collapse the search results by clicking the arrow
3. From this moment if you start typing, or even create another link, the search results will always stayed collapsed

Desired behavior: on typing new search term the SelectBox should always open.