### PR TITLE
TASK: Make Keyboard Navigation in SelectBox more robust

### DIFF
--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -127,7 +127,7 @@ export default class SelectBox extends PureComponent {
 
         this.state = {
             isOpen: false,
-            selectedIndex: 0
+            selectedIndex: -1
         };
     }
 
@@ -172,8 +172,17 @@ export default class SelectBox extends PureComponent {
         if (e.target.nodeName.toLowerCase() === 'input' && e.target.type === 'text') {
             // force dropdown open if the search-input-box is focused
             this.setState({isOpen: true});
+        } else if (this.state.isOpen) {
+            // reset selected index to not get falsy preselected values
+            // if dropdown is opened more than once
+            this.setState({
+                isOpen: false,
+                selectedIndex: -1
+            });
         } else {
-            this.setState({isOpen: !this.state.isOpen});
+            this.setState({
+                isOpen: true
+            });
         }
     }
 
@@ -334,8 +343,19 @@ export default class SelectBox extends PureComponent {
         };
         const className = index === selectedIndex ? theme['selectBox__item--isSelectable--active'] : '';
 
+        const setIndex = () => {
+            this.setIndex(index);
+        };
+
         const OptionComponent = optionComponent;
-        return <OptionComponent className={className} option={option} key={index} onClick={onClick} theme={theme} IconComponent={IconComponent}/>;
+        // onMouseEnter doesn't work on OptionComponent
+        return <div key={index} onMouseEnter={setIndex}><OptionComponent className={className} option={option} key={index} onClick={onClick} theme={theme} IconComponent={IconComponent}/></div>;
+    }
+
+    setIndex = index => {
+        if (index !== this.state.selectedIndex) {
+            this.setState({selectedIndex: index});
+        }
     }
 
     handleDeleteClick = () => {

--- a/packages/react-ui-components/src/SelectBox/style.css
+++ b/packages/react-ui-components/src/SelectBox/style.css
@@ -158,9 +158,6 @@
     height: var(--goldenUnit);
     line-height: var(--goldenUnit);
     padding: 0 var(--spacing);
-    &:hover {
-        background: var(--brandColorsPrimaryBlue);
-    }
 }
 
 .selectBox__item--isSelectable--active {


### PR DESCRIPTION
This fixes the double 'selected hover state' (it was possible to, at least visual, select 2 items when using mouse and keyboard in a specific way) and resets the selectbox after closing

Edit: This currently doesn't work for searchable selectboxes and also breaks  their hover state.
But I'm on it while implementing keyboard navigation along the way https://github.com/neos/neos-ui/issues/1162