### PR TITLE
BUGFIX: fixes inline editable property triggering page reload on each change

### DIFF
--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/Property.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/Property.php
@@ -159,7 +159,7 @@ class Property extends AbstractChange
 
             $reloadIfChangedConfigurationPath = sprintf('properties.%s.ui.reloadIfChanged', $propertyName);
             if ($node->getNodeType()->getConfiguration($reloadIfChangedConfigurationPath)) {
-                if ($this->getNodeDomAddress()->getFusionPath() && $node->getParent()->getNodeType()->isOfType('Neos.Neos:ContentCollection')) {
+                if ($this->getNodeDomAddress() && $this->getNodeDomAddress()->getFusionPath() && $node->getParent()->getNodeType()->isOfType('Neos.Neos:ContentCollection')) {
                     $reloadContentOutOfBand = new ReloadContentOutOfBand();
                     $reloadContentOutOfBand->setNode($node);
                     $reloadContentOutOfBand->setNodeDomAddress($this->getNodeDomAddress());

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/Property.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/Property.php
@@ -53,6 +53,13 @@ class Property extends AbstractChange
     protected $value;
 
     /**
+     * The change has been initiated from the inline editing
+     *
+     * @var bool
+     */
+    protected $isInline;
+
+    /**
      * Set the property name
      *
      * @param string $propertyName
@@ -115,6 +122,26 @@ class Property extends AbstractChange
     }
 
     /**
+     * Set isInline
+     *
+     * @param bool $isInline
+     */
+    public function setIsInline($isInline)
+    {
+        $this->isInline = $isInline;
+    }
+
+    /**
+     * Get isInline
+     *
+     * @return bool
+     */
+    public function getIsInline()
+    {
+        return $this->isInline;
+    }
+
+    /**
      * Checks whether this change can be applied to the subject
      *
      * @return boolean
@@ -158,7 +185,7 @@ class Property extends AbstractChange
             $this->updateWorkspaceInfo();
 
             $reloadIfChangedConfigurationPath = sprintf('properties.%s.ui.reloadIfChanged', $propertyName);
-            if ($node->getNodeType()->getConfiguration($reloadIfChangedConfigurationPath)) {
+            if (!$this->getIsInline() && $node->getNodeType()->getConfiguration($reloadIfChangedConfigurationPath)) {
                 if ($this->getNodeDomAddress() && $this->getNodeDomAddress()->getFusionPath() && $node->getParent()->getNodeType()->isOfType('Neos.Neos:ContentCollection')) {
                     $reloadContentOutOfBand = new ReloadContentOutOfBand();
                     $reloadContentOutOfBand->setNode($node);
@@ -170,7 +197,7 @@ class Property extends AbstractChange
             }
 
             $reloadPageIfChangedConfigurationPath = sprintf('properties.%s.ui.reloadPageIfChanged', $propertyName);
-            if ($node->getNodeType()->getConfiguration($reloadPageIfChangedConfigurationPath)) {
+            if (!$this->getIsInline() && $node->getNodeType()->getConfiguration($reloadPageIfChangedConfigurationPath)) {
                 $this->reloadDocument();
             }
 

--- a/packages/neos-ui-ckeditor-bindings/src/createCkEditor.js
+++ b/packages/neos-ui-ckeditor-bindings/src/createCkEditor.js
@@ -44,7 +44,8 @@ export default ({propertyDomNode, propertyName, contextPath, editorOptions, glob
             subject: contextPath,
             payload: {
                 propertyName,
-                value: contents
+                value: contents,
+                isInline: true
             }
         });
     });


### PR DESCRIPTION
Fixes: #1366


Also fixes this when editing a property inline:

```
Exception in line 36 of /Data/Temporary/Development/Cache/Code/Flow_Object_Classes/Neos_Neos_Ui_Domain_Model_ChangeCollection.php: Call to a member function getFusionPath() on null

37 Neos\Neos\Ui\Domain\Model\Changes\Property_Original::apply()
36 Neos\Neos\Ui\Domain\Model\ChangeCollection_Original::apply()
35 Neos\Neos\Ui\Controller\BackendServiceController_Original::changeAction(Neos\Neos\Ui\Domain\Model\ChangeCollection)
```