### PR TITLE
BUGFIX: reset keys of publishableNodes after filtering

### DIFF
--- a/Classes/Neos/Neos/Ui/ContentRepository/Service/WorkspaceService.php
+++ b/Classes/Neos/Neos/Ui/ContentRepository/Service/WorkspaceService.php
@@ -64,9 +64,9 @@ class WorkspaceService
             }
         }, $publishableNodes);
 
-        return array_filter($publishableNodes, function ($item) {
+        return array_values(array_filter($publishableNodes, function ($item) {
             return (bool)$item;
-        });
+        }));
     }
 
     /**


### PR DESCRIPTION
Otherwise if some entries were filtered out publishableNodes will get rendered as object to JSON, and not an array, which will break publishing.