### PR TITLE
FEATURE: Expose fetchWithErrorHandling and redux store for extensibility

### DIFF
--- a/packages/neos-ui-backend-connector/src/index.js
+++ b/packages/neos-ui-backend-connector/src/index.js
@@ -1,6 +1,7 @@
 import initializeUse from './Use/index';
 import initializeFlowQuery from './FlowQuery/index';
 import initializeEndpoints from './Endpoints/index';
+import fetchWithErrorHandling from './FetchWithErrorHandling/index';
 
 const createReadOnlyValue = value => ({
     value,
@@ -56,3 +57,8 @@ export const createPlugin = (identifier, factory) => {
     factory.identifier = identifier;
     return factory;
 };
+
+//
+// Expose fetchWithErrorHandling
+//
+export {fetchWithErrorHandling};

--- a/packages/neos-ui-extensibility/scripts/helpers/webpack.config.js
+++ b/packages/neos-ui-extensibility/scripts/helpers/webpack.config.js
@@ -60,6 +60,7 @@ module.exports = function (neosPackageJson) {
                 'react-css-themr': '@neos-project/neos-ui-extensibility/src/shims/vendor/react-css-themr/index',
 
                 '@neos-project/react-ui-components': '@neos-project/neos-ui-extensibility/src/shims/neosProjectPackages/react-ui-components/index',
+                '@neos-project/neos-ui-backend-connector': '@neos-project/neos-ui-extensibility/src/shims/neosProjectPackages/neos-ui-backend-connector/index',
                 '@neos-project/neos-ui-decorators': '@neos-project/neos-ui-extensibility/src/shims/neosProjectPackages/neos-ui-decorators/index',
                 '@neos-project/neos-ui-i18n': '@neos-project/neos-ui-extensibility/src/shims/neosProjectPackages/neos-ui-i18n/index',
                 '@neos-project/neos-ui-redux-store': '@neos-project/neos-ui-extensibility/src/shims/neosProjectPackages/neos-ui-redux-store/index'

--- a/packages/neos-ui/src/apiExposureMap.js
+++ b/packages/neos-ui/src/apiExposureMap.js
@@ -16,6 +16,7 @@ import ReactUiComponents from '@neos-project/react-ui-components';
 import * as NeosUiReduxStore from '@neos-project/neos-ui-redux-store';
 import * as NeosUiDecorators from '@neos-project/neos-ui-decorators';
 import NeosUiI18n from '@neos-project/neos-ui-i18n';
+import NeosUiBackendConnectorDefault, * as NeosUiBackendConnector from '@neos-project/neos-ui-backend-connector';
 
 export default {
     '@vendor': () => ({
@@ -35,7 +36,8 @@ export default {
     }),
 
     '@NeosProjectPackages': () => ({
-        // neos-ui-backend-connector
+        NeosUiBackendConnectorDefault,
+        NeosUiBackendConnector,
         NeosUiDecorators,
         NeosUiI18n,
         NeosUiReduxStore,

--- a/packages/neos-ui/src/index.js
+++ b/packages/neos-ui/src/index.js
@@ -71,7 +71,7 @@ function * application() {
     //
     manifests
         .map(manifest => manifest[Object.keys(manifest)[0]])
-        .forEach(({bootstrap}) => bootstrap(globalRegistry));
+        .forEach(({bootstrap}) => bootstrap(globalRegistry, store));
 
     const configuration = yield system.getConfiguration;
 


### PR DESCRIPTION
I'm working on a prototype for an extension of the UI and found those two important to be generally available.

Currently there's no general way to access the redux store - only mechanisms like Feedback Handlers that expect it as a parameter. This thoroughly limits the possibilities for extensions. With this PR it is exposed as a second parameter to the manifest bootstrap function.

`fetchWithErrorHandling` is required to make Backend requests using the current CSRF token - which is inaccessible otherwise.