### PR TITLE
BUGFIX: Don't cut letters in page tree

### DIFF
--- a/packages/react-ui-components/src/Tree/node.css
+++ b/packages/react-ui-components/src/Tree/node.css
@@ -48,7 +48,7 @@
     position: relative;
     display: inline-block;
     min-width: 100%;
-    padding: .2em 0;
+    padding: .1em 0;
 
     border-left: 2px solid transparent;
 
@@ -92,7 +92,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     display: inline-block;
-    line-height: 1;
+    line-height: 1.5;
     vertical-align: middle;
 }
 .header__label {


### PR DESCRIPTION
I had to reduce the top/bottom padding of the `node__header__data`
and increate the line-height of `header__labelWrapper`
All other methods I tried looked crappy.
Maybe someone else has a nicer way of solving this.

closes #1401