### PR TITLE
BUGFIX: fix ReloadContentOutOfBand feedback

### DIFF
--- a/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/ReloadContentOutOfBand.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/ReloadContentOutOfBand.php
@@ -105,7 +105,7 @@ class ReloadContentOutOfBand implements FeedbackInterface
 
         return (
             $this->getNode()->getContextPath() === $feedback->getNode()->getContextPath() &&
-            $this->getReferenceData() == $feedback->getReferenceData()
+            $this->getNodeDomAddress() == $feedback->getNodeDomAddress()
         );
     }
 


### PR DESCRIPTION
Fixes `Call to undefined method Neos\Neos\Ui\Domain\Model\Feedback\Operations\ReloadContentOutOfBand::getReferenceData()`