### PR TITLE
BUGFIX: make document tree search more robust

### DIFF
--- a/Classes/Neos/Neos/Ui/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Neos/Neos/Ui/Fusion/Helper/NodeInfoHelper.php
@@ -139,8 +139,15 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
                 $renderedNodes[$node->getPath()] = $renderedNode;
             }
 
+            /* @var $contentContext ContentContext */
+            $contentContext = $node->getContext();
+            $siteNodePath = $contentContext->getCurrentSiteNode()->getPath();
             $parentNode = $node->getParent();
-            while ($parentNode->getNodeType()->isOfType($baseNodeTypeOverride)) {
+
+            // we additionally need to check that our parent nodes are underneath the site node; otherwise it might happen that
+            // we try to send the "/sites" node to the UI (which we cannot do, because this does not have an URL)
+            $parentNodeIsUnderneathSiteNode = (strpos($parentNode->getPath(), $siteNodePath) === 0);
+            while ($parentNode->getNodeType()->isOfType($baseNodeTypeOverride) && $parentNodeIsUnderneathSiteNode) {
                 if (array_key_exists($parentNode->getPath(), $renderedNodes)) {
                     $renderedNodes[$parentNode->getPath()]['intermediate'] = true;
                 } else {

--- a/packages/neos-ui/src/Sagas/UI/PageTree/index.js
+++ b/packages/neos-ui/src/Sagas/UI/PageTree/index.js
@@ -147,10 +147,18 @@ function * watchSearch({configuration}) {
         }
 
         yield put(actions.UI.PageTree.setAsLoading(contextPath));
+        let matchingNodes = [];
 
-        const {q} = backend.get();
-        const query = q(contextPath);
-        const matchingNodes = yield query.search(searchQuery, filterNodeType).getForTreeWithParents();
+        try {
+            const {q} = backend.get();
+            const query = q(contextPath);
+            matchingNodes = yield query.search(searchQuery, filterNodeType).getForTreeWithParents();
+        } catch (err) {
+            console.error('Error while executing a tree search: ', err);
+            yield put(actions.UI.PageTree.invalidate(contextPath));
+            yield put(actions.UI.FlashMessages.add('searchError', 'There was an error searching in the node tree. Contact your administrator for fixing this issue.', 'error'));
+            return;
+        }
         const siteNode = yield select(selectors.CR.Nodes.siteNodeSelector);
         const loadingDepth = configuration.nodeTree.loadingDepth;
 


### PR DESCRIPTION
In a project, we had the bug that the node tree search broke with an
exception because the /sites node did not have an URI path segment (which
is fine).

After debugging, I did the following two changes:

- display an error indicator if the document tree search returned with an
  exception
- in the logic which builds the rootline for the document tree, ensure we
  are always underneath the /sites node; and do not traverse upwards
  otherwise