### PR TITLE
BUGFIX: improve performance for PolicyAspect

### DIFF
--- a/Classes/Neos/Neos/Ui/Aspects/PolicyAspect.php
+++ b/Classes/Neos/Neos/Ui/Aspects/PolicyAspect.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Neos\Ui\Aspects;
 
 /*
@@ -14,11 +15,14 @@ namespace Neos\Neos\Ui\Aspects;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Aop\JoinPointInterface;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Flow\Security\Authorization\Privilege\PrivilegeInterface;
 use Neos\Flow\Security\Authorization\PrivilegeManagerInterface;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\NodePrivilegeSubject;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\PropertyAwareNodePrivilegeSubject;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\CreateNodePrivilegeSubject;
+use Neos\Flow\Security\Policy\PolicyService;
 use Neos\Neos\Security\Authorization\Privilege\NodeTreePrivilege;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\CreateNodePrivilege;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\RemoveNodePrivilege;
@@ -53,11 +57,43 @@ class PolicyAspect
     protected $nodeTypeManager;
 
     /**
+     * @Flow\Inject
+     * @var ObjectManagerInterface
+     */
+    protected $objectManager;
+
+    /**
+     * @param ObjectManagerInterface $objectManager
+     * @return array the key is a Privilege class name; the value is "true" if privileges are configured for this class name.
+     * @Flow\CompileStatic
+     */
+    public static function getUsedPrivilegeClassNames($objectManager)
+    {
+        $policyService = $objectManager->get(PolicyService::class);
+        $usedPrivilegeClassNames = [];
+        foreach ($policyService->getPrivilegeTargets() as $privilegeTarget) {
+            $usedPrivilegeClassNames[$privilegeTarget->getPrivilegeClassName()] = true;
+            foreach (class_parents($privilegeTarget->getPrivilegeClassName()) as $parentPrivilege) {
+                if (is_a($parentPrivilege, PrivilegeInterface::class)) {
+                    $usedPrivilegeClassNames[$parentPrivilege] = true;
+                }
+            }
+        }
+
+        return $usedPrivilegeClassNames;
+    }
+
+
+    /**
      * @Flow\Around("method(Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper->renderNode())")
      * @return void
      */
     public function enforceNodeTreePrivilege(JoinPointInterface $joinPoint)
     {
+        if (!isset(self::getUsedPrivilegeClassNames($this->objectManager)[NodeTreePrivilege::class])) {
+            // no NodeTreePrivilege configured; directly proceed. (Performance optimization)
+            return $joinPoint->getAdviceChain()->proceed($joinPoint);
+        }
         $node = $joinPoint->getMethodArgument('node');
         $hasNodeTreePrivilege = $this->privilegeManager->isGranted(
             NodeTreePrivilege::class,
@@ -81,14 +117,17 @@ class PolicyAspect
         $nodeInfo['policy'] = array_key_exists('policy', $nodeInfo) ? $nodeInfo['policy'] : [];
         $nodeInfo['policy']['disallowedNodeTypes'] = [];
 
-        foreach ($this->nodeTypeManager->getNodeTypes() as $nodeType) {
-            $canCreate = $this->privilegeManager->isGranted(
-                CreateNodePrivilege::class,
-                new CreateNodePrivilegeSubject($node, $nodeType)
-            );
+        // performance optimization: we ensure that CreateNodePrivilege is actually used before running this code
+        if (isset(self::getUsedPrivilegeClassNames($this->objectManager)[CreateNodePrivilege::class])) {
+            foreach ($this->nodeTypeManager->getNodeTypes() as $nodeType) {
+                $canCreate = $this->privilegeManager->isGranted(
+                    CreateNodePrivilege::class,
+                    new CreateNodePrivilegeSubject($node, $nodeType)
+                );
 
-            if (!$canCreate) {
-                $nodeInfo['policy']['disallowedNodeTypes'][] = $nodeType->getName();
+                if (!$canCreate) {
+                    $nodeInfo['policy']['disallowedNodeTypes'][] = $nodeType->getName();
+                }
             }
         }
 
@@ -104,7 +143,11 @@ class PolicyAspect
         $node = $joinPoint->getMethodArgument('node');
         $nodeInfo = $joinPoint->getAdviceChain()->proceed($joinPoint);
 
-        $canRemove = $this->privilegeManager->isGranted(RemoveNodePrivilege::class, new NodePrivilegeSubject($node));
+        if (isset(self::getUsedPrivilegeClassNames($this->objectManager)[RemoveNodePrivilege::class])) {
+            $canRemove = $this->privilegeManager->isGranted(RemoveNodePrivilege::class, new NodePrivilegeSubject($node));
+        } else {
+            $canRemove = true;
+        }
 
         $nodeInfo['policy'] = array_key_exists('policy', $nodeInfo) ? $nodeInfo['policy'] : [];
         $nodeInfo['policy']['canRemove'] = $canRemove;
@@ -121,7 +164,11 @@ class PolicyAspect
         $node = $joinPoint->getMethodArgument('node');
         $nodeInfo = $joinPoint->getAdviceChain()->proceed($joinPoint);
 
-        $canEdit = $this->privilegeManager->isGranted(EditNodePrivilege::class, new NodePrivilegeSubject($node));
+        if (isset(self::getUsedPrivilegeClassNames($this->objectManager)[EditNodePrivilege::class])) {
+            $canEdit = $this->privilegeManager->isGranted(EditNodePrivilege::class, new NodePrivilegeSubject($node));
+        } else {
+            $canEdit = true;
+        }
 
         $nodeInfo['policy'] = array_key_exists('policy', $nodeInfo) ? $nodeInfo['policy'] : [];
         $nodeInfo['policy']['canEdit'] = $canEdit;
@@ -141,14 +188,16 @@ class PolicyAspect
         $nodeInfo['policy'] = array_key_exists('policy', $nodeInfo) ? $nodeInfo['policy'] : [];
         $nodeInfo['policy']['disallowedProperties'] = [];
 
-        foreach ($node->getNodeType()->getProperties() as $propertyName => $propertyConfiguration) {
-            $canEdit = $this->privilegeManager->isGranted(
-                EditNodePropertyPrivilege::class,
-                new PropertyAwareNodePrivilegeSubject($node, null, $propertyName)
-            );
+        if (isset(self::getUsedPrivilegeClassNames($this->objectManager)[EditNodePropertyPrivilege::class])) {
+            foreach ($node->getNodeType()->getProperties() as $propertyName => $propertyConfiguration) {
+                $canEdit = $this->privilegeManager->isGranted(
+                    EditNodePropertyPrivilege::class,
+                    new PropertyAwareNodePrivilegeSubject($node, null, $propertyName)
+                );
 
-            if (!$canEdit) {
-                $nodeInfo['policy']['disallowedProperties'][] = $propertyName;
+                if (!$canEdit) {
+                    $nodeInfo['policy']['disallowedProperties'][] = $propertyName;
+                }
             }
         }
 


### PR DESCRIPTION
With this change, we are actually checking whether there are policies configured for the given PrivilegeTargets; and if not, we skip these code blocks.

For a node tree with 1000 nodes, this improves the node tree loading time from 15 to 5 seconds (AJAX request time)