### PR TITLE
BUGFIX: PropertyGroup (un)collapsing

### DIFF
--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
@@ -41,7 +41,7 @@ export default class TabPanel extends PureComponent {
                             label={$get('label', group)}
                             icon={$get('icon', group)}
                             // overlay default collapsed state over current state
-                            collapsed={$get($get('id', group), toggledPanels) != $get('collapsed', group)} // eslint-disable-line eqeqeq
+                            collapsed={Boolean($get($get('id', group), toggledPanels)) !== Boolean($get('collapsed', group))}
                             properties={$get('properties', group).filter(this.isPropertyEnabled)}
                             views={$get('views', group)}
                             renderSecondaryInspector={renderSecondaryInspector}


### PR DESCRIPTION
**What I did**
In one instance I had the problem not being able to open up the property groups once closed.
In the other instance the "Additional Info" (node metadata) group starts up opened.

**How I did it**
Using explicit typecast to bool instead of relying on implicit typecasting.

**How to verify it**
Close & open property groups, check status of "Additional Info" property group.