### PR TITLE
BUGFIX: urlWithParams must take urlString into account

### DIFF
--- a/packages/neos-ui-backend-connector/src/Endpoints/Helpers.js
+++ b/packages/neos-ui-backend-connector/src/Endpoints/Helpers.js
@@ -37,7 +37,7 @@ export const urlWithParams = (urlString, params = {}) => {
     const url = new URL(
         urlString.indexOf(window.location.origin) === 0 ?
             urlString :
-            window.location.origin
+            window.location.origin + urlString
     );
 
     url.search = searchParams(params).toString();


### PR DESCRIPTION
Without this change, the URL path part of the UI is
completely discarded if not having absolute URLs.

On Neos.io, this is fixing various issues related to data
providers, serialization, ...

I am unsure why this does not happen locally.