### PR TITLE
TASK: Improve "Changes" saga

### DIFF
--- a/packages/neos-ui/src/Sagas/Changes/index.js
+++ b/packages/neos-ui/src/Sagas/Changes/index.js
@@ -44,7 +44,7 @@ export function * watchPersist() {
         if (action) {
             changes.push(...action.payload.changes);
         }
-        
+
         const state = yield select();
         if (changes.length > 0 && !$get('ui.remote.isSaving', state)) {
             yield call(persistChanges, changes);

--- a/packages/neos-ui/src/Sagas/Changes/index.js
+++ b/packages/neos-ui/src/Sagas/Changes/index.js
@@ -1,5 +1,5 @@
 import {take, race, put, call, select} from 'redux-saga/effects';
-import {delay} from 'redux-saga'
+import {delay} from 'redux-saga';
 import {$get} from 'plow-js';
 
 import {actionTypes, actions, selectors} from '@neos-project/neos-ui-redux-store';

--- a/packages/neos-ui/src/Sagas/Changes/index.js
+++ b/packages/neos-ui/src/Sagas/Changes/index.js
@@ -36,6 +36,15 @@ export function * watchPersist() {
     let changes = [];
 
     while (true) {
+        const {action} = yield race({
+            action: take(actionTypes.Changes.PERSIST),
+            time: call(delay, 1500)
+        });
+
+        if (action) {
+            changes.push(...action.payload.changes);
+        }
+
         const action = yield take(actionTypes.Changes.PERSIST);
         changes.push(...action.payload.changes);
 

--- a/packages/neos-ui/src/Sagas/Changes/index.js
+++ b/packages/neos-ui/src/Sagas/Changes/index.js
@@ -44,10 +44,7 @@ export function * watchPersist() {
         if (action) {
             changes.push(...action.payload.changes);
         }
-
-        const action = yield take(actionTypes.Changes.PERSIST);
-        changes.push(...action.payload.changes);
-
+        
         const state = yield select();
         if (changes.length > 0 && !$get('ui.remote.isSaving', state)) {
             yield call(persistChanges, changes);

--- a/packages/neos-ui/src/Sagas/Changes/index.js
+++ b/packages/neos-ui/src/Sagas/Changes/index.js
@@ -1,4 +1,5 @@
-import {takeEvery, put, call, select} from 'redux-saga/effects';
+import {take, race, put, call, select} from 'redux-saga/effects';
+import {delay} from 'redux-saga'
 import {$get} from 'plow-js';
 
 import {actionTypes, actions, selectors} from '@neos-project/neos-ui-redux-store';
@@ -6,29 +7,66 @@ import backend from '@neos-project/neos-ui-backend-connector';
 
 const {publishableNodesInDocumentSelector, baseWorkspaceSelector} = selectors.CR.Workspaces;
 
-export function * watchPersist() {
+const saveDelay = 2000;
+
+function * persistChanges(changes) {
     const {change} = backend.get().endpoints;
 
-    yield takeEvery(actionTypes.Changes.PERSIST, function * persistChanges(action) {
-        const changes = action.payload.changes;
+    yield put(actions.UI.Remote.startSaving());
 
-        yield put(actions.UI.Remote.startSaving());
+    try {
+        const feedback = yield call(change, changes);
+        yield put(actions.UI.Remote.finishSaving());
+        yield put(actions.ServerFeedback.handleServerFeedback(feedback));
 
-        try {
-            const feedback = yield call(change, changes);
-            yield put(actions.UI.Remote.finishSaving());
-            yield put(actions.ServerFeedback.handleServerFeedback(feedback));
+        const state = yield select();
+        const isAutoPublishingEnabled = $get('user.settings.isAutoPublishingEnabled', state);
 
-            const state = yield select();
-            const isAutoPublishingEnabled = $get('user.settings.isAutoPublishingEnabled', state);
-
-            if (isAutoPublishingEnabled) {
-                const baseWorkspace = baseWorkspaceSelector(state);
-                const publishableNodesInDocument = publishableNodesInDocumentSelector(state);
-                yield put(actions.CR.Workspaces.publish(publishableNodesInDocument.map($get('contextPath')), baseWorkspace));
-            }
-        } catch (error) {
-            console.error('Failed to persist changes', error);
+        if (isAutoPublishingEnabled) {
+            const baseWorkspace = baseWorkspaceSelector(state);
+            const publishableNodesInDocument = publishableNodesInDocumentSelector(state);
+            yield put(actions.CR.Workspaces.publish(publishableNodesInDocument.map($get('contextPath')), baseWorkspace));
         }
-    });
+    } catch (error) {
+        console.error('Failed to persist changes', error);
+    } finally {
+        yield put(actions.UI.Remote.finishSaving());
+    }
 }
+
+export function * watchPersist() {
+    let changes = [];
+    let lastPush = Date.now();
+    let actionsTaken = 0;
+
+    while (true) {
+        const now = Date.now();
+        const timeSinceLastPush = now - lastPush;
+
+        const {action} = yield race({
+            action: take(actionTypes.Changes.PERSIST),
+            time: call(delay, saveDelay)
+        });
+
+        if (action) {
+            changes.push(...action.payload.changes);
+            actionsTaken++;
+        }
+
+        const state = yield select();
+
+        /*
+         *  We actually persist IF:
+         *  - we have changes AND
+         *  - there is not another request running
+         *  - either the "saveDelay" time has passed OR we have taken 3 actions (to avoid huge change queues locally)
+         */
+        if (changes.length > 0 && !$get('ui.remote.isSaving', state) && (timeSinceLastPush > saveDelay || actionsTaken > 2)) {
+            yield call(persistChanges, changes);
+            changes = [];
+            lastPush = now;
+            actionsTaken = 0;
+        }
+    }
+}
+


### PR DESCRIPTION
In order to make behavior slightly more predictable and
avoid race conditions on the server the changes are now
sent in order and with only one request at a time.

We collect changes from change actions until one of the
following happens:

* we have taken 3 actions (to avoid too many unpersisted changes)
* 2 seconds have passed

If at that point another request is still running, the wait is
prolonged until that request has finished at which point the
new batch of changes will be persisted.
