### PR TITLE
FEATURE: implement forceCrop option for Image editor

### DIFF
--- a/packages/neos-ui-editors/src/Editors/Image/index.js
+++ b/packages/neos-ui-editors/src/Editors/Image/index.js
@@ -24,6 +24,7 @@ export default class ImageEditor extends Component {
     state = {
         image: null,
         isImageCropperOpen: false,
+        requestOpenImageCropper: false,
         isAssetLoading: false
     };
 
@@ -104,6 +105,13 @@ export default class ImageEditor extends Component {
                         this.setState({
                             image,
                             isAssetLoading: false
+                        }, () => {
+                            // When forceCrop option is enabled and we were requested to do the force cropping...
+                            if (this.state.requestOpenImageCropper && $get('crop.aspectRatio.forceCrop', this.props.options)) {
+                                this.handleCloseSecondaryScreen();
+                                this.handleOpenImageCropper();
+                                this.setState({requestOpenImageCropper: false});
+                            }
                         });
                     }
                 });
@@ -124,6 +132,7 @@ export default class ImageEditor extends Component {
             this.handleCloseSecondaryScreen();
             this.handleOpenImageCropper();
         }
+        this.setState({requestOpenImageCropper: true});
     }
 
     handleMediaCrop = cropArea => {
@@ -187,6 +196,7 @@ export default class ImageEditor extends Component {
         }, () => {
             commit(newAsset);
             this.handleCloseSecondaryScreen();
+            this.setState({requestOpenImageCropper: true});
         });
     }
 

--- a/packages/neos-ui-editors/src/Editors/Image/index.js
+++ b/packages/neos-ui-editors/src/Editors/Image/index.js
@@ -111,6 +111,9 @@ export default class ImageEditor extends Component {
                                 this.handleCloseSecondaryScreen();
                                 this.handleOpenImageCropper();
                                 this.setState({requestOpenImageCropper: false});
+                            } else if (this.state.isImageCropperOpen) {
+                                this.handleCloseSecondaryScreen();
+                                this.handleOpenImageCropper();
                             }
                         });
                     }
@@ -124,14 +127,7 @@ export default class ImageEditor extends Component {
     }
 
     afterUpload = uploadResult => {
-        const {commit} = this.props;
-        const {isImageCropperOpen} = this.state;
-
-        commit(uploadResult.object);
-        if (isImageCropperOpen) {
-            this.handleCloseSecondaryScreen();
-            this.handleOpenImageCropper();
-        }
+        this.props.commit(uploadResult.object);
         this.setState({requestOpenImageCropper: true});
     }
 

--- a/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/index.js
+++ b/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/index.js
@@ -188,6 +188,7 @@ export default class ImageCropper extends PureComponent {
                     crop={cropConfiguration.cropInformation}
                     onComplete={onComplete}
                     onAspectRatioChange={onComplete}
+                    onImageLoaded={onComplete}
                     />
             </div>
         );


### PR DESCRIPTION
Resolves: #1525 

Adds an option to the Image editor to force showing the crop dialog on image upload. Could be especially useful for image editors with locked crop aspect ratio.

TODO: add documentation

```
  properties:
    teaserImage:
      ui:
        inspector:
          editorOptions:
            crop:
              aspectRatio:
                forceCrop: TRUE
```

![peek 2018-04-22 21-38](https://user-images.githubusercontent.com/837032/39098630-6fa79af2-4676-11e8-9d5e-e4d748545ebc.gif)
