### PR TITLE
TASK: Remove quickfix for chrome border radius

### DIFF
--- a/packages/neos-ui/src/styleHostOnly.css
+++ b/packages/neos-ui/src/styleHostOnly.css
@@ -33,9 +33,3 @@ hr {
     margin: 0;
     border: 1px solid #3f3f3f;
 }
-
-
-/* Chrome v62 adds border-radius: 4px by default on buttons in OS X. This resets it until normalize is updated */
-button {
-    border-radius: 0;
-}


### PR DESCRIPTION
closes #1202

Google reverted this change so this isn't needed anymore.
Can anyone with a Mac test if this is really the case?