### PR TITLE
TASK: Validate editor elements on apply

### DIFF
--- a/packages/neos-ui-editors/src/Editors/DateTime/index.js
+++ b/packages/neos-ui-editors/src/Editors/DateTime/index.js
@@ -22,7 +22,8 @@ class DateTime extends PureComponent {
         options: PropTypes.object,
         id: PropTypes.string,
         i18nRegistry: PropTypes.object,
-        interfaceLanguage: PropTypes.string
+        interfaceLanguage: PropTypes.string,
+        validationErrors: PropTypes.array
     }
 
     render() {
@@ -34,7 +35,8 @@ class DateTime extends PureComponent {
             options,
             i18nRegistry,
             highlight,
-            interfaceLanguage
+            interfaceLanguage,
+            validationErrors
         } = this.props;
         const mappedValue = (typeof value === 'string' && value.length) ? moment(value).toDate() : (value || undefined);
 
@@ -55,6 +57,7 @@ class DateTime extends PureComponent {
                 todayLabel={i18nRegistry.translate('content.inspector.editors.dateTimeEditor.today', 'Today', {}, 'Neos.Neos', 'Main')}
                 applyLabel={i18nRegistry.translate('content.inspector.editors.dateTimeEditor.apply', 'Apply', {}, 'Neos.Neos', 'Main')}
                 locale={interfaceLanguage}
+                validationErrors={validationErrors}
                 />
         );
     }

--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
@@ -52,16 +52,37 @@ export default class NodeCreationDialog extends PureComponent {
     }
 
     handleDialogEditorValueChange = memoize(elementName => value => {
-        const {validatorRegistry, configuration} = this.props;
         const {values} = this.state;
         const newValues = Object.assign({}, values, {[elementName]: value});
+        this.validateElements(newValues);
+    })
 
