### PR TITLE
BUGFIX: Fix iframe control mechanism

### DIFF
--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -132,7 +132,7 @@ export default class ContentCanvas extends PureComponent {
     }
 
     handleFrameAccess = iframe => {
-        const {startLoading, requestRegainControl, requestLogin} = this.props;
+        const {requestRegainControl, requestLogin} = this.props;
 
         try {
             if (iframe) {
@@ -145,19 +145,6 @@ export default class ContentCanvas extends PureComponent {
                     requestLogin();
                     return;
                 }
-
-                iframe.contentWindow.addEventListener('beforeunload', event => {
-                    //
-                    // If we cannot guess the link that is responsible for
-                    // the unload, we should better hide the frame, until we're
-                    // sure that it ends up in a consistent state.
-                    //
-                    if (!event.target.activeElement.getAttribute('href')) {
-                        this.setState({isVisible: false});
-                    }
-
-                    startLoading();
-                });
 
                 this.setState({
                     isVisible: true,

--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -109,7 +109,6 @@ export default class ContentCanvas extends PureComponent {
                         mountTarget="#neos-new-backend-container"
                         contentDidUpdate={this.onFrameChange}
                         onLoad={this.handleFrameAccess}
-                        sandbox="allow-same-origin allow-scripts allow-forms"
                         role="region"
                         aria-live="assertive"
                         >

--- a/packages/react-ui-components/src/Frame/frame.js
+++ b/packages/react-ui-components/src/Frame/frame.js
@@ -24,15 +24,21 @@ export default class Frame extends PureComponent {
         this.updateIframeUrlIfNecessary();
     }
 
-    // we do not use react's magic to change to a different URL in the iFrame, but do it explicitely (in order to avoid reloads if we are already on the correct page)
+    // we do not use react's magic to change to a different URL in the iFrame, but do it
+    // explicitely (in order to avoid reloads if we are already on the correct page)
     updateIframeUrlIfNecessary() {
         if (!this.ref) {
             return;
         }
 
-        const win = this.ref.contentWindow; // eslint-disable-line react/no-find-dom-node
-        if (win.location.href !== this.props.src) {
-            win.location = this.props.src;
+        try {
+            const win = this.ref.contentWindow; // eslint-disable-line react/no-find-dom-node
+            if (win.location.href !== this.props.src) {
+                win.location = this.props.src;
+            }
+        } catch (err) {
+            console.error(`Could not update iFrame Url from within. Trying to set src attribute manually...`);
+            this.ref.setAttribute('src', this.props.src);
         }
     }
 


### PR DESCRIPTION
This PR fixes a couple of issues with the frame origin control mechanism for the Content Canvas frame:

* Primarily, the `beforeunload` event handler in the `<ContentCanvas>` container is removed (This is what caused #1324). An unfortunate side effect of that is, that if a site like "spiegel.de", which has no proper X-Frame headers (like e.g. "google.com"), is loaded in the frame, the site will be visible as long as it takes for the `load` event to fire. Afterwards, the UI will recognize that it has lost control and will navigate the user back to the last page, just as intended by the original feature.
* The `<Frame>` component did not handle cross-origin situations correctly. This PR adds error handling to the `updateIframeUrlIfNecessary` method to set the Iframe source instead of directly manipulating the iframe window's location object, in case a security error occurs.
* This PR also removes the `sandbox` attribute from the ContentCanvas frame, since it was likely to cause a lot of problems for currently existing projects.

Fixes #1324 