### PR TITLE
BUGFIX: make moving of nodes more robust

### DIFF
--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractMove.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractMove.php
@@ -11,6 +11,7 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\Node;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\RemoveNode;
 
@@ -42,5 +43,18 @@ abstract class AbstractMove extends AbstractStructuralChange
         $this->feedbackCollection->add($removeNode);
 
         parent::finish($this->getSubject());
+    }
+
+    protected static function cloneNodeWithNodeData(NodeInterface $node)
+    {
+        if ($node instanceof Node) {
+            $originalNode = $node;
+            $node = clone $originalNode;
+            $node->setNodeData(clone $originalNode->getNodeData());
+            return $node;
+        } else {
+            // do a best-effort clone
+            return clone $node;
+        }
     }
 }

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/MoveAfter.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/MoveAfter.php
@@ -28,7 +28,7 @@ class MoveAfter extends AbstractMove
     public function apply()
     {
         if ($this->canApply()) {
-            $before = clone $this->getSubject();
+            $before = self::cloneNodeWithNodeData($this->getSubject());
             $parent = $before->getParent();
 
             $this->getSubject()->moveAfter($this->getSiblingNode());

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/MoveBefore.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/MoveBefore.php
@@ -28,7 +28,7 @@ class MoveBefore extends AbstractMove
     public function apply()
     {
         if ($this->canApply()) {
-            $before = clone $this->getSubject();
+            $before = self::cloneNodeWithNodeData($this->getSubject());
             $parent = $before->getParent();
 
             $this->getSubject()->moveBefore($this->getSiblingNode());

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/MoveInto.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/MoveInto.php
@@ -28,7 +28,7 @@ class MoveInto extends AbstractMove
     public function apply()
     {
         if ($this->canApply()) {
-            $before = clone $this->getSubject();
+            $before = self::cloneNodeWithNodeData($this->getSubject());
             $parent = $before->getParent();
 
             $this->getSubject()->moveInto($this->getParentNode());


### PR DESCRIPTION
## Problem Description

when moving nodes, it sometimes happened that the node
on the original location was not removed.

## Root Cause Analysis

It turned out that the "Remove" Feedback (which is part
of the feedbacks returned on move) got transmitted
with the wrong contextNodePath (e.g. where the node was
*already moved*); thus it could not be removed in the UI.

For me in some cases it correctly worked; though I was
not able to track the issue down to specific cases. In
90% of the cases it did NOT work. I tested with a custom
4-column element; where moving in the columns 2-4 reliably
triggered the error. Interestingly, moving from Column1
mostly worked...

## Solution Fix

the "clone" only clones the node; without cloning the
corresponding NodeData object. The fix is to additionally
clone the NodeData object itself; thus we detach it
from persistence, thus it keeps the old NodePath (which is what we need).

Interesting this has not happened much more for people :-)

<!--
Thanks for your contribution, we appreciate it!
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->

