### PR TITLE
BUGFIX: correctly use default options in Select Boxes and Reference(s) editors

### DIFF
--- a/packages/neos-ui-editors/src/Editors/Reference/index.js
+++ b/packages/neos-ui-editors/src/Editors/Reference/index.js
@@ -85,7 +85,7 @@ export default class ReferenceEditor extends PureComponent {
 
     handleSearchTermChange = searchTerm => {
         this.setState({searchTerm});
-        const threshold = $get('options.threshold', this.props) || this.defaultOptions.threshold;
+        const threshold = $get('options.threshold', this.props) || this.constructor.defaultOptions.threshold;
         if (searchTerm && searchTerm.length >= threshold) {
             this.setState({isLoading: true, searchOptions: []});
             this.props.nodeLookupDataLoader.search(this.getDataLoaderOptions(), searchTerm)

--- a/packages/neos-ui-editors/src/Editors/References/index.js
+++ b/packages/neos-ui-editors/src/Editors/References/index.js
@@ -96,7 +96,7 @@ export default class ReferencesEditor extends PureComponent {
 
     handleSearchTermChange = searchTerm => {
         this.setState({searchTerm});
-        const threshold = $get('options.threshold', this.props) || this.defaultOptions.threshold;
+        const threshold = $get('options.threshold', this.props) || this.constructor.defaultOptions.threshold;
         if (searchTerm && searchTerm.length >= threshold) {
             this.setState({isLoading: true, searchOptions: []});
             this.props.nodeLookupDataLoader.search(this.getDataLoaderOptions(), searchTerm)

--- a/packages/neos-ui-editors/src/Editors/SelectBox/DataSourceBasedSelectBoxEditor.js
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/DataSourceBasedSelectBoxEditor.js
@@ -91,7 +91,7 @@ export default class DataSourceBasedSelectBoxEditor extends PureComponent {
 
     render() {
         const {commit, value, i18nRegistry, highlight} = this.props;
-        const options = Object.assign({}, this.defaultOptions, this.props.options);
+        const options = Object.assign({}, this.constructor.defaultOptions, this.props.options);
 
         const processedSelectBoxOptions = processSelectBoxOptions(i18nRegistry, this.state.selectBoxOptions);
 

--- a/packages/neos-ui-editors/src/Editors/SelectBox/SimpleSelectBoxEditor.js
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/SimpleSelectBoxEditor.js
@@ -51,7 +51,7 @@ export default class SimpleSelectBoxEditor extends PureComponent {
 
     render() {
         const {commit, value, i18nRegistry, highlight} = this.props;
-        const options = Object.assign({}, this.defaultOptions, this.props.options);
+        const options = Object.assign({}, this.constructor.defaultOptions, this.props.options);
 
         const processedSelectBoxOptions = processSelectBoxOptions(i18nRegistry, options.values);
 


### PR DESCRIPTION
This has never worked before because the defaultOptions are static; so we
need to reference them statically as well.