### PR TITLE
BUGFIX: Increase close button z- index

### DIFF
--- a/packages/build-essentials/src/styles/styleConstants.js
+++ b/packages/build-essentials/src/styles/styleConstants.js
@@ -20,7 +20,7 @@ const config = {
         secondaryToolbar: ['linkIconButtonFlyout'],
         flashMessageContainer: '2',
         loadingIndicatorContainer: '2',
-        secondaryInspector: ['context', 'close'],
+        secondaryInspector: ['context', 'iframe', 'close'],
         secondaryInspectorElevated: ['context', 'dropdownContents'],
         dialog: ['context'],
         fullScreenClose: ['context'],


### PR DESCRIPTION
The secondary inspector has two constants for z index. The close
button needs to be incresed to value higher than 3. And the
possible iFrame has not z index yet. So we define a iframe zindex constant and so we also increase the close button constant.

Fixes: #1748