### PR TITLE
TASK: Require node with "engines" in package.json instead of as a dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ In order to start contributing, follow the following steps:
 
 1) Ensure you have the `dev-master` version installed (see above).
 
-2) We require [Chrome](https://www.google.com/chrome/browser/desktop/index.html) as well as the `yarn`(https://yarnpkg.com/en/) command and GNU Make(https://www.gnu.org/software/make/) to be installed on your system.
+2) We require [Chrome](https://www.google.com/chrome/browser/desktop/index.html) as well as the [`yarn`](https://yarnpkg.com/en/) command and [GNU Make](https://www.gnu.org/software/make/) to be installed on your system.
 
 3) Inside `Configuration/Settings.yaml`, set the following property for disabling the pre-compiled files:
 
@@ -62,13 +62,17 @@ In order to start contributing, follow the following steps:
          frontendDevelopmentMode: true
    ```
 
-4) Run the initialization script:
+4) Make sure you have the correct version of [nodeJS](https://nodejs.org/en/). The currently required version can be seen in the package.json file in "Neos.Neos.Ui" under "engines"; at the moment it is 8.11.0.
+
+
+5) Change into the "Neos.Neos.Ui" folder and run the initialization script:
 
    ```
+   cd Packages/Application/Neos.Neos.Ui
    make setup
    ```
 
-5) Get an overview about the codebase. We've recorded [an introduction on YouTube](https://www.youtube.com/watch?v=RYBUS5Nxxxk) which
+6) Get an overview about the codebase. We've recorded [an introduction on YouTube](https://www.youtube.com/watch?v=RYBUS5Nxxxk) which
    gets you acquainted with the basics. Additionally, please get in touch with us on [Slack](http://slack.neos.io) in the
    channel #project-ui-rewrite. We're eager to help you get started!
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "resolutions": {
     "moment": "^2.20.1"
   },
+  "engines": {
+    "node": ">=8.11.0"
+  },
   "devDependencies": {
     "@neos-project/brand": "^1.1.0",
     "@neos-project/build-essentials": "*",
@@ -38,7 +41,6 @@
     "json-loader": "^0.5.4",
     "lerna": "^2.5.1",
     "lolex": "^1.5.1",
-    "node": "8.11.0",
     "object-assign": "^4.1.0",
     "postcss-css-variables": "^0.8.0",
     "postcss-hexrgba": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7878,12 +7878,6 @@ node-version@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/node-version/-/node-version-1.1.0.tgz#f437d7ba407e65e2c4eaef8887b1718ba523d4f0"
 
-node@8.11.0:
-  version "8.11.0"
-  resolved "https://registry.yarnpkg.com/node/-/node-8.11.0.tgz#25f4fef2b16bf681f3314ae39eb39f68ee14f4a4"
-  dependencies:
-    node-bin-setup "^1.0.0"
-
 node@^8.9.4:
   version "8.9.4"
   resolved "https://registry.yarnpkg.com/node/-/node-8.9.4.tgz#5ab1e5ec49067a25e007e361b5f80de9dc0460fc"


### PR DESCRIPTION
According to https://stackoverflow.com/questions/29349684/how-can-i-specify-the-required-node-js-version-in-packages-json, this is the "correct" way to make sure users are running the right node version.

!!! ATTN !!!
If you still have a "node" binary inside your `./node_modules/.bin`, you might have to remove it manually.
Recommendation: use "nvm" to manage your node versions: https://github.com/creationix/nvm