### PR TITLE
BUGFIX: Fix navigation in tree after an in-page navigation

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -73,6 +73,7 @@ Neos:
             active: '${documentNode.context.dimensions}'
             allowedPresets: '${Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.context.dimensions)}'
           documentNodeSerialization: '${Neos.Ui.NodeInfo.renderNode(documentNode, controllerContext)}'
+          url: '${Neos.Ui.NodeInfo.uri(documentNode, controllerContext)}'
       initialState:
         changes:
           pending: {  }

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -96,7 +96,10 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
         });
 
         window.requestIdleCallback(() => {
-            initializeCurrentNode(node);
+            // only of guest frame document did not change in the meantime, we continue initializing the node
+            if (getGuestFrameDocument() === node.ownerDocument) {
+                initializeCurrentNode(node);
+            }
             initializeSubSequentNodes();
         });
     }, () => { /* This noop function is called right at the end of content inialization */ });

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -54,6 +54,8 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
     yield put(actions.UI.ContentCanvas.setContextPath(documentInformation.metaData.contextPath, documentInformation.metaData.siteNode));
     yield put(actions.UI.ContentCanvas.setPreviewUrl(documentInformation.metaData.previewUrl));
     yield put(actions.CR.ContentDimensions.setActive(documentInformation.metaData.contentDimensions.active));
+    // the user may have navigated by clicking an inline link - that's why we need to update the contentCanvas URL to be in sync with the shown content
+    yield put(actions.UI.ContentCanvas.setSrc(documentInformation.metaData.url));
 
     getGuestFrameDocument().addEventListener('click', e => {
         const clickPath = Array.prototype.slice.call(eventPath(e));

--- a/packages/neos-ui-redux-store/src/UI/ContentCanvas/index.js
+++ b/packages/neos-ui-redux-store/src/UI/ContentCanvas/index.js
@@ -102,13 +102,7 @@ export const reducer = handleActions({
         return state;
     },
     [SET_PREVIEW_URL]: ({previewUrl}) => $set('ui.contentCanvas.previewUrl', previewUrl),
-    [SET_SRC]: ({src}) => state => {
-        if (src !== $get('ui.contentCanvas.src', state)) {
-            state = $set('ui.contentCanvas.src', src, state);
-            state = $set('ui.contentCanvas.isLoading', true, state);
-        }
-        return state;
-    },
+    [SET_SRC]: ({src}) => $set('ui.contentCanvas.src', src),
     [FORMATTING_UNDER_CURSOR]: ({formatting}) => $set('ui.contentCanvas.formattingUnderCursor', new Map(formatting)),
     [SET_CURRENTLY_EDITED_PROPERTY_NAME]: ({propertyName}) => $set('ui.contentCanvas.currentlyEditedPropertyName', propertyName),
     [STOP_LOADING]: () => $set('ui.contentCanvas.isLoading', false),

--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
@@ -157,29 +157,32 @@ export default class NodeCreationDialog extends PureComponent {
                 style="wide"
                 >
                 <div id="neos-nodeCreationDialog-body" className={style.body}>
-                    {Object.keys(configuration.elements).map((elementName, index) => {
-                        //
-                        // Only display errors after user input (isDirty)
-                        //
-                        const validationErrorsForElement = isDirty ? $get(elementName, validationErrors) : [];
-                        const element = configuration.elements[elementName];
-                        const options = $set('autoFocus', index === 0, $get('ui.editorOptions', element) || {});
+                    {Object.keys(configuration.elements)
+                        .filter(elementName => Boolean(configuration.elements[elementName]))
+                        .map((elementName, index) => {
+                            //
+                            // Only display errors after user input (isDirty)
+                            //
+                            const validationErrorsForElement = isDirty ? $get(elementName, validationErrors) : [];
+                            const element = configuration.elements[elementName];
+                            const options = $set('autoFocus', index === 0, $get('ui.editorOptions', element) || {});
 
-                        return (
-                            <div key={elementName} className={style.editor}>
-                                <EditorEnvelope
-                                    identifier={elementName}
-                                    label={$get('ui.label', element)}
-                                    editor={$get('ui.editor', element)}
-                                    options={options}
-                                    commit={this.handleDialogEditorValueChange(elementName)}
-                                    validationErrors={validationErrorsForElement}
-                                    value={this.state.values[elementName] || ''}
-                                    onKeyPress={this.handleKeyPress}
-                                    />
-                            </div>
-                        );
-                    })}
+                            return (
+                                <div key={elementName} className={style.editor}>
+                                    <EditorEnvelope
+                                        identifier={elementName}
+                                        label={$get('ui.label', element)}
+                                        editor={$get('ui.editor', element)}
+                                        options={options}
+                                        commit={this.handleDialogEditorValueChange(elementName)}
+                                        validationErrors={validationErrorsForElement}
+                                        value={this.state.values[elementName] || ''}
+                                        onKeyPress={this.handleKeyPress}
+                                        />
+                                </div>
+                            );
+                        })
+                    }
                 </div>
             </Dialog>
         );

--- a/packages/react-ui-components/src/Frame/frame.js
+++ b/packages/react-ui-components/src/Frame/frame.js
@@ -5,6 +5,7 @@ import ReactDOM from 'react-dom';
 
 export default class Frame extends PureComponent {
     static propTypes = {
+        src: PropTypes.string,
         mountTarget: PropTypes.string.isRequired,
         contentDidUpdate: PropTypes.func.isRequired,
         onLoad: PropTypes.func,
@@ -13,6 +14,26 @@ export default class Frame extends PureComponent {
 
     handleReference = ref => {
         this.ref = ref;
+    };
+
+    componentDidMount() {
+        this.updateIframeUrlIfNecessary();
+    }
+
+    componentDidUpdate() {
+        this.updateIframeUrlIfNecessary();
+    }
+
+    // we do not use react's magic to change to a different URL in the iFrame, but do it explicitely (in order to avoid reloads if we are already on the correct page)
+    updateIframeUrlIfNecessary() {
+        if (!this.ref) {
+            return;
+        }
+
+        const win = this.ref.contentWindow; // eslint-disable-line react/no-find-dom-node
+        if (win.location.href !== this.props.src) {
+            win.location = this.props.src;
+        }
     }
 
     render() {
@@ -21,7 +42,8 @@ export default class Frame extends PureComponent {
             'contentDidUpdate',
             'theme',
             'children',
-            'onLoad'
+            'onLoad',
+            'src'
         ]);
 
         return <iframe ref={this.handleReference} onLoad={this.handleLoad} {...rest}/>;


### PR DESCRIPTION
## How to reproduce

- Go to page A in document tree
- navigate to page B in content area
- select page A in document tree again
- expected: selection to page A works
- actual: no navigation is triggered to PageA

## Bugfix

- ensure the redux state is always up to date
- do not trigger page refreshes if the URL is already correct in the iFrame

Additionally, the loading indicator does not need to be handled through SET_SRC
anymore, as this is now implemented differently (so that's a code cleanup).