### PR TITLE
TASK: Add missing translations

### DIFF
--- a/Tests/IntegrationTests/contentModule.js
+++ b/Tests/IntegrationTests/contentModule.js
@@ -29,7 +29,7 @@ async function waitForIframeLoading(t) {
 async function discardAll(t) {
     await t
         .click(ReactSelector('PublishDropDown ContextDropDownHeader'))
-        .click(ReactSelector('PublishDropDown ShallowDropDownContents').find('button').withText('Discard All'));
+        .click(ReactSelector('PublishDropDown ShallowDropDownContents').find('button').withText('Discard all'));
     await waitForIframeLoading(t);
 }
 

--- a/packages/neos-ui/src/Containers/EditModePanel/index.js
+++ b/packages/neos-ui/src/Containers/EditModePanel/index.js
@@ -7,6 +7,7 @@ import {memoize} from 'ramda';
 
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {neos} from '@neos-project/neos-ui-decorators';
+import I18n from '@neos-project/neos-ui-i18n';
 
 import Panel from './Panel';
 import style from './style.css';
@@ -69,7 +70,7 @@ export default class EditModePanel extends PureComponent {
             <div className={classNames}>
                 <div className={style.editModePanel__wrapper}>
                     <Panel
-                        title="Editing Mode"
+                        title={<I18n id="content.components.editPreviewPanel.modes" fallback="Editing Modes"/>}
                         className={style.editModePanel__editingModes}
                         modes={editPreviewModesList.filter(editPreviewMode => editPreviewMode.isEditingMode && editPreviewMode.id !== editPreviewMode)}
                         current={editPreviewMode}
@@ -78,7 +79,7 @@ export default class EditModePanel extends PureComponent {
                         onPreviewModeClick={this.handleEditPreviewModeClick}
                         />
                     <Panel
-                        title="Preview Central"
+                        title={<I18n id="content.components.editPreviewPanel.previewCentral" fallback="Preview Central"/>}
                         className={style.editModePanel__previewModes}
                         modes={editPreviewModesList.filter(editPreviewMode => editPreviewMode.isPreviewMode && editPreviewMode.id !== editPreviewMode)}
                         current={editPreviewMode}

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/EditModePanelToggler/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/EditModePanelToggler/index.js
@@ -46,8 +46,8 @@ export default class EditModePanelToggler extends PureComponent {
 
         const currentEditMode = editPreviewModes[editPreviewMode];
 
-        let editLabel = <I18n id="edit" fallback="Edit"/>;
-        let previewLabel = <I18n id="preview" fallback="Preview"/>;
+        let editLabel = <I18n id="Neos.Neos:Main:edit" fallback="Edit"/>;
+        let previewLabel = <I18n id="Neos.Neos:Main:preview" fallback="Preview"/>;
 
         const toBold = string => <b>{string}</b>;
 

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/LeftSideBarToggler/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/LeftSideBarToggler/index.js
@@ -45,7 +45,7 @@ export default class LeftSideBarToggler extends PureComponent {
                 isFocused={isActive}
                 onClick={this.handleToggle}
                 >
-                <Icon className={style.icon} icon="location-arrow"/> <I18n id="navigate" fallback="Navigate"/>
+                <Icon className={style.icon} icon="location-arrow"/> <I18n id="Neos.Neos:Main:navigate" fallback="Navigate"/>
             </Button>
         );
     }

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -205,15 +205,15 @@ export default class PublishDropDown extends PureComponent {
 
         if (isSaving) {
             return {
-                mainButtonLabel: "Neos.Neos:Main:saving",
-                mainButtonTarget: "Neos.Neos:Main:saving"
+                mainButtonLabel: <I18n id='Neos.Neos:Main:saving' fallback='Workspaces'/>,
+                mainButtonTarget: 'Neos.Neos:Main:saving'
             };
         }
 
         if (isPublishing) {
             return {
-                mainButtonLabel: "Neos.Neos:Main:publishing",
-                mainButtonTarget: "Neos.Neos:Main:publishing"
+                mainButtonLabel: 'Neos.Neos:Main:publishing',
+                mainButtonTarget: 'Neos.Neos:Main:publishing'
             };
         }
 
@@ -226,21 +226,21 @@ export default class PublishDropDown extends PureComponent {
 
         if (isAutoPublishingEnabled) {
             return {
-                mainButtonLabel: "Neos.Neos:Main:autoPublish",
-                mainButtonTarget: "Neos.Neos:Main:autoPublish"
+                mainButtonLabel: 'Neos.Neos:Main:autoPublish',
+                mainButtonTarget: 'Neos.Neos:Main:autoPublish'
             };
         }
 
         if (canPublishLocally) {
             return {
-                mainButtonLabel: "Neos.Neos:Main:publish",
-                mainButtonTarget: "Neos.Neos:Main:publish"
+                mainButtonLabel: 'Neos.Neos:Main:publish',
+                mainButtonTarget: 'Neos.Neos:Main:publish'
             };
         }
 
         return {
-            mainButtonLabel: "Neos.Neos:Main:published",
-            mainButtonTarget: "Neos.Neos:Main:published"
+            mainButtonLabel: 'Neos.Neos:Main:published',
+            mainButtonTarget: 'Neos.Neos:Main:published'
         };
     }
 }

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -100,7 +100,7 @@ export default class PublishDropDown extends PureComponent {
             [style.dropDown__item]: true,
             [style['dropDown__item--noHover']]: true
         });
-        const {mainButtonLabel, mainButtonTarget} = this.getMainButtonLabeling();
+        const mainButton = this.getTranslatedMainButton(baseWorkspaceTitle);
         const dropDownBtnClassName = mergeClassNames({
             [style.dropDown__btn]: true,
             [style['dropDown__item--canPublish']]: canPublishGlobally
@@ -116,7 +116,7 @@ export default class PublishDropDown extends PureComponent {
                     isHighlighted={canPublishLocally || isSaving}
                     onClick={this.handlePublishClick}
                     >
-                    <I18n id={mainButtonLabel} fallback={mainButtonTarget}/> <I18n id="to" fallback="to"/> {isWorkspaceReadOnly ? (<Icon icon="lock"/>) : ''} {baseWorkspaceTitle}
+                    {mainButton} {isWorkspaceReadOnly ? (<Icon icon="lock"/>) : ''}
                     {publishableNodesInDocumentCount > 0 && <Badge className={style.badge} label={String(publishableNodesInDocumentCount)}/>}
                 </AbstractButton>
 
@@ -193,7 +193,7 @@ export default class PublishDropDown extends PureComponent {
         );
     }
 
-    getMainButtonLabeling() {
+    getTranslatedMainButton(baseWorkspaceTitle = '') {
         const {
             publishableNodesInDocument,
             isSaving,
@@ -204,43 +204,25 @@ export default class PublishDropDown extends PureComponent {
         const canPublishLocally = publishableNodesInDocument && (publishableNodesInDocument.count() > 0);
 
         if (isSaving) {
-            return {
-                mainButtonLabel: 'Neos.Neos:Main:saving',
-                mainButtonTarget: 'Neos.Neos:Main:saving'
-            };
+            return <I18n id="Neos.Neos:Main:saving" fallback="saving"/>;
         }
 
         if (isPublishing) {
-            return {
-                mainButtonLabel: 'Neos.Neos:Main:publishing',
-                mainButtonTarget: 'Neos.Neos:Main:publishing'
-            };
+            return <I18n id="Neos.Neos:Main:publishTo" fallback="Publish to" params={{0: baseWorkspaceTitle}}/>;
         }
 
         if (isDiscarding) {
-            return {
-                mainButtonLabel: 'discarding',
-                mainButtonTarget: 'Discarding...'
-            };
+            return 'Discarding...';
         }
 
         if (isAutoPublishingEnabled) {
-            return {
-                mainButtonLabel: 'Neos.Neos:Main:autoPublish',
-                mainButtonTarget: 'Neos.Neos:Main:autoPublish'
-            };
+            return <I18n id="Neos.Neos:Main:autoPublish" fallback="Auto publish"/>;
         }
 
         if (canPublishLocally) {
-            return {
-                mainButtonLabel: 'Neos.Neos:Main:publish',
-                mainButtonTarget: 'Neos.Neos:Main:publish'
-            };
+            return <I18n id="Neos.Neos:Main:publishTo" fallback="Publish to" params={{0: baseWorkspaceTitle}}/>;
         }
 
-        return {
-            mainButtonLabel: 'Neos.Neos:Main:published',
-            mainButtonTarget: 'Neos.Neos:Main:published'
-        };
+        return <I18n id="Neos.Neos:Main:published" fallback="Published"/>;
     }
 }

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -116,7 +116,7 @@ export default class PublishDropDown extends PureComponent {
                     isHighlighted={canPublishLocally || isSaving}
                     onClick={this.handlePublishClick}
                     >
-                    <I18n fallback={mainButtonTarget} id={mainButtonLabel}/> <I18n id="to"/> {isWorkspaceReadOnly ? (<Icon icon="lock"/>) : ''} {baseWorkspaceTitle}
+                    <I18n id={mainButtonLabel} fallback={mainButtonTarget}/> <I18n id="to" fallback="to"/> {isWorkspaceReadOnly ? (<Icon icon="lock"/>) : ''} {baseWorkspaceTitle}
                     {publishableNodesInDocumentCount > 0 && <Badge className={style.badge} label={String(publishableNodesInDocumentCount)}/>}
                 </AbstractButton>
 
@@ -143,7 +143,7 @@ export default class PublishDropDown extends PureComponent {
                                 onClick={this.handlePublishAllClick}
                                 >
                                 <Icon icon="upload"/>
-                                <I18n fallback="Publish All" id="publishAll"/>
+                                <I18n id="Neos.Neos:Main:publishAll" fallback="Publish All"/>
                                 {publishableNodesCount > 0 && ` (${publishableNodesCount})`}
                             </AbstractButton>
                         </li>
@@ -156,7 +156,7 @@ export default class PublishDropDown extends PureComponent {
                                 onClick={this.handleDiscardClick}
                                 >
                                 <Icon icon="ban"/>
-                                <I18n fallback="Discard" id="discard"/>
+                                <I18n id="Neos.Neos:Main:discard" fallback="Discard"/>
                                 {publishableNodesInDocumentCount > 0 && ` (${publishableNodesInDocumentCount})`}
                             </AbstractButton>
                         </li>
@@ -167,7 +167,7 @@ export default class PublishDropDown extends PureComponent {
                                 onClick={this.handleDiscardAllClick}
                                 >
                                 <Icon icon="ban"/>
-                                <I18n fallback="Discard All" id="discardAll"/>
+                                <I18n id="Neos.Neos:Main:discardAll" fallback="Discard All"/>
                                 {publishableNodesCount > 0 && ` (${publishableNodesCount})`}
                             </AbstractButton>
                         </li>
@@ -178,13 +178,13 @@ export default class PublishDropDown extends PureComponent {
                                     onChange={toggleAutoPublishing}
                                     isChecked={isAutoPublishingEnabled}
                                     />
-                                <I18n id="autoPublish" fallback="Auto-Publish"/>
+                                <I18n id="Neos.Neos:Main:autoPublish" fallback="Auto-Publish"/>
                             </Label>
                         </li>
                         <li className={style.dropDown__item}>
                             <a href="/neos/management/workspaces">
                                 <Icon icon="th-large"/>
-                                <I18n fallback="Workspaces" id="workspaces"/>
+                                <I18n id="Neos.Neos:Main:workspaces" fallback="Workspaces"/>
                             </a>
                         </li>
                     </DropDown.Contents>
@@ -205,15 +205,15 @@ export default class PublishDropDown extends PureComponent {
 
         if (isSaving) {
             return {
-                mainButtonLabel: 'saving',
-                mainButtonTarget: 'Saving...'
+                mainButtonLabel: "Neos.Neos:Main:saving",
+                mainButtonTarget: "Neos.Neos:Main:saving"
             };
         }
 
         if (isPublishing) {
             return {
-                mainButtonLabel: 'publishing',
-                mainButtonTarget: 'Publishing...'
+                mainButtonLabel: "Neos.Neos:Main:publishing",
+                mainButtonTarget: "Neos.Neos:Main:publishing"
             };
         }
 
@@ -226,21 +226,21 @@ export default class PublishDropDown extends PureComponent {
 
         if (isAutoPublishingEnabled) {
             return {
-                mainButtonLabel: 'autoPublish',
-                mainButtonTarget: 'Auto-Publish'
+                mainButtonLabel: "Neos.Neos:Main:autoPublish",
+                mainButtonTarget: "Neos.Neos:Main:autoPublish"
             };
         }
 
         if (canPublishLocally) {
             return {
-                mainButtonLabel: 'publish',
-                mainButtonTarget: 'Publish'
+                mainButtonLabel: "Neos.Neos:Main:publish",
+                mainButtonTarget: "Neos.Neos:Main:publish"
             };
         }
 
         return {
-            mainButtonLabel: 'published',
-            mainButtonTarget: 'Published'
+            mainButtonLabel: "Neos.Neos:Main:published",
+            mainButtonTarget: "Neos.Neos:Main:published"
         };
     }
 }

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -205,7 +205,7 @@ export default class PublishDropDown extends PureComponent {
 
         if (isSaving) {
             return {
-                mainButtonLabel: <I18n id='Neos.Neos:Main:saving' fallback='Workspaces'/>,
+                mainButtonLabel: 'Neos.Neos:Main:saving',
                 mainButtonTarget: 'Neos.Neos:Main:saving'
             };
         }

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -193,12 +193,12 @@ export default class Inspector extends PureComponent {
                     <Grid gutter="micro">
                         <Grid.Col width="half">
                             <Button style="lighter" disabled={isDiscardDisabled} onClick={this.handleDiscard} className={style.discardBtn}>
-                                <I18n id="discard"/>
+                                <I18n id="Neos.Neos:Main:discard" fallback="discard"/>
                             </Button>
                         </Grid.Col>
                         <Grid.Col width="half">
                             <Button style="lighter" disabled={isApplyDisabled} onClick={this.handleApply} className={style.publishBtn}>
-                                <I18n id="apply"/>
+                                <I18n id="Neos.Neos:Main:apply" fallback="apply"/>
                             </Button>
                         </Grid.Col>
                     </Grid>


### PR DESCRIPTION
closes #1210

It is currently not possible to translate `User Settings` in the user dropdown.
The id is: `userSettings.label` and in the code is this line: https://github.com/neos/neos-ui/blob/master/packages/neos-ui-i18n/src/registry/I18nRegistry.js#L75 which replaces every `.` with an `_`.

Don't have time to fix it now so I will open an issue.