### PR TITLE
TASK: Remove contructors from neos-ui

### DIFF
--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -50,12 +50,6 @@ export default class ContentCanvas extends PureComponent {
         loadedSrc: ''
     };
 
-    constructor(props) {
-        super(props);
-
-        this.onFrameChange = this.handleFrameChanges.bind(this);
-    }
-
     render() {
         const {
             isFringeLeft,
@@ -122,7 +116,7 @@ export default class ContentCanvas extends PureComponent {
         );
     }
 
-    handleFrameChanges(iframeWindow, iframeDocument) {
+    onFrameChange = (iframeWindow, iframeDocument) => {
         if (iframeDocument.__isInitialized) {
             return;
         }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -36,6 +36,10 @@ const decodeLabel = flowright(
 );
 
 export default class Node extends PureComponent {
+    state = {
+        shouldScrollIntoView: false
+    };
+
     static propTypes = {
         isContentTreeNode: PropTypes.bool,
         rootNode: PropTypes.object,
@@ -69,17 +73,6 @@ export default class Node extends PureComponent {
         onNodeDrag: PropTypes.func,
         onNodeDrop: PropTypes.func
     };
-
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            shouldScrollIntoView: false
-        };
-
-        this.handleNodeToggle = this.handleNodeToggle.bind(this);
-        this.handleNodeClick = this.handleNodeClick.bind(this);
-    }
 
     componentDidMount() {
         // Always request scroll on first render if given node is focused
@@ -282,12 +275,12 @@ export default class Node extends PureComponent {
         );
     }
 
-    handleNodeToggle() {
+    handleNodeToggle = () => {
         const {node, onNodeToggle} = this.props;
         onNodeToggle($get('contextPath', node));
     }
 
-    handleNodeClick() {
+    handleNodeClick = () => {
         const {node, onNodeFocus, onNodeClick} = this.props;
         onNodeFocus($get('contextPath', node));
         onNodeClick($get('uri', node), $get('contextPath', node));

--- a/packages/neos-ui/src/Containers/LeftSideBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/index.js
@@ -24,10 +24,9 @@ import style from './style.css';
     documentNode: selectors.UI.ContentCanvas.documentNodeSelector
 }))
 export default class LeftSideBar extends PureComponent {
-    constructor(props) {
-        super(props);
-        this.state = {isBottomOpen: true};
-    }
+    state = {
+        isBottomOpen: true
+    };
 
     static propTypes = {
         containerRegistry: PropTypes.object.isRequired,

--- a/packages/neos-ui/src/Containers/Modals/ReloginDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/ReloginDialog/index.js
@@ -26,12 +26,6 @@ const emptyFn = () => {};
     reauthenticationSucceeded: actions.System.reauthenticationSucceeded
 })
 export default class ReloginDialog extends PureComponent {
-    static propTypes = {
-        i18nRegistry: PropTypes.object.isRequired,
-        authenticationTimeout: PropTypes.bool.isRequired,
-        reauthenticationSucceeded: PropTypes.func.isRequired
-    };
-
     defaultState = {
         message: false,
         username: '',
@@ -39,10 +33,13 @@ export default class ReloginDialog extends PureComponent {
         isLoading: false
     };
 
-    constructor(props) {
-        super(props);
-        this.state = {...this.defaultState};
-    }
+    state = {...this.defaultState};
+
+    static propTypes = {
+        i18nRegistry: PropTypes.object.isRequired,
+        authenticationTimeout: PropTypes.bool.isRequired,
+        reauthenticationSucceeded: PropTypes.func.isRequired
+    };
 
     handleUsernameChange = username => {
         this.setState({username});

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeGroupPanel.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeGroupPanel.js
@@ -37,12 +37,6 @@ class NodeTypeGroupPanel extends PureComponent {
         i18nRegistry: PropTypes.object.isRequired
     };
 
-    constructor(props) {
-        super(props);
-
-        this.handleToggleGroup = this.handleToggleGroup.bind(this);
-    }
-
     render() {
         const {
             group,
@@ -79,7 +73,7 @@ class NodeTypeGroupPanel extends PureComponent {
         );
     }
 
-    handleToggleGroup() {
+    handleToggleGroup = () => {
         const {
             toggleNodeTypeGroup,
             group

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeItem.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeItem.js
@@ -28,12 +28,6 @@ class NodeTypeItem extends PureComponent {
         }).isRequired
     };
 
-    constructor(props) {
-        super(props);
-
-        this.handleNodeTypeClick = this.handleNodeTypeClick.bind(this);
-    }
-
     render() {
         const {ui} = this.props.nodeType;
         const icon = $get('icon', ui);
@@ -54,7 +48,7 @@ class NodeTypeItem extends PureComponent {
         );
     }
 
-    handleNodeTypeClick() {
+    handleNodeTypeClick = () => {
         this.props.onSelect(this.props.nodeType.name);
     }
 }


### PR DESCRIPTION
This removes constructors from all components in the neos-ui
package and uses arrow functions as class properties instead
of binding. This makes the code a bit more concise.

Related: #979