### PR TITLE
BUGFIX: Remove black background of load indicator

### DIFF
--- a/packages/react-ui-components/src/SelectBox/style.css
+++ b/packages/react-ui-components/src/SelectBox/style.css
@@ -86,7 +86,7 @@
     width: var(--goldenUnit);
     height: var(--goldenUnit);
     text-align: center;
-    background: var(--brandColorsContrastNeutral);
+    background: transparent;
     color: #FFF;
     line-height: 40px;
 }


### PR DESCRIPTION
The load indicator rotates and when the background is black a square is rotating. Which looks weird.

Fixes #1187