### PR TITLE
BUGFIX: add meta viewport tag to avoid resizing viewport

### DIFF
--- a/Resources/Private/Templates/Backend/Index.html
+++ b/Resources/Private/Templates/Backend/Index.html
@@ -3,7 +3,7 @@
 <html>
     <head>
         <title>Neos CMS</title>
-        <meta name="viewport" value="width=device-width">
+        <meta name="viewport" content="width=device-width,initial-scale=1.0">
         <script>_NEOS_UI_configuration = {configuration -> f:format.raw()};</script>
         <script>_NEOS_UI_nodeTypes = {nodeTypes -> f:format.raw()};</script>
         <script>_NEOS_UI_frontendConfiguration = {frontendConfiguration -> f:format.raw()};</script>

--- a/Resources/Private/Templates/Backend/Index.html
+++ b/Resources/Private/Templates/Backend/Index.html
@@ -3,6 +3,7 @@
 <html>
     <head>
         <title>Neos CMS</title>
+        <meta name="viewport" value="width=device-width">
         <script>_NEOS_UI_configuration = {configuration -> f:format.raw()};</script>
         <script>_NEOS_UI_nodeTypes = {nodeTypes -> f:format.raw()};</script>
         <script>_NEOS_UI_frontendConfiguration = {frontendConfiguration -> f:format.raw()};</script>


### PR DESCRIPTION
**What I did**

I avoided resizing the viewport on mobile devices when the right side bar slides out. This fixes #1716 

**How I did it**

I added a viewport meta tag setting the viewport width to device-width

**How to verify it**

Use any device / simulator of your choice, login to /neos, toggle right sidebar.
