### PR TITLE
TASK: Inspector editors have error boundary

### DIFF
--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -9,6 +9,8 @@ import style from './style.css';
     editorRegistry: globalRegistry.get('inspector').get('editors')
 }))
 export default class EditorEnvelope extends PureComponent {
+    state = {};
+
     static propTypes = {
         identifier: PropTypes.string.isRequired,
         label: PropTypes.string.isRequired,
@@ -22,11 +24,6 @@ export default class EditorEnvelope extends PureComponent {
 
         commit: PropTypes.func.isRequired
     };
-
-    constructor(props) {
-        super(props);
-        this.state = {};
-    }
 
     generateIdentifier() {
         return `#__neos__editor__property---${this.props.identifier}`;

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -22,6 +22,11 @@ export default class EditorEnvelope extends PureComponent {
         commit: PropTypes.func.isRequired
     };
 
+    constructor(props) {
+        super(props);
+        this.state = {};
+    }
+
     generateIdentifier() {
         return `#__neos__editor__property---${this.props.identifier}`;
     }
@@ -44,6 +49,14 @@ export default class EditorEnvelope extends PureComponent {
         return (<div>Missing Editor {editor}</div>);
     }
 
+    componentDidCatch(error, errorInfo) {
+        console.log(error);
+        console.log(errorInfo);
+        this.setState({
+            error
+        });
+    }
+
     renderLabel() {
         const {editor, editorRegistry} = this.props;
         const editorDefinition = editorRegistry.get(editor);
@@ -62,6 +75,10 @@ export default class EditorEnvelope extends PureComponent {
     }
 
     render() {
+        if (this.state.error) {
+            return <div>{this.state.error && this.state.error.toString()}</div>;
+        }
+
         return (
             <div>
                 {this.renderLabel()}

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Label from '@neos-project/react-ui-components/src/Label/';
 import I18n from '@neos-project/neos-ui-i18n';
 import {neos} from '@neos-project/neos-ui-decorators';
+import style from './style.css';
 
 @neos(globalRegistry => ({
     editorRegistry: globalRegistry.get('inspector').get('editors')
@@ -46,12 +47,11 @@ export default class EditorEnvelope extends PureComponent {
             );
         }
 
-        return (<div>Missing Editor {editor}</div>);
+        return (<div className={style.envelope__error}>Missing Editor {editor}</div>);
     }
 
     componentDidCatch(error, errorInfo) {
-        console.log(error);
-        console.log(errorInfo);
+        console.error(error, errorInfo);
         this.setState({
             error
         });
@@ -76,7 +76,7 @@ export default class EditorEnvelope extends PureComponent {
 
     render() {
         if (this.state.error) {
-            return <div>{this.state.error && this.state.error.toString()}</div>;
+            return <div className={style.envelope__error}>{this.state.error.toString()}</div>;
         }
 
         return (

--- a/packages/neos-ui-editors/src/EditorEnvelope/style.css
+++ b/packages/neos-ui-editors/src/EditorEnvelope/style.css
@@ -1,3 +1,4 @@
 .envelope__error {
-    color: var(--brandColorsError);
+    padding: .5em;
+    border: 1px solid var(--brandColorsError);
 }

--- a/packages/neos-ui-editors/src/EditorEnvelope/style.css
+++ b/packages/neos-ui-editors/src/EditorEnvelope/style.css
@@ -1,0 +1,3 @@
+.envelope__error {
+    color: var(--brandColorsError);
+}


### PR DESCRIPTION
With React 16 error boundaries were introduced to limit the effect
of errors on an react app. The EditorEnvelope is now a natural
error boundary and so effectively keeps errors in inspector editors
to the editor.

Fixes: #1137