### PR TITLE
BUGFIX: Fix rotation of separator

### DIFF
--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -316,6 +316,7 @@ export default class SelectBox extends PureComponent {
                             <span className={theme.dropDown__itemLabel}>{label}</span>
                         }
 
+                        {showResetButton || displayLoadingIndicator ? <span className={theme.selectBox__iconSeparator}/> : null}
                         {displayLoadingIndicator ?
                             <IconComponent className={theme.selectBox__loadingIcon} spin={true} icon="spinner"/> :
                             null

--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -232,6 +232,15 @@ export default class SelectBox extends PureComponent {
         }
     }
 
+    getAmountofColumns(showResetButton) {
+        const {
+            options,
+            displayLoadingIndicator
+        } = this.props;
+
+        return options.length > 0 && (showResetButton || displayLoadingIndicator) ? 2 : 1;
+    }
+
     render() {
         const {
             options,
@@ -289,9 +298,10 @@ export default class SelectBox extends PureComponent {
         });
 
         const showResetButton = !displayLoadingIndicator && allowEmpty && selectedValue;
+        const amountOfIconColumns = this.getAmountofColumns(showResetButton);
 
         let headerClass = theme.selectBox__btn;
-        if (showResetButton || displayLoadingIndicator) {
+        if (amountOfIconColumns > 1) {
             headerClass += ' ' + theme.selectBox__twoIconIndention;
         }
 
@@ -316,7 +326,7 @@ export default class SelectBox extends PureComponent {
                             <span className={theme.dropDown__itemLabel}>{label}</span>
                         }
 
-                        {showResetButton || displayLoadingIndicator ? <span className={theme.selectBox__iconSeparator}/> : null}
+                        {amountOfIconColumns > 1 ? <span className={theme.selectBox__iconSeparator}/> : null}
                         {displayLoadingIndicator ?
                             <IconComponent className={theme.selectBox__loadingIcon} spin={true} icon="spinner"/> :
                             null

--- a/packages/react-ui-components/src/SelectBox/style.css
+++ b/packages/react-ui-components/src/SelectBox/style.css
@@ -91,19 +91,18 @@
     line-height: var(--goldenUnit);
 }
 
-.selectBox__twoIconIndention {
-    .selectBox__loadingIcon::after {
-        display: block;
-        content: '';
-        position: absolute;
-        width: 1px;
-        height: 24px;
-        top: 0;
-        right: 0;
-        background-color: #fff;
-        opacity: .15;
-        margin-top: var(--halfSpacing);
-    }
+
+.selectBox__iconSeparator {
+    display: block;
+    content: '';
+    position: absolute;
+    width: 1px;
+    height: 24px;
+    top: 0;
+    right: 0;
+    background-color: #fff;
+    opacity: .15;
+    margin-top: var(--halfSpacing);
 }
 
 .selectBox__twoIconIndention {

--- a/packages/react-ui-components/src/SelectBox/style.css
+++ b/packages/react-ui-components/src/SelectBox/style.css
@@ -101,12 +101,12 @@
 
 .selectBox__twoIconIndention .selectBox__iconSeparator {
     display: block;
-    content: '';
     position: absolute;
-    width: 1px;
-    height: 24px;
+    right: calc(var(--goldenUnit) + 1px);
     top: 0;
-    right: 41px;
+    height: calc(var(--spacing) * 1.25);
+    width: 1px;
+    content: '';
     background-color: #fff;
     opacity: .15;
     margin-top: var(--halfSpacing);
@@ -114,7 +114,7 @@
 
 .selectBox__twoIconIndention .selectBox__deleteIcon,
 .selectBox__twoIconIndention .selectBox__loadingIcon {
-    right: 41px;
+    right: calc(var(--goldenUnit) + 1px);
 }
 
 .selectBox__btnIcon {

--- a/packages/react-ui-components/src/SelectBox/style.css
+++ b/packages/react-ui-components/src/SelectBox/style.css
@@ -80,7 +80,7 @@
     composes: reset from './../reset.css';
     position: absolute;
     top: 0;
-    right: 41px;
+    right: 0;
     z-index: 1;
     display: block;
     width: var(--goldenUnit);
@@ -91,26 +91,30 @@
     line-height: var(--goldenUnit);
 }
 
-
-.selectBox__iconSeparator {
-    display: block;
-    content: '';
-    position: absolute;
-    width: 1px;
-    height: 24px;
-    top: 0;
-    right: 0;
-    background-color: #fff;
-    opacity: .15;
-    margin-top: var(--halfSpacing);
+.selectBox__deleteIcon {
+    composes: selectBox__loadingIcon;
 }
 
 .selectBox__twoIconIndention {
     padding: 0 calc(var(--spacing) + var(--goldenUnit) + var(--goldenUnit)) 0 var(--spacing);
 }
 
-.selectBox__deleteIcon {
-    composes: selectBox__loadingIcon;
+.selectBox__twoIconIndention .selectBox__iconSeparator {
+    display: block;
+    content: '';
+    position: absolute;
+    width: 1px;
+    height: 24px;
+    top: 0;
+    right: 41px;
+    background-color: #fff;
+    opacity: .15;
+    margin-top: var(--halfSpacing);
+}
+
+.selectBox__twoIconIndention .selectBox__deleteIcon,
+.selectBox__twoIconIndention .selectBox__loadingIcon {
+    right: 41px;
 }
 
 .selectBox__btnIcon {


### PR DESCRIPTION
Adds separator to own element.
Also show the separator depending on the amount of icons.

You can have a chevron when the options are available together with a loader or a reset or just a single loader or reset.

The chevron is of course always in the right. So with this PR we can now have the reset and the loader also on the right position if no chevron is visible and if the chevron is there the position is left to the chevron.

The following screen shows some possible options.

![bildschirmfoto 2017-11-23 um 22 50 26](https://user-images.githubusercontent.com/1014126/33189225-1f399dfe-d0a1-11e7-83cc-3e5ba31474ab.png)


Fixes: #1336