### PR TITLE
BUGFIX: Use onTogglePanel instead of togglePanel

### DIFF
--- a/packages/react-ui-components/src/ToggablePanel/index.story.js
+++ b/packages/react-ui-components/src/ToggablePanel/index.story.js
@@ -50,7 +50,7 @@ storiesOf('ToggablePanel', module)
         'ToggablePanel - Stateless',
         () => (
             <StoryWrapper>
-                <ToggablePanel isOpen={boolean('Is Open?', true)} togglePanel={action('toggle')}>
+                <ToggablePanel isOpen={boolean('Is Open?', true)} onTogglePanel={action('toggle')}>
                     <ToggablePanel.Header>
                         Header
                     </ToggablePanel.Header>


### PR DESCRIPTION
The storybook of ToggablePanel still uses togglePanel,
but this property has been renamed.

Fixes: #1327