### PR TITLE
BUGFIX: Fix PHP 7.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ language: php
 
 php:
   - '7.0'
-  - '7.1'
 
 services:
   - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ notifications:
 language: php
 
 php:
+  - '7.0'
   - '7.1'
 
 services:

--- a/Classes/Neos/Neos/Ui/Controller/BackendServiceController.php
+++ b/Classes/Neos/Neos/Ui/Controller/BackendServiceController.php
@@ -107,7 +107,7 @@ class BackendServiceController extends ActionController
      * @param ResponseInterface $response
      * @return void
      */
-    public function initializeController(RequestInterface $request, ResponseInterface $response): void
+    public function initializeController(RequestInterface $request, ResponseInterface $response)
     {
         parent::initializeController($request, $response);
         $this->feedbackCollection->setControllerContext($this->getControllerContext());
@@ -119,7 +119,7 @@ class BackendServiceController extends ActionController
      * @param string $documentNodeContextPath
      * @return void
      */
-    protected function updateWorkspaceInfo(string $documentNodeContextPath): void
+    protected function updateWorkspaceInfo(string $documentNodeContextPath)
     {
         $updateWorkspaceInfo = new UpdateWorkspaceInfo();
         $documentNode = $this->nodeService->getNodeFromContextPath($documentNodeContextPath, null, null, true);
@@ -136,7 +136,7 @@ class BackendServiceController extends ActionController
      * @param ChangeCollection $changes
      * @return void
      */
-    public function changeAction(ChangeCollection $changes): void
+    public function changeAction(ChangeCollection $changes)
     {
         try {
             $count = $changes->count();
@@ -164,7 +164,7 @@ class BackendServiceController extends ActionController
      * @param string $targetWorkspaceName
      * @return void
      */
-    public function publishAction(array $nodeContextPaths, string $targetWorkspaceName): void
+    public function publishAction(array $nodeContextPaths, string $targetWorkspaceName)
     {
         try {
             $targetWorkspace = $this->workspaceRepository->findOneByName($targetWorkspaceName);
@@ -197,7 +197,7 @@ class BackendServiceController extends ActionController
      * @param array $nodeContextPaths
      * @return void
      */
-    public function discardAction(array $nodeContextPaths): void
+    public function discardAction(array $nodeContextPaths)
     {
         try {
             foreach ($nodeContextPaths as $contextPath) {
@@ -255,7 +255,7 @@ class BackendServiceController extends ActionController
      * @return void
      * @throws \Exception
      */
-    public function changeBaseWorkspaceAction(string $targetWorkspaceName, NodeInterface $documentNode): void
+    public function changeBaseWorkspaceAction(string $targetWorkspaceName, NodeInterface $documentNode)
     {
         try {
             $targetWorkspace = $this->workspaceRepository->findOneByName($targetWorkspaceName);
@@ -337,7 +337,7 @@ class BackendServiceController extends ActionController
      * @param boolean $includeRoot
      * @return void
      */
-    public function loadTreeAction(NodeTreeBuilder $nodeTreeArguments, $includeRoot = false): void
+    public function loadTreeAction(NodeTreeBuilder $nodeTreeArguments, $includeRoot = false)
     {
         $nodeTreeArguments->setControllerContext($this->controllerContext);
         $this->view->assign('value', $nodeTreeArguments->build($includeRoot));

--- a/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/Redirect.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/Redirect.php
@@ -33,7 +33,7 @@ class Redirect implements FeedbackInterface
      * @param NodeInterface $node
      * @return void
      */
-    public function setNode(NodeInterface $node): void
+    public function setNode(NodeInterface $node)
     {
         $this->node = $node;
     }


### PR DESCRIPTION
Removes incompatible return type annotations (`void`) and adds PHP 7.0
to Travis CI to catch bugs for PHP 7.0.