### PR TITLE
TASK: add md5 cache breaker to all resource urls

### DIFF
--- a/Classes/Neos/Neos/Ui/Domain/Service/StyleAndJavascriptInclusionService.php
+++ b/Classes/Neos/Neos/Ui/Domain/Service/StyleAndJavascriptInclusionService.php
@@ -71,11 +71,14 @@ class StyleAndJavascriptInclusionService
                 $resourceExpression = Utility::evaluateEelExpression($resourceExpression, $this->eelEvaluator, [], $this->defaultContext);
             }
 
+            // Cache breaker
+            $hash = substr(md5_file($resourceExpression), 0, 8);
+
             if (strpos($resourceExpression, 'resource://') === 0) {
                 $resourceExpression = $this->resourceManager->getPublicPackageResourceUriByPath($resourceExpression);
             }
 
-            $result .= $builderForLine($resourceExpression);
+            $result .= $builderForLine($resourceExpression . '?' . $hash);
         }
 
         return $result;

--- a/Classes/Neos/Neos/Ui/Domain/Service/StyleAndJavascriptInclusionService.php
+++ b/Classes/Neos/Neos/Ui/Domain/Service/StyleAndJavascriptInclusionService.php
@@ -70,7 +70,7 @@ class StyleAndJavascriptInclusionService
             if (substr($resourceExpression, 0, 2) === '${' && substr($resourceExpression, -1) === '}') {
                 $resourceExpression = Utility::evaluateEelExpression($resourceExpression, $this->eelEvaluator, [], $this->defaultContext);
             }
-            
+
             $hash = null;
 
             if (strpos($resourceExpression, 'resource://') === 0) {

--- a/Classes/Neos/Neos/Ui/Domain/Service/StyleAndJavascriptInclusionService.php
+++ b/Classes/Neos/Neos/Ui/Domain/Service/StyleAndJavascriptInclusionService.php
@@ -70,6 +70,8 @@ class StyleAndJavascriptInclusionService
             if (substr($resourceExpression, 0, 2) === '${' && substr($resourceExpression, -1) === '}') {
                 $resourceExpression = Utility::evaluateEelExpression($resourceExpression, $this->eelEvaluator, [], $this->defaultContext);
             }
+            
+            $hash = null;
 
             if (strpos($resourceExpression, 'resource://') === 0) {
                 // Cache breaker

--- a/Classes/Neos/Neos/Ui/Domain/Service/StyleAndJavascriptInclusionService.php
+++ b/Classes/Neos/Neos/Ui/Domain/Service/StyleAndJavascriptInclusionService.php
@@ -71,14 +71,13 @@ class StyleAndJavascriptInclusionService
                 $resourceExpression = Utility::evaluateEelExpression($resourceExpression, $this->eelEvaluator, [], $this->defaultContext);
             }
 
-            // Cache breaker
-            $hash = substr(md5_file($resourceExpression), 0, 8);
-
             if (strpos($resourceExpression, 'resource://') === 0) {
+                // Cache breaker
+                $hash = substr(md5_file($resourceExpression), 0, 8);
                 $resourceExpression = $this->resourceManager->getPublicPackageResourceUriByPath($resourceExpression);
             }
-
-            $result .= $builderForLine($resourceExpression . '?' . $hash);
+            $finalUri = $hash ? $resourceExpression . '?' . $hash : $resourceExpression;
+            $result .= $builderForLine($finalUri);
         }
 
         return $result;


### PR DESCRIPTION
Resolves: #1143

I have experienced multiple times that the old interface version got heavily cached in the editor's browser, which caused some hard to debug bugs.
I think it makes sense to add cache bursting to all asset links.