### PR TITLE
TASK: Legacy class for content shining through

### DIFF
--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -11,6 +11,7 @@ namespace Neos\Neos\Ui\Fusion\Helper;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\Node;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Eel\ProtectedContextAwareInterface;
@@ -102,7 +103,9 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
             'depth' => $node->getDepth(),
             // TODO: 'uri' =>@if.onyRenderWhenNodeIsADocument = ${q(node).is('[instanceof Neos.Neos:Document]')}
             'children' => [],
+            'matchesCurrentDimensions' => $node instanceof Node && $node->dimensionsAreMatchingTargetDimensionValues(),
         ];
+
         // It's important to not set `isFullyLoaded` to false by default, so the state would get merged correctly
         if (!$omitMostPropertiesForTreeState) {
             $nodeInfo['isFullyLoaded'] = true;

--- a/packages/neos-ui-guest-frame/src/initializeContentDomNode.js
+++ b/packages/neos-ui-guest-frame/src/initializeContentDomNode.js
@@ -15,6 +15,7 @@ export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry,
     const isHidden = $get([contextPath, 'properties', '_hidden'], nodes);
     const hasChildren = Boolean($count([contextPath, 'children'], nodes));
     const isInlineEditable = nodeTypesRegistry.isInlineEditable($get([contextPath, 'nodeType'], nodes));
+    const matchesCurrentDimensions = !$get([contextPath, 'matchesCurrentDimensions'], nodes);
 
     if (isHidden) {
         contentDomNode.classList.add(style.markHiddenNodeAsHidden);
@@ -22,6 +23,14 @@ export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry,
 
     if (!isInlineEditable && !hasChildren) {
         createNotInlineEditableOverlay(contentDomNode);
+    }
+
+    if (matchesCurrentDimensions) {
+        /**
+         * Adding legacy class for content elements shining through
+         * @see Neos\Neos\Service\ContentElementWrappingService::addCssClasses()
+         */
+        contentDomNode.classList.add('neos-contentelement-shine-through');
     }
 
     contentDomNode.addEventListener('mouseenter', e => {


### PR DESCRIPTION

**What I did**
Added reference to old Node.php, now the elements get a class called "neos-contentelement-shine-through" like in the old one if they are not matching with the current dimension.

**How I did it**
Added a reference in NodeInfoHelper.php -> renderNode() and created a const in initializeContentDomeNode.js -> called: matchesCurrentDimensions.

**How to verify it**
You need to take a look at the html object of your UI, if the dimension shines trough the css-class is added.


solves #1715 