### PR TITLE
BUGFIX: Use URI path segment generate on document creation

### DIFF
--- a/Classes/Neos/Neos/Ui/NodeCreationHandler/DocumentTitleNodeCreationHandler.php
+++ b/Classes/Neos/Neos/Ui/NodeCreationHandler/DocumentTitleNodeCreationHandler.php
@@ -1,12 +1,19 @@
 <?php
+
 namespace Neos\Neos\Ui\NodeCreationHandler;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
-use Neos\ContentRepository\Utility as NodeUtility;
+use Neos\Neos\Utility\NodeUriPathSegmentGenerator;
 
 class DocumentTitleNodeCreationHandler implements NodeCreationHandlerInterface
 {
+    /**
+     * @Flow\Inject
+     * @var NodeUriPathSegmentGenerator
+     */
+    protected $nodeUriPathSegmentGenerator;
+
     /**
      * Set the node title for the newly created Document node
      *
@@ -16,9 +23,11 @@ class DocumentTitleNodeCreationHandler implements NodeCreationHandlerInterface
      */
     public function handle(NodeInterface $node, array $data)
     {
-        if (isset($data['title']) && $node->getNodeType()->isOfType('Neos.Neos:Document')) {
-            $node->setProperty('title', $data['title']);
-            $node->setProperty('uriPathSegment', NodeUtility::renderValidNodeName($data['title']));
+        if ($node->getNodeType()->isOfType('Neos.Neos:Document')) {
+            if (isset($data['title'])) {
+                $node->setProperty('title', $data['title']);
+            }
+            $node->setProperty('uriPathSegment', $this->nodeUriPathSegmentGenerator->generateUriPathSegment($node, (isset($data['title']) ? $data['title'] : null)));
         }
     }
 }


### PR DESCRIPTION
URI path segment was md5-hash, when something other than the title-property was used in the creation dialog of a document. Using the nodeUriPathSegmentGenerator to allow label or name as URI path segment