### PR TITLE
BUGFIX: make moving of nodes more robust

### DIFF
--- a/Classes/Neos/Neos/Ui/Controller/BackendServiceController.php
+++ b/Classes/Neos/Neos/Ui/Controller/BackendServiceController.php
@@ -107,7 +107,7 @@ class BackendServiceController extends ActionController
      * @param ResponseInterface $response
      * @return void
      */
-    public function initializeController(RequestInterface $request, ResponseInterface $response): void
+    public function initializeController(RequestInterface $request, ResponseInterface $response)
     {
         parent::initializeController($request, $response);
         $this->feedbackCollection->setControllerContext($this->getControllerContext());
@@ -119,7 +119,7 @@ class BackendServiceController extends ActionController
      * @param string $documentNodeContextPath
      * @return void
      */
-    protected function updateWorkspaceInfo(string $documentNodeContextPath): void
+    protected function updateWorkspaceInfo(string $documentNodeContextPath)
     {
         $updateWorkspaceInfo = new UpdateWorkspaceInfo();
         $documentNode = $this->nodeService->getNodeFromContextPath($documentNodeContextPath, null, null, true);
@@ -136,7 +136,7 @@ class BackendServiceController extends ActionController
      * @param ChangeCollection $changes
      * @return void
      */
-    public function changeAction(ChangeCollection $changes): void
+    public function changeAction(ChangeCollection $changes)
     {
         try {
             $count = $changes->count();
@@ -164,7 +164,7 @@ class BackendServiceController extends ActionController
      * @param string $targetWorkspaceName
      * @return void
      */
-    public function publishAction(array $nodeContextPaths, string $targetWorkspaceName): void
+    public function publishAction(array $nodeContextPaths, string $targetWorkspaceName)
     {
         try {
             $targetWorkspace = $this->workspaceRepository->findOneByName($targetWorkspaceName);
@@ -197,7 +197,7 @@ class BackendServiceController extends ActionController
      * @param array $nodeContextPaths
      * @return void
      */
-    public function discardAction(array $nodeContextPaths): void
+    public function discardAction(array $nodeContextPaths)
     {
         try {
             foreach ($nodeContextPaths as $contextPath) {
@@ -255,7 +255,7 @@ class BackendServiceController extends ActionController
      * @return void
      * @throws \Exception
      */
-    public function changeBaseWorkspaceAction(string $targetWorkspaceName, NodeInterface $documentNode): void
+    public function changeBaseWorkspaceAction(string $targetWorkspaceName, NodeInterface $documentNode)
     {
         try {
             $targetWorkspace = $this->workspaceRepository->findOneByName($targetWorkspaceName);
@@ -337,7 +337,7 @@ class BackendServiceController extends ActionController
      * @param boolean $includeRoot
      * @return void
      */
-    public function loadTreeAction(NodeTreeBuilder $nodeTreeArguments, $includeRoot = false): void
+    public function loadTreeAction(NodeTreeBuilder $nodeTreeArguments, $includeRoot = false)
     {
         $nodeTreeArguments->setControllerContext($this->controllerContext);
         $this->view->assign('value', $nodeTreeArguments->build($includeRoot));

--- a/Classes/Neos/Neos/Ui/Domain/Model/AbstractFeedback.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/AbstractFeedback.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Neos\Neos\Ui\Domain\Model;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Mvc\Controller\ControllerContext;
+
+abstract class AbstractFeedback implements FeedbackInterface
+{
+    public function serialize(ControllerContext $controllerContext)
+    {
+        return [
+            'type' => $this->getType(),
+            'description' => $this->getDescription(),
+            'payload' => $this->serializePayload($controllerContext)
+        ];
+    }
+}

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractCopy.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractCopy.php
@@ -24,18 +24,6 @@ abstract class AbstractCopy extends AbstractStructuralChange
     protected $contentRepositoryNodeService;
 
     /**
-     * Checks whether this change can be applied to the subject
-     *
-     * @return boolean
-     */
-    public function canApply()
-    {
-        $nodeType = $this->getSubject()->getNodeType();
-
-        return $this->getParentNode()->isNodeTypeAllowedAsChildNode($nodeType);
-    }
-
-    /**
      * Generate a unique node name for the copied node
      *
      * @param NodeInterface $parentNode

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractMove.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractMove.php
@@ -17,17 +17,6 @@ use Neos\Neos\Ui\Domain\Model\Feedback\Operations\RemoveNode;
 
 abstract class AbstractMove extends AbstractStructuralChange
 {
-    /**
-     * Checks whether this change can be applied to the subject
-     *
-     * @return boolean
-     */
-    public function canApply()
-    {
-        $nodeType = $this->getSubject()->getNodeType();
-
-        return $this->getParentNode()->isNodeTypeAllowedAsChildNode($nodeType);
-    }
 
     /**
      * Perform finish tasks - needs to be called from inheriting class on `apply`
@@ -42,6 +31,7 @@ abstract class AbstractMove extends AbstractStructuralChange
 
         $this->feedbackCollection->add($removeNode);
 
+        // $this->getSubject() is the moved node at the NEW location!
         parent::finish($this->getSubject());
     }
 

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractStructuralChange.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/AbstractStructuralChange.php
@@ -48,11 +48,6 @@ abstract class AbstractStructuralChange extends AbstractChange
     /**
      * @var NodeInterface
      */
-    protected $cachedParentNode = null;
-
-    /**
-     * @var NodeInterface
-     */
     protected $cachedSiblingNode = null;
 
     /**
@@ -74,33 +69,15 @@ abstract class AbstractStructuralChange extends AbstractChange
     }
 
     /**
-     * Get the parent node dom address
+     * Get the DOM address of the closest RENDERED node in the DOM tree.
+     *
+     * DOES NOT HAVE TO BE THE PARENT NODE!
      *
      * @return RenderedNodeDomAddress
      */
     public function getParentDomAddress()
     {
         return $this->parentDomAddress;
-    }
-
-    /**
-     * Get the parent node
-     *
-     * @return NodeInterface
-     */
-    public function getParentNode()
-    {
-        if ($this->parentDomAddress === null) {
-            return null;
-        }
-
-        if ($this->cachedParentNode === null) {
-            $this->cachedParentNode = $this->nodeService->getNodeFromContextPath(
-                $this->parentDomAddress->getContextPath()
-            );
-        }
-
-        return $this->cachedParentNode;
     }
 
     /**
@@ -167,9 +144,16 @@ abstract class AbstractStructuralChange extends AbstractChange
         $this->updateWorkspaceInfo();
 
         if ($node->getNodeType()->isOfType('Neos.Neos:Content') && ($this->getParentDomAddress() || $this->getSiblingDomAddress())) {
+
+            // we can ONLY render out of band if:
+            // 1) the parent of our new (or copied or moved) node is a ContentCollection; so we can directly update an element of this content collection
             if ($node->getParent()->getNodeType()->isOfType('Neos.Neos:ContentCollection') &&
+
+                // 2) the parent DOM address (i.e. the closest RENDERED node in DOM is actually the ContentCollection; and
+                //    no other node in between
                 $this->getParentDomAddress() &&
-                $this->getParentDomAddress()->getFusionPath()
+                $this->getParentDomAddress()->getFusionPath() &&
+                $this->getParentDomAddress()->getContextPath() === $node->getParent()->getContextPath()
             ) {
                 $renderContentOutOfBand = new RenderContentOutOfBand();
                 $renderContentOutOfBand->setNode($node);

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/CopyAfter.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/CopyAfter.php
@@ -13,6 +13,20 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
 
 class CopyAfter extends AbstractCopy
 {
+
+    /**
+     * "Subject" is the to-be-copied node; the "sibling" node is the node after which the "Subject" should be copied.
+     *
+     * @return boolean
+     */
+    public function canApply()
+    {
+        $nodeType = $this->getSubject()->getNodeType();
+
+        return $this->getSiblingNode()->getParent()->isNodeTypeAllowedAsChildNode($nodeType);
+    }
+
+
     public function getMode()
     {
         return 'after';
@@ -26,7 +40,7 @@ class CopyAfter extends AbstractCopy
     public function apply()
     {
         if ($this->canApply()) {
-            $nodeName = $this->generateUniqueNodeName($this->getParentNode());
+            $nodeName = $this->generateUniqueNodeName($this->getSiblingNode()->getParent());
             $node = $this->getSubject()->copyAfter($this->getSiblingNode(), $nodeName);
             $this->finish($node);
         }

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/CopyBefore.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/CopyBefore.php
@@ -13,6 +13,19 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
 
 class CopyBefore extends AbstractCopy
 {
+    /**
+     * "Subject" is the to-be-copied node; the "sibling" node is the node after which the "Subject" should be copied.
+     *
+     * @return boolean
+     */
+    public function canApply()
+    {
+        $nodeType = $this->getSubject()->getNodeType();
+
+        return $this->getSiblingNode()->getParent()->isNodeTypeAllowedAsChildNode($nodeType);
+    }
+
+
     public function getMode()
     {
         return 'before';
@@ -26,7 +39,7 @@ class CopyBefore extends AbstractCopy
     public function apply()
     {
         if ($this->canApply()) {
-            $nodeName = $this->generateUniqueNodeName($this->getParentNode());
+            $nodeName = $this->generateUniqueNodeName($this->getSiblingNode()->getParent());
             $node = $this->getSubject()->copyBefore($this->getSiblingNode(), $nodeName);
             $this->finish($node);
         }

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/CopyInto.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/CopyInto.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Neos\Ui\Domain\Model\Changes;
 
 /*
@@ -11,8 +12,57 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+
 class CopyInto extends AbstractCopy
 {
+
+
+    /**
+     * @var string
+     */
+    protected $parentContextPath;
+
+    /**
+     * @var NodeInterface
+     */
+    protected $cachedParentNode;
+
+    /**
+     * @param string $parentContextPath
+     */
+    public function setParentContextPath($parentContextPath)
+    {
+        $this->parentContextPath = $parentContextPath;
+    }
+
+    /**
+     * @return NodeInterface
+     */
+    public function getParentNode()
+    {
+        if ($this->cachedParentNode === null) {
+            $this->cachedParentNode = $this->nodeService->getNodeFromContextPath(
+                $this->parentContextPath
+            );
+        }
+
+        return $this->cachedParentNode;
+    }
+
+    /**
+     * "Subject" is the to-be-copied node; the "parent" node is the new parent
+     *
+     * @return boolean
+     */
+    public function canApply()
+    {
+        $nodeType = $this->getSubject()->getNodeType();
+
+        return $this->getParentNode()->isNodeTypeAllowedAsChildNode($nodeType);
+    }
+
+
     public function getMode()
     {
         return 'into';

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/Create.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/Create.php
@@ -13,6 +13,15 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
 
 class Create extends AbstractCreate
 {
+
+    /**
+     * @param string $parentContextPath
+     */
+    public function setParentContextPath($parentContextPath)
+    {
+        // this method needs to exist; otherwise the TypeConverter breaks.
+    }
+
     /**
      * Get the insertion mode (before|after|into) that is represented by this change
      *

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/MoveAfter.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/MoveAfter.php
@@ -15,6 +15,19 @@ use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
 
 class MoveAfter extends AbstractMove
 {
+    /**
+     * "Subject" is the to-be-moved node; the "sibling" node is the node after which the "Subject" should be copied.
+     *
+     * @return boolean
+     */
+    public function canApply()
+    {
+        $nodeType = $this->getSubject()->getNodeType();
+
+        return $this->getSiblingNode()->getParent()->isNodeTypeAllowedAsChildNode($nodeType);
+    }
+
+
     public function getMode()
     {
         return 'after';

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/MoveBefore.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/MoveBefore.php
@@ -15,6 +15,19 @@ use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
 
 class MoveBefore extends AbstractMove
 {
+
+    /**
+     * "Subject" is the to-be-moved node; the "sibling" node is the node after which the "Subject" should be copied.
+     *
+     * @return boolean
+     */
+    public function canApply()
+    {
+        $nodeType = $this->getSubject()->getNodeType();
+
+        return $this->getSiblingNode()->getParent()->isNodeTypeAllowedAsChildNode($nodeType);
+    }
+
     public function getMode()
     {
         return 'before';

--- a/Classes/Neos/Neos/Ui/Domain/Model/Changes/MoveInto.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Changes/MoveInto.php
@@ -11,13 +11,65 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
 
 class MoveInto extends AbstractMove
 {
+
+    /**
+     * @var string
+     */
+    protected $parentContextPath;
+
+    /**
+     * @var NodeInterface
+     */
+    protected $cachedParentNode;
+
+    /**
+     * @param string $parentContextPath
+     */
+    public function setParentContextPath($parentContextPath)
+    {
+        $this->parentContextPath = $parentContextPath;
+    }
+
+
+    /**
+     * Get the insertion mode (before|after|into) that is represented by this change
+     *
+     * @return string
+     */
     public function getMode()
     {
         return 'into';
+    }
+
+    /**
+     * @return NodeInterface
+     */
+    public function getParentNode()
+    {
+        if ($this->cachedParentNode === null) {
+            $this->cachedParentNode = $this->nodeService->getNodeFromContextPath(
+                $this->parentContextPath
+            );
+        }
+
+        return $this->cachedParentNode;
+    }
+
+    /**
+     * "Subject" is the to-be-copied node; the "parent" node is the new parent
+     *
+     * @return boolean
+     */
+    public function canApply()
+    {
+        $nodeType = $this->getSubject()->getNodeType();
+
+        return $this->getParentNode()->isNodeTypeAllowedAsChildNode($nodeType);
     }
 
     /**

--- a/Classes/Neos/Neos/Ui/Domain/Model/Feedback/AbstractMessageFeedback.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Feedback/AbstractMessageFeedback.php
@@ -11,10 +11,11 @@ namespace Neos\Neos\Ui\Domain\Model\Feedback;
  * source code.
  */
 
+use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 
-abstract class AbstractMessageFeedback implements FeedbackInterface
+abstract class AbstractMessageFeedback extends AbstractFeedback
 {
     /**
      * @var string

--- a/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/NodeCreated.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/NodeCreated.php
@@ -12,11 +12,12 @@ namespace Neos\Neos\Ui\Domain\Model\Feedback\Operations;
  */
 
 use Neos\Neos\Ui\ContentRepository\Service\NodeService;
+use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 
-class NodeCreated implements FeedbackInterface
+class NodeCreated extends AbstractFeedback
 {
     /**
      * @var NodeInterface

--- a/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/Redirect.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/Redirect.php
@@ -3,12 +3,13 @@ namespace Neos\Neos\Ui\Domain\Model\Feedback\Operations;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Neos\Service\LinkingService;
+use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 
-class Redirect implements FeedbackInterface
+class Redirect extends AbstractFeedback
 {
     /**
      * @var NodeInterface

--- a/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/Redirect.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/Redirect.php
@@ -33,7 +33,7 @@ class Redirect implements FeedbackInterface
      * @param NodeInterface $node
      * @return void
      */
-    public function setNode(NodeInterface $node): void
+    public function setNode(NodeInterface $node)
     {
         $this->node = $node;
     }

--- a/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/ReloadContentOutOfBand.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/ReloadContentOutOfBand.php
@@ -12,6 +12,8 @@ namespace Neos\Neos\Ui\Domain\Model\Feedback\Operations;
  */
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Fusion\Exception\MissingFusionObjectException;
+use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Neos\View\FusionView as FusionView;
@@ -19,7 +21,7 @@ use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Neos\Ui\Domain\Model\RenderedNodeDomAddress;
 use Neos\Fusion\Core\Cache\ContentCache;
 
-class ReloadContentOutOfBand implements FeedbackInterface
+class ReloadContentOutOfBand extends AbstractFeedback
 {
     /**
      * @var NodeInterface
@@ -152,5 +154,16 @@ class ReloadContentOutOfBand implements FeedbackInterface
         $fusionView->setFusionPath($nodeDomAddress->getFusionPath());
 
         return $fusionView->render();
+    }
+
+    public function serialize(ControllerContext $controllerContext)
+    {
+        try {
+            return parent::serialize($controllerContext);
+        } catch (MissingFusionObjectException $e) {
+            // in case there was a rendering error, we just try to reload the document as fallback. Needed
+            // e.g. when adding validators to Neos.FormBuilder
+            return (new ReloadDocument())->serialize($controllerContext);
+        }
     }
 }

--- a/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/ReloadDocument.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/ReloadDocument.php
@@ -11,10 +11,11 @@ namespace Neos\Neos\Ui\Domain\Model\Feedback\Operations;
  * source code.
  */
 
+use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 
-class ReloadDocument implements FeedbackInterface
+class ReloadDocument extends AbstractFeedback
 {
 
     /**

--- a/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/RemoveNode.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/RemoveNode.php
@@ -11,11 +11,12 @@ namespace Neos\Neos\Ui\Domain\Model\Feedback\Operations;
  * source code.
  */
 
+use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 
-class RemoveNode implements FeedbackInterface
+class RemoveNode extends AbstractFeedback
 {
     /**
      * @var NodeInterface

--- a/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/RenderContentOutOfBand.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/RenderContentOutOfBand.php
@@ -12,6 +12,8 @@ namespace Neos\Neos\Ui\Domain\Model\Feedback\Operations;
  */
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Fusion\Exception\MissingFusionObjectException;
+use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Neos\View\FusionView as FusionView;
@@ -19,7 +21,7 @@ use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Neos\Ui\Domain\Model\RenderedNodeDomAddress;
 use Neos\Fusion\Core\Cache\ContentCache;
 
-class RenderContentOutOfBand implements FeedbackInterface
+class RenderContentOutOfBand extends AbstractFeedback
 {
     /**
      * @var NodeInterface
@@ -208,5 +210,16 @@ class RenderContentOutOfBand implements FeedbackInterface
         $fusionView->setFusionPath($parentDomAddress->getFusionPath());
 
         return $fusionView->render();
+    }
+
+    public function serialize(ControllerContext $controllerContext)
+    {
+        try {
+            return parent::serialize($controllerContext);
+        } catch (MissingFusionObjectException $e) {
+            // in case there was a rendering error, we just try to reload the document as fallback. Needed
+            // e.g. when adding validators to Neos.FormBuilder
+            return (new ReloadDocument())->serialize($controllerContext);
+        }
     }
 }

--- a/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
@@ -12,12 +12,13 @@ namespace Neos\Neos\Ui\Domain\Model\Feedback\Operations;
  */
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 
-class UpdateNodeInfo implements FeedbackInterface
+class UpdateNodeInfo extends AbstractFeedback
 {
     /**
      * @var NodeInterface

--- a/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/UpdateWorkspaceInfo.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/UpdateWorkspaceInfo.php
@@ -13,11 +13,12 @@ namespace Neos\Neos\Ui\Domain\Model\Feedback\Operations;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Domain\Model\Workspace;
+use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
 use Neos\Neos\Ui\ContentRepository\Service\WorkspaceService;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 
-class UpdateWorkspaceInfo implements FeedbackInterface
+class UpdateWorkspaceInfo extends AbstractFeedback
 {
     /**
      * @var Workspace

--- a/Classes/Neos/Neos/Ui/Domain/Model/FeedbackCollection.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/FeedbackCollection.php
@@ -67,11 +67,7 @@ class FeedbackCollection implements \JsonSerializable
         $feedbacks = [];
 
         foreach ($this->feedbacks as $feedback) {
-            $feedbacks[] = [
-                'type' => $feedback->getType(),
-                'description' => $feedback->getDescription(),
-                'payload' => $feedback->serializePayload($this->controllerContext)
-            ];
+            $feedbacks[]= $feedback->serialize($this->controllerContext);
         }
 
         return [

--- a/Classes/Neos/Neos/Ui/Domain/Model/FeedbackInterface.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/FeedbackInterface.php
@@ -16,6 +16,15 @@ use Neos\Flow\Mvc\Controller\ControllerContext;
 interface FeedbackInterface
 {
     /**
+     * main entry point for serializing the feedback before it is sent to the UI. Usually implemented
+     * in AbstractFeedback, but can be overridden to implement fallback logic in case of errors.
+     *
+     * @param ControllerContext $controllerContext
+     * @return array
+     */
+    public function serialize(ControllerContext $controllerContext);
+
+    /**
      * Get the type identifier
      *
      * @return string

--- a/packages/neos-ui/src/Sagas/CR/NodeOperations/helpers.js
+++ b/packages/neos-ui/src/Sagas/CR/NodeOperations/helpers.js
@@ -49,6 +49,7 @@ export const calculateDomAddressesFromMode = (mode, contextPath, fusionPath) => 
             const element = findNodeInGuestFrame(contextPath, fusionPath);
 
             return {
+                parentContextPath: contextPath,
                 parentDomAddress: {
                     contextPath: element ? element.getAttribute('data-__neos-node-contextpath') : contextPath,
                     fusionPath: element ? element.getAttribute('data-__neos-fusion-path') : fusionPath


### PR DESCRIPTION
Moving of nodes did not work when the *rendered parent node* in DOM was not
the parent node in the node tree.

In this case, the following happened:

- the rendered parent node was transmitted as "parentDomAddress.contextPath"
  and made available in AbstractChange as getParentNode()
- in AbstractMove::canApply(), the "getParentNode()" method was called, and
  taken into account for constraint checks -- so if the rendered parent node
  was a different node than the actual parent (e.g. the grandparent), the
  constraints might not have matched and the move could not succeed.

To fix this, I changed the following:

- removed AbstractStructuralChange::getParentNode as this is not really the parent node, but the closest rendered node.
- pushed canApply() down; not relying on getParentNode() anymore
- for the Copy/Move INTO cases, add a specific property "parentContextPath" to the
  change; which contains the parent node without further processing.
- we ensure the renderedParentNode === parentNode (==is the ContentCollection),
  otherwise out of band rendering can not work (and we need to reload the full page
  instead).
