### PR TITLE
BUGFIX: fix inclusion of CSS in extensibility modules

### DIFF
--- a/packages/build-essentials/src/webpack.config.js
+++ b/packages/build-essentials/src/webpack.config.js
@@ -126,4 +126,15 @@ if (env.isProduction) {
     }));
 }
 
+// the webpack.config.js in @neos-project/neos-ui-extensibility makes use of the ExtractTextPlugin.
+// however, if for some reasons, the instances used in "module.loaders" and "plugins" are not the same
+// ones, you get the folllowing error message when building plugins which need to load CSS:
+//   "Module build failed: Error: "extract-text-webpack-plugin" loader is used without the corresponding plugin"
+//
+// As a workaround, we need to pass on the ExtractTextPlugin *instance* from here to the webpack.config.js on 
+// @neos-project/neos-ui-extensibility
+webpackConfig.__neos = {
+    ExtractTextPlugin: ExtractTextPlugin
+};
+
 module.exports = webpackConfig;

--- a/packages/neos-ui-extensibility/scripts/helpers/webpack.config.js
+++ b/packages/neos-ui-extensibility/scripts/helpers/webpack.config.js
@@ -1,6 +1,6 @@
 const sharedWebPackConfig = require('@neos-project/build-essentials/src/webpack.config.js');
 const path = require('path');
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const ExtractTextPlugin = sharedWebPackConfig.__neos.ExtractTextPlugin;
 
 module.exports = function (neosPackageJson) {
     return Object.assign({}, sharedWebPackConfig, {


### PR DESCRIPTION
the webpack.config.js in @neos-project/neos-ui-extensibility makes use
of the ExtractTextPlugin.

however, if for some reasons, the instances used in "module.loaders" and
"plugins" are not the same ones, you get the folllowing error message 
when building plugins which need to load CSS:

	"Module build failed: Error: "extract-text-webpack-plugin" loader is
	 used without the corresponding plugin"

This happened for me in all cases where I want to load CSS in a custom extension.