### PR TITLE
TASK: Include translations from Crowdin

### DIFF
--- a/Resources/Private/Translations/af_ZA/Main.xlf
+++ b/Resources/Private/Translations/af_ZA/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="af">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="af" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="af" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="af" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="af" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="af" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="af" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="af" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="af" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="af" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="af" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="af" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="af" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="af" state="needs-translation">Link</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="af" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="af" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="af" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="af" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="af" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="af" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="af" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="af" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="af" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="af" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="af" state="needs-translation">Create new</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="af" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="af" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/ar_SA/Main.xlf
+++ b/Resources/Private/Translations/ar_SA/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ar">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="ar" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="ar" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="ar" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="ar" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="ar" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="ar" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="ar" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="ar" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="ar" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="ar" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="ar" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="ar" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="ar" state="translated">الرابط</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="ar" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="ar" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="ar" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="ar" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="ar" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="ar" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="ar" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="ar" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="ar" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="ar" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="ar" state="translated">إنشاء جديد</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="ar" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="ar" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/ca_ES/Main.xlf
+++ b/Resources/Private/Translations/ca_ES/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ca">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="ca" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="ca" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="ca" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="ca" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="ca" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="ca" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="ca" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="ca" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="ca" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="ca" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="ca" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="ca" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="ca" state="needs-translation">Link</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="ca" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="ca" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="ca" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="ca" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="ca" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="ca" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="ca" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="ca" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="ca" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="ca" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="ca" state="needs-translation">Create new</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="ca" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="ca" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/cs_CZ/Main.xlf
+++ b/Resources/Private/Translations/cs_CZ/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="cs">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="cs" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="cs" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="cs" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="cs" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="cs" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="cs" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="cs" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="cs" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="cs" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="cs" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="cs" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="cs" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="cs" state="needs-translation">Link</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="cs" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="cs" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="cs" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="cs" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="cs" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="cs" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="cs" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="cs" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="cs" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="cs" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="cs" state="translated">Vytvořit nový</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="cs" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="cs" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/da_DK/Main.xlf
+++ b/Resources/Private/Translations/da_DK/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="da">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="da" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="da" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="da" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="da" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="da" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="da" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="da" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="da" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="da" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="da" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="da" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="da" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
+				<source>Link</source>
+			<target xml:lang="da">Link</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="da" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="da" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="da" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="da" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="da" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="da" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="da" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="da" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="da" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="da" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve" approved="yes">
+				<source>Create new</source>
+			<target xml:lang="da">Opret ny</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="da" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="da" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/de_DE/Main.xlf
+++ b/Resources/Private/Translations/de_DE/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="de" state="translated">{source} zu {target} kopieren</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="de" state="translated">{source} zu {target} verschieben</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="de" state="translated">Bitte wählen Sie die Position an der Sie {source} relativ zu {target} Einfügen möchten.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="de" state="translated">Einfügen</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="de" state="translated">Einfügemodus</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="de" state="translated">Wählen Sie ein Seitenverhältnis</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="de" state="translated">Fett</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="de" state="translated">Kursiv</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="de" state="translated">Unterstrichen</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="de" state="translated">Tiefgestellt</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="de" state="translated">Hochgestellt</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="de" state="translated">Durchgestrichen</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
+				<source>Link</source>
+			<target xml:lang="de">Link</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="de" state="translated">Geordnete Liste</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="de" state="translated">Ungeordnete Liste</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="de" state="translated">Linksbündig</target><alt-trans><target xml:lang="de">Links ausrichten</target></alt-trans></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="de" state="translated">Rechtsbündig</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="de" state="translated">Zentriert</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="de" state="translated">Blocksatz</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="de" state="translated">Tabelle</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="de" state="translated">Format entfernen</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="de" state="translated">Einzug verringern</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="de" state="translated">Einzug vergrößern</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve" approved="yes">
+				<source>Create new</source>
+			<target xml:lang="de">Neu erstellen</target><alt-trans><target xml:lang="de">Neues Element erstellen</target></alt-trans></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="de" state="translated">Keine Treffer gefunden</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="de" state="translated">Bitte geben Sie ###CHARACTERS### mehr Zeichen ein</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/el_GR/Main.xlf
+++ b/Resources/Private/Translations/el_GR/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="el">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="el" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="el" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="el" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="el" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="el" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="el" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="el" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="el" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="el" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="el" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="el" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="el" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="el" state="translated">Σύνδεσμος</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="el" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="el" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="el" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="el" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="el" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="el" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="el" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="el" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="el" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="el" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="el" state="needs-translation">Create new</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="el" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="el" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/es_ES/Main.xlf
+++ b/Resources/Private/Translations/es_ES/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="es-ES">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="es-ES" state="translated">Copiar {source} a {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="es-ES" state="translated">Mover {source} a {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="es-ES" state="translated">Por favor, seleccione la posición en que desea {source} insertado en relación con {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="es-ES" state="translated">Insertar</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="es-ES" state="translated">Insertar modo</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="es-ES" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="es-ES" state="translated">Negrita</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="es-ES" state="translated">Italica</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="es-ES" state="translated">Subrayar</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="es-ES" state="translated">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="es-ES" state="translated">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="es-ES" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="es-ES" state="translated">Enlace</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="es-ES" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="es-ES" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="es-ES" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="es-ES" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="es-ES" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="es-ES" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="es-ES" state="translated">Tabla</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="es-ES" state="translated">Eliminar formato</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="es-ES" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="es-ES" state="translated">Sangría</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="es-ES" state="translated">Crear nuevo</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="es-ES" state="translated">No se encuentran coincidencias</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="es-ES" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/fi_FI/Main.xlf
+++ b/Resources/Private/Translations/fi_FI/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="fi">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="fi" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="fi" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="fi" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="fi" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="fi" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="fi" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="fi" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="fi" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="fi" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="fi" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="fi" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="fi" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
+				<source>Link</source>
+			<target xml:lang="fi">Linkki</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="fi" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="fi" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="fi" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="fi" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="fi" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="fi" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="fi" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="fi" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="fi" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="fi" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve" approved="yes">
+				<source>Create new</source>
+			<target xml:lang="fi">Luo uusi</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="fi" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="fi" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/fr_FR/Main.xlf
+++ b/Resources/Private/Translations/fr_FR/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="fr" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="fr" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="fr" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="fr" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="fr" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="fr" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="fr" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="fr" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="fr" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="fr" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="fr" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="fr" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
+				<source>Link</source>
+			<target xml:lang="fr">Lien</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="fr" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="fr" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="fr" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="fr" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="fr" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="fr" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="fr" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="fr" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="fr" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="fr" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve" approved="yes">
+				<source>Create new</source>
+			<target xml:lang="fr">Créer un nouveau</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="fr" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="fr" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/he_IL/Main.xlf
+++ b/Resources/Private/Translations/he_IL/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="he">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="he" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="he" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="he" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="he" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="he" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="he" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="he" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="he" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="he" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="he" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="he" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="he" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="he" state="needs-translation">Link</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="he" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="he" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="he" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="he" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="he" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="he" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="he" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="he" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="he" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="he" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="he" state="needs-translation">Create new</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="he" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="he" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/hu_HU/Main.xlf
+++ b/Resources/Private/Translations/hu_HU/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="hu">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="hu" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="hu" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="hu" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="hu" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="hu" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="hu" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="hu" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="hu" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="hu" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="hu" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="hu" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="hu" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="hu" state="needs-translation">Link</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="hu" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="hu" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="hu" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="hu" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="hu" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="hu" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="hu" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="hu" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="hu" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="hu" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="hu" state="translated">Új létrehozása</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="hu" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="hu" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/id_ID/Main.xlf
+++ b/Resources/Private/Translations/id_ID/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="id">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="id" state="translated">Salin {source} ke {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="id" state="translated">Memindahkan {source} ke {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="id" state="translated">Harap pilih posisi yang Anda inginkan {source} dimasukkan relatif terhadap {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="id" state="translated">Memasukkan</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="id" state="translated">Sisipkan mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="id" state="translated">Pilih Rasio Aspek</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="id" state="translated">Berani</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="id" state="translated">Miring</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="id" state="translated">Menggarisbawahi</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="id" state="translated">Tanda tangansss</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="id" state="translated">Tulisan di atas</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="id" state="translated">Dicoret</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
+				<source>Link</source>
+			<target xml:lang="id">Link / tautan</target><alt-trans><target xml:lang="id">Tautan</target></alt-trans></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="id" state="translated">Daftar pesanan</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="id" state="translated">Daftar tak berurutan</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="id" state="translated">Rata kiri</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="id" state="translated">Rata kanan</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="id" state="translated">Pusat sejajar</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="id" state="translated">Align membenarkan</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="id" state="translated">Meja</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="id" state="translated">Hapus format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="id" state="translated">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="id" state="translated">Indentasi</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="id" state="translated">Buat baru</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="id" state="translated">Tidak ditemukan kecocokan</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="id" state="translated">Silakan masukkan ###KARAKTER### lebih banyak karakter</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/it_IT/Main.xlf
+++ b/Resources/Private/Translations/it_IT/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="it" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="it" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="it" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="it" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="it" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="it" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="it" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="it" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="it" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="it" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="it" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="it" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="it" state="needs-translation">Link</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="it" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="it" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="it" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="it" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="it" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="it" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="it" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="it" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="it" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="it" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="it" state="translated">Crea nuovo</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="it" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="it" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/ja_JP/Main.xlf
+++ b/Resources/Private/Translations/ja_JP/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="ja" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="ja" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="ja" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="ja" state="translated">インサート</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="ja" state="translated">挿入モード</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="ja" state="translated">アスペクト比を選択する</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="ja" state="translated">大胆な</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="ja" state="translated">イタリック</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="ja" state="translated">アンダーライン</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="ja" state="translated">添字</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="ja" state="translated">上付き文字</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="ja" state="translated">打ち間違い</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="ja" state="needs-translation">Link</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="ja" state="translated">順序付きリスト</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="ja" state="translated">順序付けられていないリスト</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="ja" state="translated">左揃え</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="ja" state="translated">右揃え</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="ja" state="translated">中心合わせ</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="ja" state="translated">正当な理由を整える</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="ja" state="translated">表</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="ja" state="translated">フォーマットを削除</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="ja" state="translated">アウトデント</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="ja" state="translated">インデント</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="ja" state="translated">新規作成 </target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="ja" state="translated">一致が見つかりません</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="ja" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/kk_KZ/Main.xlf
+++ b/Resources/Private/Translations/kk_KZ/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="kk">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="kk" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="kk" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="kk" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="kk" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="kk" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="kk" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="kk" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="kk" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="kk" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="kk" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="kk" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="kk" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="kk" state="needs-translation">Link</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="kk" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="kk" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="kk" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="kk" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="kk" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="kk" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="kk" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="kk" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="kk" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="kk" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="kk" state="translated">Жаңасын құру</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="kk" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="kk" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/km_KH/Main.xlf
+++ b/Resources/Private/Translations/km_KH/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="km">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="km" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="km" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="km" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="km" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="km" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="km" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="km" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="km" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="km" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="km" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="km" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="km" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
+				<source>Link</source>
+			<target xml:lang="km">តំណភ្ជាប់</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="km" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="km" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="km" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="km" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="km" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="km" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="km" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="km" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="km" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="km" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve" approved="yes">
+				<source>Create new</source>
+			<target xml:lang="km">បង្កើតថ្មី</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="km" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="km" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/ko_KR/Main.xlf
+++ b/Resources/Private/Translations/ko_KR/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="ko" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="ko" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="ko" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="ko" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="ko" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="ko" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="ko" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="ko" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="ko" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="ko" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="ko" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="ko" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="ko" state="needs-translation">Link</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="ko" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="ko" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="ko" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="ko" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="ko" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="ko" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="ko" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="ko" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="ko" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="ko" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="ko" state="needs-translation">Create new</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="ko" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="ko" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/lv_LV/Main.xlf
+++ b/Resources/Private/Translations/lv_LV/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="lv">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="lv" state="translated">Kopēt {source} uz {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="lv" state="translated">Pārvietot {source} uz {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="lv" state="translated">Izvēlieties pozīciju, no kuras {source} ievietota attiecībā pret {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="lv" state="translated">Ievietot</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="lv" state="translated">Ievietot veidu</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="lv" state="translated">Izvēlieties skata proporciju</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="lv" state="translated">Trekns</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="lv" state="translated">Slīps</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="lv" state="translated">Pasvītrots</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="lv" state="translated">Apakšraksts</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="lv" state="translated">Augšraksts</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="lv" state="translated">Pārsvītrojums</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
+				<source>Link</source>
+			<target xml:lang="lv">Saite</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="lv" state="translated">Numurēts saraksts</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="lv" state="translated">Nenumurēts saraksts</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="lv" state="translated">Līdzināt pa kreisi</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="lv" state="translated">Līdzināt pa labi</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="lv" state="translated">Līdzināt uz centru</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="lv" state="translated">Izlīdzināts</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="lv" state="translated">Tabula</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="lv" state="translated">Formatējuma atcelšana</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="lv" state="translated">Negatīvā atkāpe</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="lv" state="translated">Atkāpe</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve" approved="yes">
+				<source>Create new</source>
+			<target xml:lang="lv">Izveidot jaunu</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="lv" state="translated">Nav atrasta neviena atbilstība</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="lv" state="translated">Lūdzu, ievadiet papildu rakstzīmes # # #CHARACTERS###</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/mr_IN/Main.xlf
+++ b/Resources/Private/Translations/mr_IN/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="mr">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="mr" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="mr" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="mr" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="mr" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="mr" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="mr" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="mr" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="mr" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="mr" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="mr" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="mr" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="mr" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="mr" state="needs-translation">Link</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="mr" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="mr" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="mr" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="mr" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="mr" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="mr" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="mr" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="mr" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="mr" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="mr" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="mr" state="needs-translation">Create new</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="mr" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="mr" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/nl_NL/Main.xlf
+++ b/Resources/Private/Translations/nl_NL/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="nl">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="nl" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="nl" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="nl" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="nl" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="nl" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="nl" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="nl" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="nl" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="nl" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="nl" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="nl" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="nl" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
+				<source>Link</source>
+			<target xml:lang="nl">Link</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="nl" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="nl" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="nl" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="nl" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="nl" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="nl" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="nl" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="nl" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="nl" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="nl" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve" approved="yes">
+				<source>Create new</source>
+			<target xml:lang="nl">Maak nieuw</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="nl" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="nl" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/no_NO/Main.xlf
+++ b/Resources/Private/Translations/no_NO/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="no">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="no" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="no" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="no" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="no" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="no" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="no" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="no" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="no" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="no" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="no" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="no" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="no" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="no" state="translated">Link</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="no" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="no" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="no" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="no" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="no" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="no" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="no" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="no" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="no" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="no" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="no" state="translated">Opprett ny</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="no" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="no" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/pl_PL/Main.xlf
+++ b/Resources/Private/Translations/pl_PL/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="pl">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve" approved="yes">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="pl">Skopiuj {source} do {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve" approved="yes">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="pl">Przenieś {source} do {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve" approved="yes">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="pl">Wybierz pozycję na jakiej chcesz wstawić {source} względem {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve" approved="yes">
+				<source>Insert</source>
+			<target xml:lang="pl">Wstaw</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve" approved="yes">
+				<source>Insert mode</source>
+			<target xml:lang="pl">Tryb wstawiania</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve" approved="yes">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="pl">Wybierz współczynnik proporcji</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve" approved="yes">
+				<source>Bold</source>
+			<target xml:lang="pl">Pogrubienie</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve" approved="yes">
+				<source>Italic</source>
+			<target xml:lang="pl">Kursywa</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve" approved="yes">
+				<source>Underline</source>
+			<target xml:lang="pl">Podkreślenie</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve" approved="yes">
+				<source>Subscript</source>
+			<target xml:lang="pl">Indeks dolny</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve" approved="yes">
+				<source>Superscript</source>
+			<target xml:lang="pl">Indeks górny</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve" approved="yes">
+				<source>Strikethrough</source>
+			<target xml:lang="pl">Przekreślenie</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
+				<source>Link</source>
+			<target xml:lang="pl">Odnośnik</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve" approved="yes">
+				<source>Ordered list</source>
+			<target xml:lang="pl">Lista uporządkowana</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve" approved="yes">
+				<source>Unordered list</source>
+			<target xml:lang="pl">Lista nieuporządkowana</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve" approved="yes">
+				<source>Align left</source>
+			<target xml:lang="pl">Wyrównaj do lewej</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve" approved="yes">
+				<source>Align right</source>
+			<target xml:lang="pl">Wyrównaj do prawej</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve" approved="yes">
+				<source>Align center</source>
+			<target xml:lang="pl">Wyrównaj do środka</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve" approved="yes">
+				<source>Align justify</source>
+			<target xml:lang="pl">Wyjustuj</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve" approved="yes">
+				<source>Table</source>
+			<target xml:lang="pl">Tabela</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve" approved="yes">
+				<source>Remove format</source>
+			<target xml:lang="pl">Usuń formatowanie</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve" approved="yes">
+				<source>Outdent</source>
+			<target xml:lang="pl">Zmniejsz wcięcie</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve" approved="yes">
+				<source>Indent</source>
+			<target xml:lang="pl">Wcięcie</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve" approved="yes">
+				<source>Create new</source>
+			<target xml:lang="pl">Utwórz nowy</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve" approved="yes">
+				<source>No matches found</source>
+			<target xml:lang="pl">Nie znaleziono dopasowań</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve" approved="yes">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="pl">Wprowadź ###CHARACTERS### znaków więcej</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/ps_AF/Main.xlf
+++ b/Resources/Private/Translations/ps_AF/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ps">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="ps" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="ps" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="ps" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="ps" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="ps" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="ps" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="ps" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="ps" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="ps" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="ps" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="ps" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="ps" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="ps" state="needs-translation">Link</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="ps" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="ps" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="ps" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="ps" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="ps" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="ps" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="ps" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="ps" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="ps" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="ps" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="ps" state="needs-translation">Create new</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="ps" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="ps" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/pt_BR/Main.xlf
+++ b/Resources/Private/Translations/pt_BR/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="pt-BR" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="pt-BR" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="pt-BR" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="pt-BR" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="pt-BR" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="pt-BR" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="pt-BR" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="pt-BR" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="pt-BR" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="pt-BR" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="pt-BR" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="pt-BR" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="pt-BR" state="translated">Link</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="pt-BR" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="pt-BR" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="pt-BR" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="pt-BR" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="pt-BR" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="pt-BR" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="pt-BR" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="pt-BR" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="pt-BR" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="pt-BR" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="pt-BR" state="translated">Criar novo</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="pt-BR" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="pt-BR" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/pt_PT/Main.xlf
+++ b/Resources/Private/Translations/pt_PT/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="pt-PT">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="pt-PT" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="pt-PT" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="pt-PT" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="pt-PT" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="pt-PT" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="pt-PT" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="pt-PT" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="pt-PT" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="pt-PT" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="pt-PT" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="pt-PT" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="pt-PT" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="pt-PT" state="needs-translation">Link</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="pt-PT" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="pt-PT" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="pt-PT" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="pt-PT" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="pt-PT" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="pt-PT" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="pt-PT" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="pt-PT" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="pt-PT" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="pt-PT" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="pt-PT" state="translated">Criar novo</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="pt-PT" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="pt-PT" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/ro_RO/Main.xlf
+++ b/Resources/Private/Translations/ro_RO/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ro">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="ro" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="ro" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="ro" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="ro" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="ro" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="ro" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="ro" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="ro" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="ro" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="ro" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="ro" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="ro" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="ro" state="needs-translation">Link</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="ro" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="ro" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="ro" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="ro" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="ro" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="ro" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="ro" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="ro" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="ro" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="ro" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="ro" state="needs-translation">Create new</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="ro" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="ro" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/ru_RU/Main.xlf
+++ b/Resources/Private/Translations/ru_RU/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="ru" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="ru" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="ru" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="ru" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="ru" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="ru" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="ru" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="ru" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="ru" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="ru" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="ru" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="ru" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
+				<source>Link</source>
+			<target xml:lang="ru">Ссылка</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="ru" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="ru" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="ru" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="ru" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="ru" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="ru" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="ru" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="ru" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="ru" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="ru" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve" approved="yes">
+				<source>Create new</source>
+			<target xml:lang="ru">Создать новый</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="ru" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="ru" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/sr_SP/Main.xlf
+++ b/Resources/Private/Translations/sr_SP/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="sr">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="sr" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="sr" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="sr" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="sr" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="sr" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="sr" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="sr" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="sr" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="sr" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="sr" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="sr" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="sr" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="sr" state="needs-translation">Link</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="sr" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="sr" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="sr" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="sr" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="sr" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="sr" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="sr" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="sr" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="sr" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="sr" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="sr" state="translated">Креирај нови</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="sr" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="sr" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/sv_SE/Main.xlf
+++ b/Resources/Private/Translations/sv_SE/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="sv-SE">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="sv-SE" state="translated">Kopiera {source} till {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="sv-SE" state="translated">Flytta {source} till {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="sv-SE" state="translated">Välj vart {source} ska sättas in relativt till {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="sv-SE" state="translated">Infoga</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="sv-SE" state="translated">Infogningsläge</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="sv-SE" state="translated">Välj bildförhållande</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="sv-SE" state="translated">Fetstil</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="sv-SE" state="translated">Kursiv</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="sv-SE" state="translated">Understrykning</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="sv-SE" state="translated">Nedsänkt</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="sv-SE" state="translated">Upphöjt</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="sv-SE" state="translated">Genomstruken</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="sv-SE" state="translated">Länk</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="sv-SE" state="translated">Sorterad lista</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="sv-SE" state="translated">Osorterad lista</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="sv-SE" state="translated">Vänsterjustera</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="sv-SE" state="translated">Högerjustera</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="sv-SE" state="translated">Centrera</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="sv-SE" state="translated">Justera</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="sv-SE" state="translated">Tabell</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="sv-SE" state="translated">Ta bort formatering</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="sv-SE" state="translated">Minska indrag</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="sv-SE" state="translated">Indrag</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="sv-SE" state="translated">Skapa ny</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="sv-SE" state="translated">Inga träffar hittades</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="sv-SE" state="translated">Vänligen ange ## #CHARACTERS### fler tecken</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/tr_TR/Main.xlf
+++ b/Resources/Private/Translations/tr_TR/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="tr">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="tr" state="translated">{source}'ı, {target}'e kopyala</target><alt-trans><target xml:lang="tr">{source}'ı {target}'e kopyala</target></alt-trans></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="tr" state="translated">{source}'ı, {target}'e taşı</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="tr" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="tr" state="translated">Ekle</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="tr" state="translated">Ekleme Modu</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="tr" state="translated">Bir görünüm açısı seç</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="tr" state="translated">Kalın</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="tr" state="translated">İtalik / Eğik</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="tr" state="translated">Altıçizili</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="tr" state="translated">Altsimge</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="tr" state="translated">Üstsimge</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="tr" state="translated">Üstü Çizili</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="tr" state="translated">Bağlantı</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="tr" state="translated">Maddeli Liste</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="tr" state="translated">Sırasız Liste</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="tr" state="translated">Sola Hizala</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="tr" state="translated">Sağa Hizala</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="tr" state="translated">Oraya Hizala</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="tr" state="translated">Geniş Hizala</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="tr" state="translated">Tablo</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="tr" state="translated">Biçimi Sil</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="tr" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="tr" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="tr" state="translated">Yeni Oluştur</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="tr" state="translated">Eşleşme Bulunamadı</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="tr" state="translated">Lütfen ###CHARACTERS### daha karakter yazın</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/uk_UA/Main.xlf
+++ b/Resources/Private/Translations/uk_UA/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="uk">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="uk" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="uk" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="uk" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="uk" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="uk" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="uk" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="uk" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="uk" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="uk" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="uk" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="uk" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="uk" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="uk" state="translated">Посилання</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="uk" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="uk" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="uk" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="uk" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="uk" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="uk" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="uk" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="uk" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="uk" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="uk" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="uk" state="translated">Створити новий(у)</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="uk" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="uk" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/vi_VN/Main.xlf
+++ b/Resources/Private/Translations/vi_VN/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="vi">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="vi" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="vi" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="vi" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="vi" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="vi" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="vi" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="vi" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="vi" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="vi" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="vi" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="vi" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="vi" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="vi" state="translated">Liên kết</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="vi" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="vi" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="vi" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="vi" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="vi" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="vi" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="vi" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="vi" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="vi" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="vi" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="vi" state="translated">Tạo mới</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="vi" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="vi" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/zh_CN/Main.xlf
+++ b/Resources/Private/Translations/zh_CN/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="zh-CN">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="zh-CN" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="zh-CN" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="zh-CN" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="zh-CN" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="zh-CN" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="zh-CN" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="zh-CN" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="zh-CN" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="zh-CN" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="zh-CN" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="zh-CN" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="zh-CN" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="zh-CN" state="translated">链接</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="zh-CN" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="zh-CN" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="zh-CN" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="zh-CN" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="zh-CN" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="zh-CN" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="zh-CN" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="zh-CN" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="zh-CN" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="zh-CN" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="zh-CN" state="translated">新建</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="zh-CN" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="zh-CN" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/zh_TW/Main.xlf
+++ b/Resources/Private/Translations/zh_TW/Main.xlf
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="zh-TW">
+    <body>
+      <trans-unit id="copy__from__to--title" xml:space="preserve">
+				<source>Copy {source} to {target}</source>
+			<target xml:lang="zh-TW" state="needs-translation">Copy {source} to {target}</target></trans-unit>
+      <trans-unit id="move__from__to--title" xml:space="preserve">
+				<source>Move {source} to {target}</source>
+			<target xml:lang="zh-TW" state="needs-translation">Move {source} to {target}</target></trans-unit>
+      <trans-unit id="copy__from__to--description" xml:space="preserve">
+				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
+			<target xml:lang="zh-TW" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
+      <trans-unit id="insert" xml:space="preserve">
+				<source>Insert</source>
+			<target xml:lang="zh-TW" state="needs-translation">Insert</target></trans-unit>
+      <trans-unit id="insertMode" xml:space="preserve">
+				<source>Insert mode</source>
+			<target xml:lang="zh-TW" state="needs-translation">Insert mode</target></trans-unit>
+      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+				<source>Choose an Aspect Ratio</source>
+			<target xml:lang="zh-TW" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+				<source>Bold</source>
+			<target xml:lang="zh-TW" state="needs-translation">Bold</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+				<source>Italic</source>
+			<target xml:lang="zh-TW" state="needs-translation">Italic</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+				<source>Underline</source>
+			<target xml:lang="zh-TW" state="needs-translation">Underline</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+				<source>Subscript</source>
+			<target xml:lang="zh-TW" state="needs-translation">Subscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+				<source>Superscript</source>
+			<target xml:lang="zh-TW" state="needs-translation">Superscript</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+				<source>Strikethrough</source>
+			<target xml:lang="zh-TW" state="needs-translation">Strikethrough</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+				<source>Link</source>
+			<target xml:lang="zh-TW" state="translated">連結</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+				<source>Ordered list</source>
+			<target xml:lang="zh-TW" state="needs-translation">Ordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+				<source>Unordered list</source>
+			<target xml:lang="zh-TW" state="needs-translation">Unordered list</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+				<source>Align left</source>
+			<target xml:lang="zh-TW" state="needs-translation">Align left</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+				<source>Align right</source>
+			<target xml:lang="zh-TW" state="needs-translation">Align right</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+				<source>Align center</source>
+			<target xml:lang="zh-TW" state="needs-translation">Align center</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+				<source>Align justify</source>
+			<target xml:lang="zh-TW" state="needs-translation">Align justify</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+				<source>Table</source>
+			<target xml:lang="zh-TW" state="needs-translation">Table</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+				<source>Remove format</source>
+			<target xml:lang="zh-TW" state="needs-translation">Remove format</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+				<source>Outdent</source>
+			<target xml:lang="zh-TW" state="needs-translation">Outdent</target></trans-unit>
+      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+				<source>Indent</source>
+			<target xml:lang="zh-TW" state="needs-translation">Indent</target></trans-unit>
+      <trans-unit id="createNew" xml:space="preserve">
+				<source>Create new</source>
+			<target xml:lang="zh-TW" state="translated">新增</target></trans-unit>
+      <trans-unit id="noMatchesFound" xml:space="preserve">
+				<source>No matches found</source>
+			<target xml:lang="zh-TW" state="needs-translation">No matches found</target></trans-unit>
+      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+				<source>Please enter ###CHARACTERS### more character</source>
+			<target xml:lang="zh-TW" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
**What I did**

Download current translations from Crowdin and manually copied the translations to the Neos.Neos.Ui package.

**How to verify it**

Other languages should now have translations in the UI (e.g. in CKEditor) instead of placeholders.

In the long run there needs to be tooling to do this automatically or the neos-ui repository should be moved to the neos-development-collection to handle this package the same as other Neos core packages.