### PR TITLE
BUGFIX: Determine closest documentNode for `reloadPageIfChanged`

### DIFF
--- a/Classes/Domain/Model/AbstractChange.php
+++ b/Classes/Domain/Model/AbstractChange.php
@@ -98,7 +98,9 @@ abstract class AbstractChange implements ChangeInterface
     {
         $reloadDocument = new ReloadDocument();
         if ($node) {
-            $reloadDocument->setNode($node);
+            $nodeService = new NodeService();
+            $documentNode = $nodeService->getClosestDocument($node);
+            $reloadDocument->setNode($documentNode);
         }
 
         $this->feedbackCollection->add($reloadDocument);


### PR DESCRIPTION
Without this change the ui caused an "Could not resolve a route for building an URI for the given resolve context." error whenever `reloadPageIfChanged` was used on a non-document nodes because it tried to route the actual content node to the frontend controller.