### PR TITLE
TASK: Allow custom icon classnames

### DIFF
--- a/packages/react-ui-components/src/Icon/icon.js
+++ b/packages/react-ui-components/src/Icon/icon.js
@@ -20,11 +20,6 @@ export const iconPropValidator = (props, propName) => {// eslint-disable-line co
 Please adjust the icon configurations in your .yaml files to the new icon name "${iconName}".
 
 https://github.com/FortAwesome/Font-Awesome/wiki/Upgrading-from-3.2.1-to-4`);
-        } else if (!iconName) {
-            return new Error(`Icon name "${id}" was not a found in Font-Awesome 4.5.
-Please use the icon names from the Font-Awesome website.
-
-http://fortawesome.github.io/Font-Awesome/icons/`);
         }
     }
 };
@@ -32,7 +27,8 @@ http://fortawesome.github.io/Font-Awesome/icons/`);
 const Icon = props => {
     const {size, padded, theme, iconMap, label, _makeGetClassName} = props;
     const getClassName = _makeGetClassName(iconMap);
-    const iconClassName = getClassName(props.icon);
+    const faIconClassName = getClassName(props.icon);
+    const iconClassName = faIconClassName ? faIconClassName : props.icon;
     const classNames = mergeClassNames({
         [theme.icon]: true,
         [iconClassName]: true,

--- a/packages/react-ui-components/src/Icon/icon.spec.js
+++ b/packages/react-ui-components/src/Icon/icon.spec.js
@@ -33,6 +33,12 @@ describe('<Icon/>', () => {
 
         expect(wrapper.hasClass('fooIconClassName')).toBeTruthy();
     });
+
+    it('should allow the propagation of custom "icon" with the "icon" prop.', () => {
+        const wrapper = shallow(<Icon {...props} icon="bazIconClassName"/>);
+
+        expect(wrapper.hasClass('bazIconClassName')).toBeTruthy();
+    });
 });
 
 describe('iconPropValidator()', () => {
@@ -58,15 +64,6 @@ describe('iconPropValidator()', () => {
         iconPropValidator(props, 'icon');
 
         expect(props.onDeprecate.mock.calls.length).toBe(1);
-    });
-    it('should return an error if the iconName was not found.', () => {
-        const props = {
-            icon: 'bazIconClassName',
-            _makeValidateId: () => () => ({isValid: false, isMigrationNeeded: false, iconName: null})
-        };
-        const result = iconPropValidator(props, 'icon');
-
-        expect(result instanceof Error).toBeTruthy();
     });
     it('should not return an error if no condition was matched.', () => {
         const props = {


### PR DESCRIPTION
Removes the FontAwesome warning and allows custom icon classnames.

Fixes 1572
