### PR TITLE
Fix: preview mode with scrollbars

### DIFF
--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -86,16 +86,30 @@ export default class ContentCanvas extends PureComponent {
         const height = $get('height', currentEditPreviewModeConfiguration);
 
         const canvasContentStyle = {};
+        const inlineStyles = {};
+        const canvasContentOnlyStyle = {};
+
+        if (width) {
+            inlineStyles.width = width;
+            canvasContentOnlyStyle.overflow = 'auto';
+        }
+
+        if (height) {
+            inlineStyles.height = height;
+            canvasContentOnlyStyle.overflow = 'auto';
+        }
+
         if (backgroundColor) {
             canvasContentStyle.background = backgroundColor;
         }
 
         // ToDo: Is the `[data-__neos__hook]` attr used?
         return (
-            <div className={classNames} style={canvasContentStyle}>
+            <div className={classNames} style={{...canvasContentStyle, ...canvasContentOnlyStyle}}>
                 <div id="centerArea"/>
                 <div
                     className={style.contentCanvas__itemWrapper}
+                    style={inlineStyles}
                     data-__neos__hook="contentCanvas"
                     >
                     {src && (<Frame
@@ -109,8 +123,6 @@ export default class ContentCanvas extends PureComponent {
                         onLoad={this.handleFrameAccess}
                         role="region"
                         aria-live="assertive"
-                        height={height}
-                        width={width}
                         >
                         {InlineUI && <InlineUI/>}
                     </Frame>)}

--- a/packages/react-ui-components/src/Frame/frame.js
+++ b/packages/react-ui-components/src/Frame/frame.js
@@ -49,9 +49,7 @@ export default class Frame extends PureComponent {
             'theme',
             'children',
             'onLoad',
-            'src',
-            'height',
-            'width'
+            'src'
         ]);
 
         return <iframe ref={this.handleReference} onLoad={this.handleLoad} {...rest}/>;
@@ -78,15 +76,6 @@ export default class Frame extends PureComponent {
 
         // Center iframe
         iframeHtml.style.margin = '0 auto';
-
-        // Set height and width inline to make the iframe scrollable if needed
-        if (this.props.width !== undefined) {
-            iframeHtml.style.width = this.props.width + 'px';
-        }
-
-        if (this.props.height !== undefined) {
-            iframeHtml.style.height = this.props.height + 'px';
-        }
 
         ReactDOM.unstable_renderSubtreeIntoContainer(this, contents, mountTarget, () => {
             this.props.contentDidUpdate(win, doc, mountTarget);


### PR DESCRIPTION
# Fixes preview mode problems after #1662: 

* Setting width and height on the html element led to false behaviour by using the media queries referring to the browser window not the (preview) viewport size. 
* Elements with fixed or absolute position had the wrong reference container (like on the Neos.Demo) 
* animation of the Preview Frame was broken.

Reverted #1662 and added overflow: auto to surrounding container if width or height are set to keep scrollbars in small browser windows.

## before:
![before](https://user-images.githubusercontent.com/10942229/36855078-f7c2c402-1d72-11e8-9a03-960587acae2f.png)

## after: 
![after](https://user-images.githubusercontent.com/10942229/36855084-faa5273c-1d72-11e8-81ab-c982f3d646ba.png)


