### PR TITLE
BUGFIX: Filter all in asset editor

### DIFF
--- a/packages/neos-ui-editors/src/SecondaryEditors/MediaSelectionScreen/index.js
+++ b/packages/neos-ui-editors/src/SecondaryEditors/MediaSelectionScreen/index.js
@@ -13,7 +13,7 @@ const MediaSelectionScreen = props => {
 
     // TODO: hard-coded url
     return (
-        <iframe src="/neos/media/browser/images.html" className={style.iframe}/>
+        <iframe src="/neos/media/browser/assets.html" className={style.iframe}/>
     );
 };
 MediaSelectionScreen.propTypes = {


### PR DESCRIPTION
It's still the hard coded URL but it fixes this bug for now.

closes #1353