### PR TITLE
TASK: Update uuid to version 3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "regenerator": "^0.8.46",
     "reselect": "^2.4.0",
     "url-loader": "^0.6.2",
-    "uuid": "^2.0.2",
+    "uuid": "^3.2.1",
     "whatwg-fetch": "^2.0.0"
   },
   "workspaces": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -11684,13 +11684,17 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
-uuid@^2.0.1, uuid@^2.0.2:
+uuid@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
 uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+
+uuid@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
 v8flags@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
The uuid package is some versions behind. This updates the package to the latest version 3.2.1.

Resolves: #1810 