### PR TITLE
BUGFIX: Do not focus link editor when navigating through text

### DIFF
--- a/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/LinkIconButton.js
+++ b/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/LinkIconButton.js
@@ -191,7 +191,7 @@ class LinkTextField extends PureComponent {
                     placeholder="Paste a link, or search"
                     displayLoadingIndicator={this.state.isLoading}
                     displaySearchBox={true}
-                    setFocus={true}
+                    setFocus={!this.props.hrefValue}
                     showDropDownToggle={false}
                     allowEmpty={true}
                     searchTerm={this.state.searchTerm}


### PR DESCRIPTION
To reproduce:
- create an external link in some text
- place the cursor after the text
- navigate using the arrow keys into the linked text

actual behavior (bug):
- focus jumps into the Link-Text-Box

expected behavior:
- focus stays in the main text