### PR TITLE
TASK: Define a global outline to be the same in all browsers

### DIFF
--- a/packages/react-ui-components/src/Button/style.css
+++ b/packages/react-ui-components/src/Button/style.css
@@ -14,6 +14,10 @@
     background-color: var(--colors-ContrastNeutral);
     font-size: var(--fontSize-Base);
 
+    &:focus {
+        outline: 1px solid var(--colors-PrimaryBlue);
+    }
+
     &[disabled] {
         opacity: .5;
         cursor: not-allowed;

--- a/packages/react-ui-components/src/DropDown/style.css
+++ b/packages/react-ui-components/src/DropDown/style.css
@@ -20,6 +20,10 @@
     white-space: nowrap;
     line-height: var(--spacing-GoldenUnit);
     background: var(--colors-ContrastNeutral);
+
+    &:focus{
+        outline: 1px solid var(--colors-PrimaryBlue);
+    }
 }
 .dropDown__btn--withChevron {
     padding-right: var(--spacing-GoldenUnit);


### PR DESCRIPTION
I tried this today and it seems firefox isn't really set the focus selector properly when navigating with the keyboard.
But when toggling the pseudoselector via dev-tools I can see that it is applied correctly to that element.

Maybe anyone has an idea?


closes #1600