### PR TITLE
TASK: Set isOpen default state to true

### DIFF
--- a/packages/react-ui-components/src/ToggablePanel/__snapshots__/toggablePanel.spec.js.snap
+++ b/packages/react-ui-components/src/ToggablePanel/__snapshots__/toggablePanel.spec.js.snap
@@ -47,7 +47,7 @@ exports[`<ToggablePanel/> should render correctly. 1`] = `
 <StatelessToggablePanel
   HeadlineComponent={[Function]}
   IconButtonComponent={[Function]}
-  isOpen={false}
+  isOpen={true}
   onPanelToggle={[Function]}
   theme={
     Object {

--- a/packages/react-ui-components/src/ToggablePanel/toggablePanel.js
+++ b/packages/react-ui-components/src/ToggablePanel/toggablePanel.js
@@ -7,7 +7,7 @@ const validStyleKeys = ['condensed'];
 
 export default class ToggablePanel extends PureComponent {
     state = {
-        isOpen: false
+        isOpen: true
     };
 
     static propTypes = {
@@ -34,7 +34,7 @@ export default class ToggablePanel extends PureComponent {
     };
 
     static defaultProps = {
-        isOpen: false
+        isOpen: true
     };
 
     componentWillReceiveProps(newProps) {
@@ -129,11 +129,11 @@ export class StatelessToggablePanel extends PureComponent {
     }
 
     render() {
-        const {children, className, theme, style} = this.props;
+        const {children, className, theme, style, isOpen} = this.props;
         const finalClassName = mergeClassNames({
             [className]: className && className.length,
             [theme.panel]: true,
-            [theme['panel--isOpen']]: this.props.isOpen,
+            [theme['panel--isOpen']]: isOpen,
             [theme[`panel--${style}`]]: validStyleKeys.includes(style)
         });
 
@@ -141,7 +141,7 @@ export class StatelessToggablePanel extends PureComponent {
             <section className={finalClassName}>
                 {React.Children.map(
                     children,
-                    child => child.type ? <child.type {...child.props} isPanelOpen={this.props.isOpen}/> : child
+                    child => child.type ? <child.type {...child.props} isPanelOpen={isOpen}/> : child
                 )}
             </section>
         );

--- a/packages/react-ui-components/src/ToggablePanel/toggablePanel.spec.js
+++ b/packages/react-ui-components/src/ToggablePanel/toggablePanel.spec.js
@@ -49,17 +49,17 @@ describe('<ToggablePanel/>', () => {
     it('should initialize with a state of {isOpen: props.isOpen}.', () => {
         const wrapper = shallow(<ToggablePanel {...props}/>);
 
-        expect(wrapper.state('isOpen')).toBe(false);
+        expect(wrapper.state('isOpen')).toBe(true);
     });
 
     it('should toggle the "isOpen" state when calling the instance "toggle" method.', () => {
         const wrapper = shallow(<ToggablePanel {...props}/>);
 
-        expect(wrapper.state('isOpen')).toBe(false);
+        expect(wrapper.state('isOpen')).toBe(true);
 
         wrapper.instance().toggle();
 
-        expect(wrapper.state('isOpen')).toBe(true);
+        expect(wrapper.state('isOpen')).toBe(false);
     });
 
     it('should propagate the "isOpen" prop to the the "StatelessToggablePanel" component in case a "onPanelToggle" prop was provided.', () => {


### PR DESCRIPTION
The most ToggablePanel components does not provide the `onPanelToggle` prop and if the prop is provided, the component will not use the internal state, instead it will be controlled by the props.

The default state is false and so the most ToggablePanel does not open on default.
Therefore the default is changed to true.

Fixes: #1323