### PR TITLE
FEATURE: Make EditPreviewMode backgroundColor configurable

### DIFF
--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -106,8 +106,10 @@ export default class ContentCanvas extends PureComponent {
             canvasContentOnlyStyle.overflow = 'auto';
         }
 
-        if (backgroundColor) {
+        if (backgroundColor && !currentEditPreviewModeConfiguration.backgroundColor) {
             canvasContentStyle.background = backgroundColor;
+        } else if (currentEditPreviewModeConfiguration.backgroundColor) {
+            canvasContentStyle.background = currentEditPreviewModeConfiguration.backgroundColor;
         }
 
         // ToDo: Is the `[data-__neos__hook]` attr used?

--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -106,10 +106,10 @@ export default class ContentCanvas extends PureComponent {
             canvasContentOnlyStyle.overflow = 'auto';
         }
 
-        if (backgroundColor && !currentEditPreviewModeConfiguration.backgroundColor) {
-            canvasContentStyle.background = backgroundColor;
-        } else if (currentEditPreviewModeConfiguration.backgroundColor) {
+        if (currentEditPreviewModeConfiguration.backgroundColor) {
             canvasContentStyle.background = currentEditPreviewModeConfiguration.backgroundColor;
+        } else if (backgroundColor) {
+            canvasContentStyle.background = backgroundColor;
         }
 
         // ToDo: Is the `[data-__neos__hook]` attr used?


### PR DESCRIPTION
This enables the user to configure the backgroundColor of an `editPreviewMode` via `Settings.yaml`

```
Neos:
  Neos:
    userInterface:
      editPreviewModes:
        myPrev:
          isEditingMode: false
          isPreviewMode: true
          title: 'My Preview'
          position: 200
          width: 500px
          backgroundColor: '#000000'
```

closes #1700