### PR TITLE
TASK: enable sourceMaps in production build

### DIFF
--- a/packages/build-essentials/src/webpack.config.js
+++ b/packages/build-essentials/src/webpack.config.js
@@ -116,6 +116,7 @@ if (!env.isCi && !env.isTesting && !env.isStorybook && !env.isProduction) {
 /* eslint camelcase: ["error", {properties: "never"}] */
 if (env.isProduction) {
     webpackConfig.plugins.push(new webpack.optimize.UglifyJsPlugin({
+        sourceMap: true,
         minimize: true,
         compress: {
             keep_fnames: true,


### PR DESCRIPTION
UglifyJs disables sourcemaps by default: https://github.com/webpack/webpack/issues/2704
We need sourcemaps to be enabled, right now it's next to impossible to debug issues in production.