### PR TITLE
BUGFIX: show padding in ListPreviewElement

### DIFF
--- a/packages/react-ui-components/src/ListPreviewElement/style.css
+++ b/packages/react-ui-components/src/ListPreviewElement/style.css
@@ -9,7 +9,7 @@
 
     /* subtract the size of padding */
     line-height: calc(var(--goldenUnit) - 10px);
-    padding: 5px var(--spacing);
+    padding: 5px var(--spacing) !important;
 }
 
 .listPreviewElement--isHighlighted {


### PR DESCRIPTION
Before:
<img width="466" alt="bildschirmfoto 2017-12-13 um 14 37 52" src="https://user-images.githubusercontent.com/873002/33941898-7b05d5c6-e014-11e7-8fea-2672898e3f65.png">
<img width="452" alt="bildschirmfoto 2017-12-13 um 15 02 33" src="https://user-images.githubusercontent.com/873002/33942610-bed6013e-e016-11e7-8c40-39ca19b51efc.png">

After:
<img width="484" alt="bildschirmfoto 2017-12-13 um 14 37 12" src="https://user-images.githubusercontent.com/873002/33941899-7b2065e4-e014-11e7-9c50-0854c7d4b2c8.png">
<img width="450" alt="bildschirmfoto 2017-12-13 um 15 02 01" src="https://user-images.githubusercontent.com/873002/33942620-c4089982-e016-11e7-857a-6f062c19d961.png">
