### PR TITLE
BUGFIX: correctly trigger fallback parameters by not passing null in I18n component

### DIFF
--- a/packages/neos-ui-i18n/src/index.js
+++ b/packages/neos-ui-i18n/src/index.js
@@ -19,7 +19,7 @@ export default class I18n extends PureComponent {
         sourceName: PropTypes.string,
 
         // Additional parameters which are passed to the i18n service.
-        params: PropTypes.object.isRequired,
+        params: PropTypes.object,
 
         // Optional className which gets added to the translation span.
         className: PropTypes.string,

--- a/packages/neos-ui-i18n/src/index.js
+++ b/packages/neos-ui-i18n/src/index.js
@@ -27,12 +27,6 @@ export default class I18n extends PureComponent {
         i18nRegistry: PropTypes.object.isRequired
     };
 
-    static defaultProps = {
-        packageKey: null,
-        sourceName: null,
-        params: {}
-    };
-
     render() {
         const {i18nRegistry, packageKey, sourceName, params, id, fallback} = this.props;
 


### PR DESCRIPTION
`null` does NOT trigger fallback parameters, `undefined` does!

Fixes: #1339 