### PR TITLE
BUGFIX: Catch all fusion exceptions when rendering content "out of band"

### DIFF
--- a/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/ReloadContentOutOfBand.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/ReloadContentOutOfBand.php
@@ -11,15 +11,15 @@ namespace Neos\Neos\Ui\Domain\Model\Feedback\Operations;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Flow\Annotations as Flow;
-use Neos\Fusion\Exception\MissingFusionObjectException;
+use Neos\Flow\Mvc\Controller\ControllerContext;
+use Neos\Fusion\Core\Cache\ContentCache;
+use Neos\Fusion\Exception as FusionException;
 use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
-use Neos\ContentRepository\Domain\Model\NodeInterface;
-use Neos\Neos\View\FusionView as FusionView;
-use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Neos\Ui\Domain\Model\RenderedNodeDomAddress;
-use Neos\Fusion\Core\Cache\ContentCache;
+use Neos\Neos\View\FusionView as FusionView;
 
 class ReloadContentOutOfBand extends AbstractFeedback
 {
@@ -160,7 +160,7 @@ class ReloadContentOutOfBand extends AbstractFeedback
     {
         try {
             return parent::serialize($controllerContext);
-        } catch (MissingFusionObjectException $e) {
+        } catch (FusionException $e) {
             // in case there was a rendering error, we just try to reload the document as fallback. Needed
             // e.g. when adding validators to Neos.FormBuilder
             return (new ReloadDocument())->serialize($controllerContext);

--- a/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/RenderContentOutOfBand.php
+++ b/Classes/Neos/Neos/Ui/Domain/Model/Feedback/Operations/RenderContentOutOfBand.php
@@ -11,15 +11,15 @@ namespace Neos\Neos\Ui\Domain\Model\Feedback\Operations;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Flow\Annotations as Flow;
-use Neos\Fusion\Exception\MissingFusionObjectException;
+use Neos\Flow\Mvc\Controller\ControllerContext;
+use Neos\Fusion\Core\Cache\ContentCache;
+use Neos\Fusion\Exception as FusionException;
 use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
-use Neos\ContentRepository\Domain\Model\NodeInterface;
-use Neos\Neos\View\FusionView as FusionView;
-use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Neos\Ui\Domain\Model\RenderedNodeDomAddress;
-use Neos\Fusion\Core\Cache\ContentCache;
+use Neos\Neos\View\FusionView as FusionView;
 
 class RenderContentOutOfBand extends AbstractFeedback
 {
@@ -216,7 +216,7 @@ class RenderContentOutOfBand extends AbstractFeedback
     {
         try {
             return parent::serialize($controllerContext);
-        } catch (MissingFusionObjectException $e) {
+        } catch (FusionException $e) {
             // in case there was a rendering error, we just try to reload the document as fallback. Needed
             // e.g. when adding validators to Neos.FormBuilder
             return (new ReloadDocument())->serialize($controllerContext);


### PR DESCRIPTION
This extends the `try/catch` block in `ReloadContentOutOfBand` and
`RenderContentOutOfBand` so that if falls back to reloading the whole
document when a Fusion exception occurs.
Previously only the more specific `MissingFusionObjectException` was
caught.

Note: This is a follow up to #1693