### PR TITLE
TASK: refactor nodes loading

### DIFF
--- a/Classes/Neos/Neos/Ui/Aspects/NodeTypeSchemaCacheHeaderAspect.php
+++ b/Classes/Neos/Neos/Ui/Aspects/NodeTypeSchemaCacheHeaderAspect.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Neos\Neos\Ui\Aspects;
+
+/*                                                                        *
+ * This script belongs to the Neos Flow package "Neos.Neos.Ui".          *
+ *                                                                        *
+ *                                                                        */
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Service\AuthorizationService;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Aop\JoinPointInterface;
+use Neos\Flow\Session\SessionInterface;
+use Neos\FluidAdaptor\Core\Rendering\FlowAwareRenderingContextInterface;
+use Neos\Neos\Controller\Backend\SchemaController;
+use Neos\Neos\Domain\Service\ContentContext;
+use Neos\Neos\Domain\Service\UserService;
+use Neos\Neos\Service\HtmlAugmenter;
+use Neos\Neos\Ui\Domain\Service\UserLocaleService;
+use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
+
+/**
+ * adds a Cache-Control: max-age=3600 header to the /schema/node-types endpoint; speeds up loading the new UI
+ * if having many node types.
+ *
+ * NOTE: we currently do this in an aspect, to also increase performance on older Neos versions (some people still
+ * need time to upgrade to the latest Neos version...)
+ *
+ * @Flow\Scope("singleton")
+ * @Flow\Aspect
+ */
+class NodeTypeSchemaCacheHeaderAspect
+{
+
+    /**
+     * @Flow\Inject
+     * @var SessionInterface
+     */
+    protected $session;
+
+    /**
+     * @Flow\Before("method(Neos\Neos\Controller\Backend\SchemaController->nodeTypeSchemaAction())")
+     * @param JoinPointInterface $joinPoint
+     * @return mixed
+     */
+    public function setControllerContextFromContentElementWrappingImplementation(JoinPointInterface $joinPoint)
+    {
+        if ($this->session->isStarted() && $this->session->getData('__neosEnabled__')) {
+            /** @var SchemaController $proxy */
+            $proxy = $joinPoint->getProxy();
+            $proxy->getControllerContext()->getResponse()->setHeader('Cache-Control', 'max-age=3600');
+        }
+    }
+}

--- a/Classes/Neos/Neos/Ui/Aspects/NodeTypeSchemaCacheHeaderAspect.php
+++ b/Classes/Neos/Neos/Ui/Aspects/NodeTypeSchemaCacheHeaderAspect.php
@@ -49,7 +49,9 @@ class NodeTypeSchemaCacheHeaderAspect
         if ($this->session->isStarted() && $this->session->getData('__neosEnabled__')) {
             /** @var SchemaController $proxy */
             $proxy = $joinPoint->getProxy();
-            $proxy->getControllerContext()->getResponse()->setHeader('Cache-Control', 'max-age=3600');
+
+            // Cache for one week!
+            $proxy->getControllerContext()->getResponse()->setHeader('Cache-Control', 'max-age=' . (3600 * 24 * 7));
         }
     }
 }

--- a/Classes/Neos/Neos/Ui/Controller/BackendServiceController.php
+++ b/Classes/Neos/Neos/Ui/Controller/BackendServiceController.php
@@ -102,7 +102,7 @@ class BackendServiceController extends ActionController
      * @param ResponseInterface $response
      * @return void
      */
