### PR TITLE
BUGFIX: prevent "backend in backend" behavior after session expires

### DIFF
--- a/Classes/Neos/Neos/Ui/Aspects/AugmentationAspect.php
+++ b/Classes/Neos/Neos/Ui/Aspects/AugmentationAspect.php
@@ -128,7 +128,7 @@ class AugmentationAspect
 
         if (
             !$this->session->isStarted()
-            || !$this->session->getData('__neosEnabled__')
+            || $this->session->getData('__neosLegacyUiEnabled__')
             || $node->getContext()->getWorkspace()->isPublicWorkspace()
         ) {
             return $joinPoint->getAdviceChain()->proceed($joinPoint);
@@ -170,7 +170,7 @@ class AugmentationAspect
      */
     public function editableElementAugmentation(JoinPointInterface $joinPoint)
     {
-        if (!$this->session->isStarted() || !$this->session->getData('__neosEnabled__')) {
+        if (!$this->session->isStarted() || $this->session->getData('__neosLegacyUiEnabled__')) {
             return $joinPoint->getAdviceChain()->proceed($joinPoint);
         }
 

--- a/Classes/Neos/Neos/Ui/Aspects/NodeTypeSchemaCacheHeaderAspect.php
+++ b/Classes/Neos/Neos/Ui/Aspects/NodeTypeSchemaCacheHeaderAspect.php
@@ -38,7 +38,7 @@ class NodeTypeSchemaCacheHeaderAspect
      */
     public function setControllerContextFromContentElementWrappingImplementation(JoinPointInterface $joinPoint)
     {
-        if ($this->session->isStarted() && $this->session->getData('__neosEnabled__')) {
+        if ($this->session->isStarted() && !$this->session->getData('__neosLegacyUiEnabled__')) {
             /** @var SchemaController $proxy */
             $proxy = $joinPoint->getProxy();
 

--- a/Classes/Neos/Neos/Ui/Aspects/XliffConfigurationCacheHeaderAspect.php
+++ b/Classes/Neos/Neos/Ui/Aspects/XliffConfigurationCacheHeaderAspect.php
@@ -37,7 +37,7 @@ class XliffConfigurationCacheHeaderAspect
      */
     public function setControllerContextFromContentElementWrappingImplementation(JoinPointInterface $joinPoint)
     {
-        if ($this->session->isStarted() && $this->session->getData('__neosEnabled__')) {
+        if ($this->session->isStarted() && !$this->session->getData('__neosLegacyUiEnabled__')) {
             /** @var SchemaController $proxy */
             $proxy = $joinPoint->getProxy();
 

--- a/Classes/Neos/Neos/Ui/Controller/BackendController.php
+++ b/Classes/Neos/Neos/Ui/Controller/BackendController.php
@@ -115,7 +115,7 @@ class BackendController extends ActionController
     public function indexAction(NodeInterface $node = null)
     {
         $this->session->start();
-        $this->session->putData('__neosEnabled__', true);
+        $this->session->putData('__neosLegacyUiEnabled__', false);
         $user = $this->userService->getBackendUser();
 
         if ($user === null) {
@@ -151,7 +151,7 @@ class BackendController extends ActionController
         }
 
         $this->session->start();
-        $this->session->putData('__neosEnabled__', false);
+        $this->session->putData('__neosLegacyUiEnabled__', true);
 
         $this->redirect('show', 'Frontend\Node', 'Neos.Neos', ['node' => $node]);
     }

--- a/Classes/Neos/Neos/Ui/Fusion/Helper/ActivationHelper.php
+++ b/Classes/Neos/Neos/Ui/Fusion/Helper/ActivationHelper.php
@@ -26,7 +26,7 @@ class ActivationHelper implements ProtectedContextAwareInterface
 
     public function enableNewBackend()
     {
-        return $this->session->isStarted() && $this->session->getData('__neosEnabled__');
+        return $this->session->isStarted() && $this->session->getData('__neosLegacyUiEnabled__') ? false : true;
     }
 
     /**


### PR DESCRIPTION
Fixes: #1729 

With this change we invert the behavior of the session parameter and make the new UI activated by default, and storing `__neosLegacyUiEnabled__` into the session with the user clicks "Switch to old UI".

Obviously it won't alter the behavior of old systems without the neos-ui package installed.
