### PR TITLE
BUGFIX: fix forceCrop mode on auto-reloaded properties

### DIFF
--- a/packages/neos-ui-editors/src/Editors/Image/index.js
+++ b/packages/neos-ui-editors/src/Editors/Image/index.js
@@ -148,6 +148,7 @@ export default class ImageEditor extends Component {
         commit(value, {
             'Neos.UI:Hook.BeforeSave.CreateImageVariant': nextimage
         });
+        this.setState({isImageCropperOpen: false});
     }
 
     handleResize = resizeAdjustment => {


### PR DESCRIPTION
Before the fix, if you had `forceCrop` enabled for image editor, and had a property configured to reload the page, after page reload you would see the image cropper again.