### PR TITLE
BUGFIX: set correct translation value to delete confirmation

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/DeleteNode/index.js
+++ b/packages/neos-ui/src/Containers/Modals/DeleteNode/index.js
@@ -89,7 +89,7 @@ export default class DeleteNodeModal extends PureComponent {
                 hoverStyle="brand"
                 onClick={this.handleConfirm}
                 >
-                <I18n id="Neos.Neos:Main:confirm" fallback="Confirm"/>
+                <I18n id="Neos.Neos:Main:deleteConfirm" fallback="Confirm"/>
             </Button>
         );
     }


### PR DESCRIPTION
Fixes the translation in the Delete Confirmation Dialog by using the right identifier

