### PR TITLE
FEATURE: Add a signal after node creation handles are applied

### DIFF
--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractCreate.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractCreate.php
@@ -157,5 +157,19 @@ abstract class AbstractCreate extends AbstractStructuralChange
                 }
             }
         }
+
+        $this->emitNodeCreationHandlersApplied($node);
+    }
+
+    /**
+     * Signals, that all changes by node creation handlers are applied
+     *
+     * @Flow\Signal
+     *
+     * @param NodeInterface $node The node, the node creation handlers are applied to
+     * @return void
+     */
+    public function emitNodeCreationHandlersApplied(NodeInterface $node)
+    {
     }
 }


### PR DESCRIPTION
Node creation handlers are a new way to react on node creation triggered by a front-end action. One implementation is the node template package, which makes it possible to add arbitrary child nodes to the created node. We only have signals for nodeCreation of a single node, but none to react on the completion of the complete node creation process.

Usage Example: 
1. A node is created, a news node for example.
2. [Node templates](https://github.com/Flowpack/Flowpack.NodeTemplates) create a structure of nested nodes beneath the news node, including one that contains the date of the news.
3. After all nodes are created, the news node now needs to be moved into a date hierarchy using [archivist](https://github.com/punktDe/archivist) using this date.