### PR TITLE
TASK: Update react-collapse to version 4.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "react-click-outside": "^2.3.1",
     "react-close-on-escape": "^2.0.0",
     "react-codemirror": "^1.0.0",
-    "react-collapse": "^2.4.1",
+    "react-collapse": "^4.0.3",
     "react-css-themr": "^2.1.0",
     "react-datetime": "^2.8.10",
     "react-dnd": "^2.5.1",

--- a/packages/react-ui-components/package.json
+++ b/packages/react-ui-components/package.json
@@ -45,7 +45,7 @@
     "react": "^16.0.0",
     "react-click-outside": "^2.3.1",
     "react-close-on-escape": "^2.0.0",
-    "react-collapse": "^2.4.1",
+    "react-collapse": "^4.0.3",
     "react-css-themr": "^2.1.0",
     "react-datetime": "^2.8.10",
     "react-dnd": "^2.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9232,11 +9232,11 @@ react-codemirror@^1.0.0:
     lodash.isequal "^4.5.0"
     prop-types "^15.5.4"
 
-react-collapse@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/react-collapse/-/react-collapse-2.4.1.tgz#999a9969b2633752acba4847c28101edd2dcab89"
+react-collapse@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/react-collapse/-/react-collapse-4.0.3.tgz#b96de959ed0092a43534630b599a4753dd76d543"
   dependencies:
-    prop-types "15.5.8"
+    prop-types "^15.5.8"
 
 react-color@^2.11.4:
   version "2.13.8"


### PR DESCRIPTION
Fixes two things:
* warning while install process with yarn
* lot off bugs in the library and get closer to the green dependency bar :)

Relates: #877 
Resolves: #1799 

