### PR TITLE
BUGFIX: Enable basic entities encoding

### DIFF
--- a/packages/neos-ui-ckeditor-bindings/src/createCkEditor.js
+++ b/packages/neos-ui-ckeditor-bindings/src/createCkEditor.js
@@ -30,7 +30,7 @@ export default ({propertyDomNode, propertyName, contextPath, editorOptions, glob
                 removePlugins: 'floatingspace,maximize,resize,liststyle',
                 autoParagraph: isAutoParagraphEnabled,
                 entities: false,
-                basicEntities: false,
+                basicEntities: true,
                 title: propertyName,
                 language: interfaceLanguage
             },


### PR DESCRIPTION
This (re-) enables basic HTML entity encoding, to avoid
for example opening HTML comments breaking the site.

Fixes: #1257