### PR TITLE
TASK: pin Neos to 3.2 for Travis E2E tests

### DIFF
--- a/Build/TravisCi/composer.json
+++ b/Build/TravisCi/composer.json
@@ -6,7 +6,7 @@
         "bin-dir": "bin"
     },
     "require": {
-        "neos/neos-development-collection": "@dev",
+        "neos/neos-development-collection": "~3.2@dev",
         "neos/flow-development-collection": "@dev",
         "neos/demo": "dev-master@dev",
 


### PR DESCRIPTION
We are having some issues with autoload on master: https://neos-project.slack.com/archives/C050KKBEB/p1513598394000259