### PR TITLE
TASK: add native tooltips to buttons

### DIFF
--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -20,6 +20,57 @@
 			<trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
 				<source>Choose an Aspect Ratio</source>
 			</trans-unit>
+			<trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			</trans-unit>
+			<trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			</trans-unit>
+			<trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			</trans-unit>
+			<trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			</trans-unit>
+			<trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			</trans-unit>
+			<trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			</trans-unit>
+			<trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			</trans-unit>
+			<trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			</trans-unit>
+			<trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			</trans-unit>
+			<trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			</trans-unit>
+			<trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			</trans-unit>
+			<trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			</trans-unit>
+			<trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			</trans-unit>
+			<trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			</trans-unit>
+			<trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			</trans-unit>
+			<trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			</trans-unit>
+			<trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			</trans-unit>
 			<trans-unit id="createNew" xml:space="preserve">
 				<source>Create new</source>
 			</trans-unit>

--- a/packages/neos-ui-ckeditor-bindings/package.json
+++ b/packages/neos-ui-ckeditor-bindings/package.json
@@ -25,7 +25,8 @@
     "@neos-project/neos-ui-extensibility": "1.0.0-beta8",
     "@neos-project/neos-ui-guest-frame": "1.0.0-beta8",
     "@neos-project/neos-ui-redux-store": "1.0.0-beta8",
-    "@neos-project/react-ui-components": "1.0.0-beta8"
+    "@neos-project/react-ui-components": "1.0.0-beta8",
+    "@neos-project/neos-ui-i18n": "1.0.0-beta8"
   },
   "license": "GNU GPLv3",
   "jest": {

--- a/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/LinkIconButton.js
+++ b/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/LinkIconButton.js
@@ -19,6 +19,9 @@ import style from './style.css';
 @connect($transform({
     formattingUnderCursor: selectors.UI.ContentCanvas.formattingUnderCursor
 }))
+@neos(globalRegistry => ({
+    i18nRegistry: globalRegistry.get('i18n')
+}))
 export default class LinkIconButton extends PureComponent {
 
     static propTypes = {
@@ -27,7 +30,8 @@ export default class LinkIconButton extends PureComponent {
             PropTypes.bool,
             PropTypes.object
         ])),
-        formattingRule: PropTypes.string
+        formattingRule: PropTypes.string,
+        i18nRegistry: PropTypes.object.isRequired
     };
 
     handleLinkButtonClick = () => {
@@ -41,9 +45,12 @@ export default class LinkIconButton extends PureComponent {
     }
 
     render() {
+        const {i18nRegistry} = this.props;
+
         return (
             <div>
                 <IconButton
+                    title={`${i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link')}`}
                     isActive={Boolean(this.getHrefValue())}
                     icon="link"
                     onClick={this.handleLinkButtonClick}

--- a/packages/neos-ui-ckeditor-bindings/src/manifest.richtextToolbar.js
+++ b/packages/neos-ui-ckeditor-bindings/src/manifest.richtextToolbar.js
@@ -1,16 +1,27 @@
-import React from 'react';
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
 import omit from 'lodash.omit';
 import {$get} from 'plow-js';
 import IconButton from '@neos-project/react-ui-components/src/IconButton/';
+import {neos} from '@neos-project/neos-ui-decorators';
 
 import LinkIconButton from './EditorToolbar/LinkIconButton';
 import StyleSelect from './EditorToolbar/StyleSelect';
 import RichTextToolbarRegistry from './registry/RichTextToolbarRegistry';
 
-const IconButtonComponent = props => {
-    const finalProps = omit(props, ['formattingRule']);
-    return (<IconButton {...finalProps}/>);
-};
+@neos(globalRegistry => ({
+    i18nRegistry: globalRegistry.get('i18n')
+}))
+class IconButtonComponent extends PureComponent {
+    static propTypes = {
+        i18nRegistry: PropTypes.object,
+        tooltip: PropTypes.string
+    };
+    render() {
+        const finalProps = omit(this.props, ['formattingRule', 'i18nRegistry', 'tooltip']);
+        return (<IconButton {...finalProps} title={this.props.i18nRegistry.translate(this.props.tooltip)}/>);
+    }
+}
 
 //
 // Create richtext editing toolbar registry
@@ -57,7 +68,8 @@ export default ckEditorRegistry => {
         callbackPropName: 'onClick',
 
         icon: 'bold',
-        hoverStyle: 'brand'
+        hoverStyle: 'brand',
+        tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__bold'
     });
 
     // Italic
@@ -67,7 +79,8 @@ export default ckEditorRegistry => {
         callbackPropName: 'onClick',
 
         icon: 'italic',
-        hoverStyle: 'brand'
+        hoverStyle: 'brand',
+        tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__italic'
     });
 
     // Underline
@@ -77,7 +90,8 @@ export default ckEditorRegistry => {
         callbackPropName: 'onClick',
 
         icon: 'underline',
-        hoverStyle: 'brand'
+        hoverStyle: 'brand',
+        tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__underline'
     });
 
     // Subscript
