### PR TITLE
BUGFIX: Let the SelectboxInput look good in firefox

### DIFF
--- a/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/style.css
+++ b/packages/neos-ui-ckeditor-bindings/src/EditorToolbar/style.css
@@ -20,7 +20,7 @@
     z-index: var(--zIndex-SecondaryToolbar-LinkIconButtonFlyout);
     width: 460px;
     border: var(--spacing-Half) solid var(--colors-ContrastDarker);
-    height: calc(var(--spacing-GoldenUnit) + var(--spacing-Full) + 1px);
+    height: calc(var(--spacing-GoldenUnit) + var(--spacing-Full));
 }
 
 .linkIconButton__item {


### PR DESCRIPTION
The border is 8px top and bottom so I think it is correct
that the height of this is xx + 16px (spacing-Full)

closes #1609