### PR TITLE
FEATURE: pluginsRegistry

### DIFF
--- a/packages/neos-ui-ckeditor-bindings/src/boostrapCkEditorApi.js
+++ b/packages/neos-ui-ckeditor-bindings/src/boostrapCkEditorApi.js
@@ -1,8 +1,9 @@
 import {getGuestFrameWindow} from '@neos-project/neos-ui-guest-frame/src/dom';
 
-export default formattingRulesRegistry => ({setFormattingUnderCursor, setCurrentlyEditedPropertyName}) => {
+export default (formattingRulesRegistry, pluginsRegistry) => ({setFormattingUnderCursor, setCurrentlyEditedPropertyName}) => {
     getGuestFrameWindow().NeosCKEditorApi.initialize({
         formattingRules: formattingRulesRegistry.getAllAsObject(),
+        plugins: pluginsRegistry.getAllAsObject(),
         setFormattingUnderCursor,
         setCurrentlyEditedPropertyName
     });

--- a/packages/neos-ui-ckeditor-bindings/src/ckeditor/index.js
+++ b/packages/neos-ui-ckeditor-bindings/src/ckeditor/index.js
@@ -1,7 +1,0 @@
-import neosPlaceholder from './neosPlaceholder';
-import fixPasteIntoInlineElements from './fixPasteIntoInlineElements';
-
-export default CKEDITOR => {
-    neosPlaceholder(CKEDITOR);
-    fixPasteIntoInlineElements(CKEDITOR);
-};

--- a/packages/neos-ui-ckeditor-bindings/src/createCkEditor.js
+++ b/packages/neos-ui-ckeditor-bindings/src/createCkEditor.js
@@ -5,6 +5,7 @@ import {getGuestFrameWindow} from '@neos-project/neos-ui-guest-frame/src/dom';
 export default ({propertyDomNode, propertyName, contextPath, nodeType, editorOptions, globalRegistry, persistChange}) => {
     const formattingRulesRegistry = globalRegistry.get('ckEditor').get('formattingRules');
     const richtextToolbarRegistry = globalRegistry.get('ckEditor').get('richtextToolbar');
+    const pluginsRegistry = globalRegistry.get('ckEditor').get('plugins');
     const i18nRegistry = globalRegistry.get('i18n');
     const enabledFormattingRuleIds = richtextToolbarRegistry
         .getEnabledFormattingRulesForNodeTypeAndProperty(nodeType.name)(propertyName);
@@ -24,7 +25,7 @@ export default ({propertyDomNode, propertyName, contextPath, nodeType, editorOpt
         }, Object.assign(
             {
                 skin: 'neos-build',
-                extraPlugins: 'neos_placeholder,neos_fixPasteIntoInlineElements',
+                extraPlugins: pluginsRegistry.getExtraPluginsString(),
                 removePlugins: 'floatingspace,maximize,resize,liststyle',
                 autoParagraph: isAutoParagraphEnabled,
                 entities: false,

--- a/packages/neos-ui-ckeditor-bindings/src/guestFrameApi.js
+++ b/packages/neos-ui-ckeditor-bindings/src/guestFrameApi.js
@@ -1,6 +1,5 @@
 import throttle from 'lodash.throttle';
 import debounce from 'lodash.debounce';
-import registerNeosCkeditorPlugins from './ckeditor/index';
 import removeTags from './ckeditor/removeTags';
 
 const noop = {
@@ -22,8 +21,6 @@ const createCKEditorAPI = CKEDITOR => {
         //
         return noop;
     }
-
-    registerNeosCkeditorPlugins(CKEDITOR);
 
     // an object with the following keys:
     // - globalRegistry
@@ -118,6 +115,9 @@ const createCKEditorAPI = CKEDITOR => {
     return {
         initialize(_editorConfig) {
             editorConfig = _editorConfig;
+            Object.values(editorConfig.plugins).forEach(plugin => {
+                plugin.initFn(CKEDITOR);
+            });
         },
 
         toggleFormat(formatting, formattingOptions = {}) {

--- a/packages/neos-ui-ckeditor-bindings/src/manifest.js
+++ b/packages/neos-ui-ckeditor-bindings/src/manifest.js
@@ -8,6 +8,7 @@ import boostrapCkEditorApi from './boostrapCkEditorApi';
 
 import initializeFormattingRulesRegistry from './manifest.formattingRules';
 import initializeRichtextToolbarRegistry from './manifest.richtextToolbar';
+import initializePluginsRegistry from './manifest.plugins';
 
 manifest('@neos-project/neos-ui-ckeditor-bindings', {}, globalRegistry => {
     const ckEditorRegistry = globalRegistry.set(
@@ -20,6 +21,7 @@ manifest('@neos-project/neos-ui-ckeditor-bindings', {}, globalRegistry => {
     );
 
     const formattingRulesRegistry = initializeFormattingRulesRegistry(ckEditorRegistry);
+    const pluginsRegistry = initializePluginsRegistry(ckEditorRegistry);
     initializeRichtextToolbarRegistry(ckEditorRegistry, globalRegistry.get('@neos-project/neos-ui-contentrepository'));
 
     //
@@ -27,7 +29,7 @@ manifest('@neos-project/neos-ui-ckeditor-bindings', {}, globalRegistry => {
     //
     const inlineEditorRegistry = globalRegistry.get('inlineEditors');
     inlineEditorRegistry.set('ckeditor', {
-        bootstrap: boostrapCkEditorApi(formattingRulesRegistry),
+        bootstrap: boostrapCkEditorApi(formattingRulesRegistry, pluginsRegistry),
         createInlineEditor: createCkEditor,
         ToolbarComponent: EditorToolbar
     });

--- a/packages/neos-ui-ckeditor-bindings/src/manifest.plugins.js
+++ b/packages/neos-ui-ckeditor-bindings/src/manifest.plugins.js
@@ -1,0 +1,33 @@
+import CkEditorPluginsRegistry from './registry/CkEditorPluginsRegistry';
+import neosPlaceholder from './ckeditor/neosPlaceholder';
+import fixPasteIntoInlineElements from './ckeditor/fixPasteIntoInlineElements';
+
+//
+// Create richtext editing toolbar registry
+//
+export default ckEditorRegistry => {
+    const plugins = ckEditorRegistry.set('plugins', new CkEditorPluginsRegistry(`
+        Contains custom plugins for CkEditor.
+
+        plugins.set('plugin_key', {
+            initFn: pluginInitFunction
+        });
+
+        pluginInitFunction is passed CKEDITOR as the first argument.
+        In that function you may register your plugin with CKeditor via its API (CKEDITOR.plugins.add).
+        Take custom plugins as examples.
+    `));
+
+    //
+    // Configure our custom ckEditor plugins
+    //
+    plugins.set('neos_placeholder', {
+        initFn: neosPlaceholder
+    });
+
+    plugins.set('neos_fixPasteIntoInlineElements', {
+        initFn: fixPasteIntoInlineElements
+    });
+
+    return plugins;
+};

--- a/packages/neos-ui-ckeditor-bindings/src/registry/CkEditorPluginsRegistry.js
+++ b/packages/neos-ui-ckeditor-bindings/src/registry/CkEditorPluginsRegistry.js
@@ -1,0 +1,7 @@
+import {SynchronousRegistry} from '@neos-project/neos-ui-extensibility/src/registry';
+
+export default class CkEditorPluginsRegistry extends SynchronousRegistry {
+    getExtraPluginsString() {
+        return this._registry.map(i => i.key).join(',');
+    }
+}


### PR DESCRIPTION
This PR implements a way to register custom CKeditor plugins via a registry.

THIS IS NOT A PUBLIC API YET!
May break as we migrate to CKE5 soon.