### PR TITLE
BUGFIX: update react-collapse, fixes overflow of text inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "react-click-outside": "^2.3.1",
     "react-close-on-escape": "^2.0.0",
     "react-codemirror2": "^5.0.1",
-    "react-collapse": "^5.0.0-alpha.0",
+    "react-collapse": "^2.4.1",
     "react-css-themr": "^2.1.0",
     "react-datetime": "^2.8.10",
     "react-dnd": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "react-click-outside": "^2.3.1",
     "react-close-on-escape": "^2.0.0",
     "react-codemirror2": "^5.0.1",
-    "react-collapse": "^4.0.3",
+    "react-collapse": "^5.0.0-alpha.0",
     "react-css-themr": "^2.1.0",
     "react-datetime": "^2.8.10",
     "react-dnd": "^2.5.1",

--- a/packages/react-ui-components/package.json
+++ b/packages/react-ui-components/package.json
@@ -45,7 +45,7 @@
     "react": "^16.0.0",
     "react-click-outside": "^2.3.1",
     "react-close-on-escape": "^2.0.0",
-    "react-collapse": "^4.0.3",
+    "react-collapse": "^5.0.0-alpha.0",
     "react-css-themr": "^2.1.0",
     "react-datetime": "^2.8.10",
     "react-dnd": "^2.5.1",

--- a/packages/react-ui-components/package.json
+++ b/packages/react-ui-components/package.json
@@ -45,7 +45,7 @@
     "react": "^16.0.0",
     "react-click-outside": "^2.3.1",
     "react-close-on-escape": "^2.0.0",
-    "react-collapse": "^5.0.0-alpha.0",
+    "react-collapse": "^2.4.1",
     "react-css-themr": "^2.1.0",
     "react-datetime": "^2.8.10",
     "react-dnd": "^2.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9223,11 +9223,11 @@ react-codemirror2@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/react-codemirror2/-/react-codemirror2-5.0.1.tgz#81eb8e17bfe859633a6855a9ce40307914d42891"
 
-react-collapse@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/react-collapse/-/react-collapse-4.0.3.tgz#b96de959ed0092a43534630b599a4753dd76d543"
+react-collapse@^5.0.0-alpha.0:
+  version "5.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/react-collapse/-/react-collapse-5.0.0-alpha.0.tgz#c71d95d427f4db336336dc9bcb74e94172cfc16a"
   dependencies:
-    prop-types "^15.5.8"
+    prop-types "^15.6.0"
 
 react-color@^2.11.4:
   version "2.13.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9223,11 +9223,11 @@ react-codemirror2@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/react-codemirror2/-/react-codemirror2-5.0.1.tgz#81eb8e17bfe859633a6855a9ce40307914d42891"
 
-react-collapse@^5.0.0-alpha.0:
-  version "5.0.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/react-collapse/-/react-collapse-5.0.0-alpha.0.tgz#c71d95d427f4db336336dc9bcb74e94172cfc16a"
+react-collapse@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/react-collapse/-/react-collapse-2.4.1.tgz#999a9969b2633752acba4847c28101edd2dcab89"
   dependencies:
-    prop-types "^15.6.0"
+    prop-types "15.5.8"
 
 react-color@^2.11.4:
   version "2.13.8"


### PR DESCRIPTION
Without updating to 5x version there's this bug with overflow text inputs in Firefox:
![peek 2018-05-11 11-42](https://user-images.githubusercontent.com/837032/39919621-dca9bb1c-551c-11e8-8408-6ce84b7310da.gif)
