### PR TITLE
TASK: allow the UI to run on Neos 3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "NEOS CMS UI rewritten in React",
     "license": ["GPL-3.0-or-later"],
     "require": {
-        "neos/neos": "^4.0 || dev-master",
+        "neos/neos": "^3.3 || ^4.0 || dev-master",
         "neos/neos-ui-compiled": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
Since we are technically compatible with Neos 3.3, let's allow the UI to run there, without requiring extra branches.