### PR TITLE
TASK: Optionally disable old UI button

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -54,7 +54,7 @@ Neos:
         #   someKey: someValue
 
         legacy:
-          enableLegacyUiSwitch: false
+          enableUiSwitch: false
 
       #################################
       # INTERNAL CONFIG (no API)

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -24,6 +24,7 @@ Neos:
       autoInclude:
         Neos.Neos.Ui: true
     Ui:
+
       # API: "start 100" and smaller numbers; "no numbers", ...
       resources:
 
@@ -51,6 +52,9 @@ Neos:
         # You may use this place to deliver some configuration to your custom UI components, e.g.:
         # 'Your.Own:Package':
         #   someKey: someValue
+
+        legacy:
+          enableLegacyUiSwitch: false
 
       #################################
       # INTERNAL CONFIG (no API)

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/UserDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/UserDropDown/index.js
@@ -14,13 +14,13 @@ import style from './style.css';
     userName: $get('user.name.fullName')
 }))
 @neos(globalRegistry => ({
-    disableLegacyUiSwitch: $get('disableLegacyUiSwitch', globalRegistry.get('frontendConfiguration').get('legacy'))
+    enableLegacyUiSwitch: $get('enableLegacyUiSwitch', globalRegistry.get('frontendConfiguration').get('legacy'))
 }))
 export default class UserDropDown extends PureComponent {
     static propTypes = {
         userName: PropTypes.string.isRequired,
         neos: PropTypes.object.isRequired,
-        disableLegacyUiSwitch: PropTypes.bool
+        enableLegacyUiSwitch: PropTypes.bool
     };
 
     render() {
@@ -28,9 +28,12 @@ export default class UserDropDown extends PureComponent {
         const userSettingsUri = $get('routes.core.modules.userSettings', this.props.neos);
         const csrfToken = document.getElementById('appContainer').dataset.csrfToken;
 
-        const switchToOldUiButton = () => {
-            const disableLegacyUiSwitch = this.props.disableLegacyUiSwitch;
-            if (disableLegacyUiSwitch === true) {
+        const legacyUiSwitch = () => {
+            const enableLegacyUiSwitch = this.props.enableLegacyUiSwitch;
+
+            // Don't show legacy ui switch only if
+            // explicitly set to false
+            if (enableLegacyUiSwitch === false) {
                 return null;
             }
 
@@ -61,7 +64,7 @@ export default class UserDropDown extends PureComponent {
                                 </button>
                             </form>
                         </li>
-                        {switchToOldUiButton()}
+                        {legacyUiSwitch()}
                         <li className={style.dropDown__item}>
                             <a title="User Settings" href={userSettingsUri}>
                                 <Icon icon="wrench" aria-hidden="true" className={style.dropDown__itemIcon}/>

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/UserDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/UserDropDown/index.js
@@ -14,7 +14,7 @@ import style from './style.css';
     userName: $get('user.name.fullName')
 }))
 @neos(globalRegistry => ({
-    enableLegacyUiSwitch: $get('enableLegacyUiSwitch', globalRegistry.get('frontendConfiguration').get('legacy'))
+    enableLegacyUiSwitch: $get('enableUiSwitch', globalRegistry.get('frontendConfiguration').get('legacy'))
 }))
 export default class UserDropDown extends PureComponent {
     static propTypes = {

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/UserDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/UserDropDown/index.js
@@ -13,17 +13,37 @@ import style from './style.css';
 @connect($transform({
     userName: $get('user.name.fullName')
 }))
-@neos()
+@neos(globalRegistry => ({
+    disableLegacyUiSwitch: $get('disableLegacyUiSwitch', globalRegistry.get('frontendConfiguration').get('legacy'))
+}))
 export default class UserDropDown extends PureComponent {
     static propTypes = {
         userName: PropTypes.string.isRequired,
-        neos: PropTypes.object.isRequired
+        neos: PropTypes.object.isRequired,
+        disableLegacyUiSwitch: PropTypes.bool
     };
 
     render() {
         const logoutUri = $get('routes.core.logout', this.props.neos);
         const userSettingsUri = $get('routes.core.modules.userSettings', this.props.neos);
         const csrfToken = document.getElementById('appContainer').dataset.csrfToken;
+
+        const switchToOldUiButton = () => {
+            const disableLegacyUiSwitch = this.props.disableLegacyUiSwitch;
+            if (disableLegacyUiSwitch === true) {
+                return null;
+            }
+
+            return (
+                <li className={style.dropDown__item}>
+                    <a title="User Settings" href="/neos/legacy">
+                        <Icon icon="far frown" aria-hidden="true" className={style.dropDown__itemIcon}/>
+                        <I18n id="userSettings_swtichUi" sourceName="Modules" fallback="Switch to old UI"/>
+                    </a>
+                </li>
+            );
+        };
+
         return (
             <div className={style.wrapper}>
                 <DropDown className={style.dropDown}>
@@ -41,12 +61,7 @@ export default class UserDropDown extends PureComponent {
                                 </button>
                             </form>
                         </li>
-                        <li className={style.dropDown__item}>
-                            <a title="User Settings" href="/neos/legacy">
-                                <Icon icon="far frown" aria-hidden="true" className={style.dropDown__itemIcon}/>
-                                <I18n id="userSettings_swtichUi" sourceName="Modules" fallback="Switch to old UI"/>
-                            </a>
-                        </li>
+                        {switchToOldUiButton()}
                         <li className={style.dropDown__item}>
                             <a title="User Settings" href={userSettingsUri}>
                                 <Icon icon="wrench" aria-hidden="true" className={style.dropDown__itemIcon}/>


### PR DESCRIPTION
This introduces a new Setting to control whether the switch to old UI button should be shown or not.

```
Neos:
  Neos:
    Ui:
      frontendConfiguration:
        legacy:
          enableUiSwitch: <bool>
```

related https://github.com/neos/neos-development-collection/pull/2021