### PR TITLE
BUGFIX: use correct delimiter for extraAllowedContent rules

### DIFF
--- a/packages/neos-ui-ckeditor-bindings/src/registry/CkEditorFormattingRulesRegistry.js
+++ b/packages/neos-ui-ckeditor-bindings/src/registry/CkEditorFormattingRulesRegistry.js
@@ -88,7 +88,7 @@ export default class CkEditorFormattingRulesRegistry extends SynchronousRegistry
             addToExtraAllowedContent: extraExpression =>
                 config => {
                     if (config.extraAllowedContent) {
-                        config.extraAllowedContent += ' ' + extraExpression;
+                        config.extraAllowedContent += ';' + extraExpression;
                     } else {
                         config.extraAllowedContent = extraExpression;
                     }


### PR DESCRIPTION
Space delimiter only works with tag names. If you have also attributes in the rule, they should be semicolon delimited.