### PR TITLE
TASK: Remove usage of `window.requestCallback()`

### DIFF
--- a/packages/neos-ui-guest-frame/package.json
+++ b/packages/neos-ui-guest-frame/package.json
@@ -18,7 +18,8 @@
     "@neos-project/build-essentials": "1.0.0-beta6"
   },
   "dependencies": {
-    "@neos-project/neos-ui-extensibility": "1.0.0-beta6"
+    "@neos-project/neos-ui-extensibility": "1.0.0-beta6",
+    "@neos-project/utils-helpers": "1.0.0-beta6"
   },
   "jest": {
     "transformIgnorePatterns": [],

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -95,11 +95,20 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
             nodes
         });
 
-        // only of guest frame document did not change in the meantime, we continue initializing the node
-        if (getGuestFrameDocument() === node.ownerDocument) {
-            initializeCurrentNode(node);
+        if ('requestIdleCallback' in window) {
+            window.requestIdleCallback(() => {
+              // only of guest frame document did not change in the meantime, we continue initializing the node
+                if (getGuestFrameDocument() === node.ownerDocument) {
+                    initializeCurrentNode(node);
+                }
+                initializeSubSequentNodes();
+            });
+        } else {
+            if (getGuestFrameDocument() === node.ownerDocument) {
+                initializeCurrentNode(node);
+            }
+            initializeSubSequentNodes();
         }
-        initializeSubSequentNodes();
     }, () => { /* This noop function is called right at the end of content inialization */ });
 
     initializeNodes();

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -95,13 +95,11 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
             nodes
         });
 
-        window.requestIdleCallback(() => {
-            // only of guest frame document did not change in the meantime, we continue initializing the node
-            if (getGuestFrameDocument() === node.ownerDocument) {
-                initializeCurrentNode(node);
-            }
-            initializeSubSequentNodes();
-        });
+        // only of guest frame document did not change in the meantime, we continue initializing the node
+        if (getGuestFrameDocument() === node.ownerDocument) {
+            initializeCurrentNode(node);
+        }
+        initializeSubSequentNodes();
     }, () => { /* This noop function is called right at the end of content inialization */ });
 
     initializeNodes();

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -2,6 +2,7 @@ import {takeEvery} from 'redux-saga';
 import {put, select} from 'redux-saga/effects';
 
 import {selectors, actions, actionTypes} from '@neos-project/neos-ui-redux-store';
+import {requestIdleCallback} from '@neos-project/utils-helpers';
 
 import initializeContentDomNode from './initializeContentDomNode';
 import {
@@ -95,20 +96,13 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
             nodes
         });
 
-        if ('requestIdleCallback' in window) {
-            window.requestIdleCallback(() => {
-              // only of guest frame document did not change in the meantime, we continue initializing the node
-                if (getGuestFrameDocument() === node.ownerDocument) {
-                    initializeCurrentNode(node);
-                }
-                initializeSubSequentNodes();
-            });
-        } else {
+        requestIdleCallback(() => {
+            // only of guest frame document did not change in the meantime, we continue initializing the node
             if (getGuestFrameDocument() === node.ownerDocument) {
                 initializeCurrentNode(node);
             }
             initializeSubSequentNodes();
-        }
+        });
     }, () => { /* This noop function is called right at the end of content inialization */ });
 
     initializeNodes();

--- a/packages/utils-helpers/src/cancelIdleCallback.js
+++ b/packages/utils-helpers/src/cancelIdleCallback.js
@@ -1,7 +1,4 @@
-window.cancelIdleCallback = window.cancelIdleCallback || function (id) {
+const cancelIdleCallback = window.cancelIdleCallback || function (id) {
     clearTimeout(id);
 };
-
-export default function cancelIdleCallback(id) {
-    window.cancelIdleCallback(id);
-}
+export default cancelIdleCallback;

--- a/packages/utils-helpers/src/cancelIdleCallback.js
+++ b/packages/utils-helpers/src/cancelIdleCallback.js
@@ -1,0 +1,7 @@
+window.cancelIdleCallback = window.cancelIdleCallback || function (id) {
+    clearTimeout(id);
+};
+
+export default function cancelIdleCallback(id) {
+    window.cancelIdleCallback(id);
+}

--- a/packages/utils-helpers/src/index.js
+++ b/packages/utils-helpers/src/index.js
@@ -5,6 +5,8 @@ import loadScript from './loadScript';
 import positionalArraySorter from './positionalArraySorter';
 import {stripTags, stripTagsEncoded} from './stripTags';
 import {decodeHtml} from './decodeHtml';
+import requestIdleCallback from './requestIdleCallback';
+import cancelIdleCallback from './cancelIdleCallback';
 
 export {
     delay,
@@ -14,5 +16,7 @@ export {
     loadScript,
     positionalArraySorter,
     stripTags,
-    stripTagsEncoded
+    stripTagsEncoded,
+    cancelIdleCallback,
+    requestIdleCallback
 };

--- a/packages/utils-helpers/src/requestIdleCallback.js
+++ b/packages/utils-helpers/src/requestIdleCallback.js
@@ -1,0 +1,18 @@
+// Polyfil for window.requestIdleCallback
+// https://developer.mozilla.org/en-US/docs/Web/API/Background_Tasks_API#Falling_back_to_setTimeout
+window.requestIdleCallback = window.requestIdleCallback || function (handler) {
+    const startTime = Date.now();
+
+    return setTimeout(() => {
+        handler({
+            didTimeout: false,
+            timeRemaining: () => {
+                return Math.max(0, 50.0 - (Date.now() - startTime));
+            }
+        });
+    }, 1);
+};
+
+export default function requestIdleCallback(handler) {
+    window.requestIdleCallback(handler);
+}

--- a/packages/utils-helpers/src/requestIdleCallback.js
+++ b/packages/utils-helpers/src/requestIdleCallback.js
@@ -1,6 +1,6 @@
 // Polyfil for window.requestIdleCallback
 // https://developer.mozilla.org/en-US/docs/Web/API/Background_Tasks_API#Falling_back_to_setTimeout
-window.requestIdleCallback = window.requestIdleCallback || function (handler) {
+const requestIdleCallback = window.requestIdleCallback || function (handler) {
     const startTime = Date.now();
 
     return setTimeout(() => {
@@ -12,7 +12,4 @@ window.requestIdleCallback = window.requestIdleCallback || function (handler) {
         });
     }, 1);
 };
-
-export default function requestIdleCallback(handler) {
-    window.requestIdleCallback(handler);
-}
+export default requestIdleCallback;


### PR DESCRIPTION
This change removes the usage of `window.requestCallback()` as it is not supported in Safari right now.