### PR TITLE
BUGFIX: In- & outdent can be disabled outside of lists

### DIFF
--- a/packages/neos-ui-ckeditor-bindings/src/manifest.richtextToolbar.js
+++ b/packages/neos-ui-ckeditor-bindings/src/manifest.richtextToolbar.js
@@ -231,8 +231,15 @@ export default ckEditorRegistry => {
         hoverStyle: 'brand',
         tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__indent',
         isVisibleWhen: (inlineEditorOptions, formattingUnderCursor) => {
-            return ((Boolean($get('formatting.ul', inlineEditorOptions)) || Boolean($get('formatting.ol', inlineEditorOptions))) &&
-                formattingUnderCursor.indent !== richtextToolbar.TRISTATE_DISABLED);
+            // Indent possible at cursor position
+            return formattingUnderCursor.indent !== richtextToolbar.TRISTATE_DISABLED && (
+                // Cursor in ol
+                formattingUnderCursor.ol === richtextToolbar.TRISTATE_ON ||
+                // Cursor in ul
+                formattingUnderCursor.ul === richtextToolbar.TRISTATE_ON ||
+                // Indent generally enabled
+                Boolean($get('formatting.indent', inlineEditorOptions))
+            );
         }
     });
 
@@ -246,8 +253,15 @@ export default ckEditorRegistry => {
         hoverStyle: 'brand',
         tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__outdent',
         isVisibleWhen: (inlineEditorOptions, formattingUnderCursor) => {
-            return ((Boolean($get('formatting.ul', inlineEditorOptions)) || Boolean($get('formatting.ol', inlineEditorOptions))) &&
-                formattingUnderCursor.indent !== richtextToolbar.TRISTATE_DISABLED);
+            // Outdent possible at cursor position
+            return formattingUnderCursor.outdent !== richtextToolbar.TRISTATE_DISABLED && (
+                // Cursor in ol
+                formattingUnderCursor.ol === richtextToolbar.TRISTATE_ON ||
+                // Cursor in ul
+                formattingUnderCursor.ul === richtextToolbar.TRISTATE_ON ||
+                // Outdent generally enabled
+                Boolean($get('formatting.outdent', inlineEditorOptions))
+            );
         }
     });
 


### PR DESCRIPTION
**What I did**
Indent & outdent buttons of CKEditor show:
* only if they are possible (outdent only if indented)
* if cursor is in `ol` or `ul` OR
* if configured to `true`

**How I did it**
Adjusted `isVisibleWhen` condition.

**How to verify it**
![indent](https://user-images.githubusercontent.com/11410095/38247636-4c66e5b4-3746-11e8-87e6-752675a21359.gif)

