### PR TITLE
BUGFIX: revert back to an unsemantical tag name for icons

### DIFF
--- a/packages/react-ui-components/src/Icon/__snapshots__/icon.spec.js.snap
+++ b/packages/react-ui-components/src/Icon/__snapshots__/icon.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Icon/> should render correctly. 1`] = `
-<span
+<i
   className=""
   role="img"
 />

--- a/packages/react-ui-components/src/Icon/icon.js
+++ b/packages/react-ui-components/src/Icon/icon.js
@@ -46,7 +46,7 @@ const Icon = props => {
         [theme['icon--spin']]: props.spin
     });
 
-    return <span role="img" aria-label={label} className={classNames}/>;
+    return <i role="img" aria-label={label} className={classNames}/>;
 };
 Icon.propTypes = {
     /**

--- a/packages/react-ui-components/src/Tree/node.css
+++ b/packages/react-ui-components/src/Tree/node.css
@@ -22,7 +22,7 @@
         color: var(--brandColorsPrimaryBlue);
     }
 }
-.header__chevron--isCollapsed > span {
+.header__chevron--isCollapsed > i {
     transform: translateY(3px) translateX(-2px) rotate(-90deg);
 }
 .header__chevron--isHiddenInIndex,


### PR DESCRIPTION
Currently it's not feasible to switch without major styles refactoring,
it's way too breaking