### PR TITLE
 TASK: better editing of external links

### DIFF
--- a/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/LinkIconButton.js
+++ b/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/LinkIconButton.js
@@ -110,16 +110,9 @@ class LinkTextField extends PureComponent {
 
     refreshState() {
         if (isUri(this.props.hrefValue)) {
-            const options = [{
-                icon: 'icon-external-link',
-                identifier: this.props.hrefValue,
-                label: this.props.hrefValue,
-                loaderUri: this.props.hrefValue
-            }];
-
             this.setState({
                 searchTerm: this.props.hrefValue,
-                options
+                options: []
             });
         } else {
             if (this.props.hrefValue) {
@@ -155,16 +148,11 @@ class LinkTextField extends PureComponent {
     handleSearchTermChange = searchTerm => {
         this.setState({searchTerm});
         if (isUri(searchTerm)) {
-            const searchOptions = [{
-                icon: 'icon-external-link',
-                identifier: searchTerm,
-                label: searchTerm,
-                loaderUri: searchTerm
-            }];
+            this.commitValue(searchTerm);
 
             this.setState({
                 isLoading: false,
-                searchOptions
+                searchOptions: []
             });
         } else if (!searchTerm && isUri(this.props.hrefValue)) {
             // the user emptied the URL value, so we need to reset it
@@ -204,7 +192,8 @@ class LinkTextField extends PureComponent {
                 <SelectBox
                     options={this.props.hrefValue ? this.state.options : this.state.searchOptions}
                     optionValueField="loaderUri"
-                    value={this.props.hrefValue}
+                    value={isUri(this.props.hrefValue) ? '' : this.props.hrefValue}
+                    plainInputMode={isUri(this.props.hrefValue)}
                     onValueChange={this.handleValueChange}
                     placeholder="Paste a link, or search"
                     displayLoadingIndicator={this.state.isLoading}

--- a/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/style.css
+++ b/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/style.css
@@ -20,10 +20,7 @@
     z-index: var(--zIndex-SecondaryToolbar-LinkIconButtonFlyout);
     width: 460px;
     border: var(--spacing-Half) solid var(--colors-ContrastDarker);
-    /* 8px border top and bottom (spacing-Full) */
-    /* the height of the SelectBox header is 50 px, GoldenUnit is 40px */
-    /* so I have to add 10px */
-    height: calc(var(--spacing-GoldenUnit) + var(--spacing-Full) + 10px);
+    height: calc(var(--spacing-GoldenUnit) + var(--spacing-Full) + 1px);
 }
 
 .linkIconButton__item {

--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -358,7 +358,7 @@ export default class SelectBox extends PureComponent {
                     focusedValue: optionValueAccessor(options[newIndex])
                 });
             } else if (e.key === 'Enter') {
-                if (0 >= currentIndex < options.length) {
+                if (currentIndex < options.length && currentIndex >= 0) {
                     this.handleChange(options[currentIndex]);
                 }
 

--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -358,7 +358,7 @@ export default class SelectBox extends PureComponent {
                     focusedValue: optionValueAccessor(options[newIndex])
                 });
             } else if (e.key === 'Enter') {
-                if (currentIndex < options.length) {
+                if (0 >= currentIndex < options.length) {
                     this.handleChange(options[currentIndex]);
                 }
 


### PR DESCRIPTION
Fixes: #1527

This behavior fully replicates the one from the old UI:
![peek 2018-02-04 12-01](https://user-images.githubusercontent.com/837032/35775928-07308218-09a4-11e8-825d-2cc4ae1a89c0.gif)
