### PR TITLE
BUGFIX: fix background color for content canvas

### DIFF
--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -91,7 +91,7 @@ export default class ContentCanvas extends PureComponent {
 
         // ToDo: Is the `[data-__neos__hook]` attr used?
         return (
-            <div className={classNames}>
+            <div className={classNames} style={canvasContentStyle}>
                 <div id="centerArea"/>
                 <div
                     className={style.contentCanvas__itemWrapper}


### PR DESCRIPTION
Re-fix #863 - this was broken by one of the changes in the meantime.