### PR TITLE
BUGFIX: Use flexbox to align the drawer menu

### DIFF
--- a/packages/neos-ui/src/Containers/Drawer/index.js
+++ b/packages/neos-ui/src/Containers/Drawer/index.js
@@ -113,14 +113,16 @@ export default class Drawer extends PureComponent {
                 onMouseLeave={this.handleMouseLeave}
                 aria-hidden={isHidden ? 'true' : 'false'}
                 >
-                {!isHidden && Object.values(menuData).map((item, index) => (
-                    <MenuItemGroup
-                        key={index}
-                        onClick={this.handleMenuItemClick}
-                        onChildClick={this.handleMenuItemClick}
-                        {...item}
-                        />
-                ))}
+                <div className={style.drawer__menuItemGroupsWrapper}>
+                    {!isHidden && Object.values(menuData).map((item, index) => (
+                        <MenuItemGroup
+                            key={index}
+                            onClick={this.handleMenuItemClick}
+                            onChildClick={this.handleMenuItemClick}
+                            {...item}
+                            />
+                    ))}
+                </div>
                 <div className={style.drawer__version}>{version}</div>
             </div>
         );

--- a/packages/neos-ui/src/Containers/Drawer/style.css
+++ b/packages/neos-ui/src/Containers/Drawer/style.css
@@ -55,5 +55,5 @@
 .drawer__version {
     color: var(--colors-ContrastBright);
     padding: var(--spacing-Full);
-    margin-top:auto;
+    margin-top: auto;
 }

--- a/packages/neos-ui/src/Containers/Drawer/style.css
+++ b/packages/neos-ui/src/Containers/Drawer/style.css
@@ -1,19 +1,33 @@
 .drawer {
     position: fixed;
-    top: 41px;
+    display: flex;
+    flex-flow: column;
+    flex-shrink: 0;
+    justify-content: flex-start;
+    top: calc(var(--spacing-GoldenUnit) + 1px);
     left: 0;
     z-index: var(--zIndex-Drawer-Context);
     height: 100%;
     width: var(--size-SidebarWidth);
     background: var(--colors-ContrastDarker);
     transition: var(--transition-Default) ease transform;
-    padding-bottom: 41px;
+    padding-bottom: calc(var(--spacing-GoldenUnit) + 1px);
     overflow: scroll;
 }
 .drawer--isHidden {
     transform: translateX(-var(--size-SidebarWidth));
 }
+
+.drawer__menuItemGroupsWrapper {
+    display: flex;
+    flex-shrink: 0;
+    flex-direction: column;
+    overflow-y: auto;
+}
+
 .drawer__menuItem {
+    display: flex;
+    flex-direction: column;
     border-top: 1px solid var(--colors-ContrastDark);
     cursor: pointer;
 
@@ -23,6 +37,7 @@
 }
 .drawer__menuItemGroupBtn,
 .drawer__menuItemBtn {
+    display: flex;
     width: 100%;
     padding: 0;
     text-align: left;
@@ -40,6 +55,5 @@
 .drawer__version {
     color: var(--colors-ContrastBright);
     padding: var(--spacing-Full);
-    bottom: var(--spacing-GoldenUnit);
-    position: absolute;
+    margin-top:auto;
 }

--- a/packages/neos-ui/src/Containers/Drawer/style.css
+++ b/packages/neos-ui/src/Containers/Drawer/style.css
@@ -7,11 +7,10 @@
     top: calc(var(--spacing-GoldenUnit) + 1px);
     left: 0;
     z-index: var(--zIndex-Drawer-Context);
-    height: 100%;
+    height: calc(100% - calc(var(--spacing-GoldenUnit) + 1px));
     width: var(--size-SidebarWidth);
     background: var(--colors-ContrastDarker);
     transition: var(--transition-Default) ease transform;
-    padding-bottom: calc(var(--spacing-GoldenUnit) + 1px);
     overflow: scroll;
 }
 .drawer--isHidden {
@@ -23,6 +22,7 @@
     flex-shrink: 0;
     flex-direction: column;
     overflow-y: auto;
+    padding-bottom: calc(var(--spacing-GoldenUnit) + 1px);
 }
 
 .drawer__menuItem {


### PR DESCRIPTION
The version number needs to be sticky at the bottom of the drawer.
So we use now flexbox to align the menu item groups and the version number.
If the List of menu items become to long we now get a scrollbar.

Fixes: #1890 