@@ -87,7 +101,8 @@ export default ckEditorRegistry => {
         callbackPropName: 'onClick',
 
         icon: 'subscript',
-        hoverStyle: 'brand'
+        hoverStyle: 'brand',
+        tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__subscript'
     });
 
     // Superscript
@@ -97,7 +112,8 @@ export default ckEditorRegistry => {
         callbackPropName: 'onClick',
 
         icon: 'superscript',
-        hoverStyle: 'brand'
+        hoverStyle: 'brand',
+        tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__superscript'
     });
 
     // Strike-Through
@@ -107,7 +123,8 @@ export default ckEditorRegistry => {
         callbackPropName: 'onClick',
 
         icon: 'strikethrough',
-        hoverStyle: 'brand'
+        hoverStyle: 'brand',
+        tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__strikethrough'
     });
 
     // Strike-Through
@@ -117,7 +134,8 @@ export default ckEditorRegistry => {
         callbackPropName: 'onClick',
 
         icon: 'link',
-        hoverStyle: 'brand'
+        hoverStyle: 'brand',
+        tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__link'
     });
 
     /**
@@ -188,7 +206,8 @@ export default ckEditorRegistry => {
         callbackPropName: 'onClick',
 
         icon: 'list-ol',
-        hoverStyle: 'brand'
+        hoverStyle: 'brand',
+        tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__ordered-list'
     });
 
     // unordered list
@@ -198,7 +217,8 @@ export default ckEditorRegistry => {
         callbackPropName: 'onClick',
 
         icon: 'list-ul',
-        hoverStyle: 'brand'
+        hoverStyle: 'brand',
+        tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__unordered-list'
     });
 
     // Indent
@@ -209,6 +229,7 @@ export default ckEditorRegistry => {
 
         icon: 'indent',
         hoverStyle: 'brand',
+        tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__indent',
         isVisibleWhen: (inlineEditorOptions, formattingUnderCursor) => {
             return ((Boolean($get('formatting.ul', inlineEditorOptions)) || Boolean($get('formatting.ol', inlineEditorOptions))) &&
                 formattingUnderCursor.indent !== richtextToolbar.TRISTATE_DISABLED);
@@ -223,6 +244,7 @@ export default ckEditorRegistry => {
 
         icon: 'outdent',
         hoverStyle: 'brand',
+        tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__outdent',
         isVisibleWhen: (inlineEditorOptions, formattingUnderCursor) => {
             return ((Boolean($get('formatting.ul', inlineEditorOptions)) || Boolean($get('formatting.ol', inlineEditorOptions))) &&
                 formattingUnderCursor.indent !== richtextToolbar.TRISTATE_DISABLED);
@@ -238,7 +260,8 @@ export default ckEditorRegistry => {
         callbackPropName: 'onClick',
 
         icon: 'align-left',
-        hoverStyle: 'brand'
+        hoverStyle: 'brand',
+        tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__align-left'
     });
 
     richtextToolbar.set('aligncenter', {
@@ -247,7 +270,8 @@ export default ckEditorRegistry => {
         callbackPropName: 'onClick',
 
         icon: 'align-center',
-        hoverStyle: 'brand'
+        hoverStyle: 'brand',
+        tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__align-center'
     });
 
     richtextToolbar.set('alignright', {
@@ -256,7 +280,8 @@ export default ckEditorRegistry => {
         callbackPropName: 'onClick',
 
         icon: 'align-right',
-        hoverStyle: 'brand'
+        hoverStyle: 'brand',
+        tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__align-right'
     });
 
     richtextToolbar.set('alignjustify', {
@@ -265,7 +290,8 @@ export default ckEditorRegistry => {
         callbackPropName: 'onClick',
 
         icon: 'align-justify',
-        hoverStyle: 'brand'
+        hoverStyle: 'brand',
+        tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__align-justify'
     });
 
     /**
@@ -277,7 +303,8 @@ export default ckEditorRegistry => {
         callbackPropName: 'onClick',
 
         icon: 'table',
-        hoverStyle: 'brand'
+        hoverStyle: 'brand',
+        tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__table'
     });
 
     /**
@@ -289,7 +316,8 @@ export default ckEditorRegistry => {
         callbackPropName: 'onClick',
 
         icon: 'eraser',
-        hoverStyle: 'brand'
+        hoverStyle: 'brand',
+        tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__remove-format'
     });
 
     return richtextToolbar;

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/AddNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/AddNode/index.js
@@ -33,7 +33,8 @@ export default class AddNode extends PureComponent {
         fusionPath: PropTypes.string,
         className: PropTypes.string,
         commenceNodeCreation: PropTypes.func.isRequired,
-        isAllowedToAddChildOrSiblingNodes: PropTypes.bool
+        isAllowedToAddChildOrSiblingNodes: PropTypes.bool,
+        i18nRegistry: PropTypes.object.isRequired
     };
 
     handleCommenceNodeCreation = () => {
@@ -47,7 +48,7 @@ export default class AddNode extends PureComponent {
     }
 
     render() {
-        const {isAllowedToAddChildOrSiblingNodes} = this.props;
+        const {isAllowedToAddChildOrSiblingNodes, i18nRegistry} = this.props;
 
         return (
             <span>
@@ -57,6 +58,7 @@ export default class AddNode extends PureComponent {
                     icon="plus"
                     onClick={this.handleCommenceNodeCreation}
                     hoverStyle="clean"
+                    title={i18nRegistry.translate('createNew')}
                     />
             </span>
         );

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/CopySelectedNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/CopySelectedNode/index.js
@@ -15,7 +15,8 @@ export default class CopySelectedNode extends PureComponent {
         contextPath: PropTypes.string,
         destructiveOperationsAreDisabled: PropTypes.bool.isRequired,
         isActive: PropTypes.bool.isRequired,
-        copyNode: PropTypes.func.isRequired
+        copyNode: PropTypes.func.isRequired,
+        i18nRegistry: PropTypes.object.isRequired
     };
 
     handleCopySelectedNodeClick = () => {
@@ -25,7 +26,7 @@ export default class CopySelectedNode extends PureComponent {
     }
 
     render() {
-        const {destructiveOperationsAreDisabled, className, isActive} = this.props;
+        const {destructiveOperationsAreDisabled, className, isActive, i18nRegistry} = this.props;
 
         return (
             <IconButton
@@ -35,6 +36,7 @@ export default class CopySelectedNode extends PureComponent {
                 onClick={this.handleCopySelectedNodeClick}
                 icon="copy"
                 hoverStyle="clean"
+                title={i18nRegistry.translate('copy')}
                 />
         );
     }

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/CutSelectedNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/CutSelectedNode/index.js
@@ -16,7 +16,8 @@ export default class CutSelectedNode extends PureComponent {
         destructiveOperationsAreDisabled: PropTypes.bool.isRequired,
         isActive: PropTypes.bool.isRequired,
         canBeEdited: PropTypes.bool.isRequired,
-        cutNode: PropTypes.func.isRequired
+        cutNode: PropTypes.func.isRequired,
+        i18nRegistry: PropTypes.object.isRequired
     };
 
     handleCutSelectedNodeClick = () => {
@@ -30,7 +31,8 @@ export default class CutSelectedNode extends PureComponent {
             destructiveOperationsAreDisabled,
             isActive,
             className,
-            canBeEdited
+            canBeEdited,
+            i18nRegistry
         } = this.props;
 
         return (
@@ -41,6 +43,7 @@ export default class CutSelectedNode extends PureComponent {
                 onClick={this.handleCutSelectedNodeClick}
                 icon="cut"
                 hoverStyle="clean"
+                title={i18nRegistry.translate('cut')}
                 />
         );
     }

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/DeleteSelectedNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/DeleteSelectedNode/index.js
@@ -16,7 +16,8 @@ export default class DeleteSelectedNode extends PureComponent {
         destructiveOperationsAreDisabled: PropTypes.bool.isRequired,
         canBeDeleted: PropTypes.bool.isRequired,
         canBeEdited: PropTypes.bool.isRequired,
-        commenceNodeRemoval: PropTypes.func.isRequired
+        commenceNodeRemoval: PropTypes.func.isRequired,
+        i18nRegistry: PropTypes.object.isRequired
     };
 
     handleDeleteSelectedNodeClick = () => {
@@ -28,7 +29,7 @@ export default class DeleteSelectedNode extends PureComponent {
     }
 
     render() {
-        const {className, destructiveOperationsAreDisabled, canBeDeleted, canBeEdited} = this.props;
+        const {className, destructiveOperationsAreDisabled, canBeDeleted, canBeEdited, i18nRegistry} = this.props;
 
         return (
             <IconButton
@@ -37,6 +38,7 @@ export default class DeleteSelectedNode extends PureComponent {
                 onClick={this.handleDeleteSelectedNodeClick}
                 icon="trash"
                 hoverStyle="clean"
+                title={i18nRegistry.translate('delete')}
                 />
         );
     }

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/HideSelectedNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/HideSelectedNode/index.js
@@ -20,7 +20,8 @@ export default class HideSelectedNode extends PureComponent {
         showNode: PropTypes.func.isRequired,
         destructiveOperationsAreDisabled: PropTypes.bool.isRequired,
         canBeEdited: PropTypes.bool.isRequired,
-        visibilityCanBeToggled: PropTypes.bool.isRequired
+        visibilityCanBeToggled: PropTypes.bool.isRequired,
+        i18nRegistry: PropTypes.object.isRequired
     };
 
     handleHideNode = () => {
@@ -40,7 +41,7 @@ export default class HideSelectedNode extends PureComponent {
     }
 
     render() {
-        const {className, node, destructiveOperationsAreDisabled, canBeEdited, visibilityCanBeToggled} = this.props;
+        const {className, node, destructiveOperationsAreDisabled, canBeEdited, visibilityCanBeToggled, i18nRegistry} = this.props;
         const isHidden = $get('properties._hidden', node);
 
         return (
@@ -51,6 +52,7 @@ export default class HideSelectedNode extends PureComponent {
                 onClick={isHidden ? this.handleShowNode : this.handleHideNode}
                 icon="eye-slash"
                 hoverStyle="clean"
+                title={i18nRegistry.translate('hideUnhide')}
                 />
         );
     }

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/PasteClipBoardNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/PasteClipBoardNode/index.js
@@ -33,7 +33,8 @@ export default class PasteClipBoardNode extends PureComponent {
         contextPath: PropTypes.string,
         fusionPath: PropTypes.string,
 
-        pasteNode: PropTypes.func.isRequired
+        pasteNode: PropTypes.func.isRequired,
+        i18nRegistry: PropTypes.object.isRequired
     };
 
     handlePasteButtonClick = () => {
@@ -43,7 +44,7 @@ export default class PasteClipBoardNode extends PureComponent {
     }
 
     render() {
-        const {className, canBePasted} = this.props;
+        const {className, canBePasted, i18nRegistry} = this.props;
 
         if (!canBePasted) {
             return null;
@@ -55,6 +56,7 @@ export default class PasteClipBoardNode extends PureComponent {
                 icon="paste"
                 onClick={this.handlePasteButtonClick}
                 hoverStyle="clean"
+                title={i18nRegistry.translate('paste')}
                 />
         );
     }

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
@@ -11,6 +11,8 @@ import {
     getGuestFrameWindow
 } from '@neos-project/neos-ui-guest-frame/src/dom';
 
+import {neos} from '@neos-project/neos-ui-decorators';
+
 import {
     AddNode,
     CopySelectedNode,
@@ -21,6 +23,10 @@ import {
 } from './Buttons/index';
 import style from './style.css';
 
+@neos(globalRegistry => ({
+    nodeTypesRegistry: globalRegistry.get('@neos-project/neos-ui-contentrepository'),
+    i18nRegistry: globalRegistry.get('i18n')
+}))
 export default class NodeToolbar extends PureComponent {
     static propTypes = {
         contextPath: PropTypes.string,
@@ -34,7 +40,8 @@ export default class NodeToolbar extends PureComponent {
         canBeEdited: PropTypes.bool.isRequired,
         visibilityCanBeToggled: PropTypes.bool.isRequired,
         // Unsets the flag
-        requestScrollIntoView: PropTypes.func.isRequired
+        requestScrollIntoView: PropTypes.func.isRequired,
+        i18nRegistry: PropTypes.object.isRequired
     };
 
     state = {
@@ -89,7 +96,8 @@ export default class NodeToolbar extends PureComponent {
             isCopied,
             canBeDeleted,
             canBeEdited,
-            visibilityCanBeToggled
+            visibilityCanBeToggled,
+            i18nRegistry
         } = this.props;
 
         if (!contextPath) {
@@ -97,6 +105,7 @@ export default class NodeToolbar extends PureComponent {
         }
 
         const props = {
+            i18nRegistry,
             contextPath,
             fusionPath,
             destructiveOperationsAreDisabled,

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/AddNode/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/AddNode/index.js
@@ -8,7 +8,8 @@ export default class AddNode extends PureComponent {
         className: PropTypes.string,
         onClick: PropTypes.func.isRequired,
         focusedNodeContextPath: PropTypes.string.isRequired,
-        isDisabled: PropTypes.bool.isRequired
+        isDisabled: PropTypes.bool.isRequired,
+        i18nRegistry: PropTypes.object.isRequired
     };
 
     handleClick = () => {
@@ -18,7 +19,7 @@ export default class AddNode extends PureComponent {
     }
 
     render() {
-        const {focusedNodeContextPath, isDisabled, className} = this.props;
+        const {focusedNodeContextPath, isDisabled, className, i18nRegistry} = this.props;
 
         return (
             <span>
@@ -28,6 +29,7 @@ export default class AddNode extends PureComponent {
                     icon="plus"
                     onClick={this.handleClick}
                     hoverStyle="clean"
+                    title={i18nRegistry.translate('createNew')}
                     />
             </span>
         );

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/CopySelectedNode/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/CopySelectedNode/index.js
@@ -13,7 +13,9 @@ export default class CopySelectedNode extends PureComponent {
 
         isDisabled: PropTypes.bool,
 
-        isActive: PropTypes.bool
+        isActive: PropTypes.bool,
+
+        i18nRegistry: PropTypes.object.isRequired
     };
 
     handleClick = () => {
@@ -26,7 +28,8 @@ export default class CopySelectedNode extends PureComponent {
         const {
             className,
             isDisabled,
-            isActive
+            isActive,
+            i18nRegistry
         } = this.props;
 
         return (
@@ -37,6 +40,7 @@ export default class CopySelectedNode extends PureComponent {
                 onClick={this.handleClick}
                 icon="copy"
                 hoverStyle="clean"
+                title={i18nRegistry.translate('copy')}
                 />
         );
     }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/CutSelectedNode/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/CutSelectedNode/index.js
@@ -10,7 +10,8 @@ export default class CutSelectedNode extends PureComponent {
         isDisabled: PropTypes.bool.isRequired,
         isActive: PropTypes.bool.isRequired,
 
-        onClick: PropTypes.func.isRequired
+        onClick: PropTypes.func.isRequired,
+        i18nRegistry: PropTypes.object.isRequired
     };
 
     handleClick = () => {
@@ -20,7 +21,7 @@ export default class CutSelectedNode extends PureComponent {
     }
 
     render() {
-        const {className, isDisabled, isActive} = this.props;
+        const {className, isDisabled, isActive, i18nRegistry} = this.props;
 
         return (
             <IconButton
@@ -30,6 +31,7 @@ export default class CutSelectedNode extends PureComponent {
                 onClick={this.handleClick}
                 icon="cut"
                 hoverStyle="clean"
+                title={i18nRegistry.translate('cut')}
                 />
         );
     }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/DeleteSelectedNode/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/DeleteSelectedNode/index.js
@@ -10,7 +10,9 @@ export default class DeleteSelectedNode extends PureComponent {
         focusedNodeContextPath: PropTypes.string.isRequired,
         isDisabled: PropTypes.bool.isRequired,
 
-        onClick: PropTypes.func.isRequired
+        onClick: PropTypes.func.isRequired,
+
+        i18nRegistry: PropTypes.object.isRequired
     };
 
     handleClick = () => {
@@ -20,7 +22,7 @@ export default class DeleteSelectedNode extends PureComponent {
     }
 
     render() {
-        const {className, isDisabled} = this.props;
+        const {className, isDisabled, i18nRegistry} = this.props;
 
         return (
             <IconButton
@@ -29,6 +31,7 @@ export default class DeleteSelectedNode extends PureComponent {
                 onClick={this.handleClick}
                 icon="trash"
                 hoverStyle="clean"
+                title={i18nRegistry.translate('delete')}
                 />
         );
     }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/HideSelectedNode/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/HideSelectedNode/index.js
@@ -12,7 +12,8 @@ export default class HideSelectedNode extends PureComponent {
         isHidden: PropTypes.bool.isRequired,
 
         onHide: PropTypes.func.isRequired,
-        onShow: PropTypes.func.isRequired
+        onShow: PropTypes.func.isRequired,
+        i18nRegistry: PropTypes.object.isRequired
     };
 
     handleHide = () => {
@@ -28,7 +29,7 @@ export default class HideSelectedNode extends PureComponent {
     }
 
     render() {
-        const {className, isDisabled, isHidden} = this.props;
+        const {className, isDisabled, isHidden, i18nRegistry} = this.props;
 
         return (
             <IconButton
@@ -38,6 +39,7 @@ export default class HideSelectedNode extends PureComponent {
                 onClick={isHidden ? this.handleShow : this.handleHide}
                 icon="eye-slash"
                 hoverStyle="clean"
+                title={i18nRegistry.translate('hideUnhide')}
                 />
         );
     }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/PasteClipBoardNode/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/PasteClipBoardNode/index.js
@@ -10,7 +10,8 @@ export default class PasteClipBoardNode extends PureComponent {
         focusedNodeContextPath: PropTypes.string.isRequired,
         isDisabled: PropTypes.bool.isRequired,
 
-        onClick: PropTypes.func.isRequired
+        onClick: PropTypes.func.isRequired,
+        i18nRegistry: PropTypes.object.isRequired
     };
 
     handleClick = () => {
@@ -22,7 +23,8 @@ export default class PasteClipBoardNode extends PureComponent {
     render() {
         const {
             className,
-            isDisabled
+            isDisabled,
+            i18nRegistry
         } = this.props;
 
         return (
@@ -32,6 +34,7 @@ export default class PasteClipBoardNode extends PureComponent {
                 icon="paste"
                 onClick={this.handleClick}
                 hoverStyle="clean"
+                title={i18nRegistry.translate('paste')}
                 />
         );
     }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/RefreshPageTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/RefreshPageTree/index.js
@@ -11,7 +11,9 @@ export default class RefreshPageTree extends PureComponent {
 
         isLoading: PropTypes.bool.isRequired,
 
-        onClick: PropTypes.func.isRequired
+        onClick: PropTypes.func.isRequired,
+
+        i18nRegistry: PropTypes.object.isRequired
     };
 
     handleClick = () => {
@@ -21,7 +23,7 @@ export default class RefreshPageTree extends PureComponent {
     }
 
     render() {
-        const {isLoading, className} = this.props;
+        const {isLoading, className, i18nRegistry} = this.props;
         const finalClassName = mergeClassNames({
             [style.spinning]: isLoading,
             [className]: className && className.length
@@ -34,6 +36,7 @@ export default class RefreshPageTree extends PureComponent {
                 onClick={this.handleClick}
                 icon="refresh"
                 hoverStyle="clean"
+                title={i18nRegistry.translate('refresh')}
                 />
         );
     }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
@@ -17,9 +17,13 @@ import {
 } from './Buttons/index';
 import style from './style.css';
 
+@neos(globalRegistry => ({
+    i18nRegistry: globalRegistry.get('i18n')
+}))
 export default class NodeTreeToolBar extends PureComponent {
     static propTypes = {
         nodeTypesRegistry: PropTypes.object.isRequired,
+        i18nRegistry: PropTypes.object.isRequired,
         focusedNodeContextPath: PropTypes.string,
         canBePasted: PropTypes.bool.isRequired,
         canBeDeleted: PropTypes.bool.isRequired,
@@ -114,19 +118,22 @@ export default class NodeTreeToolBar extends PureComponent {
             isCopied,
             isLoading,
             destructiveOperationsAreDisabled,
-            isAllowedToAddChildOrSiblingNodes
+            isAllowedToAddChildOrSiblingNodes,
+            i18nRegistry
         } = this.props;
 
         return (
             <div className={style.toolBar}>
                 <div className={style.toolBar__btnGroup}>
                     <AddNode
+                        i18nRegistry={i18nRegistry}
                         className={style.toolBar__btnGroup__btn}
                         focusedNodeContextPath={focusedNodeContextPath}
                         isDisabled={!isAllowedToAddChildOrSiblingNodes}
                         onClick={this.handleAddNode}
                         />
                     <HideSelectedNode
+                        i18nRegistry={i18nRegistry}
                         className={style.toolBar__btnGroup__btn}
                         focusedNodeContextPath={focusedNodeContextPath}
                         isDisabled={destructiveOperationsAreDisabled || !canBeEdited || !visibilityCanBeToggled}
@@ -135,6 +142,7 @@ export default class NodeTreeToolBar extends PureComponent {
                         onShow={this.handleShowNode}
                         />
                     <CopySelectedNode
+                        i18nRegistry={i18nRegistry}
                         className={style.toolBar__btnGroup__btn}
                         focusedNodeContextPath={focusedNodeContextPath}
                         onClick={this.handleCopyNode}
@@ -142,6 +150,7 @@ export default class NodeTreeToolBar extends PureComponent {
                         isDisabled={destructiveOperationsAreDisabled}
                         />
                     <CutSelectedNode
+                        i18nRegistry={i18nRegistry}
                         className={style.toolBar__btnGroup__btn}
                         focusedNodeContextPath={focusedNodeContextPath}
                         isActive={isCut}
@@ -149,18 +158,21 @@ export default class NodeTreeToolBar extends PureComponent {
                         onClick={this.handleCutNode}
                         />
                     <PasteClipBoardNode
+                        i18nRegistry={i18nRegistry}
                         className={style.toolBar__btnGroup__btn}
                         focusedNodeContextPath={focusedNodeContextPath}
                         isDisabled={!canBePasted}
                         onClick={this.handlePasteNode}
                         />
                     <DeleteSelectedNode
+                        i18nRegistry={i18nRegistry}
                         className={style.toolBar__btnGroup__btn}
                         focusedNodeContextPath={focusedNodeContextPath}
                         isDisabled={destructiveOperationsAreDisabled || !canBeDeleted || !canBeEdited}
                         onClick={this.handleDeleteNode}
                         />
                     <RefreshPageTree
+                        i18nRegistry={i18nRegistry}
                         className={style.toolBar__btnGroup__btn}
                         focusedNodeContextPath={focusedNodeContextPath}
                         isLoading={isLoading}

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -17,7 +17,8 @@ import style from './style.css';
 
 @neos(globalRegistry => ({
     nodeTypesRegistry: globalRegistry.get('@neos-project/neos-ui-contentrepository'),
-    validatorRegistry: globalRegistry.get('validators')
+    validatorRegistry: globalRegistry.get('validators'),
+    i18nRegistry: globalRegistry.get('i18n')
 }))
 @connect((state, {nodeTypesRegistry, validatorRegistry}) => {
     const isApplyDisabledSelector = selectors.UI.Inspector.makeIsApplyDisabledSelector(nodeTypesRegistry, validatorRegistry);
@@ -48,6 +49,7 @@ import style from './style.css';
 export default class Inspector extends PureComponent {
     static propTypes = {
         nodeTypesRegistry: PropTypes.object,
+        i18nRegistry: PropTypes.object.isRequired,
 
         focusedNode: PropTypes.object,
         node: PropTypes.object.isRequired,
@@ -144,7 +146,8 @@ export default class Inspector extends PureComponent {
             isApplyDisabled,
             isDiscardDisabled,
             shouldShowUnappliedChangesOverlay,
-            shouldShowSecondaryInspector
+            shouldShowSecondaryInspector,
+            i18nRegistry
         } = this.props;
 
         if (!focusedNode) {
@@ -190,6 +193,7 @@ export default class Inspector extends PureComponent {
                                     key={tab.id}
                                     icon={tab.icon}
                                     groups={tab.groups}
+                                    tooltip={i18nRegistry.translate(tab.label)}
                                     renderSecondaryInspector={this.renderSecondaryInspector}
                                     node={node}
                                     commit={commit}

--- a/packages/neos-ui/src/Containers/RightSideBar/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/index.js
@@ -11,7 +11,8 @@ import {neos} from '@neos-project/neos-ui-decorators';
 import style from './style.css';
 
 @neos(globalRegistry => ({
-    containerRegistry: globalRegistry.get('containers')
+    containerRegistry: globalRegistry.get('containers'),
+    i18nRegistry: globalRegistry.get('i18n')
 }))
 @connect($transform({
     isHidden: selectors.UI.RightSideBar.isHidden,
@@ -22,6 +23,7 @@ import style from './style.css';
 export default class RightSideBar extends PureComponent {
     static propTypes = {
         containerRegistry: PropTypes.object.isRequired,
+        i18nRegistry: PropTypes.object.isRequired,
 
         isHidden: PropTypes.bool.isRequired,
         isFullScreen: PropTypes.bool.isRequired,
@@ -35,7 +37,7 @@ export default class RightSideBar extends PureComponent {
     }
 
     render() {
-        const {isHidden, isFullScreen, containerRegistry} = this.props;
+        const {isHidden, isFullScreen, containerRegistry, i18nRegistry} = this.props;
         const isSideBarHidden = isHidden || isFullScreen;
         const classNames = mergeClassNames({
             [style.rightSideBar]: true,
@@ -47,6 +49,7 @@ export default class RightSideBar extends PureComponent {
                 icon={toggleIcon}
                 className={style.rightSideBar__toggleBtn}
                 onClick={this.handleToggle}
+                title={i18nRegistry.translate('Neos.Neos:Main:toggleInspector')}
                 />
         );
 

--- a/packages/react-ui-components/src/Tabs/tabs.js
+++ b/packages/react-ui-components/src/Tabs/tabs.js
@@ -84,6 +84,7 @@ export default class Tabs extends PureComponent {
                 theme={theme}
                 title={panel.props.title}
                 icon={panel.props.icon}
+                tooltip={panel.props.tooltip}
                 />
         ));
 
@@ -166,6 +167,11 @@ export class TabMenuItem extends PureComponent {
         icon: PropTypes.string,
 
         /**
+         * An optional tooltip for the given Panel.
+         */
+        tooltip: PropTypes.string,
+
+        /**
          * An optional css theme to be injected.
          */
         theme: PropTypes.shape({// eslint-disable-line quote-props
@@ -197,6 +203,7 @@ export class TabMenuItem extends PureComponent {
             IconComponent,
             icon,
             title,
+            tooltip,
             ...restProps
         } = this.props;
         const rest = omit(restProps, ['onClick']);
@@ -217,6 +224,7 @@ export class TabMenuItem extends PureComponent {
                     role="tab"
                     aria-selected={isActive ? 'true' : 'false'}
                     aria-controls={`section${index}`}
+                    title={tooltip}
                     >
                     {icon ? <IconComponent icon={icon} className={finalIconClassName}/> : null}
                     {title}


### PR DESCRIPTION
This PR is based on the work of @janinadanger and @johannessteu here: #997 

It uses native tooltips for simple things like buttons. This has the advantage of better performance and native UX.

The custom tooltips will be ported in a separate PR and used for things like validation or help messages.