### PR TITLE
BUGFIX: fix urls with multiple dimensions

### DIFF
--- a/packages/neos-ui/src/Sagas/Browser/index.js
+++ b/packages/neos-ui/src/Sagas/Browser/index.js
@@ -2,7 +2,7 @@ import {call, takeEvery} from 'redux-saga/effects';
 import {actionTypes} from '@neos-project/neos-ui-redux-store';
 
 export function * reflectChangeInAddressBar(action) {
-    yield call([history, history.replaceState], {}, '', `?node=${action.payload.contextPath}`);
+    yield call([history, history.replaceState], {}, '', `?node=${encodeURIComponent(action.payload.contextPath)}`);
 }
 
 export function * watchContentURIChange() {


### PR DESCRIPTION
Fixes: #1751 

Fully encodes the node context path argument so `&` between different dimensions doesn't break it.
The url would look like `/neos/content?node=%2Fsites%2Fneosdemo%2Fnode-4nriy1uwtm2x0%40user-admin%3Blanguage%3Dde%26country%3Dde%2Cglobal`
Ugly but editors shouldn't care about contextPath anyways...