### PR TITLE
BUGFIX: Fix red borders for invalid datetimes

### DIFF
--- a/packages/react-ui-components/src/DateInput/style.css
+++ b/packages/react-ui-components/src/DateInput/style.css
@@ -6,8 +6,8 @@
     outline: 2px solid var(--colors-Success);
 }
 .calendarInputWrapper--invalid {
-    outline: 2px solid var(--colors-Error);
-    color: var(--colors-Error);
+    outline: 2px solid var(--colors-Error) !important;
+    color: var(--colors-Error) !important;
 }
 .closeCalendarIconBtn,
 .calendarIconBtn {


### PR DESCRIPTION
The datetime form field does not render the invalid border
color red when the input field is in the right inspector bar.

In the create dialog it works without important!

Fixes: #1780
