### PR TITLE
BUGFIX: ensure JS backend information is not stale (fixes node tree after node creation)

### DIFF
--- a/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -36,6 +36,28 @@ prototype(Neos.Neos:Page) {
                 inBackend = ${documentNode.context.inBackend}
                 newBackend = ${Neos.Ui.Activation.enableNewBackend()}
             }
+
+            // We need to ensure the JS backend information is always up to date, especially
+            // when child nodes change. Otherwise errors like the following might happen:
+            // - create a new child (document) node
+            // - again visit the parent node
+            // - the parent node still has the stale "children" infos (without the newly created child)
+            // - thus, the document tree will have the newly created node REMOVED again (visually).
+            //
+            // as a fix, we ensure that the JS backend information creates an own cache entry, which is flushed
+            // whenever children are modified.
+            @cache {
+                mode = 'cached'
+                entryIdentifier {
+                    jsBackendInfo = 'javascriptBackendInformation'
+                    documentNode = ${documentNode}
+                    inBackend = ${documentNode.context.inBackend}
+                }
+                entryTags {
+                    1 = ${'Node_' + documentNode.identifier}
+                    2 = ${'DescendantOf_' + documentNode.identifier}
+                }
+            }
         }
 
         guestFrameApplication = Neos.Fusion:Template {


### PR DESCRIPTION
## Problem Description

- create a document node A underneath root node R
- navigate back to root node R
- the node A disappears from the document node tree.

After a cache flush OR a modification on root node R, the node stays visible.

However, on the demo page, the cache is flushed nevertheless because of the tag
`NodeType_Neos.Neos:Document`, which the Menu Cache Segment listens to. If you
place a Menu on the page, then this menu has its own cache segment, which gets
flushed on ANY Document change -- and then we re-render the full page, because
ContentCache::replaceCachePlaceholders returns FALSE as soon as it cannot find
a single sub-entry.

In order to test the issue on the Demo page, you need to:
- remove all Menu and DimensionMenu elements from Fusion
- remove the Neos.Seo package (because that internally also uses a Menu)

## Bugfix

We need to ensure the JS backend information is always up to date, especially
when child nodes change.
Thus, we ensure that the JS backend information creates an own cache entry,
which is flushed whenever children are modified (using "DescendantOf_*")