### PR TITLE
TASK: Remove debug statements

### DIFF
--- a/Classes/Neos/Neos/Ui/Domain/Dto/LoadTreeDto.php
+++ b/Classes/Neos/Neos/Ui/Domain/Dto/LoadTreeDto.php
@@ -51,8 +51,6 @@ class LoadTreeDto
      */
     public function getRoot()
     {
-        var_dump($this->active->geContext()->getCurrentSiteNode());
-        die;
         return $this->active->geContext()->getCurrentSiteNode();
     }
 


### PR DESCRIPTION
Remove var_dump and die() that has been added in commit
a67a8bd4071e149156a5503e6468f7822e996b79.

It looks like an accidental leftover from the early beta phase.
