### PR TITLE
TASK: Render separator of chevron only with additional button

### DIFF
--- a/packages/react-ui-components/src/DropDown/style.css
+++ b/packages/react-ui-components/src/DropDown/style.css
@@ -36,18 +36,6 @@
     top: 50%;
     transform: translateY(-50%);
 }
-.dropDown__chevron::after {
-    display: block;
-    content: '';
-    position: absolute;
-    width: 1px;
-    height: 24px;
-    top: 0;
-    right: 25px;
-    background-color: #fff;
-    opacity: .15;
-    margin-top: -5px;
-}
 .dropDown__contents {
     composes: reset from './../reset.css';
     position: absolute;

--- a/packages/react-ui-components/src/SelectBox/style.css
+++ b/packages/react-ui-components/src/SelectBox/style.css
@@ -92,6 +92,21 @@
 }
 
 .selectBox__twoIconIndention {
+    .selectBox__loadingIcon::after {
+        display: block;
+        content: '';
+        position: absolute;
+        width: 1px;
+        height: 24px;
+        top: 0;
+        right: 0;
+        background-color: #fff;
+        opacity: .15;
+        margin-top: var(--halfSpacing);
+    }
+}
+
+.selectBox__twoIconIndention {
     padding: 0 calc(var(--spacing) + var(--goldenUnit) + var(--goldenUnit)) 0 var(--spacing);
 }
 


### PR DESCRIPTION
The selectBox has a dropdown chevron icon and can
have also a loading indicator or a reset button.

The rendered separator should be optional so that the dropdown without
additional button has no separator.

Fixes: #1319