### PR TITLE
TASK: Move the loading indicator on the top of the UI

### DIFF
--- a/packages/build-essentials/src/styles/styleConstants.js
+++ b/packages/build-essentials/src/styles/styleConstants.js
@@ -10,6 +10,7 @@ const config = {
     zIndex: {
         secondaryToolbar: ['linkIconButtonFlyout'],
         flashMessageContainer: '2',
+        loadingIndicatorContainer: '2',
         secondaryInspector: ['context', 'close'],
         secondaryInspectorElevated: ['context', 'dropdownContents'],
         dialog: ['context'],

--- a/packages/neos-ui/src/Containers/App.js
+++ b/packages/neos-ui/src/Containers/App.js
@@ -15,6 +15,7 @@ const App = ({globalRegistry, menu}) => {
     const LeftSideBar = containerRegistry.get('LeftSideBar');
     const ContentCanvas = containerRegistry.get('ContentCanvas');
     const RightSideBar = containerRegistry.get('RightSideBar');
+    const LoadingIndicator = containerRegistry.get('SecondaryToolbar/LoadingIndicator');
 
     // HINT: the SecondaryToolbar must be *BELOW* the
     // ContentCanvas; to ensure the SecondaryToolbar is rendered
@@ -25,6 +26,7 @@ const App = ({globalRegistry, menu}) => {
             <Modals/>
             <FlashMessages/>
             <FullScreen/>
+            <LoadingIndicator/>
             <PrimaryToolbar/>
             <ContentCanvas/>
             <SecondaryToolbar/>

--- a/packages/neos-ui/src/Containers/SecondaryToolbar/LoadingIndicator/style.css
+++ b/packages/neos-ui/src/Containers/SecondaryToolbar/LoadingIndicator/style.css
@@ -1,10 +1,10 @@
 .loadingIndicator__container {
-    left: 50%;
-    top: 39px;
+    left: 0;
+    top: 0;
+    height: 2px;
     position: absolute;
-    transform: translateX(-50%);
-    padding: 0 320px;
-    width: 100%;
+    width: 100vw;
+    z-index: var(--zIndex-LoadingIndicatorContainer);
 }
 
 .loadingIndicator {

--- a/packages/neos-ui/src/Containers/SecondaryToolbar/index.js
+++ b/packages/neos-ui/src/Containers/SecondaryToolbar/index.js
@@ -73,7 +73,6 @@ export default class SecondaryToolbar extends PureComponent {
         });
 
         const Toolbar = this.getToolbarComponent();
-        const LoadingIndicator = containerRegistry.get('SecondaryToolbar/LoadingIndicator');
         const SecondaryToolbarRight = containerRegistry.getChildren('SecondaryToolbar/Right');
 
         return (
@@ -83,7 +82,6 @@ export default class SecondaryToolbar extends PureComponent {
                 <div className={style.secondaryToolbar__rightHandedActions}>
                     {SecondaryToolbarRight.map((Item, key) => <Item key={key}/>)}
                 </div>
-                <LoadingIndicator/>
             </div>
         );
     }


### PR DESCRIPTION
This change move the loading indicator from bellow the SecondaryToolbar to the top of the UI. 

This fix an issue when loading with the navigate component closed (wrong left position), but also make the loading indicator more global from the user perspective. We can use the loading indicator during publishing or any other action that require a bit of time. In the future, the loading a backend module can also use this indicator, or an action performed in a backend modules.