### PR TITLE
BUGFIX: Pass placeholder to TextArea

### DIFF
--- a/packages/neos-ui-editors/src/Editors/TextArea/index.js
+++ b/packages/neos-ui-editors/src/Editors/TextArea/index.js
@@ -6,7 +6,9 @@ const defaultOptions = {
     disabled: false,
     maxlength: null,
     readonly: false,
-    placeholder: ''
+    placeholder: '',
+    minRows: 2,
+    expandedRows: 6
 };
 
 const TextAreaEditor = props => {
@@ -23,6 +25,8 @@ const TextAreaEditor = props => {
         maxLength={finalOptions.maxlength}
         readOnly={finalOptions.readonly}
         placeholder={finalOptions.placeholder}
+        minRows={finalOptions.minRows}
+        expandedRows={finalOptions.expandedRows}
         />
     );
 };

--- a/packages/neos-ui-editors/src/Editors/TextArea/index.js
+++ b/packages/neos-ui-editors/src/Editors/TextArea/index.js
@@ -5,7 +5,8 @@ import TextArea from '@neos-project/react-ui-components/src/TextArea/';
 const defaultOptions = {
     disabled: false,
     maxlength: null,
-    readonly: false
+    readonly: false,
+    placeholder: ''
 };
 
 const TextAreaEditor = props => {
@@ -21,6 +22,7 @@ const TextAreaEditor = props => {
         disabled={finalOptions.disabled}
         maxLength={finalOptions.maxlength}
         readOnly={finalOptions.readonly}
+        placeholder={finalOptions.placeholder}
         />
     );
 };

--- a/packages/neos-ui-editors/src/Editors/TextArea/index.js
+++ b/packages/neos-ui-editors/src/Editors/TextArea/index.js
@@ -12,7 +12,7 @@ const defaultOptions = {
 };
 
 const TextAreaEditor = props => {
-    const {id, value, commit, highlight, options} = props;
+    const {id, value, commit, highlight, options, validationErrors} = props;
 
     const finalOptions = Object.assign({}, defaultOptions, options);
 
@@ -27,6 +27,7 @@ const TextAreaEditor = props => {
         placeholder={finalOptions.placeholder}
         minRows={finalOptions.minRows}
         expandedRows={finalOptions.expandedRows}
+        validationErrors={validationErrors}
         />
     );
 };

--- a/packages/neos-ui-editors/src/Editors/TextArea/index.js
+++ b/packages/neos-ui-editors/src/Editors/TextArea/index.js
@@ -36,7 +36,8 @@ TextAreaEditor.propTypes = {
     value: PropTypes.string,
     highlight: PropTypes.bool,
     commit: PropTypes.func.isRequired,
-    options: PropTypes.object
+    options: PropTypes.object,
+    validationErrors: PropTypes.array
 };
 
 export default TextAreaEditor;

--- a/packages/react-ui-components/src/TextArea/textArea.js
+++ b/packages/react-ui-components/src/TextArea/textArea.js
@@ -59,7 +59,7 @@ class TextArea extends PureComponent {
         minRows: PropTypes.number,
 
         /**
-         * Optional number to set the minRows of the TextArea if expanded
+         * Optional number to set the expandedRows of the TextArea if expanded
          */
         expandedRows: PropTypes.number
     };


### PR DESCRIPTION
The Placeholder option wasn't not correctly passed to the textarea

This also passes the expandedRows and minRows to the texarea

closes #1660
closes #1487
