### PR TITLE
BUGFIX: Add safeguard to AugumentationAspect

### DIFF
--- a/Classes/Neos/Neos/Ui/Aspects/AugmentationAspect.php
+++ b/Classes/Neos/Neos/Ui/Aspects/AugmentationAspect.php
@@ -145,6 +145,7 @@ class AugmentationAspect
             return $content;
         }
 
+        // TODO: Add safeguard if argument is not specified
         $attributes = $joinPoint->getMethodArgument('additionalAttributes');
         $attributes['data-__neos-node-contextpath'] = $node->getContextPath();
         $attributes['data-__neos-fusion-path'] = $fusionPath;

--- a/Classes/Neos/Neos/Ui/Aspects/AugmentationAspect.php
+++ b/Classes/Neos/Neos/Ui/Aspects/AugmentationAspect.php
@@ -145,8 +145,7 @@ class AugmentationAspect
             return $content;
         }
 
-        // TODO: Add safeguard if argument is not specified
-        $attributes = $joinPoint->getMethodArgument('additionalAttributes');
+        $attributes = $joinPoint->isMethodArgument('additionalAttributes') ? $joinPoint->getMethodArgument('additionalAttributes') : [];
         $attributes['data-__neos-node-contextpath'] = $node->getContextPath();
         $attributes['data-__neos-fusion-path'] = $fusionPath;
 


### PR DESCRIPTION
This is a follow-up to #1648 that adds a safeguard to `AugmentationAspect::contentElementAugmentation()` hopefully fixing the CI

Related: #1647