### PR TITLE
TASK: Update nodejs dependecy to version 8.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "json-loader": "^0.5.4",
     "lerna": "^2.5.1",
     "lolex": "^1.5.1",
-    "node": "8.10.0",
+    "node": "8.11.0",
     "object-assign": "^4.1.0",
     "postcss-css-variables": "^0.8.0",
     "postcss-hexrgba": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7773,9 +7773,9 @@ node-version@1.1.0, node-version@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/node-version/-/node-version-1.1.0.tgz#f437d7ba407e65e2c4eaef8887b1718ba523d4f0"
 
-node@8.10.0:
-  version "8.10.0"
-  resolved "https://registry.yarnpkg.com/node/-/node-8.10.0.tgz#0ec17a14acbd38ede97087eee9df4e40fa152b3f"
+node@8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/node/-/node-8.11.0.tgz#25f4fef2b16bf681f3314ae39eb39f68ee14f4a4"
   dependencies:
     node-bin-setup "^1.0.0"
 


### PR DESCRIPTION
Updates the node js version to the latest 8.x release. The latest release was a security release and guess we should use it.

Resolves: #1731
