### PR TITLE
TASK: better styling of AssetOption, with bigger image

### DIFF
--- a/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/style.css
+++ b/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/style.css
@@ -1,6 +1,7 @@
 .multiLineWithThumbnail__item {
     box-sizing: content-box;
     line-height: 20px;
+    padding: 0;
 }
 
 .multiLineWithThumbnail__secondaryLabel {
@@ -16,8 +17,10 @@
 }
 
 .multiLineWithThumbnail__image {
-    max-height: 1.5em;
-    max-width: 1.5em;
+    width: calc(1.33 * var(--goldenUnit));
+    height: var(--goldenUnit);
+    object-fit: contain;
+    background-color: var(--brandColorsContrastDarkest);
     margin-right: .75em;
     display: inline-block;
     vertical-align: middle;


### PR DESCRIPTION
Resolves: #1406 

More or less how it looked in the old UI:
![image](https://user-images.githubusercontent.com/837032/33798773-c9b707fe-dd2f-11e7-8c04-17d07b941258.png)
