### PR TITLE
TASK: bundle fonte-awesome styles in a safer way

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "regenerator-runtime": "^0.10.3",
     "rimraf": "^2.5.4",
     "semantic-release": "^6.3.2",
+    "string-replace-loader": "^2.1.1",
     "style-loader": "^0.19.0",
     "stylelint": "^8.4.0",
     "testcafe": "^0.19.2",

--- a/packages/build-essentials/src/webpack.config.js
+++ b/packages/build-essentials/src/webpack.config.js
@@ -58,7 +58,24 @@ const webpackConfig = {
                 }]
             },
             {
+                test: /node_modules\/@fortawesome\/fontawesome\/styles\.css$/,
+                use: extractCss.extract({
+                    use: [{
+                        loader: 'css-loader'
+                    }, {
+                        loader: 'string-replace-loader',
+                        options: {
+                            search: 'svg-inline--fa',
+                            replace: 'neos-svg-inline--fa',
+                            flags: 'g'
+                        }
+                    }],
+                    fallback: 'style-loader'
+                })
+            },
+            {
                 test: /\.css$/,
+                exclude: /node_modules\/@fortawesome\/fontawesome\/styles\.css$/,
                 use: extractCss.extract({
                     use: [{
                         loader: 'css-loader',

--- a/packages/react-ui-components/src/Icon/index.js
+++ b/packages/react-ui-components/src/Icon/index.js
@@ -6,7 +6,13 @@ import {themr} from 'react-css-themr';
 import identifiers from './../identifiers.js';
 import style from './style.css';
 import Icon from './icon.js';
+/* eslint-disable no-unused-vars */
+import faStyle from '@fortawesome/fontawesome/styles.css';
+/* eslint-enable no-unused-vars */
 
+fontawesome.config.autoAddCss = false;
+fontawesome.config.familyPrefix = 'neos-fa';
+fontawesome.config.replacementClass = 'neos-svg-inline--fa';
 fontawesome.library.add(brands, solid, regular);
 
 const ThemedIcon = themr(identifiers.icon, style)(Icon);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10271,7 +10271,7 @@ schema-utils@^0.3.0:
   dependencies:
     ajv "^5.0.0"
 
-schema-utils@^0.4.3:
+schema-utils@^0.4.3, schema-utils@^0.4.5:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.5.tgz#21836f0608aac17b78f9e3e24daff14a5ca13a3e"
   dependencies:
@@ -10746,6 +10746,13 @@ string-length@^2.0.0:
   dependencies:
     astral-regex "^1.0.0"
     strip-ansi "^4.0.0"
+
+string-replace-loader@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-replace-loader/-/string-replace-loader-2.1.1.tgz#b72e7b57b6ef04efe615aff0ad989b5c14ca63d1"
+  dependencies:
+    loader-utils "^1.1.0"
+    schema-utils "^0.4.5"
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR does a few things:
- Prefixes FA CSS classes with `neos-` namespace to avoid conflicts
- Disables automatic injection of FA styles into head (as they will not affect the guest frame)
- Loads FA styles together with the rest of 3rd-party vanilla CSS