### PR TITLE
BUGFIX: ensure other people's personal workspaces are never shown in workspace selector

### DIFF
--- a/Classes/Neos/Neos/Ui/ContentRepository/Service/WorkspaceService.php
+++ b/Classes/Neos/Neos/Ui/ContentRepository/Service/WorkspaceService.php
@@ -91,6 +91,11 @@ class WorkspaceService
                 continue;
             }
 
+            if ($workspace->isPersonalWorkspace()) {
+                // Skip other personal workspaces
+                continue;
+            }
+
             $workspaceArray = [
                 'name' => $workspace->getName(),
                 'title' => $workspace->getTitle(),


### PR DESCRIPTION
In the old UI code, this was done in TargetWorkspaceController.js#targetWorkspaces;
where a check of "isUserWorkspace" happened (which
in turn checked whether the workspace name started
with "user-").

We now replicate this logic in the backend.

I am not 100% sure why this is needed, as this might
only occur when the "OWNER" of the user workspace is NULL
(and I am not sure how this can happen - maybe when a user
is deleted but the corresponding workspace prevails?)