### PR TITLE
TASK: Change node title label in creation dialog to i18n

### DIFF
--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -6,7 +6,7 @@
         title:
           type: string
           ui:
-            label: 'Node title'
+            label: i18n
             editor: 'Neos.Neos/Inspector/Editors/TextFieldEditor'
           validation:
             'Neos.Neos/Validation/NotEmptyValidator': []


### PR DESCRIPTION
Depends on this change: neos/neos-development-collection#1871

Fixes: #1539