### PR TITLE
BUGFIX: Correct the phony target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,4 +163,6 @@ clean:
 	rm -Rf node_modules; rm -rf packages/*/node_modules
 
 
-.PHONY: $@
+# Make ALL targets phony targets
+# (Rebuild every time)
+.PHONY: *


### PR DESCRIPTION
The `PHONY`-target was wrong. 
This change correctly marks every target as the special phony target and therefore shouldn't make any problems with case-insensitive filesystems now.  (make build and the folder Build didn't work well together)

For everyone who didn't know: 
`make build` is the target build `make test` would be the target test and so on.
Make can remember when it performed a task and doesn't retrigger it if nothing has changed since then.
The target is usually a file or folder and make compares the timestamp from the last run of this target and the last changed time the file was changed on disk and don't rerun the target if file/folder >= last run.

PHONY tells make to re-run the target everytime without comparing timestamps and stuff.