+    validateElements = newValues => {
+        const {validatorRegistry, configuration} = this.props;
+        const validationErrors = validate(newValues, configuration.elements, validatorRegistry);
         this.setState({
             values: newValues,
-            validationErrors: validate(newValues, configuration.elements, validatorRegistry),
+            validationErrors: validationErrors,
             isDirty: true
         });
-    })
+
+        return validationErrors;
+    }
+
+    defineDefaultValueForElementName = elementName => {
+        const {values} = this.state;
+        if (!(elementName in values)) {
+            const defaultValues = Object.assign(values, {[elementName]: ''});
+            this.setState({values: defaultValues});
+        }
+    }
+
+    replenishValuesWithDefaults = () => {
+        // fill up the values that has not been edited at the moment
+        Object.keys(this.props.configuration.elements).forEach(elementName => {
+            this.defineDefaultValueForElementName(elementName);
+        });
+    }
 
     handleCancel = () => {
         const {cancel} = this.props;
@@ -78,11 +99,14 @@ export default class NodeCreationDialog extends PureComponent {
     }
 
     handleApply = () => {
+        this.replenishValuesWithDefaults();
         const {apply} = this.props;
-        const {values} = this.state;
-
-        apply(values);
-        this.resetState();
+        const validationErrors = this.validateElements(this.state.values);
+        const {isDirty, values} = this.state;
+        if (!validationErrors && isDirty) {
+            apply(values);
+            this.resetState();
+        }
     }
 
     handleKeyPress = event => {
@@ -118,12 +142,9 @@ export default class NodeCreationDialog extends PureComponent {
     }
 
     renderSaveAction() {
-        const {validationErrors, isDirty} = this.state;
-
         return (
             <Button
                 id="neos-NodeCreationDialog-CreateNew"
-                disabled={Boolean(validationErrors || !isDirty)}
                 key="save"
                 style="lighter"
                 hoverStyle="brand"
@@ -162,7 +183,6 @@ export default class NodeCreationDialog extends PureComponent {
                             const validationErrorsForElement = isDirty ? $get(elementName, validationErrors) : [];
                             const element = configuration.elements[elementName];
                             const options = $set('autoFocus', index === 0, $get('ui.editorOptions', element) || {});
-
                             return (
                                 <div key={elementName} className={style.editor}>
                                     <EditorEnvelope

--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
@@ -137,6 +137,7 @@ export default class NodeCreationDialog extends PureComponent {
     }
 
     renderSaveAction() {
+        const {isDirty, validationErrors} = this.state;
         return (
             <Button
                 id="neos-NodeCreationDialog-CreateNew"
@@ -144,6 +145,7 @@ export default class NodeCreationDialog extends PureComponent {
                 style="lighter"
                 hoverStyle="brand"
                 onClick={this.handleApply}
+                disabled={validationErrors && isDirty}
                 >
                 <I18n id="Neos.Neos:Main:createNew" fallback="Create"/>
             </Button>

--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
@@ -60,12 +60,7 @@ export default class NodeCreationDialog extends PureComponent {
     validateElements = newValues => {
         const {validatorRegistry, configuration} = this.props;
         const validationErrors = validate(newValues, configuration.elements, validatorRegistry);
-        this.setState({
-            values: newValues,
-            validationErrors: validationErrors,
-            isDirty: true
-        });
-
+        this.setState({values: newValues, isDirty: true, validationErrors});
         return validationErrors;
     }
 

--- a/packages/react-ui-components/src/DateInput/dateInput.js
+++ b/packages/react-ui-components/src/DateInput/dateInput.js
@@ -62,6 +62,16 @@ export class DateInput extends PureComponent {
         locale: PropTypes.string,
 
         /**
+         * Static component dependencies which are injected from the outside (index.js)
+         */
+        TooltipComponent: PropTypes.any.isRequired,
+
+        /**
+         * An array of error messages
+         */
+        validationErrors: PropTypes.array,
+
+        /**
          * The changehandler to call when the date changes.
          */
         onChange: PropTypes.func.isRequired,
@@ -95,6 +105,7 @@ export class DateInput extends PureComponent {
             IconComponent,
             DatePickerComponent,
             CollapseComponent,
+            TooltipComponent,
             placeholder,
             theme,
             value,
@@ -105,13 +116,20 @@ export class DateInput extends PureComponent {
             dateOnly,
             timeOnly,
             highlight,
-            locale
+            locale,
+            validationErrors
         } = this.props;
         const selectedDate = value ? moment(value).format(labelFormat) : '';
 
+        console.log(validationErrors);
+        const renderedErrors = validationErrors && validationErrors.length > 0 && validationErrors.map((validationError, key) => {
+            return <div key={key}>{validationError}</div>;
+        });
+
         const calendarInputWrapper = mergeClassNames({
             [theme.calendarInputWrapper]: true,
-            [theme['calendarInputWrapper--highlight']]: highlight
+            [theme['calendarInputWrapper--highlight']]: highlight,
+            [theme['calendarInputWrapper--invalid']]: validationErrors && validationErrors.length > 0
         });
 
         return (
@@ -169,6 +187,7 @@ export class DateInput extends PureComponent {
                         {applyLabel}
                     </ButtonComponent>
                 </CollapseComponent>
+                {renderedErrors && <TooltipComponent>{renderedErrors}</TooltipComponent>}
             </div>
         );
     }

--- a/packages/react-ui-components/src/DateInput/dateInput.js
+++ b/packages/react-ui-components/src/DateInput/dateInput.js
@@ -121,7 +121,6 @@ export class DateInput extends PureComponent {
         } = this.props;
         const selectedDate = value ? moment(value).format(labelFormat) : '';
 
-        console.log(validationErrors);
         const renderedErrors = validationErrors && validationErrors.length > 0 && validationErrors.map((validationError, key) => {
             return <div key={key}>{validationError}</div>;
         });

--- a/packages/react-ui-components/src/DateInput/index.js
+++ b/packages/react-ui-components/src/DateInput/index.js
@@ -13,9 +13,11 @@ import Button from './../Button/index';
 import Icon from './../Icon/index';
 import DatePicker from 'react-datetime';
 import Collapse from 'react-collapse';
+import Tooltip from '../Tooltip/index';
 
 export default injectProps({
     ButtonComponent: Button,
+    TooltipComponent: Tooltip,
     IconComponent: Icon,
     DatePickerComponent: DatePicker,
     CollapseComponent: Collapse

--- a/packages/react-ui-components/src/DateInput/style.css
+++ b/packages/react-ui-components/src/DateInput/style.css
@@ -6,8 +6,8 @@
     outline: 2px solid var(--colors-Success);
 }
 .calendarInputWrapper--invalid {
-    outline: 2px solid var(--colors-Error) !important;
-    color: var(--colors-Error) !important;
+    outline: 2px solid var(--colors-Error);
+    color: var(--colors-Error);
 }
 .closeCalendarIconBtn,
 .calendarIconBtn {

--- a/packages/react-ui-components/src/DateInput/style.css
+++ b/packages/react-ui-components/src/DateInput/style.css
@@ -5,6 +5,10 @@
 .calendarInputWrapper--highlight {
     outline: 2px solid var(--colors-Success);
 }
+.calendarInputWrapper--invalid {
+    outline: 2px solid var(--colors-Error) !important;
+    color: var(--colors-Error) !important;
+}
 .closeCalendarIconBtn,
 .calendarIconBtn {
     composes: reset from './../reset.css';


### PR DESCRIPTION
The createDialog apply button now will be not disabled anymore
and validates all elements in the dialog. Even if the element
has not been edited yet.

Fixes: #1320
