### PR TITLE
BUGFIX: do not validate elements if no element configuration exists

### DIFF
--- a/packages/neos-ui-validators/src/index.js
+++ b/packages/neos-ui-validators/src/index.js
@@ -17,8 +17,8 @@ const validate = (values, elementConfigurations, validatorRegistry) => {
     };
 
     const validateElement = (elementValue, elementConfiguration) => {
-        const validators = elementConfiguration.validation;
-        if (validators) {
+        if (elementConfiguration && elementConfiguration.validation) {
+            const validators = elementConfiguration.validation;
             const validationResults = Object.keys(validators).map(validatorName => {
                 const validatorConfiguration = validators[validatorName];
                 return checkValidator(elementValue, validatorName, validatorConfiguration);


### PR DESCRIPTION
closes #1878 