### PR TITLE
BUGFIX: Prevent error when no defaultOptions are defined

### DIFF
--- a/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/model.js
+++ b/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/model.js
@@ -1,5 +1,6 @@
 import {values, merge, memoize} from 'ramda';
 import {Maybe, Some, None} from 'monet';
+import {$get} from 'plow-js';
 
 //
 // AspectRatioStrategies
@@ -175,7 +176,13 @@ const determineInitialAspectRatioStrategy = (image, neosConfiguration) => {
         )
 
         .orElse(
-            when(defaultOption)(new ConfiguredAspectRatioStrategy(options[defaultOption].width, options[defaultOption].height, options[defaultOption].label))
+            when(defaultOption)(
+                new ConfiguredAspectRatioStrategy(
+                    $get([defaultOption, 'width'], options),
+                    $get([defaultOption, 'height'], options),
+                    $get([defaultOption, 'label'], options)
+                )
+            )
         )
 
         //


### PR DESCRIPTION
Uses plow.js to be sure that the value is defined for the default option.

Fixes: #1759