-    public function initializeController(RequestInterface $request, ResponseInterface $response)
+    public function initializeController(RequestInterface $request, ResponseInterface $response): void
     {
         parent::initializeController($request, $response);
         $this->feedbackCollection->setControllerContext($this->getControllerContext());
@@ -114,7 +114,7 @@ class BackendServiceController extends ActionController
      * @param string $documentNodeContextPath
      * @return void
      */
-    protected function updateWorkspaceInfo($documentNodeContextPath)
+    protected function updateWorkspaceInfo(string $documentNodeContextPath): void
     {
         $updateWorkspaceInfo = new UpdateWorkspaceInfo();
         $documentNode = $this->nodeService->getNodeFromContextPath($documentNodeContextPath, null, null, true);
@@ -131,7 +131,7 @@ class BackendServiceController extends ActionController
      * @param ChangeCollection $changes
      * @return void
      */
-    public function changeAction(ChangeCollection $changes)
+    public function changeAction(ChangeCollection $changes): void
     {
         try {
             $count = $changes->count();
@@ -159,7 +159,7 @@ class BackendServiceController extends ActionController
      * @param string $targetWorkspaceName
      * @return void
      */
-    public function publishAction(array $nodeContextPaths, $targetWorkspaceName)
+    public function publishAction(array $nodeContextPaths, string $targetWorkspaceName): void
     {
         try {
             $targetWorkspace = $this->workspaceRepository->findOneByName($targetWorkspaceName);
@@ -192,7 +192,7 @@ class BackendServiceController extends ActionController
      * @param array $nodeContextPaths
      * @return void
      */
-    public function discardAction(array $nodeContextPaths)
+    public function discardAction(array $nodeContextPaths): void
     {
         try {
             foreach ($nodeContextPaths as $contextPath) {
@@ -248,8 +248,9 @@ class BackendServiceController extends ActionController
      * @param string $targetWorkspaceName,
      * @param NodeInterface $documentNode
      * @return void
+     * @throws \Exception
      */
-    public function changeBaseWorkspaceAction($targetWorkspaceName, $documentNode)
+    public function changeBaseWorkspaceAction(string $targetWorkspaceName, NodeInterface $documentNode): void
     {
         try {
             $targetWorkspace = $this->workspaceRepository->findOneByName($targetWorkspaceName);
@@ -286,7 +287,7 @@ class BackendServiceController extends ActionController
                 } else {
                     $redirectNode = $redirectNode->getParent();
                     if (!$redirectNode) {
-                        throw new \Exception('Wasn\'t able to locate any valid node in rootline in the target workspace.');
+                        throw new \Exception(sprintf('Wasn\'t able to locate any valid node in rootline of node %s in the workspace %s.', $documentNode->getContextPath(), $targetWorkspaceName), 1458814469);
                     }
                 }
             }
@@ -331,7 +332,7 @@ class BackendServiceController extends ActionController
      * @param boolean $includeRoot
      * @return void
      */
-    public function loadTreeAction(NodeTreeBuilder $nodeTreeArguments, $includeRoot = false)
+    public function loadTreeAction(NodeTreeBuilder $nodeTreeArguments, $includeRoot = false): void
     {
         $nodeTreeArguments->setControllerContext($this->controllerContext);
         $this->view->assign('value', $nodeTreeArguments->build($includeRoot));
@@ -343,7 +344,7 @@ class BackendServiceController extends ActionController
      * @param array $chain
      * @return string
      */
-    public function flowQueryAction(array $chain)
+    public function flowQueryAction(array $chain): string
     {
         $createContext = array_shift($chain);
         $finisher = array_pop($chain);

--- a/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/Redirect.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/Redirect.php
@@ -33,7 +33,7 @@ class Redirect implements FeedbackInterface
      * @param NodeInterface $node
      * @return void
      */
-    public function setNode(NodeInterface $node)
+    public function setNode(NodeInterface $node): void
     {
         $this->node = $node;
     }
@@ -43,7 +43,7 @@ class Redirect implements FeedbackInterface
      *
      * @return NodeInterface
      */
-    public function getNode()
+    public function getNode(): NodeInterface
     {
         return $this->node;
     }
@@ -53,7 +53,7 @@ class Redirect implements FeedbackInterface
      *
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return 'Neos.Neos.Ui:Redirect';
     }
@@ -63,7 +63,7 @@ class Redirect implements FeedbackInterface
      *
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return sprintf('Redirect to node "%s".', $this->getNode()->getContextPath());
     }
@@ -74,7 +74,7 @@ class Redirect implements FeedbackInterface
      * @param FeedbackInterface $feedback
      * @return boolean
      */
-    public function isSimilarTo(FeedbackInterface $feedback)
+    public function isSimilarTo(FeedbackInterface $feedback): boolean
     {
         if (!$feedback instanceof UpdateNodeInfo) {
             return false;
@@ -87,9 +87,9 @@ class Redirect implements FeedbackInterface
      * Serialize the payload for this feedback
      *
      * @param ControllerContext $controllerContext
-     * @return mixed
+     * @return array
      */
-    public function serializePayload(ControllerContext $controllerContext)
+    public function serializePayload(ControllerContext $controllerContext): array
     {
         $node = $this->getNode();
         $redirectUri = $this->linkingService->createNodeUri($controllerContext, $node, null, null, true, array(), '', false, array(), false);

--- a/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/Redirect.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/Redirect.php
@@ -1,0 +1,101 @@
+<?php
+namespace Neos\Neos\Ui\Domain\Model\Feedback\Operations;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Neos\Service\LinkingService;
+use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
+use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Flow\Mvc\Controller\ControllerContext;
+
+class Redirect implements FeedbackInterface
+{
+    /**
+     * @var NodeInterface
+     */
+    protected $node;
+
+    /**
+     * @Flow\Inject
+     * @var NodeInfoHelper
+     */
+    protected $nodeInfoHelper;
+
+    /**
+     * @Flow\Inject
+     * @var LinkingService
+     */
+    protected $linkingService;
+
+    /**
+     * Set the node
+     *
+     * @param NodeInterface $node
+     * @return void
+     */
+    public function setNode(NodeInterface $node)
+    {
+        $this->node = $node;
+    }
+
+    /**
+     * Get the node
+     *
+     * @return NodeInterface
+     */
+    public function getNode()
+    {
+        return $this->node;
+    }
+
+    /**
+     * Get the type identifier
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return 'Neos.Neos.Ui:Redirect';
+    }
+
+    /**
+     * Get the description
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return sprintf('Redirect to node "%s".', $this->getNode()->getContextPath());
+    }
+
+    /**
+     * Checks whether this feedback is similar to another
+     *
+     * @param FeedbackInterface $feedback
+     * @return boolean
+     */
+    public function isSimilarTo(FeedbackInterface $feedback)
+    {
+        if (!$feedback instanceof UpdateNodeInfo) {
+            return false;
+        }
+
+        return $this->getNode()->getContextPath() === $feedback->getNode()->getContextPath();
+    }
+
+    /**
+     * Serialize the payload for this feedback
+     *
+     * @param ControllerContext $controllerContext
+     * @return mixed
+     */
+    public function serializePayload(ControllerContext $controllerContext)
+    {
+        $node = $this->getNode();
+        $redirectUri = $this->linkingService->createNodeUri($controllerContext, $node, null, null, true, array(), '', false, array(), false);
+        return [
+            'redirectUri' => $redirectUri,
+            'redirectContextPath' => $node->getContextPath()
+        ];
+    }
+}

--- a/Classes/Neos/Neos/Ui/FlowQueryOperations/NeosUiDefaultNodesOperation.php
+++ b/Classes/Neos/Neos/Ui/FlowQueryOperations/NeosUiDefaultNodesOperation.php
@@ -17,7 +17,7 @@ use Neos\Eel\FlowQuery\Operations\AbstractOperation;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 
 /**
- * Renders nodes that are initially required by the user interface
+ * Fetches all nodes needed for the given state of the UI
  */
 class NeosUiDefaultNodesOperation extends AbstractOperation
 {
@@ -55,28 +55,37 @@ class NeosUiDefaultNodesOperation extends AbstractOperation
      */
     public function evaluate(FlowQuery $flowQuery, array $arguments)
     {
-        list($site, $documentNode) = $flowQuery->getContext();
-        list($baseNodeType, $loadingDepth) = array_replace([
-            '',
-            0
-        ], $arguments);
+        list($siteNode, $documentNode) = $flowQuery->getContext();
+        list($baseNodeType, $loadingDepth, $toggledNodes) = $arguments;
 
-        $nodes = [];
-        if ($site !== $documentNode) {
-            $nodes[] = $site;
+        // Collect all parents of documentNode up to siteNode
+        $parents = [];
+        $currentNode = $documentNode->getParent();
+        $parentNodeIsUnderneathSiteNode = strpos($currentNode->getPath(), $siteNode->getPath()) === 0;
+        while ($currentNode !== $siteNode && $parentNodeIsUnderneathSiteNode) {
+            $parents[] = $currentNode->getContextPath();
+            $currentNode = $currentNode->getParent();
         }
 
-        $gatherNodesRecursively = function (&$nodes, $baseNode, $level = 0) use (&$gatherNodesRecursively, $baseNodeType, $loadingDepth) {
-            if ($level < $loadingDepth || $loadingDepth === 0) {
+        $nodes = [$siteNode];
+        $gatherNodesRecursively = function (&$nodes, $baseNode, $level = 0) use (&$gatherNodesRecursively, $baseNodeType, $loadingDepth, $toggledNodes, $parents) {
+            if (
+                $level < $loadingDepth || // load all nodes within loadingDepth
+                $loadingDepth === 0 || // unlimited loadingDepth
+                in_array($baseNode->getContextPath(), $toggledNodes) || // load toggled nodes
+                in_array($baseNode->getContextPath(), $parents) // load children of all parents of documentNode
+            ) {
                 foreach ($baseNode->getChildNodes($baseNodeType) as $childNode) {
                     $nodes[] = $childNode;
                     $gatherNodesRecursively($nodes, $childNode, $level + 1);
                 }
             }
         };
-        $gatherNodesRecursively($nodes, $site);
+        $gatherNodesRecursively($nodes, $siteNode);
 
-        $nodes[] = $documentNode;
+        if (!in_array($documentNode, $nodes)) {
+            $nodes[] = $documentNode;
+        }
 
         $flowQuery->setContext($nodes);
     }

--- a/Classes/Neos/Neos/Ui/FlowQueryOperations/NeosUiDefaultNodesOperation.php
+++ b/Classes/Neos/Neos/Ui/FlowQueryOperations/NeosUiDefaultNodesOperation.php
@@ -56,7 +56,12 @@ class NeosUiDefaultNodesOperation extends AbstractOperation
     public function evaluate(FlowQuery $flowQuery, array $arguments)
     {
         list($siteNode, $documentNode) = $flowQuery->getContext();
-        list($baseNodeType, $loadingDepth, $toggledNodes) = $arguments;
+        // set default values for arguments
+        list($baseNodeType, $loadingDepth, $toggledNodes) = array_replace([
+            '',
+            0,
+            []
+        ], $arguments);
 
         // Collect all parents of documentNode up to siteNode
         $parents = [];

--- a/Classes/Neos/Neos/Ui/FlowQueryOperations/NeosUiDefaultNodesOperation.php
+++ b/Classes/Neos/Neos/Ui/FlowQueryOperations/NeosUiDefaultNodesOperation.php
@@ -56,12 +56,7 @@ class NeosUiDefaultNodesOperation extends AbstractOperation
     public function evaluate(FlowQuery $flowQuery, array $arguments)
     {
         list($siteNode, $documentNode) = $flowQuery->getContext();
-        // set default values for arguments
-        list($baseNodeType, $loadingDepth, $toggledNodes) = array_replace([
-            '',
-            0,
-            []
-        ], $arguments);
+        list($baseNodeType, $loadingDepth, $toggledNodes) = $arguments;
 
         // Collect all parents of documentNode up to siteNode
         $parents = [];

--- a/Classes/Neos/Neos/Ui/FlowQueryOperations/NeosUiDefaultNodesOperation.php
+++ b/Classes/Neos/Neos/Ui/FlowQueryOperations/NeosUiDefaultNodesOperation.php
@@ -66,10 +66,12 @@ class NeosUiDefaultNodesOperation extends AbstractOperation
         // Collect all parents of documentNode up to siteNode
         $parents = [];
         $currentNode = $documentNode->getParent();
-        $parentNodeIsUnderneathSiteNode = strpos($currentNode->getPath(), $siteNode->getPath()) === 0;
-        while ($currentNode !== $siteNode && $parentNodeIsUnderneathSiteNode) {
-            $parents[] = $currentNode->getContextPath();
-            $currentNode = $currentNode->getParent();
+        if ($currentNode) {
+            $parentNodeIsUnderneathSiteNode = strpos($currentNode->getPath(), $siteNode->getPath()) === 0;
+            while ($currentNode !== $siteNode && $parentNodeIsUnderneathSiteNode) {
+                $parents[] = $currentNode->getContextPath();
+                $currentNode = $currentNode->getParent();
+            }
         }
 
         $nodes = [$siteNode];

--- a/Classes/Neos/Neos/Ui/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Neos/Neos/Ui/Fusion/Helper/NodeInfoHelper.php
@@ -202,13 +202,9 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
 
     public function defaultNodesForBackend(NodeInterface $site, NodeInterface $documentNode, ControllerContext $controllerContext)
     {
-        $flowQuery = new FlowQuery([$site, $documentNode]);
-        $nodes = $flowQuery->neosUiDefaultNodes($this->baseNodeType, $this->loadingDepth)->get();
-
         $result = [];
-        foreach ($nodes as $node) {
-            $this->renderNodeToList($result, $node, $controllerContext);
-        }
+        $this->renderNodeToList($result, $site, $controllerContext);
+        $this->renderNodeToList($result, $documentNode, $controllerContext);
 
         return $result;
     }

--- a/packages/neos-ui-backend-connector/src/Endpoints/index.js
+++ b/packages/neos-ui-backend-connector/src/Endpoints/index.js
@@ -48,7 +48,7 @@ export default routes => {
     })).then(response => response.json())
     .catch(reason => fetchWithErrorHandling.generalErrorHandler(reason));
 
-    const changeBaseWorkspace = targetWorkspaceName => fetchWithErrorHandling.withCsrfToken(csrfToken => ({
+    const changeBaseWorkspace = (targetWorkspaceName, documentNode) => fetchWithErrorHandling.withCsrfToken(csrfToken => ({
         url: routes.ui.service.changeBaseWorkspace,
 
         method: 'POST',
@@ -58,7 +58,8 @@ export default routes => {
             'Content-Type': 'application/json'
         },
         body: JSON.stringify({
-            targetWorkspaceName
+            targetWorkspaceName,
+            documentNode
         })
     })).then(response => response.json())
     .catch(reason => fetchWithErrorHandling.generalErrorHandler(reason));

--- a/packages/neos-ui-backend-connector/src/FlowQuery/Operations/NeosUiDefaultNodes/index.js
+++ b/packages/neos-ui-backend-connector/src/FlowQuery/Operations/NeosUiDefaultNodes/index.js
@@ -1,4 +1,4 @@
-export default () => (baseNodeType, loadingDepth) => ({
+export default () => (baseNodeType, loadingDepth, toggledNodes) => ({
     type: 'neosUiDefaultNodes',
-    payload: [baseNodeType, loadingDepth]
+    payload: [baseNodeType, loadingDepth, toggledNodes]
 });

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -49,12 +49,6 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
         [documentInformation.metaData.contextPath]: documentInformation.metaData.documentNodeSerialization
     });
 
-    yield put(actions.CR.Nodes.reloadState({
-        siteNodeContextPath: documentInformation.metaData.siteNode,
-        documentNodeContextPath: documentInformation.metaData.contextPath,
-        merge: true
-    }));
-
     yield put(actions.CR.Nodes.add(nodes));
 
     // Remove the inline scripts after initialization

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -49,6 +49,12 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
         [documentInformation.metaData.contextPath]: documentInformation.metaData.documentNodeSerialization
     });
 
+    yield put(actions.CR.Nodes.reloadState({
+        siteNodeContextPath: documentInformation.metaData.siteNode,
+        documentNodeContextPath: documentInformation.metaData.contextPath,
+        merge: true
+    }));
+
     yield put(actions.CR.Nodes.add(nodes));
 
     // Remove the inline scripts after initialization

--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.js
@@ -322,7 +322,7 @@ export const reducer = handleActions({
             contextPath: '',
             fusionPath: ''
         })),
-        merge ? $set('cr.nodes.byContextPath', Immutable.fromJS(nodes)) : $set('cr.nodes.byContextPath', Immutable.fromJS(nodes))
+        merge ? $merge('cr.nodes.byContextPath', Immutable.fromJS(nodes)) : $set('cr.nodes.byContextPath', Immutable.fromJS(nodes))
     ),
     [COPY]: contextPath => $all(
         $set('cr.nodes.clipboard', contextPath),

--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.js
@@ -17,7 +17,8 @@ const COMMENCE_REMOVAL = '@neos/neos-ui/CR/Nodes/COMMENCE_REMOVAL';
 const REMOVAL_ABORTED = '@neos/neos-ui/CR/Nodes/REMOVAL_ABORTED';
 const REMOVAL_CONFIRMED = '@neos/neos-ui/CR/Nodes/REMOVAL_CONFIRMED';
 const REMOVE = '@neos/neos-ui/CR/Nodes/REMOVE';
-const SWITCH_DIMENSION = '@neos/neos-ui/CR/Nodes/SWITCH_DIMENSION';
+const SET_STATE = '@neos/neos-ui/CR/Nodes/SET_STATE';
+const RELOAD_STATE = '@neos/neos-ui/CR/Nodes/RELOAD_STATE';
 const COPY = '@neos/neos-ui/CR/Nodes/COPY';
 const CUT = '@neos/neos-ui/CR/Nodes/CUT';
 const MOVE = '@neos/neos-ui/CR/Nodes/MOVE';
@@ -39,7 +40,8 @@ export const actionTypes = {
     REMOVAL_ABORTED,
     REMOVAL_CONFIRMED,
     REMOVE,
-    SWITCH_DIMENSION,
+    SET_STATE,
+    RELOAD_STATE,
     COPY,
     CUT,
     MOVE,
@@ -115,16 +117,22 @@ const confirmRemoval = createAction(REMOVAL_CONFIRMED);
 const remove = createAction(REMOVE, contextPath => contextPath);
 
 /**
- * Switch to new site- and documentNodes, add initial nodes for the new dimension
+ * Set CR state on page load or after dimensions or workspaces switch
  */
-const switchDimension = createAction(
-    SWITCH_DIMENSION,
-    ({siteNodeContextPath, documentNodeContextPath, nodes}) => ({
+const setState = createAction(
+    SET_STATE,
+    ({siteNodeContextPath, documentNodeContextPath, nodes, merge}) => ({
         siteNodeContextPath,
         documentNodeContextPath,
-        nodes
+        nodes,
+        merge
     })
 );
+
+/**
+ * Reload CR nodes state
+ */
+const reloadState = createAction(RELOAD_STATE, args => args);
 
 /**
  * Mark a node for copy on paste
@@ -193,7 +201,8 @@ export const actions = {
     abortRemoval,
     confirmRemoval,
     remove,
-    switchDimension,
+    setState,
+    reloadState,
     copy,
     cut,
     move,
@@ -306,14 +315,14 @@ export const reducer = handleActions({
     [REMOVAL_ABORTED]: () => $set('cr.nodes.toBeRemoved', ''),
     [REMOVAL_CONFIRMED]: () => $set('cr.nodes.toBeRemoved', ''),
     [REMOVE]: contextPath => $drop(['cr', 'nodes', 'byContextPath', contextPath]),
-    [SWITCH_DIMENSION]: ({siteNodeContextPath, documentNodeContextPath, nodes}) => $all(
+    [SET_STATE]: ({siteNodeContextPath, documentNodeContextPath, nodes, merge}) => $all(
         $set('cr.nodes.siteNode', siteNodeContextPath),
         $set('ui.contentCanvas.contextPath', documentNodeContextPath),
         $set('cr.nodes.focused', new Map({
             contextPath: '',
             fusionPath: ''
         })),
-        $merge('cr.nodes.byContextPath', Immutable.fromJS(nodes))
+        merge ? $set('cr.nodes.byContextPath', Immutable.fromJS(nodes)) : $set('cr.nodes.byContextPath', Immutable.fromJS(nodes))
     ),
     [COPY]: contextPath => $all(
         $set('cr.nodes.clipboard', contextPath),

--- a/packages/neos-ui-redux-store/src/UI/PageTree/index.js
+++ b/packages/neos-ui-redux-store/src/UI/PageTree/index.js
@@ -13,7 +13,6 @@ const INVALIDATE = '@neos/neos-ui/UI/PageTree/INVALIDATE';
 const SET_AS_LOADING = '@neos/neos-ui/UI/PageTree/SET_AS_LOADING';
 const SET_AS_LOADED = '@neos/neos-ui/UI/PageTree/SET_AS_LOADED';
 const REQUEST_CHILDREN = '@neos/neos-ui/UI/PageTree/REQUEST_CHILDREN';
-const RELOAD_TREE = '@neos/neos-ui/UI/PageTree/RELOAD_TREE';
 const COMMENCE_SEARCH = '@neos/neos-ui/UI/PageTree/COMMENCE_SEARCH';
 const SET_SEARCH_RESULT = '@neos/neos-ui/UI/PageTree/SET_SEARCH_RESULT';
 //
@@ -26,7 +25,6 @@ export const actionTypes = {
     SET_AS_LOADING,
     SET_AS_LOADED,
     REQUEST_CHILDREN,
-    RELOAD_TREE,
     COMMENCE_SEARCH,
     SET_SEARCH_RESULT
 };
@@ -37,7 +35,6 @@ const invalidate = createAction(INVALIDATE, contextPath => ({contextPath}));
 const requestChildren = createAction(REQUEST_CHILDREN, (contextPath, {unCollapse = true, activate = false} = {}) => ({contextPath, opts: {unCollapse, activate}}));
 const setAsLoading = createAction(SET_AS_LOADING, contextPath => ({contextPath}));
 const setAsLoaded = createAction(SET_AS_LOADED, contextPath => ({contextPath}));
-const reloadTree = createAction(RELOAD_TREE);
 const commenceSearch = createAction(COMMENCE_SEARCH, (contextPath, {query, filterNodeType}) => ({contextPath, query, filterNodeType}));
 const setSearchResult = createAction(SET_SEARCH_RESULT, result => (result));
 
@@ -51,7 +48,6 @@ export const actions = {
     setAsLoading,
     setAsLoaded,
     requestChildren,
-    reloadTree,
     commenceSearch,
     setSearchResult
 };

--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -52,6 +52,12 @@ export default class ContentCanvas extends PureComponent {
         loadedSrc: ''
     };
 
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.src !== this.props.src) {
+            this.props.startLoading();
+        }
+    }
+
     render() {
         const {
             isFringeLeft,

--- a/packages/neos-ui/src/Containers/Drawer/index.js
+++ b/packages/neos-ui/src/Containers/Drawer/index.js
@@ -113,7 +113,7 @@ export default class Drawer extends PureComponent {
                 onMouseLeave={this.handleMouseLeave}
                 aria-hidden={isHidden ? 'true' : 'false'}
                 >
-                {Object.values(menuData).map((item, index) => (
+                {!isHidden && Object.values(menuData).map((item, index) => (
                     <MenuItemGroup
                         key={index}
                         onClick={this.handleMenuItemClick}

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
@@ -260,7 +260,7 @@ export const PageTreeToolbar = withNodeTypesRegistry(connect(
         hideNode: actions.CR.Nodes.hide,
         showNode: actions.CR.Nodes.show,
         pasteNode: actions.CR.Nodes.paste,
-        reloadTree: actions.UI.PageTree.reloadTree
+        reloadTree: actions.CR.Nodes.reloadState
     }
 )(NodeTreeToolBar));
 

--- a/packages/neos-ui/src/Containers/LeftSideBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/index.js
@@ -63,7 +63,7 @@ export default class LeftSideBar extends PureComponent {
                 <hr style={{borderTop: 'none'}}/>
 
                 <div className={bottomClassNames}>
-                    {!isHidden && !isHiddenContentTree && <ContentTreeToolbar/>}
+                    <ContentTreeToolbar/>
                     {!isHidden && !isHiddenContentTree && LeftSideBarBottom.map((Item, key) => <Item key={key}/>)}
                 </div>
             </SideBar>

--- a/packages/neos-ui/src/Containers/LeftSideBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/index.js
@@ -56,15 +56,15 @@ export default class LeftSideBar extends PureComponent {
                 aria-hidden={isHidden ? 'true' : 'false'}
                 >
                 <div className={style.leftSideBar__top}>
-                    {LeftSideBarTop.map((Item, key) => <Item key={key} isExpanded={!isHiddenContentTree}/>)}
+                    {!isHidden && LeftSideBarTop.map((Item, key) => <Item key={key} isExpanded={!isHiddenContentTree}/>)}
                 </div>
 
                 {/* Disable top border to get only a 1px combined border size */}
                 <hr style={{borderTop: 'none'}}/>
 
                 <div className={bottomClassNames}>
-                    <ContentTreeToolbar/>
-                    {LeftSideBarBottom.map((Item, key) => <Item key={key}/>)}
+                    {!isHidden && !isHiddenContentTree && <ContentTreeToolbar/>}
+                    {!isHidden && !isHiddenContentTree && LeftSideBarBottom.map((Item, key) => <Item key={key}/>)}
                 </div>
             </SideBar>
         );

--- a/packages/neos-ui/src/Containers/RightSideBar/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/index.js
@@ -64,7 +64,7 @@ export default class RightSideBar extends PureComponent {
                 aria-hidden={isSideBarHidden ? 'true' : 'false'}
                 >
                 {toggle}
-                {RightSideBarComponents.map((Item, key) => <Item key={key}/>)}
+                {!isSideBarHidden && RightSideBarComponents.map((Item, key) => <Item key={key}/>)}
             </SideBar>
         );
     }

--- a/packages/neos-ui/src/Sagas/CR/ContentDimensions/index.js
+++ b/packages/neos-ui/src/Sagas/CR/ContentDimensions/index.js
@@ -14,7 +14,7 @@ import backend from '@neos-project/neos-ui-backend-connector';
  *
  * 3. Load all default nodes needed for the tree
  */
-export function * watchSelectPreset({configuration}) {
+export function * watchSelectPreset() {
     yield take(actionTypes.System.READY);
 
     let sourceDimensions = yield select(selectors.CR.ContentDimensions.active);
@@ -38,24 +38,15 @@ export function * watchSelectPreset({configuration}) {
 
         const {nodeFrontendUri, nodeContextPath} = informationAboutNodeInTargetDimension;
 
-        const {q} = backend.get();
         const siteNode = yield select(selectors.CR.Nodes.siteNodeSelector);
         const siteNodeContextPath = $get('contextPath', siteNode);
         const targetSiteNodeContextPath = `${siteNodeContextPath.split('@')[0]}@${nodeContextPath.split('@')[1]}`;
 
         yield put(actions.UI.ContentCanvas.setSrc(nodeFrontendUri));
-        const nodes = yield q([targetSiteNodeContextPath, nodeContextPath]).neosUiDefaultNodes(
-            configuration.nodeTree.presets.default.baseNodeType,
-            configuration.nodeTree.loadingDepth
-        ).get();
 
-        yield put(actions.CR.Nodes.switchDimension({
+        yield put(actions.CR.Nodes.reloadState({
             siteNodeContextPath: targetSiteNodeContextPath,
-            documentNodeContextPath: nodeContextPath,
-            nodes: nodes.reduce((nodes, node) => {
-                nodes[node.contextPath] = node;
-                return nodes;
-            }, {})
+            documentNodeContextPath: nodeContextPath
         }));
 
         sourceDimensions = targetDimensions;
@@ -113,4 +104,3 @@ function * ensureNodeInSelectedDimension({nodeIdentifier, sourceDimensions, targ
         return {nodeFrontendUri, nodeContextPath};
     }
 }
-

--- a/packages/neos-ui/src/Sagas/CR/NodeOperations/index.js
+++ b/packages/neos-ui/src/Sagas/CR/NodeOperations/index.js
@@ -5,6 +5,7 @@ import cutAndPasteNode from './cutAndPasteNode';
 import moveDroppedNode from './moveDroppedNode';
 import hideNode from './hideNode';
 import showNode from './showNode';
+import reloadState from './reloadState';
 
 export {
     addNode,
@@ -13,5 +14,6 @@ export {
     cutAndPasteNode,
     moveDroppedNode,
     hideNode,
-    showNode
+    showNode,
+    reloadState
 };

--- a/packages/neos-ui/src/Sagas/CR/NodeOperations/reloadState.js
+++ b/packages/neos-ui/src/Sagas/CR/NodeOperations/reloadState.js
@@ -1,0 +1,30 @@
+import {takeLatest, put, select} from 'redux-saga/effects';
+import {$get} from 'plow-js';
+import backend from '@neos-project/neos-ui-backend-connector';
+
+import {actions, actionTypes} from '@neos-project/neos-ui-redux-store';
+
+export default function * watchReloadState({configuration}) {
+    yield takeLatest(actionTypes.CR.Nodes.RELOAD_STATE, function * reloadState(action) {
+        const {q} = backend.get();
+        const currentSiteNodeContextPath = yield select($get('cr.nodes.siteNode'));
+        const siteNodeContextPath = $get('payload.siteNodeContextPath', action) || currentSiteNodeContextPath;
+        const documentNodeContextPath = yield $get('payload.documentNodeContextPath', action) || select($get('ui.contentCanvas.contextPath'));
+        yield put(actions.UI.PageTree.setAsLoading(currentSiteNodeContextPath));
+        const nodes = yield q([siteNodeContextPath, documentNodeContextPath]).neosUiDefaultNodes(
+            configuration.nodeTree.presets.default.baseNodeType,
+            configuration.nodeTree.loadingDepth
+        ).getForTree();
+        const nodeMap = nodes.reduce((nodeMap, node) => {
+            nodeMap[$get('contextPath', node)] = node;
+            return nodeMap;
+        }, {});
+        yield put(actions.CR.Nodes.setState({
+            siteNodeContextPath,
+            documentNodeContextPath,
+            nodes: nodeMap,
+            merge: $get('payload.merge', action)
+        }));
+        yield put(actions.UI.PageTree.setAsLoaded(currentSiteNodeContextPath));
+    });
+}

--- a/packages/neos-ui/src/Sagas/CR/NodeOperations/reloadState.js
+++ b/packages/neos-ui/src/Sagas/CR/NodeOperations/reloadState.js
@@ -8,12 +8,14 @@ export default function * watchReloadState({configuration}) {
     yield takeLatest(actionTypes.CR.Nodes.RELOAD_STATE, function * reloadState(action) {
         const {q} = backend.get();
         const currentSiteNodeContextPath = yield select($get('cr.nodes.siteNode'));
+        const toggledNodes = yield select($get('ui.pageTree.toggled'));
         const siteNodeContextPath = $get('payload.siteNodeContextPath', action) || currentSiteNodeContextPath;
         const documentNodeContextPath = yield $get('payload.documentNodeContextPath', action) || select($get('ui.contentCanvas.contextPath'));
         yield put(actions.UI.PageTree.setAsLoading(currentSiteNodeContextPath));
         const nodes = yield q([siteNodeContextPath, documentNodeContextPath]).neosUiDefaultNodes(
             configuration.nodeTree.presets.default.baseNodeType,
-            configuration.nodeTree.loadingDepth
+            configuration.nodeTree.loadingDepth,
+            toggledNodes.toJS()
         ).getForTree();
         const nodeMap = nodes.reduce((nodeMap, node) => {
             nodeMap[$get('contextPath', node)] = node;

--- a/packages/neos-ui/src/Sagas/Publish/index.js
+++ b/packages/neos-ui/src/Sagas/Publish/index.js
@@ -59,6 +59,9 @@ export function * watchChangeBaseWorkspace() {
         try {
             const feedback = yield call(changeBaseWorkspace, action.payload);
             yield put(actions.ServerFeedback.handleServerFeedback(feedback));
+
+            // reload the page tree
+            yield put(actions.CR.Nodes.reloadState());
         } catch (error) {
             console.error('Failed to change base workspace', error);
         }
@@ -99,7 +102,7 @@ export function * discardIfConfirmed() {
                 }
 
                 // reload the page tree
-                yield put(actions.UI.PageTree.reloadTree());
+                yield put(actions.CR.Nodes.reloadState());
             } catch (error) {
                 console.error('Failed to discard', error);
             }

--- a/packages/neos-ui/src/Sagas/Publish/index.js
+++ b/packages/neos-ui/src/Sagas/Publish/index.js
@@ -57,7 +57,8 @@ export function * watchChangeBaseWorkspace() {
     const {changeBaseWorkspace} = backend.get().endpoints;
     yield takeEvery(actionTypes.CR.Workspaces.CHANGE_BASE_WORKSPACE, function * change(action) {
         try {
-            const feedback = yield call(changeBaseWorkspace, action.payload);
+            const documentNode = yield select($get('ui.contentCanvas.contextPath'));
+            const feedback = yield call(changeBaseWorkspace, action.payload, documentNode);
             yield put(actions.ServerFeedback.handleServerFeedback(feedback));
 
             // reload the page tree

--- a/packages/neos-ui/src/Sagas/UI/PageTree/index.js
+++ b/packages/neos-ui/src/Sagas/UI/PageTree/index.js
@@ -98,11 +98,32 @@ export function * watchReloadTree({globalRegistry, configuration}) {
     });
 }
 
+//
+// Hackish way to keep the state if the default nodes had already been loaded.
+// Still I'm somehow reluctant to use Redux for such rubish.
+// Maybe it's possible to do it Saga-way?
+//
+let defaultNodesLoaded = false;
 export function * watchCurrentDocument({configuration}) {
     yield takeLatest(actionTypes.UI.ContentCanvas.SET_CONTEXT_PATH, function * loadDocumentRootLine(action) {
         const {contextPath} = action.payload;
         const siteNodeContextPath = yield select($get('cr.nodes.siteNode'));
         const {q} = backend.get();
+
+        if (!defaultNodesLoaded) {
+            defaultNodesLoaded = true;
+            yield put(actions.UI.PageTree.setAsLoading(siteNodeContextPath));
+            const nodes = yield q([siteNodeContextPath, contextPath]).neosUiDefaultNodes(
+                configuration.nodeTree.presets.default.baseNodeType,
+                configuration.nodeTree.loadingDepth
+            ).getForTree();
+
+            yield put(actions.CR.Nodes.add(nodes.reduce((nodeMap, node) => {
+                nodeMap[$get('contextPath', node)] = node;
+                return nodeMap;
+            }, {})));
+            yield put(actions.UI.PageTree.setAsLoaded(siteNodeContextPath));
+        }
 
         let parentContextPath = contextPath;
 

--- a/packages/neos-ui/src/Sagas/UI/PageTree/index.js
+++ b/packages/neos-ui/src/Sagas/UI/PageTree/index.js
@@ -88,6 +88,7 @@ export function * watchCurrentDocument({configuration}) {
 
         const siteNode = yield select(selectors.CR.Nodes.siteNodeSelector);
         const loadingDepth = configuration.nodeTree.loadingDepth;
+        let hasLoadedNodes = false;
         while (parentContextPath !== siteNodeContextPath) {
             parentContextPath = parentNodeContextPath(parentContextPath);
             const getNodeByContextPathSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector(parentContextPath);
@@ -102,6 +103,7 @@ export function * watchCurrentDocument({configuration}) {
                     return nodeMap;
                 }, {})));
                 node = yield select(getNodeByContextPathSelector);
+                hasLoadedNodes = true;
             }
 
             // Calculate if the given node is collapsed, and if so the uncollapse it
@@ -113,7 +115,9 @@ export function * watchCurrentDocument({configuration}) {
         }
 
         yield put(actions.UI.PageTree.focus(contextPath));
-        yield put(actions.UI.PageTree.setAsLoaded(siteNodeContextPath));
+        if (hasLoadedNodes) {
+            yield put(actions.UI.PageTree.setAsLoaded(siteNodeContextPath));
+        }
     });
 }
 

--- a/packages/neos-ui/src/index.js
+++ b/packages/neos-ui/src/index.js
@@ -4,9 +4,10 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {createStore, applyMiddleware, compose} from 'redux';
 import createSagaMiddleware from 'redux-saga';
-import {put} from 'redux-saga/effects';
+import {put, select} from 'redux-saga/effects';
 import {Map} from 'immutable';
 import merge from 'lodash.merge';
+import {$get} from 'plow-js';
 
 import {actions} from '@neos-project/neos-ui-redux-store';
 import {createConsumerApi} from '@neos-project/neos-ui-extensibility';
@@ -128,7 +129,6 @@ function * application() {
     //
     // Load translations
     //
-    const translations = yield getJsonResource(configuration.endpoints.translations);
     const i18nRegistry = globalRegistry.get('i18n');
     i18nRegistry.setTranslations(translations);
 
@@ -182,6 +182,14 @@ function * application() {
             />,
         appContainer
     );
+
+    const siteNodeContextPath = yield select($get('cr.nodes.siteNode'));
+    const documentNodeContextPath = yield select($get('ui.contentCanvas.contextPath'));
+    yield put(actions.CR.Nodes.reloadState({
+        siteNodeContextPath,
+        documentNodeContextPath,
+        merge: true
+    }));
 }
 
 sagaMiddleWare.run(application);

--- a/packages/neos-ui/src/index.js
+++ b/packages/neos-ui/src/index.js
@@ -102,11 +102,17 @@ function * application() {
     store.dispatch(actions.System.boot());
 
     const {getJsonResource} = backend.get().endpoints;
-    //
-    // Load node types
-    //
+
     const groupsAndRoles = yield system.getNodeTypes;
-    const nodeTypesSchema = yield getJsonResource(configuration.endpoints.nodeTypeSchema);
+
+    //
+    // Load json resources
+    //
+    const nodeTypesSchemaPromise = getJsonResource(configuration.endpoints.nodeTypeSchema);
+    const translationsPromise = getJsonResource(configuration.endpoints.translations);
+
+    // Fire multiple async requests in parallel
+    const [nodeTypesSchema, translations] = yield [nodeTypesSchemaPromise, translationsPromise];
     const nodeTypesRegistry = globalRegistry.get('@neos-project/neos-ui-contentrepository');
     Object.keys(nodeTypesSchema.nodeTypes).forEach(nodeTypeName => {
         nodeTypesRegistry.set(nodeTypeName, {

--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -246,6 +246,14 @@ manifest('main', {}, globalRegistry => {
     });
 
     //
+    // Redirect to node
+    //
+    serverFeedbackHandlers.set('Neos.Neos.Ui:Redirect/Main', (feedbackPayload, {store}) => {
+        store.dispatch(actions.UI.ContentCanvas.setSrc(feedbackPayload.redirectUri));
+        store.dispatch(actions.UI.ContentCanvas.setContextPath(feedbackPayload.redirectContextPath));
+    });
+
+    //
     // When the server has updated node info, apply it to the store
     //
     serverFeedbackHandlers.set('Neos.Neos.Ui:UpdateNodeInfo/Main', (feedbackPayload, {store}) => {
@@ -275,7 +283,7 @@ manifest('main', {}, globalRegistry => {
                 // This is an extreme case when even the top node does not exist in the given dimension
                 // TODO: still find a nicer way to break out of this situation
                 if (redirectContextPath === false) {
-                    window.location = '/neos!';
+                    window.location = '/neos';
                     break;
                 }
                 redirectUri = $get(['cr', 'nodes', 'byContextPath', redirectContextPath, 'uri'], state);

--- a/packages/neos-ui/src/manifest.sagas.js
+++ b/packages/neos-ui/src/manifest.sagas.js
@@ -38,6 +38,7 @@ manifest('main.sagas', {}, globalRegistry => {
     sagasRegistry.set('neos-ui/CR/NodeOperations/hideNode', {saga: crNodeOperations.hideNode});
     sagasRegistry.set('neos-ui/CR/NodeOperations/showNode', {saga: crNodeOperations.showNode});
     sagasRegistry.set('neos-ui/CR/NodeOperations/removeNodeIfConfirmed', {saga: crNodeOperations.removeNodeIfConfirmed});
+    sagasRegistry.set('neos-ui/CR/NodeOperations/reloadState', {saga: crNodeOperations.reloadState});
 
     sagasRegistry.set('neos-ui/Publish/watchChangeBaseWorkspace', {saga: publish.watchChangeBaseWorkspace});
     sagasRegistry.set('neos-ui/Publish/discardIfConfirmed', {saga: publish.discardIfConfirmed});
@@ -60,7 +61,6 @@ manifest('main.sagas', {}, globalRegistry => {
 
     sagasRegistry.set('neos-ui/UI/PageTree/watchCurrentDocument', {saga: uiPageTree.watchCurrentDocument});
     sagasRegistry.set('neos-ui/UI/PageTree/watchNodeCreated', {saga: uiPageTree.watchNodeCreated});
-    sagasRegistry.set('neos-ui/UI/PageTree/watchReloadTree', {saga: uiPageTree.watchReloadTree});
     sagasRegistry.set('neos-ui/UI/PageTree/watchRequestChildrenForContextPath', {saga: uiPageTree.watchRequestChildrenForContextPath});
     sagasRegistry.set('neos-ui/UI/PageTree/watchSearch', {saga: uiPageTree.watchSearch});
     sagasRegistry.set('neos-ui/UI/PageTree/watchToggle', {saga: uiPageTree.watchToggle});

--- a/packages/react-ui-components/src/DropDown/contents.js
+++ b/packages/react-ui-components/src/DropDown/contents.js
@@ -28,7 +28,7 @@ const ShallowDropDownContents = props => {
             role="listbox"
             onClick={closeDropDown}
             >
-            {children}
+            {isOpen && children}
         </ul>
     );
 };

--- a/packages/react-ui-components/src/Tabs/tabs.js
+++ b/packages/react-ui-components/src/Tabs/tabs.js
@@ -118,7 +118,7 @@ export default class Tabs extends PureComponent {
                             role="tabpanel"
                             aria-hidden={isActive ? 'false' : 'true'}
                             >
-                            {panel}
+                            {isActive && panel}
                         </div>
                     );
                 })}

--- a/packages/react-ui-components/src/Tree/node.js
+++ b/packages/react-ui-components/src/Tree/node.js
@@ -149,6 +149,7 @@ export class Header extends PureComponent {
             isHidden,
             isHiddenInIndex,
             isDirty,
+            isLoading,
             label,
             icon,
             iconLabel,
@@ -164,7 +165,7 @@ export class Header extends PureComponent {
             canDrop,
             ...restProps
         } = this.props;
-        const rest = omit(restProps, ['onToggle', 'isCollapsed', 'isLoading', 'hasError', 'isDragging', 'dragForbidden']);
+        const rest = omit(restProps, ['onToggle', 'isCollapsed', 'hasError', 'isDragging', 'dragForbidden']);
         const dataClassNames = mergeClassNames({
             [theme.header__data]: true,
             [theme['header__data--isActive']]: isActive,
@@ -212,7 +213,7 @@ export class Header extends PureComponent {
                             mode="after"
                             />
                     )}
-                    {hasChildren ? this.renderCollapseControl() : null}
+                    {hasChildren || isLoading ? this.renderCollapseControl() : null}
                 </div>
             </div>
         );


### PR DESCRIPTION
- Eases the pain of slow nodes state rendering by fetching default nodes asynchronously (#1579)
- Unify logic for re-fetching nodes state
- Reload nodes when switching workspaces, redirect to correct node if it doesn't exist in target (Fixes: #1464)
- Reloads the tree in one gulp, without extra requests
- Fixes loading indicator
- Loads default nodes + toggled nodes + nodes up to the current document node in one request
- Parallelizes JSON fetch requests for translations and other stuff (Improves #1020)
- Don't render hidden elements (improves render time from 1100ms down to 120-360ms!) (Fixes: #887 )