### PR TITLE
TAKS: Adjust lerna version after publishing the extensibility package

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.5.1",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/react-ui-components/package.json
+++ b/packages/react-ui-components/package.json
@@ -58,6 +58,5 @@
   "license": "GNU GPLv3",
   "jest": {
     "preset": "@neos-project/jest-preset-neos-ui"
-  },
-  "dependencies": {}
+  }
 }


### PR DESCRIPTION
This is autogenerated by `node_modules/.bin/lerna publish --skip-git --exact --repo-version=1.0.5 --yes --force-publish --skip-npm
` so the empty dependency object should remain in the react-ui-components package I think.