### PR TITLE
BUGFIX: dimension switcher shouldn't disappear when focusing document node in content tree

### DIFF
--- a/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
@@ -28,7 +28,15 @@ export const isDocumentNodeSelectedSelector = createSelector(
     }
 );
 
-export const hasFocusedContentNode = createSelector(focused, focused => Boolean(focused));
+export const hasFocusedContentNode = createSelector(
+    [
+        focused,
+        getCurrentContentCanvasContextPath
+    ],
+    (focused, currentContentCanvasContextPath) => {
+        return Boolean(focused && (focused !== currentContentCanvasContextPath));
+    }
+);
 
 export const nodeByContextPath = state => contextPath =>
     $get(['cr', 'nodes', 'byContextPath', contextPath], state);


### PR DESCRIPTION
Steps to reproduce:
1. focus the document node in content tree
2. see the dimension switcher dissapear