### PR TITLE
BUGFIX: Hide empty groups in inspector

### DIFF
--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
@@ -34,7 +34,7 @@ export default class TabPanel extends PureComponent {
             <Tabs.Panel theme={{panel: style.inspectorTabPanel}}>
                 <SelectedElement/>
                 {
-                    groups.filter(g => ($get('properties', g) && $get('properties', g).filter(this.isPropertyEnabled).count()) || $get('views', g)).map(group => (
+                    groups.filter(g => ($get('properties', g) && $get('properties', g).filter(this.isPropertyEnabled).count()) || ($get('views', g) && $get('views', g).count())).map(group => (
                         <PropertyGroup
                             key={$get('id', group)}
                             label={$get('label', group)}


### PR DESCRIPTION
Hiding empty groups in inspector view

Added not empty condition to view that got lost in d4f8a09

