### PR TITLE
BUGFIX: show the loading indicator as soon as the src has changed

### DIFF
--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -52,6 +52,13 @@ export default class ContentCanvas extends PureComponent {
         loadedSrc: ''
     };
 
+    componentDidUpdate(prevProps) {
+        // Start loading as soon as the src has changed
+        if (this.props.src !== prevProps.src) {
+            this.props.startLoading();
+        }
+    }
+
     render() {
         const {
             isFringeLeft,


### PR DESCRIPTION
Before the loading indicator would only show when the iframe started to unload. For pages with long TTFB that could be quite a while.