### PR TITLE
TASK: Apply Inspector changes by pressing the enter key in TextFields

### DIFF
--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.js
@@ -23,6 +23,7 @@ export default class PropertyGroup extends PureComponent {
 
         node: PropTypes.object.isRequired,
         handlePanelToggle: PropTypes.func.isRequired,
+        handleInspectorApply: PropTypes.func,
         commit: PropTypes.func.isRequired
     };
 
@@ -31,7 +32,7 @@ export default class PropertyGroup extends PureComponent {
     };
 
     render() {
-        const {items, label, icon, collapsed, handlePanelToggle, renderSecondaryInspector, node, commit} = this.props;
+        const {items, label, icon, collapsed, handlePanelToggle, handleInspectorApply, renderSecondaryInspector, node, commit} = this.props;
         const headerTheme = {
             panel__headline: style.propertyGroupLabel // eslint-disable-line camelcase
         };
@@ -56,6 +57,7 @@ export default class PropertyGroup extends PureComponent {
                                     renderSecondaryInspector={renderSecondaryInspector}
                                     node={node}
                                     commit={commit}
+                                    onEnterKey={handleInspectorApply}
                                     />);
                         }
                         if (itemType === 'view') {

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
@@ -14,7 +14,8 @@ export default class TabPanel extends PureComponent {
         groups: PropTypes.object,
         renderSecondaryInspector: PropTypes.func.isRequired,
         node: PropTypes.object.isRequired,
-        commit: PropTypes.func.isRequired
+        commit: PropTypes.func.isRequired,
+        handleInspectorApply: PropTypes.func
     };
 
     isPropertyEnabled = ({id}) => {
@@ -24,7 +25,7 @@ export default class TabPanel extends PureComponent {
     };
 
     render() {
-        const {handlePanelToggle, toggledPanels, groups, renderSecondaryInspector, node, commit} = this.props;
+        const {handlePanelToggle, handleInspectorApply, toggledPanels, groups, renderSecondaryInspector, node, commit} = this.props;
 
         if (!groups) {
             return (<div>...</div>);
@@ -37,6 +38,7 @@ export default class TabPanel extends PureComponent {
                     groups.filter(g => ($get('items', g) && $get('items', g).filter(this.isPropertyEnabled).count())).map(group => (
                         <PropertyGroup
                             handlePanelToggle={() => handlePanelToggle([$get('id', group)])}
+                            handleInspectorApply={handleInspectorApply}
                             key={$get('id', group)}
                             label={$get('label', group)}
                             icon={$get('icon', group)}

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -271,6 +271,7 @@ export default class Inspector extends PureComponent {
                                     handlePanelToggle={path => {
                                         this.handlePanelToggle([$get('id', tab), ...path]);
                                     }}
+                                    handleInspectorApply={this.handleApply}
                                     />);
                         })
                     }


### PR DESCRIPTION
Fixes #1832 

InspectorEditorEnvelope sets now onEnterKey={handleInspectorApply}, so that now every Editor can use onEnterKey directly to apply the inspector changes. 