### PR TITLE
BUGIFX: remove Safaris webkit-apperance default

### DIFF
--- a/packages/react-ui-components/src/reset.css
+++ b/packages/react-ui-components/src/reset.css
@@ -28,4 +28,8 @@
     input::-webkit-search-cancel-button {
         display: none;
     }
+    /* webkit adds white box around search box */
+    input {
+        -webkit-appearance: none;
+    }
 }

--- a/packages/react-ui-components/src/reset.css
+++ b/packages/react-ui-components/src/reset.css
@@ -30,6 +30,6 @@
     }
     /* webkit adds white box around search box */
     input {
-        -webkit-appearance: none;
+        appearance: none;
     }
 }


### PR DESCRIPTION
In Safari all search boxes looked like this:
<img width="319" alt="bildschirmfoto 2017-12-12 um 22 34 19" src="https://user-images.githubusercontent.com/873002/33910301-8ff75044-df8e-11e7-90fc-a431d529f238.png">

Now they are looking fine:
<img width="315" alt="bildschirmfoto 2017-12-12 um 22 41 21" src="https://user-images.githubusercontent.com/873002/33910321-a5d4ffec-df8e-11e7-8006-04f4a243e698.png">

It also fixes #1403.
<img width="315" alt="bildschirmfoto 2017-12-12 um 22 57 33" src="https://user-images.githubusercontent.com/873002/33910677-de846e9e-df8f-11e7-8f77-ba33099f7a01.png">
