### PR TITLE
BUGFIX: Show all modes in Preview Central

### DIFF
--- a/packages/neos-ui/src/Containers/EditModePanel/Panel/slick-styles.vanilla-css
+++ b/packages/neos-ui/src/Containers/EditModePanel/Panel/slick-styles.vanilla-css
@@ -38,6 +38,7 @@
     top: 0;
     left: 0;
     display: block;
+    width: 5000px; /* Set initial width because Slick does not set it correct. (See https://github.com/neos/neos-ui/pull/1591) */
 }
 .slick-track:before,
 .slick-track:after


### PR DESCRIPTION
The width of the slick slider was not set, so not all modes were displayed.

Fixes: #1589