### PR TITLE
TASK: set button default type to button

### DIFF
--- a/packages/react-ui-components/src/Button/__snapshots__/button.spec.js.snap
+++ b/packages/react-ui-components/src/Button/__snapshots__/button.spec.js.snap
@@ -5,6 +5,7 @@ exports[`<Button/> should render correctly. 1`] = `
   className="cleanClassName cleanHoverClassName foo className"
   onClick={[Function]}
   role="button"
+  type="button"
 >
   Foo children
 </button>

--- a/packages/react-ui-components/src/Button/button.js
+++ b/packages/react-ui-components/src/Button/button.js
@@ -18,6 +18,7 @@ const Button = props => {
         hoverStyle,
         size,
         theme,
+        type,
         _refHandler,
         ...rest
     } = props;
@@ -42,7 +43,7 @@ const Button = props => {
     }
 
     return (
-        <button {...rest} {...attributes} className={finalClassName} role="button" ref={_refHandler(isFocused)}>
+        <button {...rest} {...attributes} type={type} className={finalClassName} role="button" ref={_refHandler(isFocused)}>
             {children}
         </button>
     );
@@ -111,6 +112,11 @@ Button.propTypes = {
     }).isRequired,
 
     /**
+     * The HTML type of the button.
+     */
+    type: PropTypes.string,
+
+    /**
      * An interal prop for testing purposes, do not set this prop manually.
      */
     _refHandler: PropTypes.func
@@ -122,6 +128,7 @@ Button.defaultProps = {
     isFocused: false,
     isDisabled: false,
     isActive: false,
+    type: 'button',
     _refHandler: makeFocusNode
 };
 

--- a/packages/react-ui-components/src/Button/button.spec.js
+++ b/packages/react-ui-components/src/Button/button.spec.js
@@ -18,7 +18,8 @@ describe('<Button/>', () => {
             children: 'Foo children',
             onClick: () => null,
             style: 'clean',
-            hoverStyle: 'clean'
+            hoverStyle: 'clean',
+            type: 'button'
         };
     });
 
@@ -32,6 +33,12 @@ describe('<Button/>', () => {
         const wrapper = shallow(<Button {...props} className="fooClassName"/>);
 
         expect(wrapper.prop('className')).toContain('fooClassName');
+    });
+
+    it('should allow the propagation of "type" with the "type" prop.', () => {
+        const wrapper = shallow(<Button {...props} type="submit"/>);
+
+        expect(wrapper.prop('type')).toContain('submit');
     });
 
     it('should allow the propagation of additional props to the wrapper.', () => {


### PR DESCRIPTION
default type is submit if not given. Thus browsers are supposed to submit the form with the button which breaks react onClick handlers. By giving a default type of type="button" browsers won't submit automagically while we wait for react to do something (testable in Firefox)