### PR TITLE
BUGFIX: Restore keyboard handling for selectBox

### DIFF
--- a/packages/react-ui-components/src/SelectBox/config.js
+++ b/packages/react-ui-components/src/SelectBox/config.js
@@ -1,5 +1,5 @@
 import {Keys} from 'react-keydown';
 
-const {ENTER, UP, DOWN} = Keys;
+const {ENTER, UP, DOWN, ESC} = Keys;
 
-export const keys = [ENTER, UP, DOWN];
+export const keys = [ENTER, UP, DOWN, ESC];

--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -299,7 +299,7 @@ export default class SelectBox extends PureComponent {
     }
 
     handleKeyDown = e => {
-        if (this.state.isExpanded && e && ['ArrowDown', 'ArrowUp', 'Enter'].includes(e.key)) {
+        if (this.state.isExpanded && e && ['ArrowDown', 'ArrowUp', 'Enter', 'Escape'].includes(e.key)) {
             // do not scroll while we are doing keyboard interaction
             e.preventDefault();
 
@@ -323,6 +323,11 @@ export default class SelectBox extends PureComponent {
                 }
 
                 this.setState({
+                    isExpanded: false
+                });
+            } else if (e.key === 'Escape') {
+                this.setState({
+                    focusedValue: '',
                     isExpanded: false
                 });
             }

--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -225,6 +225,7 @@ export default class SelectBox extends PureComponent {
                 <SelectBox_HeaderWithSearchInput
                     {...this.props}
                     onSearchTermChange={this.handleSearchTermChange}
+                    onKeyDown={this.handleKeyDown}
                     />
             );
         }
@@ -298,7 +299,7 @@ export default class SelectBox extends PureComponent {
     }
 
     handleKeyDown = e => {
-        if (this.state.isExpanded && e) {
+        if (this.state.isExpanded && e && ['ArrowDown', 'ArrowUp', 'Enter'].includes(e.key)) {
             // do not scroll while we are doing keyboard interaction
             e.preventDefault();
 

--- a/packages/react-ui-components/src/SelectBox_HeaderWithSearchInput/selectBox_HeaderWithSearchInput.js
+++ b/packages/react-ui-components/src/SelectBox_HeaderWithSearchInput/selectBox_HeaderWithSearchInput.js
@@ -21,6 +21,9 @@ export default class SelectBox_HeaderWithSearchInput extends PureComponent {
         onSearchTermChange: PropTypes.func.isRequired,
         setFocus: PropTypes.bool,
 
+        // For keyboard handling
+        onKeyDown: PropTypes.func,
+
         /* ------------------------------
          * Theme & Dependencies
          * ------------------------------ */
@@ -39,6 +42,7 @@ export default class SelectBox_HeaderWithSearchInput extends PureComponent {
         const {
             searchTerm,
             onSearchTermChange,
+            onKeyDown,
             placeholder,
             displayLoadingIndicator,
             setFocus,
@@ -64,6 +68,7 @@ export default class SelectBox_HeaderWithSearchInput extends PureComponent {
                     className={theme.selectBoxHeaderWithSearchInput__input}
                     value={searchTerm}
                     onChange={onSearchTermChange}
+                    onKeyDown={onKeyDown}
                     placeholder={placeholder}
                     setFocus={setFocus}
                     type="search"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6147,7 +6147,7 @@ micromatch@^3.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-"micromatch@github:jonschlinkert/micromatch#2.2.0":
+micromatch@jonschlinkert/micromatch#2.2.0:
   version "2.2.0"
   resolved "https://codeload.github.com/jonschlinkert/micromatch/tar.gz/5017fd78202e04c684cc31d3c2fb1f469ea222ff"
   dependencies:


### PR DESCRIPTION
Arrow handling in searchable selectbox is working now.
The ESC button is working in a normal selectbox, in searchable selectboxes I have to press ESC two times because the first keypress got absorbed somewhere.

references #1388 
