### PR TITLE
BUGFIX: rework Navigate component CSS to use flexbox

### DIFF
--- a/packages/neos-ui-redux-store/src/UI/LeftSideBar/index.js
+++ b/packages/neos-ui-redux-store/src/UI/LeftSideBar/index.js
@@ -39,7 +39,7 @@ export const reducer = handleActions({
         new Map({
             isHidden: $get('ui.leftSideBar.isHidden', state) ? $get('ui.leftSideBar.isHidden', state) : false,
             contentTree: new Map({
-                isHidden: $get('ui.leftSideBar.contentTree.isHidden', state) ? $get('ui.leftSideBar.contentTree.isHidden', state) : false
+                isHidden: $get('ui.leftSideBar.contentTree.isHidden', state) ? $get('ui.leftSideBar.contentTree.isHidden', state) : true
             })
         })
     ),

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
@@ -15,7 +15,6 @@ import style from './style.css';
 
 export default class NodeTree extends PureComponent {
     static propTypes = {
-        isExpanded: PropTypes.bool,
         ChildRenderer: PropTypes.func,
         rootNode: PropTypes.object,
         nodeTypeRole: PropTypes.string,
@@ -70,14 +69,13 @@ export default class NodeTree extends PureComponent {
     }
 
     render() {
-        const {rootNode, ChildRenderer, isExpanded} = this.props;
+        const {rootNode, ChildRenderer} = this.props;
         if (!rootNode) {
             return (<div>...</div>);
         }
 
         const classNames = mergeClassNames({
-            [style.pageTree]: true,
-            [style['pageTree--expanded']]: isExpanded
+            [style.pageTree]: true
         });
 
         return (

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/style.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/style.css
@@ -1,9 +1,6 @@
-/* TODO: get rid of magick numbers here, they are not safe! */
 .pageTree {
     overflow-y: auto;
-    height: calc(50vh - 85px);
+    /* Node Tree is expected to be rendered inside a display: flex container - and it will take up all remaining space */
+    flex: 1 0 0px;
     transition: var(--transition-Slow) ease height, overflow-y var(--transition-Slow);
-}
-.pageTree--expanded {
-    height: calc(100vh - 164px);
 }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/style.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/style.css
@@ -1,4 +1,5 @@
 .searchBar {
+    flex: 0 0 var(--spacing-GoldenUnit);
     display: flex;
     line-height: 0;
     border-bottom: 1px solid var(--colors-ContrastDark);

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/ToggleContentTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/ToggleContentTree/index.js
@@ -9,7 +9,7 @@ export default class ToggleContentTree extends PureComponent {
 
         isPanelOpen: PropTypes.bool.isRequired,
 
-        onClick: PropTypes.func.isRequired,
+        onClick: PropTypes.func.isRequired
     };
 
     handleClick = () => {

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/ToggleContentTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/ToggleContentTree/index.js
@@ -23,6 +23,7 @@ export default class ToggleContentTree extends PureComponent {
 
         return (
             <IconButton
+                id="neos-contentTree-toggle"
                 className={className}
                 onClick={this.handleClick}
                 icon={isPanelOpen ? 'chevron-down' : 'chevron-up'}

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/ToggleContentTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/ToggleContentTree/index.js
@@ -1,0 +1,33 @@
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+
+import IconButton from '@neos-project/react-ui-components/src/IconButton/';
+
+export default class ToggleContentTree extends PureComponent {
+    static propTypes = {
+        className: PropTypes.string,
+
+        isPanelOpen: PropTypes.bool.isRequired,
+
+        onClick: PropTypes.func.isRequired,
+    };
+
+    handleClick = () => {
+        const {onClick} = this.props;
+
+        onClick();
+    }
+
+    render() {
+        const {className, isPanelOpen} = this.props;
+
+        return (
+            <IconButton
+                className={className}
+                onClick={this.handleClick}
+                icon={isPanelOpen ? 'chevron-down' : 'chevron-up'}
+                hoverStyle="clean"
+                />
+        );
+    }
+}

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/ToggleContentTree/index.spec.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/ToggleContentTree/index.spec.js
@@ -1,0 +1,3 @@
+test(`write tests`, () => {
+    expect(true).toBe(true);
+});

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/index.js
@@ -5,6 +5,7 @@ import DeleteSelectedNode from './DeleteSelectedNode/index';
 import HideSelectedNode from './HideSelectedNode/index';
 import PasteClipBoardNode from './PasteClipBoardNode/index';
 import RefreshPageTree from './RefreshPageTree/index';
+import ToggleContentTree from './ToggleContentTree/index';
 
 export {
     AddNode,
@@ -13,5 +14,6 @@ export {
     DeleteSelectedNode,
     HideSelectedNode,
     PasteClipBoardNode,
-    RefreshPageTree
+    RefreshPageTree,
+    ToggleContentTree
 };

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
@@ -37,6 +37,7 @@ export default class NodeTreeToolBar extends PureComponent {
         isCopied: PropTypes.bool.isRequired,
         destructiveOperationsAreDisabled: PropTypes.bool.isRequired,
         isAllowedToAddChildOrSiblingNodes: PropTypes.bool.isRequired,
+        isHiddenContentTree: PropTypes.bool,
 
         addNode: PropTypes.func.isRequired,
         copyNode: PropTypes.func.isRequired,
@@ -45,7 +46,8 @@ export default class NodeTreeToolBar extends PureComponent {
         hideNode: PropTypes.func.isRequired,
         showNode: PropTypes.func.isRequired,
         pasteNode: PropTypes.func.isRequired,
-        reloadTree: PropTypes.func.isRequired
+        reloadTree: PropTypes.func.isRequired,
+        toggleContentTree: PropTypes.func
     }
 
     static defaultProps = {

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
@@ -13,7 +13,8 @@ import {
     DeleteSelectedNode,
     HideSelectedNode,
     PasteClipBoardNode,
-    RefreshPageTree
+    RefreshPageTree,
+    ToggleContentTree
 } from './Buttons/index';
 import style from './style.css';
 
@@ -24,6 +25,7 @@ export default class NodeTreeToolBar extends PureComponent {
     static propTypes = {
         nodeTypesRegistry: PropTypes.object.isRequired,
         i18nRegistry: PropTypes.object.isRequired,
+        displayToggleContentTreeButton: PropTypes.bool,
         focusedNodeContextPath: PropTypes.string,
         canBePasted: PropTypes.bool.isRequired,
         canBeDeleted: PropTypes.bool.isRequired,
@@ -106,9 +108,16 @@ export default class NodeTreeToolBar extends PureComponent {
         reloadTree();
     }
 
+    handleToggleContentTree = () => {
+        const {toggleContentTree} = this.props;
+
+        toggleContentTree();
+    }
+
     render() {
         const {
             focusedNodeContextPath,
+            displayToggleContentTreeButton,
             canBePasted,
             canBeDeleted,
             canBeEdited,
@@ -119,7 +128,8 @@ export default class NodeTreeToolBar extends PureComponent {
             isLoading,
             destructiveOperationsAreDisabled,
             isAllowedToAddChildOrSiblingNodes,
-            i18nRegistry
+            i18nRegistry,
+            isHiddenContentTree
         } = this.props;
 
         return (
@@ -178,6 +188,12 @@ export default class NodeTreeToolBar extends PureComponent {
                         isLoading={isLoading}
                         onClick={this.handleReloadTree}
                         />
+                    {Boolean(displayToggleContentTreeButton) && <ToggleContentTree
+                        i18nRegistry={i18nRegistry}
+                        className={style.toolBar__btnGroup__btn}
+                        isPanelOpen={!isHiddenContentTree}
+                        onClick={this.handleToggleContentTree}
+                        />}
                 </div>
             </div>
         );
@@ -272,9 +288,11 @@ export const ContentTreeToolbar = withNodeTypesRegistry(connect(
             const isAllowedToAddChildOrSiblingNodes = isAllowedToAddChildOrSiblingNodesSelector(state, {
                 reference: focusedNodeContextPath
             });
+            const isHiddenContentTree = $get('ui.leftSideBar.contentTree.isHidden', state);
 
             return {
                 focusedNodeContextPath,
+                displayToggleContentTreeButton: true,
                 canBePasted,
                 canBeDeleted,
                 canBeEdited,
@@ -284,7 +302,8 @@ export const ContentTreeToolbar = withNodeTypesRegistry(connect(
                 destructiveOperationsAreDisabled,
                 isAllowedToAddChildOrSiblingNodes,
                 isCut,
-                isCopied
+                isCopied,
+                isHiddenContentTree
             };
         };
     }, {
@@ -295,6 +314,7 @@ export const ContentTreeToolbar = withNodeTypesRegistry(connect(
         hideNode: actions.CR.Nodes.hide,
         showNode: actions.CR.Nodes.show,
         pasteNode: actions.CR.Nodes.paste,
-        reloadTree: actions.UI.ContentTree.reloadTree
+        reloadTree: actions.UI.ContentTree.reloadTree,
+        toggleContentTree: actions.UI.LeftSideBar.toggleContentTree
     }
 )(NodeTreeToolBar));

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/style.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/style.css
@@ -4,6 +4,7 @@
     &:first-child {
         border-top: 0;
     }
+    flex: 0 0 var(--spacing-GoldenUnit);
 }
 .toolBar__btnGroup {
     &:before,
@@ -17,5 +18,5 @@
 }
 .toolBar__btnGroup__btn {
     float: left;
-    width: 40px;
+    width: var(--spacing-GoldenUnit);
 }

--- a/packages/neos-ui/src/Containers/LeftSideBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/index.js
@@ -23,20 +23,17 @@ import style from './style.css';
     isHiddenContentTree: $get('ui.leftSideBar.contentTree.isHidden'),
     siteNode: selectors.CR.Nodes.siteNodeSelector,
     documentNode: selectors.UI.ContentCanvas.documentNodeSelector
-}), {
-    toggleContentTree: actions.UI.LeftSideBar.toggleContentTree
-})
+}))
 export default class LeftSideBar extends PureComponent {
     static propTypes = {
         containerRegistry: PropTypes.object.isRequired,
 
         isHidden: PropTypes.bool.isRequired,
         isHiddenContentTree: PropTypes.bool.isRequired,
-        toggleContentTree: PropTypes.func.isRequired
     };
 
     render() {
-        const {isHidden, isHiddenContentTree, containerRegistry, toggleContentTree} = this.props;
+        const {isHidden, isHiddenContentTree, containerRegistry} = this.props;
 
         const classNames = mergeClassNames({
             [style.leftSideBar]: true,
@@ -45,7 +42,7 @@ export default class LeftSideBar extends PureComponent {
 
         const bottomClassNames = mergeClassNames({
             [style.leftSideBar__bottom]: true,
-            [style['leftSideBar__bottom--isCollapsed']]: !isHiddenContentTree
+            [style['leftSideBar__bottom--isCollapsed']]: isHiddenContentTree
         });
 
         const LeftSideBarTop = containerRegistry.getChildren('LeftSideBar/Top');
@@ -68,15 +65,10 @@ export default class LeftSideBar extends PureComponent {
 
                 <hr/>
 
-                <ToggablePanel className={bottomClassNames} onPanelToggle={toggleContentTree} isOpen={isHiddenContentTree} closesToBottom={true}>
-                    <ToggablePanel.Header noPadding={true} openedIcon={openedIcon} closedIcon={closedIcon} toggleButtonId="neos-contentTree-toggle">
-                        <ContentTreeToolbar/>
-                    </ToggablePanel.Header>
-                    <ToggablePanel.Contents noPadding={true}>
-                        {LeftSideBarBottom.map((Item, key) => <Item key={key}/>)}
-                    </ToggablePanel.Contents>
-                </ToggablePanel>
-
+                <div className={bottomClassNames}>
+                    <ContentTreeToolbar/>
+                    {LeftSideBarBottom.map((Item, key) => <Item key={key}/>)}
+                </div>
             </SideBar>
         );
     }

--- a/packages/neos-ui/src/Containers/LeftSideBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/index.js
@@ -4,10 +4,9 @@ import mergeClassNames from 'classnames';
 import {connect} from 'react-redux';
 import {$transform, $get, $or} from 'plow-js';
 
-import {selectors, actions} from '@neos-project/neos-ui-redux-store';
+import {selectors} from '@neos-project/neos-ui-redux-store';
 
 import SideBar from '@neos-project/react-ui-components/src/SideBar/';
-import ToggablePanel from '@neos-project/react-ui-components/src/ToggablePanel/';
 import {neos} from '@neos-project/neos-ui-decorators';
 
 import style from './style.css';
@@ -29,7 +28,7 @@ export default class LeftSideBar extends PureComponent {
         containerRegistry: PropTypes.object.isRequired,
 
         isHidden: PropTypes.bool.isRequired,
-        isHiddenContentTree: PropTypes.bool.isRequired,
+        isHiddenContentTree: PropTypes.bool.isRequired
     };
 
     render() {
@@ -49,9 +48,6 @@ export default class LeftSideBar extends PureComponent {
         const LeftSideBarBottom = containerRegistry.getChildren('LeftSideBar/Bottom');
 
         const ContentTreeToolbar = containerRegistry.get('LeftSideBar/ContentTreeToolbar');
-
-        const openedIcon = 'chevron-down';
-        const closedIcon = 'chevron-up';
 
         return (
             <SideBar

--- a/packages/neos-ui/src/Containers/LeftSideBar/style.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/style.css
@@ -23,16 +23,18 @@
 
 .leftSideBar__top {
     flex-basis: 100%;
+    display: flex;
+    flex-direction: column;
 }
 
 .leftSideBar__bottom {
-    height: auto;
-    flex-basis: 100%;
+    flex: 0 0 50%;
     transition: flex-basis var(--transition-Slow), height var(--transition-Slow), overflow-y var(--transition-Slow);
+    display: flex;
+    flex-direction: column;
 }
 
 .leftSideBar__bottom--isCollapsed {
-    flex-basis: 0%;
-    height: auto;
-    overflow-y: visible;
+    flex: 0 0 var(--spacing-GoldenUnit);
+    overflow-y: hidden;
 }


### PR DESCRIPTION
This removes magic numbers from CSS; and fixes styling bugs
when new components are rendered in the Navigate Component using
unplanned extensibility (e.g. like https://github.com/sandstorm/FulltextSearchInNodeTree).

It should not have any UI/style implications; I checked the old
and new UI side-by-side and took screenshots of both of them, and
I think they match pixel-perfect.

By not relying on ToggablePanel and the inner logic thereof for
auto-sizing and animation; and instead using flexbox, the robustness
of the CSS in the navigate component could be improved and the logic
simplified.