### PR TITLE
BUGFIX: remove margin from publish button

### DIFF
--- a/packages/react-ui-components/src/reset.css
+++ b/packages/react-ui-components/src/reset.css
@@ -11,12 +11,13 @@
         box-sizing: border-box;
     }
 
-    /* some browsers set a font-size in their user stylesheets */
+    /* some browsers set a font-size or margin in their user stylesheets */
     input,
     textarea,
     select,
     button {
         font-size: var(--baseFontSize);
+        margin: 0;
     }
     ul {
         padding: 0;


### PR DESCRIPTION
The publish button has a margin on the right hand side in safari. This bugfix sets the margin explicitly to 0.

Before: 
<img width="276" alt="bildschirmfoto 2017-12-12 um 23 31 20" src="https://user-images.githubusercontent.com/873002/33912041-a16db6aa-df94-11e7-9813-b410d658365d.png">

After:
<img width="273" alt="bildschirmfoto 2017-12-12 um 23 31 37" src="https://user-images.githubusercontent.com/873002/33912052-a6adce2a-df94-11e7-8a6e-9388daa2a137.png">
