### PR TITLE
TASK: Replace  react-codemirror with  react-codemirror2

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "react": "^16.0.0",
     "react-click-outside": "^2.3.1",
     "react-close-on-escape": "^2.0.0",
-    "react-codemirror": "^1.0.0",
+    "react-codemirror2": "^5.0.1",
     "react-collapse": "^4.0.3",
     "react-css-themr": "^2.1.0",
     "react-datetime": "^2.8.10",

--- a/packages/neos-ui-editors/src/SecondaryEditors/CodeMirrorWrap/index.js
+++ b/packages/neos-ui-editors/src/SecondaryEditors/CodeMirrorWrap/index.js
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import CodeMirror from 'react-codemirror';
+import {UnControlled as CodeMirror} from 'react-codemirror2';
 
 // TODO: Find way to dynamically load any mode?
 /* eslint-disable no-unused-vars */
@@ -25,12 +25,12 @@ export default class CodeMirrorWrap extends PureComponent {
         if (!ref) {
             return;
         }
-        const codeMirrorRef = ref.getCodeMirror();
-        const codeMirrorWrapperDomElement = codeMirrorRef.display.wrapper;
+        const codeMirrorRef = ref;
+        const codeMirrorWrapperDomElement = codeMirrorRef.editor.display.wrapper;
         const offsetTop = codeMirrorWrapperDomElement.getBoundingClientRect().top;
         const clientHeight = window.innerHeight || document.clientHeight || document.getElementByTagName('body').clientHeight;
         const height = clientHeight - offsetTop;
-        codeMirrorRef.setSize(null, height);
+        codeMirrorRef.editor.setSize(null, height);
     }
 
     render() {
@@ -44,12 +44,8 @@ export default class CodeMirrorWrap extends PureComponent {
         };
 
         return (
-            <CodeMirror value={this.props.value} onChange={this.handleChange} options={options} ref={this.editorRefCallback}/>
+            <CodeMirror value={this.props.value} options={options} ref={this.editorRefCallback}
+                onChange={(editor, data, value) => this.props.onChange(value)} />
         );
-    }
-
-    // ToDo: Why not directly passing the commit prop down if the argument just gets forwarded?
-    handleChange = newValue => {
-        this.props.onChange(newValue);
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2691,7 +2691,7 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-codemirror@^5.18.2, codemirror@^5.24.0:
+codemirror@^5.24.0:
   version "5.33.0"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.33.0.tgz#462ad9a6fe8d38b541a9536a3997e1ef93b40c6a"
 
@@ -3127,7 +3127,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.5.1, create-react-class@^15.5.2:
+create-react-class@^15.5.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.2.tgz#cf1ed15f12aad7f14ef5f2dfe05e6c42f91ef02a"
   dependencies:
@@ -9219,16 +9219,9 @@ react-close-on-escape@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/react-close-on-escape/-/react-close-on-escape-2.0.0.tgz#d3bf6d18fac516979d76e7732fda39057176f017"
 
-react-codemirror@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-codemirror/-/react-codemirror-1.0.0.tgz#91467b53b1f5d80d916a2fd0b4c7adb85a9001ba"
-  dependencies:
-    classnames "^2.2.5"
-    codemirror "^5.18.2"
-    create-react-class "^15.5.1"
-    lodash.debounce "^4.0.8"
-    lodash.isequal "^4.5.0"
-    prop-types "^15.5.4"
+react-codemirror2@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-codemirror2/-/react-codemirror2-5.0.1.tgz#81eb8e17bfe859633a6855a9ce40307914d42891"
 
 react-collapse@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
The react-codemirror package is more or less unmaintained and
so we switch to the fork react-codemirror2.

So this replaces the package and adjusts the SecondaryEditor.

Resolves: #1814 