### PR TITLE
TASK: Use loading spinner instead of (non-localized) text

### DIFF
--- a/packages/neos-ui/src/index.js
+++ b/packages/neos-ui/src/index.js
@@ -22,6 +22,8 @@ import Root from './Containers/Root';
 import apiExposureMap from './apiExposureMap';
 import DelegatingReducer from './DelegatingReducer';
 
+import Icon from '@neos-project/react-ui-components/src/Icon/';
+
 const devToolsArePresent = typeof window === 'object' && typeof window.devToolsExtension !== 'undefined';
 const devToolsStoreEnhancer = () => devToolsArePresent ? window.devToolsExtension() : f => f;
 const sagaMiddleWare = createSagaMiddleware();
@@ -59,8 +61,8 @@ function * application() {
     // until we're good to go
     //
     ReactDOM.render(
-        <div style={{width: '100vw', height: '100vh', backgroundColor: 'black', display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
-            <h1>Loading...</h1>
+        <div style={{width: '100vw', height: '100vh', backgroundColor: 'black', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '30px'}}>
+            <Icon icon="circle-o-notch" label="Loading..." spin="true" size="big"/>
         </div>,
         appContainer
     );


### PR DESCRIPTION
When loading the Neos UI, a text "Loading..." appears that is not
localized. It is displayed at a very early stage of UI initialization
when the language labels have not been fetched yet.

This change makes use of a spinning icon instead of text.

Fixes: #1459