### PR TITLE
BUGFIX: don't allow to publish/discard while publishing/discarding/saving

### DIFF
--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -90,6 +90,7 @@ export default class PublishDropDown extends PureComponent {
             publishableNodes,
             publishableNodesInDocument,
             isSaving,
+            isPublishing,
             isAutoPublishingEnabled,
             isWorkspaceReadOnly,
             toggleAutoPublishing,
@@ -102,8 +103,8 @@ export default class PublishDropDown extends PureComponent {
         const workspaceModuleUri = $get('routes.core.modules.workspaces', neos);
         const allowedWorkspaces = $get('configuration.allowedTargetWorkspaces', neos);
         const baseWorkspaceTitle = $get([baseWorkspace, 'title'], allowedWorkspaces);
-        const canPublishLocally = publishableNodesInDocument && (publishableNodesInDocument.count() > 0);
-        const canPublishGlobally = publishableNodes && (publishableNodes.count() > 0);
+        const canPublishLocally = !isSaving && !isPublishing && publishableNodesInDocument && (publishableNodesInDocument.count() > 0);
+        const canPublishGlobally = !isSaving && !isPublishing && publishableNodes && (publishableNodes.count() > 0);
         const changingWorkspaceAllowed = !canPublishGlobally;
         const autoPublishWrapperClassNames = mergeClassNames({
             [style.dropDown__item]: true,

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -91,6 +91,7 @@ export default class PublishDropDown extends PureComponent {
             publishableNodesInDocument,
             isSaving,
             isPublishing,
+            isDiscarding,
             isAutoPublishingEnabled,
             isWorkspaceReadOnly,
             toggleAutoPublishing,
@@ -103,8 +104,8 @@ export default class PublishDropDown extends PureComponent {
         const workspaceModuleUri = $get('routes.core.modules.workspaces', neos);
         const allowedWorkspaces = $get('configuration.allowedTargetWorkspaces', neos);
         const baseWorkspaceTitle = $get([baseWorkspace, 'title'], allowedWorkspaces);
-        const canPublishLocally = !isSaving && !isPublishing && publishableNodesInDocument && (publishableNodesInDocument.count() > 0);
-        const canPublishGlobally = !isSaving && !isPublishing && publishableNodes && (publishableNodes.count() > 0);
+        const canPublishLocally = !isSaving && !isPublishing && !isDiscarding && publishableNodesInDocument && (publishableNodesInDocument.count() > 0);
+        const canPublishGlobally = !isSaving && !isPublishing && !isDiscarding && publishableNodes && (publishableNodes.count() > 0);
         const changingWorkspaceAllowed = !canPublishGlobally;
         const autoPublishWrapperClassNames = mergeClassNames({
             [style.dropDown__item]: true,


### PR DESCRIPTION
Currently it's possible to publish/discard twice, while another publish is in progress. That lead to corruption of CR sometimes (which should be a separate issue actually).
