### PR TITLE
FEATURE: Improve ckeditor configurability

### DIFF
--- a/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/Helpers/hideDisallowedToolbarComponents.js
+++ b/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/Helpers/hideDisallowedToolbarComponents.js
@@ -1,10 +1,11 @@
+import {$get} from 'plow-js';
 //
 // Used to contextually filter toolbar components
 //
-export default (enabledFormattingRuleIds, formattingUnderCursor) => componentDefinition => {
+export default (inlineEditorOptions, formattingUnderCursor) => componentDefinition => {
     if (componentDefinition.isVisibleWhen) {
-        return componentDefinition.isVisibleWhen(enabledFormattingRuleIds, formattingUnderCursor);
+        return componentDefinition.isVisibleWhen(inlineEditorOptions, formattingUnderCursor);
     }
 
-    return enabledFormattingRuleIds.indexOf(componentDefinition.formattingRule) !== -1;
+    return Boolean($get(['formatting', componentDefinition.formattingRule], inlineEditorOptions));
 };

--- a/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/Helpers/renderToolbarComponents.js
+++ b/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/Helpers/renderToolbarComponents.js
@@ -17,10 +17,10 @@ const isTopLevelToolbarComponent = componentDefinition =>
 export default richtextToolbarRegistry => {
     const toolbarComponents = richtextToolbarRegistry.getAllAsList();
 
-    return (onToggleFormat, enabledFormattingRuleIds, formattingUnderCursor) => {
+    return (onToggleFormat, inlineEditorOptions, formattingUnderCursor) => {
         return toolbarComponents
             .filter(isTopLevelToolbarComponent)
-            .filter(hideDisallowedToolbarComponents(enabledFormattingRuleIds, formattingUnderCursor))
+            .filter(hideDisallowedToolbarComponents(inlineEditorOptions, formattingUnderCursor))
             .map((componentDefinition, index) => {
                 const {component, formattingRule, callbackPropName, ...props} = componentDefinition;
                 const restProps = omit(props, ['isVisibleWhen']);

--- a/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/StyleSelect.js
+++ b/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/StyleSelect.js
@@ -24,6 +24,7 @@ const startsWith = prefix => element => element.id.startsWith(prefix);
     formattingUnderCursor: selectors.UI.ContentCanvas.formattingUnderCursor
 }))
 @neos(globalRegistry => ({
+    nodeTypesRegistry: globalRegistry.get('@neos-project/neos-ui-contentrepository'),
     toolbarRegistry: globalRegistry.get('ckEditor').get('richtextToolbar')
 }))
 export default class StyleSelect extends PureComponent {
@@ -59,14 +60,13 @@ export default class StyleSelect extends PureComponent {
     }
 
     render() {
-        const {toolbarRegistry, currentlyEditedPropertyName, focusedNode} = this.props;
+        const {nodeTypesRegistry, toolbarRegistry, currentlyEditedPropertyName, focusedNode} = this.props;
         const nodeTypeName = $get('nodeType', focusedNode);
 
-        const enabledFormattingRuleIds = toolbarRegistry
-            .getEnabledFormattingRulesForNodeTypeAndProperty(nodeTypeName)(currentlyEditedPropertyName);
+        const inlineEditorOptions = nodeTypesRegistry.getInlineEditorOptionsForProperty(nodeTypeName, currentlyEditedPropertyName);
         const nestedStyles = toolbarRegistry.getAllAsList()
             .filter(startsWith(`${this.props.id}/`))
-            .filter(hideDisallowedToolbarComponents(enabledFormattingRuleIds || []));
+            .filter(hideDisallowedToolbarComponents(inlineEditorOptions || []));
 
         const options = nestedStyles.map(style => ({
             label: style.label,

--- a/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/StyleSelect.js
+++ b/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/StyleSelect.js
@@ -41,6 +41,7 @@ export default class StyleSelect extends PureComponent {
             PropTypes.object
         ])),
 
+        nodeTypesRegistry: PropTypes.object.isRequired,
         toolbarRegistry: PropTypes.object.isRequired
     };
 

--- a/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/index.js
+++ b/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/index.js
@@ -55,17 +55,17 @@ export default class EditorToolbar extends PureComponent {
             focusedNodeType,
             currentlyEditedPropertyName,
             formattingUnderCursor,
-            toolbarRegistry
+            nodeTypesRegistry
         } = this.props;
-        const enabledFormattingRuleIds = toolbarRegistry
-            .getEnabledFormattingRulesForNodeTypeAndProperty(focusedNodeType)(currentlyEditedPropertyName);
+        const inlineEditorOptions = nodeTypesRegistry
+            .getInlineEditorOptionsForProperty(focusedNodeType, currentlyEditedPropertyName);
 
         const classNames = mergeClassNames({
             [style.toolBar]: true
         });
         const renderedToolbarComponents = this.renderToolbarComponents(
             this.onToggleFormat,
-            enabledFormattingRuleIds || [],
+            inlineEditorOptions,
             formattingUnderCursor
         );
 

--- a/packages/neos-ui-ckeditor-bindings/src/createCkEditor.js
+++ b/packages/neos-ui-ckeditor-bindings/src/createCkEditor.js
@@ -2,9 +2,8 @@ import {$get} from 'plow-js';
 
 import {getGuestFrameWindow} from '@neos-project/neos-ui-guest-frame/src/dom';
 
-export default ({propertyDomNode, propertyName, contextPath, nodeType, editorOptions, globalRegistry, userPreferences, persistChange}) => {
+export default ({propertyDomNode, propertyName, contextPath, editorOptions, globalRegistry, userPreferences, persistChange}) => {
     const formattingRulesRegistry = globalRegistry.get('ckEditor').get('formattingRules');
-    const richtextToolbarRegistry = globalRegistry.get('ckEditor').get('richtextToolbar');
     const pluginsRegistry = globalRegistry.get('ckEditor').get('plugins');
     const i18nRegistry = globalRegistry.get('i18n');
     const formattingEditorOptions = $get('formatting', editorOptions);

--- a/packages/neos-ui-ckeditor-bindings/src/createCkEditor.js
+++ b/packages/neos-ui-ckeditor-bindings/src/createCkEditor.js
@@ -7,19 +7,20 @@ export default ({propertyDomNode, propertyName, contextPath, nodeType, editorOpt
     const richtextToolbarRegistry = globalRegistry.get('ckEditor').get('richtextToolbar');
     const pluginsRegistry = globalRegistry.get('ckEditor').get('plugins');
     const i18nRegistry = globalRegistry.get('i18n');
-    const enabledFormattingRuleIds = richtextToolbarRegistry
-        .getEnabledFormattingRulesForNodeTypeAndProperty(nodeType.name)(propertyName);
+    const formattingEditorOptions = $get('formatting', editorOptions);
     const placeholder = unescape(i18nRegistry.translate($get('placeholder', editorOptions)));
     const isAutoParagraphEnabled = Boolean($get('autoparagraph', editorOptions));
     const interfaceLanguage = String($get('interfaceLanguage', userPreferences));
 
-    const ckEditorConfiguration = enabledFormattingRuleIds
-        .map(formattingRuleId => formattingRulesRegistry.get(formattingRuleId))
-        .reduce((ckEditorConfiguration, formattingDefinition) => {
-            const {config} = formattingDefinition;
+    const ckEditorConfiguration = Object.entries(formattingEditorOptions || {})
+        .reduce((ckEditorConfiguration, [formattingRuleId, isFormattingRuleEnabled]) => {
+            if (isFormattingRuleEnabled) {
+                const formattingDefinition = formattingRulesRegistry.get(formattingRuleId);
+                const {config} = formattingDefinition;
 
-            if (config) {
-                return Object.assign({}, ckEditorConfiguration, config(ckEditorConfiguration));
+                if (config) {
+                    ckEditorConfiguration = Object.assign({}, ckEditorConfiguration, config(ckEditorConfiguration, formattingEditorOptions[formattingRuleId]));
+                }
             }
 
             return ckEditorConfiguration;

--- a/packages/neos-ui-ckeditor-bindings/src/manifest.formattingRules.js
+++ b/packages/neos-ui-ckeditor-bindings/src/manifest.formattingRules.js
@@ -39,7 +39,8 @@ export default ckEditorRegistry => {
             adhering to CKEDITOR.style(...), so for example: \`{ style: {element: 'h1'}\`
 
         - \`config\` (function, optional): This function needs to adjust the CKEditor config to e.g. configure ACF
-            correctly. The function gets passed in the config so-far, and needs to return the modified config. See
+            correctly. The function gets passed in the config so-far, AND the configuration from the node type underneath
+            "ui.inline.editorOptions.formatting.[formatingRuleName]" and needs to return the modified config. See
             "CKEditor Configuration Helpers" below for helper functions.
 
         - \`extractCurrentFormatFn\` (function, optional): If specified, this function will extract the current format.

--- a/packages/neos-ui-ckeditor-bindings/src/manifest.js
+++ b/packages/neos-ui-ckeditor-bindings/src/manifest.js
@@ -22,7 +22,7 @@ manifest('@neos-project/neos-ui-ckeditor-bindings', {}, globalRegistry => {
 
     const formattingRulesRegistry = initializeFormattingRulesRegistry(ckEditorRegistry);
     const pluginsRegistry = initializePluginsRegistry(ckEditorRegistry);
-    initializeRichtextToolbarRegistry(ckEditorRegistry, globalRegistry.get('@neos-project/neos-ui-contentrepository'));
+    initializeRichtextToolbarRegistry(ckEditorRegistry);
 
     //
     // Add CK Editor to the list of inline editors

--- a/packages/neos-ui-ckeditor-bindings/src/manifest.richtextToolbar.js
+++ b/packages/neos-ui-ckeditor-bindings/src/manifest.richtextToolbar.js
@@ -210,7 +210,7 @@ export default ckEditorRegistry => {
         icon: 'indent',
         hoverStyle: 'brand',
         isVisibleWhen: (inlineEditorOptions, formattingUnderCursor) => {
-            return (Boolean($get('formatting.ul', inlineEditorOptions)) || Boolean($get('formatting.ol', inlineEditorOptions)) &&
+            return ((Boolean($get('formatting.ul', inlineEditorOptions)) || Boolean($get('formatting.ol', inlineEditorOptions))) &&
                 formattingUnderCursor.indent !== richtextToolbar.TRISTATE_DISABLED);
         }
     });
@@ -224,7 +224,7 @@ export default ckEditorRegistry => {
         icon: 'outdent',
         hoverStyle: 'brand',
         isVisibleWhen: (inlineEditorOptions, formattingUnderCursor) => {
-            return (Boolean($get('formatting.ul', inlineEditorOptions)) || Boolean($get('formatting.ol', inlineEditorOptions)) &&
+            return ((Boolean($get('formatting.ul', inlineEditorOptions)) || Boolean($get('formatting.ol', inlineEditorOptions))) &&
                 formattingUnderCursor.indent !== richtextToolbar.TRISTATE_DISABLED);
         }
     });

--- a/packages/neos-ui-ckeditor-bindings/src/manifest.richtextToolbar.js
+++ b/packages/neos-ui-ckeditor-bindings/src/manifest.richtextToolbar.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import omit from 'lodash.omit';
+import {$get} from 'plow-js';
 import IconButton from '@neos-project/react-ui-components/src/IconButton/';
 
 import LinkIconButton from './EditorToolbar/LinkIconButton';
@@ -14,14 +15,14 @@ const IconButtonComponent = props => {
 //
 // Create richtext editing toolbar registry
 //
-export default (ckEditorRegistry, nodeTypesRegistry) => {
+export default ckEditorRegistry => {
     const richtextToolbar = ckEditorRegistry.set('richtextToolbar', new RichTextToolbarRegistry(`
         Contains the Rich Text Editing Toolbar components.
 
         The values are objects of the following form:
 
             {
-                formatting: 'h1' // References a key inside "formattingRules"
+                formattingRule: 'h1' // References a key inside "formattingRules"
                 component: Button // the React component being used for rendering
                 callbackPropName: 'onClick' // Name of the callback prop of the Component which is
                                             fired when the component's value changes.
@@ -31,7 +32,7 @@ export default (ckEditorRegistry, nodeTypesRegistry) => {
 
         ## Component wiring
 
-        - Each toolbar component receives all properties except "formatting" and "component" directly as props.
+        - Each toolbar component receives all properties except "formattingRule" and "component" directly as props.
         - Furthermore, the "isActive" property is bound, which is a boolean flag defining whether the text style
             referenced by "formatting" is currently active or not.
         - Furthermore, the callback specified in "callbackPropName" is wired, which toggles the value.
@@ -40,8 +41,6 @@ export default (ckEditorRegistry, nodeTypesRegistry) => {
         If you need this, you'll most likely need to listen to selectors.UI.ContentCanvas.formattingUnderCursor and extract
         your relevant information manually.
     `));
-
-    richtextToolbar.setNodeTypesRegistry(nodeTypesRegistry);
 
     //
     // Configure richtext editing toolbar
@@ -210,9 +209,9 @@ export default (ckEditorRegistry, nodeTypesRegistry) => {
 
         icon: 'indent',
         hoverStyle: 'brand',
-        isVisibleWhen: (enabledFormattingRuleIds, formattingUnderCursor) => {
-            return (enabledFormattingRuleIds.indexOf('ul') !== -1 || enabledFormattingRuleIds.indexOf('ol') !== -1) &&
-                formattingUnderCursor.indent !== richtextToolbar.TRISTATE_DISABLED;
+        isVisibleWhen: (inlineEditorOptions, formattingUnderCursor) => {
+            return (Boolean($get('formatting.ul', inlineEditorOptions)) || Boolean($get('formatting.ol', inlineEditorOptions)) &&
+                formattingUnderCursor.indent !== richtextToolbar.TRISTATE_DISABLED);
         }
     });
 
@@ -224,9 +223,9 @@ export default (ckEditorRegistry, nodeTypesRegistry) => {
 
         icon: 'outdent',
         hoverStyle: 'brand',
-        isVisibleWhen: (enabledFormattingRuleIds, formattingUnderCursor) => {
-            return (enabledFormattingRuleIds.indexOf('ul') !== -1 || enabledFormattingRuleIds.indexOf('ol') !== -1) &&
-                formattingUnderCursor.outdent !== richtextToolbar.TRISTATE_DISABLED;
+        isVisibleWhen: (inlineEditorOptions, formattingUnderCursor) => {
+            return (Boolean($get('formatting.ul', inlineEditorOptions)) || Boolean($get('formatting.ol', inlineEditorOptions)) &&
+                formattingUnderCursor.indent !== richtextToolbar.TRISTATE_DISABLED);
         }
     });
 

--- a/packages/neos-ui-ckeditor-bindings/src/registry/RichTextToolbarRegistry.js
+++ b/packages/neos-ui-ckeditor-bindings/src/registry/RichTextToolbarRegistry.js
@@ -9,22 +9,4 @@ export default class RichTextToolbarRegistry extends SynchronousRegistry {
         this.TRISTATE_ON = 1;
         this.TRISTATE_OFF = 2;
     }
-
-    setNodeTypesRegistry(nodeTypesRegistry) {
-        this.nodeTypesRegistry = nodeTypesRegistry;
-    }
-
-    hasFormattingRule = formattingRuleId =>
-        this._registry.some(option => option.value.formattingRule === formattingRuleId);
-
-    getEnabledFormattingRulesForNodeTypeAndProperty = memoize(nodeTypeName => memoize(propertyName => {
-        const editorOptions = this.nodeTypesRegistry
-            .getInlineEditorOptionsForProperty(nodeTypeName, propertyName) || {};
-
-        return [].concat(
-            ...['format', 'link', 'list', 'table', 'alignment']
-                .map(configurationKey => editorOptions[configurationKey])
-                .filter(i => i)
-        ).filter(this.hasFormattingRule);
-    }));
 }

--- a/packages/neos-ui-ckeditor-bindings/src/registry/RichTextToolbarRegistry.js
+++ b/packages/neos-ui-ckeditor-bindings/src/registry/RichTextToolbarRegistry.js
@@ -1,4 +1,3 @@
-import {memoize} from 'ramda';
 import {SynchronousRegistry} from '@neos-project/neos-ui-extensibility/src/registry';
 
 export default class RichTextToolbarRegistry extends SynchronousRegistry {

--- a/packages/neos-ui/src/index.js
+++ b/packages/neos-ui/src/index.js
@@ -67,11 +67,16 @@ function * application() {
     yield system.getNeos;
 
     //
+    // Load frontend configuration very early, as we want to make it available in manifests
+    //
+    const frontendConfiguration = yield system.getFrontendConfiguration;
+
+    //
     // Initialize extensions
     //
     manifests
         .map(manifest => manifest[Object.keys(manifest)[0]])
-        .forEach(({bootstrap}) => bootstrap(globalRegistry, store));
+        .forEach(({bootstrap}) => bootstrap(globalRegistry, {store, frontendConfiguration}));
 
     const configuration = yield system.getConfiguration;
 
@@ -110,10 +115,6 @@ function * application() {
     const i18nRegistry = globalRegistry.get('i18n');
     i18nRegistry.setTranslations(translations);
 
-    //
-    // Load frontend configuration (edit/preview modes)
-    //
-    const frontendConfiguration = yield system.getFrontendConfiguration;
     const frontendConfigurationRegistry = globalRegistry.get('frontendConfiguration');
 
     Object.keys(frontendConfiguration).forEach(key => {


### PR DESCRIPTION
While building https://github.com/sandstorm/BlockStyles, I found the internal
API for configuring the RTE lacking some features. Specifically, the following
has changed with this PR:

## create more explicit inline editor configuration format

The old format looked like this:

```
ui.aloha:
  […]
    h2: true
    h1: false
```

This was then server-side transformed to:

```
aloha:
  […]: h2
```

-> i.e. false values were removed automatically.

Now, I wanted to make it possible to add specific options to the inline
editor instance (more than the "TRUE/FALSE" from above).

Thus, I created a new format:

```
ui.inline.editorOptions:
  formatting:
    h2: true
    h1: false
  placeholder: "placeholder string"
  autoparagraph: true
```

… which is used internally throughout the codebase; and the old "aloha"
format is converted to the new format.

This enables to pass in arbitrary objects for configuring a specific
editor instance.


## make FrontendConfiguration available in manifests

We now load the FrontendConfiguration early and pass them into the manifest

## !!! change way Store is passed to manifest

before, the store was passed to the manifest as 2nd parameter. To make this
more extensible, we now pass an object as 2nd parameter, currently containing
store and frontendConfiguration