### PR TITLE
WIP FEATURE: Show Backend Modules inside of the new UI

### DIFF
--- a/packages/neos-ui/src/Containers/App.js
+++ b/packages/neos-ui/src/Containers/App.js
@@ -17,6 +17,17 @@ const App = ({globalRegistry, menu}) => {
     const RightSideBar = containerRegistry.get('RightSideBar');
     const LoadingIndicator = containerRegistry.get('SecondaryToolbar/LoadingIndicator');
 
+    const isBackendModule = false;
+
+    if (isBackendModule) {
+        return (
+            <div>
+                <PrimaryToolbar isBackendModule={isBackendModule}/>
+                <Drawer menuData={menu}/>
+            </div>
+        );
+    }
+
     // HINT: the SecondaryToolbar must be *BELOW* the
     // ContentCanvas; to ensure the SecondaryToolbar is rendered
     // afterwards and can overlay the ContentCanvas

--- a/packages/neos-ui/src/Containers/App.js
+++ b/packages/neos-ui/src/Containers/App.js
@@ -17,13 +17,14 @@ const App = ({globalRegistry, menu}) => {
     const RightSideBar = containerRegistry.get('RightSideBar');
     const LoadingIndicator = containerRegistry.get('SecondaryToolbar/LoadingIndicator');
 
-    const isBackendModule = false;
+    const isBackendModule = true;
 
     if (isBackendModule) {
         return (
             <div>
                 <PrimaryToolbar isBackendModule={isBackendModule}/>
-                <Drawer menuData={menu}/>
+                <ContentCanvas isBackendModule={isBackendModule}/>
+                <Drawer menuData={menu} isBackendModule={isBackendModule}/>
             </div>
         );
     }

--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -42,6 +42,7 @@ export default class ContentCanvas extends PureComponent {
         requestRegainControl: PropTypes.func.isRequired,
         requestLogin: PropTypes.func.isRequired,
         currentEditPreviewMode: PropTypes.string.isRequired,
+        isBackendModule: PropTypes.bool,
 
         editPreviewModes: PropTypes.object.isRequired,
         guestFrameRegistry: PropTypes.object.isRequired
@@ -68,7 +69,8 @@ export default class ContentCanvas extends PureComponent {
             currentEditPreviewMode,
             editPreviewModes,
             guestFrameRegistry,
-            backgroundColor
+            backgroundColor,
+            isBackendModule
         } = this.props;
         const {isVisible} = this.state;
         const classNames = mergeClassNames({
@@ -77,7 +79,8 @@ export default class ContentCanvas extends PureComponent {
             [style['contentCanvas--isFringeRight']]: isFringeRight,
             [style['contentCanvas--isMovedDown']]: !isEditModePanelHidden,
             [style['contentCanvas--isFullScreen']]: isFullScreen,
-            [style['contentCanvas--isHidden']]: !isVisible
+            [style['contentCanvas--isHidden']]: !isVisible,
+            [style['contentCanvas--fullWidth']]: isBackendModule
         });
         const InlineUI = guestFrameRegistry.get('InlineUIComponent');
         const currentEditPreviewModeConfiguration = editPreviewModes[currentEditPreviewMode];

--- a/packages/neos-ui/src/Containers/ContentCanvas/style.css
+++ b/packages/neos-ui/src/Containers/ContentCanvas/style.css
@@ -13,6 +13,9 @@
         position: absolute;
     }
 }
+.contentCanvas--fullWidth {
+    padding: 41px 0 0;
+}
 .contentCanvas--isFringeLeft {
     padding-left: 0;
 }

--- a/packages/neos-ui/src/Containers/Drawer/MenuItem/index.js
+++ b/packages/neos-ui/src/Containers/Drawer/MenuItem/index.js
@@ -21,9 +21,9 @@ export default class MenuItem extends PureComponent {
     };
 
     handleClick = () => {
-        const {uri, target, onClick} = this.props;
+        const {uri, onClick} = this.props;
 
-        onClick(target, uri);
+        onClick(uri);
     }
 
     render() {

--- a/packages/neos-ui/src/Containers/Drawer/MenuItemGroup/index.js
+++ b/packages/neos-ui/src/Containers/Drawer/MenuItemGroup/index.js
@@ -33,9 +33,9 @@ export default class MenuItemGroup extends PureComponent {
     };
 
     handleClick = () => {
-        const {uri, target, onClick} = this.props;
+        const {uri, onClick} = this.props;
 
-        onClick(target, uri);
+        onClick(uri);
     }
 
     render() {

--- a/packages/neos-ui/src/Containers/Drawer/index.js
+++ b/packages/neos-ui/src/Containers/Drawer/index.js
@@ -10,8 +10,6 @@ import {getVersion} from '@neos-project/utils-helpers';
 import MenuItemGroup from './MenuItemGroup/index';
 import style from './style.css';
 
-const TARGET_WINDOW = 'Window';
-const TARGET_CONTENT_CANVAS = 'ContentCanvas';
 const THRESHOLD_MOUSE_LEAVE = 500;
 
 @connect($transform({
@@ -80,19 +78,15 @@ export default class Drawer extends PureComponent {
         }
     }
 
-    handleMenuItemClick = (target, uri) => {
+    handleMenuItemClick = uri => {
         const {setContentCanvasSrc, hideDrawer} = this.props;
+        const targetURL = new URL(uri);
 
-        switch (target) {
-            case TARGET_CONTENT_CANVAS:
-                setContentCanvasSrc(uri);
-                hideDrawer();
-                break;
-
-            case TARGET_WINDOW:
-            default:
-                window.location.href = uri;
-                break;
+        if (targetURL.pathname === '/neos') {
+            window.location = uri;
+        } else {
+            setContentCanvasSrc(uri);
+            hideDrawer();
         }
     }
 

--- a/packages/neos-ui/src/Containers/Drawer/index.js
+++ b/packages/neos-ui/src/Containers/Drawer/index.js
@@ -80,14 +80,20 @@ export default class Drawer extends PureComponent {
 
     handleMenuItemClick = uri => {
         const {setContentCanvasSrc, hideDrawer} = this.props;
-        const targetURL = new URL(uri);
 
-        if (targetURL.pathname === '/neos') {
-            window.location = uri;
-        } else {
-            setContentCanvasSrc(uri);
-            hideDrawer();
+        try {
+            const targetURL = new URL(uri);
+            if (targetURL.pathname === '/neos') {
+                window.location = uri;
+                return;
+            }
+        } catch (e) {
+            // Move on, we need the next step not only
+            // when this fails, so I let the block empty
         }
+
+        setContentCanvasSrc(uri);
+        hideDrawer();
     }
 
     render() {

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/index.js
@@ -18,14 +18,16 @@ export default class PrimaryToolbar extends PureComponent {
     static propTypes = {
         containerRegistry: PropTypes.object.isRequired,
 
-        isHidden: PropTypes.bool.isRequired
+        isHidden: PropTypes.bool.isRequired,
+        isBackendModule: PropTypes.bool
     };
 
     render() {
-        const {isHidden, containerRegistry} = this.props;
+        const {isHidden, containerRegistry, isBackendModule} = this.props;
 
-        const PrimaryToolbarLeft = containerRegistry.getChildren('PrimaryToolbar/Left');
-        const PrimaryToolbarRight = containerRegistry.getChildren('PrimaryToolbar/Right');
+        // TODO: Find a generic way to identify the drawer and user settings
+        const PrimaryToolbarLeft = isBackendModule ? [containerRegistry.getChildren('PrimaryToolbar/Left')[0]] : containerRegistry.getChildren('PrimaryToolbar/Left');
+        const PrimaryToolbarRight = isBackendModule ? [containerRegistry.getChildren('PrimaryToolbar/Right')[0]] : containerRegistry.getChildren('PrimaryToolbar/Right');
 
         const classNames = mergeClassNames({
             [style.primaryToolbar]: true,


### PR DESCRIPTION
This will be needed when we get this: https://github.com/neos/neos-development-collection/pull/1937

TODO:
routing - e.g. instead of `tld.com/neos/content?node=path` something like `tld.com/neos/module?module=myModule` 
dont use hardcoded parameter