### PR TITLE
FEATURE: Expose neos-ui-views

### DIFF
--- a/packages/neos-ui-extensibility/scripts/helpers/webpack.config.js
+++ b/packages/neos-ui-extensibility/scripts/helpers/webpack.config.js
@@ -66,6 +66,7 @@ module.exports = function (neosPackageJson) {
                 '@neos-project/neos-ui-editors': '@neos-project/neos-ui-extensibility/src/shims/neosProjectPackages/neos-ui-editors/index',
                 '@neos-project/neos-ui-i18n': '@neos-project/neos-ui-extensibility/src/shims/neosProjectPackages/neos-ui-i18n/index',
                 '@neos-project/neos-ui-redux-store': '@neos-project/neos-ui-extensibility/src/shims/neosProjectPackages/neos-ui-redux-store/index',
+                '@neos-project/neos-ui-views': '@neos-project/neos-ui-extensibility/src/shims/neosProjectPackages/neos-ui-views/index',
                 '@neos-project/utils-redux': '@neos-project/neos-ui-extensibility/src/shims/neosProjectPackages/utils-redux/index'
             }
         }

--- a/packages/neos-ui-extensibility/src/shims/neosProjectPackages/neos-ui-views/index.js
+++ b/packages/neos-ui-extensibility/src/shims/neosProjectPackages/neos-ui-views/index.js
@@ -1,0 +1,3 @@
+import readFromConsumerApi from '../../../readFromConsumerApi';
+
+module.exports = readFromConsumerApi('NeosProjectPackages')().NeosUiViews;

--- a/packages/neos-ui-views/package.json
+++ b/packages/neos-ui-views/package.json
@@ -2,7 +2,7 @@
   "name": "@neos-project/neos-ui-views",
   "version": "1.1.0",
   "description": "Neos CMS UI Views for use in the inspector.",
-  "main": "src/manifest.js",
+  "main": "./src/index.js",
   "private": true,
   "scripts": {
     "prepublish": "exit 0",

--- a/packages/neos-ui-views/src/index.js
+++ b/packages/neos-ui-views/src/index.js
@@ -2,5 +2,4 @@ import dataLoader from './Data/DataLoader/index';
 
 export {
     dataLoader
-}
-
+};

--- a/packages/neos-ui-views/src/index.js
+++ b/packages/neos-ui-views/src/index.js
@@ -1,0 +1,6 @@
+import dataLoader from './Data/DataLoader/index';
+
+export {
+    dataLoader
+}
+

--- a/packages/neos-ui/src/apiExposureMap.js
+++ b/packages/neos-ui/src/apiExposureMap.js
@@ -19,6 +19,7 @@ import EditorEnvelope from '@neos-project/neos-ui-editors/src/EditorEnvelope/ind
 import * as UtilsRedux from '@neos-project/utils-redux';
 import NeosUiI18n from '@neos-project/neos-ui-i18n';
 import NeosUiBackendConnectorDefault, * as NeosUiBackendConnector from '@neos-project/neos-ui-backend-connector';
+import * as NeosUiViews from '@neos-project/neos-ui-views';
 
 export default {
     '@vendor': () => ({
@@ -44,6 +45,7 @@ export default {
         NeosUiEditors: EditorEnvelope,
         NeosUiI18n,
         NeosUiReduxStore,
+        NeosUiViews,
         // react-proptypes (optional)
         ReactUiComponents,
         UtilsRedux

--- a/packages/neos-ui/src/index.js
+++ b/packages/neos-ui/src/index.js
@@ -43,7 +43,7 @@ createConsumerApi(manifests, apiExposureMap);
 require('./manifest');
 require('@neos-project/neos-ui-contentrepository');
 require('@neos-project/neos-ui-editors');
-require('@neos-project/neos-ui-views');
+require('@neos-project/neos-ui-views/src/manifest');
 require('@neos-project/neos-ui-guest-frame');
 require('@neos-project/neos-ui-ckeditor-bindings');
 require('@neos-project/neos-ui-validators');


### PR DESCRIPTION
**What I did**
I exposed neos-ui-views so the dataLoader can be used in custom DataSource Views

**How I did it**
I added a shim in neos-ui-extensibility, a webpack alias and added that to the apiExposureMap.js.