### PR TITLE
TASK: Remove constructors from the neos-ui-editors package

### DIFF
--- a/packages/neos-ui-editors/src/Editors/CodeMirror/index.js
+++ b/packages/neos-ui-editors/src/Editors/CodeMirror/index.js
@@ -26,12 +26,6 @@ export default class CodeMirror extends PureComponent {
         highlightingMode: 'htmlmixed'
     };
 
-    constructor(props) {
-        super(props);
-        this.handleOpenCodeEditor = this.handleOpenCodeEditor.bind(this);
-        this.handleChange = this.handleChange.bind(this);
-    }
-
     render() {
         const {label, identifier} = this.props;
 
@@ -47,11 +41,11 @@ export default class CodeMirror extends PureComponent {
         );
     }
 
-    handleChange(newValue) {
+    handleChange = newValue => {
         this.props.commit(newValue);
     }
 
-    handleOpenCodeEditor() {
+    handleOpenCodeEditor = () => {
         const {secondaryEditorsRegistry} = this.props;
         const {component: CodeMirrorWrap} = secondaryEditorsRegistry.get('Neos.Neos/Inspector/Secondary/Editors/CodeMirrorWrap');
 

--- a/packages/neos-ui-editors/src/Editors/Image/Components/PreviewScreen/index.js
+++ b/packages/neos-ui-editors/src/Editors/Image/Components/PreviewScreen/index.js
@@ -16,12 +16,6 @@ export default class PreviewScreen extends PureComponent {
         highlight: PropTypes.bool
     };
 
-    constructor(props) {
-        super(props);
-
-        this.setDropDownRef = this.setDropDownRef.bind(this);
-    }
-
     chooseFromLocalFileSystem() {
         this.dropzone.open();
     }
@@ -70,7 +64,7 @@ export default class PreviewScreen extends PureComponent {
         );
     }
 
-    setDropDownRef(ref) {
+    setDropDownRef = ref => {
         this.dropzone = ref;
     }
 }

--- a/packages/neos-ui-editors/src/Editors/Image/index.js
+++ b/packages/neos-ui-editors/src/Editors/Image/index.js
@@ -23,6 +23,12 @@ const DEFAULT_FEATURES = {
     siteNodePath: $get('cr.nodes.siteNode')
 }))
 export default class ImageEditor extends Component {
+    state = {
+        image: null,
+        isImageCropperOpen: false,
+        isAssetLoading: false
+    };
+
     static propTypes = {
         value: PropTypes.oneOfType([
             PropTypes.shape({
@@ -58,26 +64,6 @@ export default class ImageEditor extends Component {
     static defaultProps = {
         allowedFileTypes: 'jpg,jpeg,png,gif,svg'
     };
-
-    constructor(props) {
-        super(props);
-
-        this.setPreviewScreenRef = this.setPreviewScreenRef.bind(this);
-        this.handleThumbnailClicked = this.handleThumbnailClicked.bind(this);
-        this.handleFilesDrop = this.upload.bind(this);
-        this.handleChooseFile = this.onChooseFile.bind(this);
-        this.handleRemoveFile = this.onRemoveFile.bind(this);
-        this.handleMediaSelected = this.onMediaSelected.bind(this);
-        this.handleMediaCrop = this.onCrop.bind(this);
-        this.handleCloseSecondaryScreen = this.handleCloseSecondaryScreen.bind(this);
-        this.handleChooseFromMedia = this.handleChooseFromMedia.bind(this);
-        this.handleOpenImageCropper = this.handleOpenImageCropper.bind(this);
-        this.state = {
-            image: null,
-            isImageCropperOpen: false,
-            isAssetLoading: false
-        };
-    }
 
     componentDidMount() {
         const {loadImageMetadata} = backend.get().endpoints;
@@ -135,7 +121,7 @@ export default class ImageEditor extends Component {
         return features[featureName];
     }
 
-    onCrop(cropArea) {
+    handleMediaCrop = cropArea => {
         const {commit, value} = this.props;
         const {image} = this.state;
 
@@ -165,7 +151,7 @@ export default class ImageEditor extends Component {
         });
     }
 
-    handleCloseSecondaryScreen() {
+    handleCloseSecondaryScreen = () => {
         this.props.renderSecondaryInspector(undefined, undefined);
     }
 
@@ -173,7 +159,7 @@ export default class ImageEditor extends Component {
         return this.props.value ? this.props.value : {};
     }
 
-    onRemoveFile() {
+    handleRemoveFile = () => {
         const {commit} = this.props;
 
         this.handleCloseSecondaryScreen();
@@ -184,7 +170,7 @@ export default class ImageEditor extends Component {
         });
     }
 
-    onMediaSelected(assetIdentifier) {
+    handleMediaSelected = assetIdentifier => {
         const {commit} = this.props;
         const value = this.getValue();
         const newAsset = $set('__identity', assetIdentifier, value);
@@ -198,7 +184,7 @@ export default class ImageEditor extends Component {
         });
     }
 
-    handleThumbnailClicked() {
+    handleThumbnailClicked = () => {
         const {secondaryEditorsRegistry} = this.props;
         const {component: MediaDetailsScreen} = secondaryEditorsRegistry.get('Neos.Neos/Inspector/Secondary/Editors/MediaDetailsScreen');
         const imageIdentity = $get('__identity', this.props.value);
@@ -211,15 +197,15 @@ export default class ImageEditor extends Component {
                     />
             );
         } else {
-            this.onChooseFile();
+            this.handleChooseFile();
         }
     }
 
-    onChooseFile() {
+    handleChooseFile = () => {
         this.previewScreen.chooseFromLocalFileSystem();
     }
 
-    upload(files) {
+    handleFilesDrop = files => {
         const {uploadAsset} = backend.get().endpoints;
         const {commit, siteNodePath} = this.props;
         const {isImageCropperOpen} = this.state;
@@ -240,7 +226,7 @@ export default class ImageEditor extends Component {
         });
     }
 
-    handleChooseFromMedia() {
+    handleChooseFromMedia = () => {
         const {secondaryEditorsRegistry} = this.props;
         const {component: MediaSelectionScreen} = secondaryEditorsRegistry.get('Neos.Neos/Inspector/Secondary/Editors/MediaSelectionScreen');
 
@@ -249,7 +235,7 @@ export default class ImageEditor extends Component {
         );
     }
 
-    handleOpenImageCropper() {
+    handleOpenImageCropper = () => {
         const {secondaryEditorsRegistry} = this.props;
         const {component: ImageCropper} = secondaryEditorsRegistry.get('Neos.Neos/Inspector/Secondary/Editors/ImageCropper');
 
@@ -293,7 +279,7 @@ export default class ImageEditor extends Component {
         return this.props.hooks ? this.props.hooks['Neos.UI:Hook.BeforeSave.CreateImageVariant'] : this.state.image;
     }
 
-    setPreviewScreenRef(ref) {
+    setPreviewScreenRef = ref => {
         this.previewScreen = ref;
     }
 

--- a/packages/neos-ui-editors/src/SecondaryEditors/CodeMirrorWrap/index.js
+++ b/packages/neos-ui-editors/src/SecondaryEditors/CodeMirrorWrap/index.js
@@ -21,11 +21,6 @@ export default class CodeMirrorWrap extends PureComponent {
         value: PropTypes.string
     };
 
-    constructor(props) {
-        super(props);
-        this.handleChange = this.handleChange.bind(this);
-    }
-
     editorRefCallback = ref => {
         if (!ref) {
             return;
@@ -53,7 +48,7 @@ export default class CodeMirrorWrap extends PureComponent {
         );
     }
 
-    handleChange(newValue) {
+    handleChange = newValue => {
         this.props.onChange(newValue);
     }
 }

--- a/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/AspectRatioDropDown/index.js
+++ b/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/AspectRatioDropDown/index.js
@@ -14,12 +14,6 @@ class AspectRatioDropDownitem extends PureComponent {
         onClick: PropTypes.func.isRequired
     };
 
-    constructor(props) {
-        super(props);
-
-        this.handleClick = this.handleClick.bind(this);
-    }
-
     render() {
         const {label} = this.props;
 
@@ -30,7 +24,7 @@ class AspectRatioDropDownitem extends PureComponent {
         );
     }
 
-    handleClick() {
+    handleClick = () => {
         const {value, onClick} = this.props;
 
         onClick(value);

--- a/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/index.js
+++ b/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/index.js
@@ -25,14 +25,6 @@ class AspectRatioItem extends PureComponent {
         isLocked: PropTypes.bool
     };
 
-    constructor(props) {
-        super(props);
-
-        this.handleWidthInputChange = this.handleInputChange.bind(this, 'width');
-        this.handleHeightInputChange = this.handleInputChange.bind(this, 'height');
-        this.handleFlipAspectRatio = this.props.onFlipAspectRatio.bind(this);
-    }
-
     render() {
         const {width, height, key, isLocked} = this.props;
 
@@ -48,7 +40,7 @@ class AspectRatioItem extends PureComponent {
                 <IconButton
                     icon="exchange"
                     disabled={isLocked}
-                    onClick={this.handleFlipAspectRatio}
+                    onClick={this.props.onFlipAspectRatio}
                     />
                 <TextInput
                     className={style.dimensionInput}
@@ -60,6 +52,9 @@ class AspectRatioItem extends PureComponent {
             </span>
         );
     }
+
+    handleWidthInputChange = val => this.handleInputChange('width', val);
+    handleHeightInputChange = val => this.handleInputChange('height', val);
 
     handleInputChange(type, val) {
         const width = type === 'width' ? val : this.props.width;
@@ -73,28 +68,19 @@ class AspectRatioItem extends PureComponent {
     i18nRegistry: globalRegistry.get('i18n')
 }))
 export default class ImageCropper extends PureComponent {
+    state = {
+        cropConfiguration: CropConfiguration.fromNeosConfiguration(
+            this.props.sourceImage,
+            this.props.options.crop.aspectRatio
+        )
+    };
+
     static propTypes = {
         onComplete: PropTypes.func.isRequired,
         sourceImage: PropTypes.object.isRequired,
         options: PropTypes.object,
         i18nRegistry: PropTypes.object.isRequired
     };
-
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            cropConfiguration: CropConfiguration.fromNeosConfiguration(
-                this.props.sourceImage,
-                this.props.options.crop.aspectRatio
-            )
-        };
-
-        this.handleSetAspectRatio = this.setAspectRatio.bind(this);
-        this.handleClearAspectRatio = this.clearAspectRatio.bind(this);
-        this.handleFlipAspectRatio = this.flipAspectRatio.bind(this);
-        this.handleSetCustomAspectRatioDimensions = this.setCustomAspectRatioDimensions.bind(this);
-    }
 
     componentDidMount() {
         //
@@ -118,14 +104,14 @@ export default class ImageCropper extends PureComponent {
         });
     }
 
-    setAspectRatio(aspectRatioOption) {
+    handleSetAspectRatio = aspectRatioOption => {
         const {cropConfiguration} = this.state;
         this.setState({
             cropConfiguration: cropConfiguration.selectAspectRatioOption(aspectRatioOption)
         });
     }
 
-    setCustomAspectRatioDimensions(width, height) {
+    handleSetCustomAspectRatioDimensions = (width, height) => {
         const {cropConfiguration} = this.state;
 
         this.setState({
@@ -133,7 +119,7 @@ export default class ImageCropper extends PureComponent {
         });
     }
 
-    flipAspectRatio() {
+    handleFlipAspectRatio = () => {
         const {cropConfiguration} = this.state;
 
         this.setState({
@@ -141,7 +127,7 @@ export default class ImageCropper extends PureComponent {
         });
     }
 
-    clearAspectRatio() {
+    handleClearAspectRatio = () => {
         const {cropConfiguration} = this.state;
 
         this.setState({


### PR DESCRIPTION
This removes constructors from all components in the `neos-ui-editors`
package and uses arrow functions as class properties instead
of binding. This makes the code a bit more concise.

Related: #979