### PR TITLE
TASK: Render custom icon component to visualize node status

### DIFF
--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -96,7 +96,10 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
             'nodeType' => $node->getNodeType()->getName(),
             'properties' => $omitMostPropertiesForTreeState ? [
                 // if we are only rendering the tree state, ensure _isHidden is sent to hidden nodes are correctly shown in the tree.
-                '_hidden' => $node->isHidden()
+                '_hidden' => $node->isHidden(),
+                '_hiddenInIndex' => $node->isHiddenInIndex(),
+                '_hiddenBefore' => $node->getHiddenBeforeDateTime() instanceof \DateTime,
+                '_hiddenAfter' => $node->getHiddenAfterDateTime() instanceof \DateTime,
             ] : $this->nodePropertyConverterService->getPropertiesArray($node),
             'label' => $node->getLabel(),
             'isAutoCreated' => $node->isAutoCreated(),

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -98,8 +98,8 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
                 // if we are only rendering the tree state, ensure _isHidden is sent to hidden nodes are correctly shown in the tree.
                 '_hidden' => $node->isHidden(),
                 '_hiddenInIndex' => $node->isHiddenInIndex(),
-                '_hiddenBefore' => $node->getHiddenBeforeDateTime() instanceof \DateTime,
-                '_hiddenAfter' => $node->getHiddenAfterDateTime() instanceof \DateTime,
+                '_hiddenBeforeDateTime' => $node->getHiddenBeforeDateTime() instanceof \DateTime,
+                '_hiddenAfterDateTime' => $node->getHiddenAfterDateTime() instanceof \DateTime,
             ] : $this->nodePropertyConverterService->getPropertiesArray($node),
             'label' => $node->getLabel(),
             'isAutoCreated' => $node->isAutoCreated(),

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -5,6 +5,7 @@ import {connect} from 'react-redux';
 
 import flowright from 'lodash.flowright';
 import Tree from '@neos-project/react-ui-components/src/Tree/';
+import Icon from '@neos-project/react-ui-components/src/Icon/';
 import {stripTags, decodeHtml} from '@neos-project/utils-helpers';
 
 import {selectors} from '@neos-project/neos-ui-redux-store';
@@ -152,6 +153,40 @@ export default class Node extends PureComponent {
         return $get('ui.icon', nodeTypesRegistry.get(nodeType));
     }
 
+    /**
+     * This function will render some additons to the nodetype icon
+     * if the page is (currently) hidden
+     */
+    getCustomIconComponent() {
+        const {node} = this.props;
+
+        const isHidden = $get('properties._hidden', node);
+        const isHiddenBefore = $get('properties._hiddenBeforeDateTime', node);
+        const isHiddenAfter = $get('properties._hiddenAfterDateTime', node);
+
+        if (isHidden) {
+            return (
+                <span className="fa-layers fa-fw">
+                    <Icon icon={this.getIcon()} />
+                    <Icon icon="circle" color="error" transform="shrink-3 down-6 right-4" />
+                    <Icon icon="times" transform="shrink-7 down-6 right-4" />
+                </span>
+            );
+        }
+
+        if (isHiddenBefore || isHiddenAfter) {
+            return (
+                <span className="fa-layers fa-fw">
+                    <Icon icon={this.getIcon()} />
+                    <Icon icon="circle" color="primaryBlue" transform="shrink-5 down-6 right-4" />
+                    <Icon icon="clock" transform="shrink-9 down-6 right-4" />
+                </span>
+            );
+        }
+
+        return null;
+    }
+
     getNodeTypeLabel() {
         const {node, nodeTypesRegistry, i18nRegistry} = this.props;
         const nodeType = $get('nodeType', node);
@@ -260,6 +295,7 @@ export default class Node extends PureComponent {
                     hasError={this.hasError()}
                     label={decodeLabel($get('label', node))}
                     icon={this.getIcon()}
+                    customIconComponent={this.getCustomIconComponent()}
                     iconLabel={this.getNodeTypeLabel()}
                     level={level}
                     onToggle={this.handleNodeToggle}

--- a/packages/react-ui-components/src/Icon/icon.js
+++ b/packages/react-ui-components/src/Icon/icon.js
@@ -5,7 +5,7 @@ import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import mapper from './mapper';
 
 const Icon = props => {
-    const {size, padded, theme, label, icon, className, ...rest} = props;
+    const {size, padded, theme, label, icon, className, color, ...rest} = props;
     const iconClassName = icon;
     const classNames = mergeClassNames({
         [theme.icon]: true,
@@ -16,7 +16,10 @@ const Icon = props => {
         [theme['icon--small']]: size === 'small',
         [theme['icon--tiny']]: size === 'tiny',
         [theme['icon--paddedLeft']]: padded === 'left',
-        [theme['icon--paddedRight']]: padded === 'right'
+        [theme['icon--paddedRight']]: padded === 'right',
+        [theme['icon--color-warn']]: color === 'warn',
+        [theme['icon--color-error']]: color === 'error',
+        [theme['icon--color-primaryBlue']]: color === 'primaryBlue'
     });
 
     const mappedIcon = mapper(icon);
@@ -69,10 +72,15 @@ Icon.propTypes = {
     className: PropTypes.string,
 
     /**
+     *  Adjust the color of the icon
+     */
+    color: PropTypes.oneOf(['default', 'warn', 'error', 'primaryBlue']),
+
+    /**
     * An optional css theme to be injected.
     */
     theme: PropTypes.shape({
-        'icon': PropTypes.string,
+        icon: PropTypes.string,
         'icon--big': PropTypes.string,
         'icon--small': PropTypes.string,
         'icon--tiny': PropTypes.string,

--- a/packages/react-ui-components/src/Icon/style.css
+++ b/packages/react-ui-components/src/Icon/style.css
@@ -25,3 +25,15 @@
 .icon--paddedRight {
     margin-right: .75em;
 }
+
+.icon--color-warn {
+  color: var(--colors-Warn)
+}
+
+.icon--color-error {
+  color: var(--colors-Error)
+}
+
+.icon--color-primaryBlue {
+  color: var(--colors-PrimaryBlue)
+}

--- a/packages/react-ui-components/src/Icon/style.css
+++ b/packages/react-ui-components/src/Icon/style.css
@@ -27,13 +27,13 @@
 }
 
 .icon--color-warn {
-  color: var(--colors-Warn)
+    color: var(--colors-Warn);
 }
 
 .icon--color-error {
-  color: var(--colors-Error)
+    color: var(--colors-Error);
 }
 
 .icon--color-primaryBlue {
-  color: var(--colors-PrimaryBlue)
+    color: var(--colors-PrimaryBlue);
 }

--- a/packages/react-ui-components/src/Tree/node.css
+++ b/packages/react-ui-components/src/Tree/node.css
@@ -25,8 +25,7 @@
 .header__chevron--isCollapsed > svg {
     transform: translateY(3px) translateX(-2px) rotate(-90deg);
 }
-.header__chevron--isHiddenInIndex,
-.header__data--isHidden {
+.header__chevron--isHiddenInIndex {
     opacity: .5;
 }
 
@@ -61,7 +60,6 @@
     opacity: .5;
 }
 .header__data--isHidden {
-    opacity: .5;
     text-decoration: line-through;
 }
 .header__data--isDragging {

--- a/packages/react-ui-components/src/Tree/node.js
+++ b/packages/react-ui-components/src/Tree/node.js
@@ -97,6 +97,7 @@ export class Header extends PureComponent {
         hasError: PropTypes.bool.isRequired,
         label: PropTypes.string.isRequired,
         icon: PropTypes.string,
+        customIconComponent: PropTypes.node,
         iconLabel: PropTypes.string,
         level: PropTypes.number.isRequired,
         dragAndDropContext: PropTypes.shape({
@@ -152,6 +153,7 @@ export class Header extends PureComponent {
             isLoading,
             label,
             icon,
+            customIconComponent,
             iconLabel,
             level,
             onClick,
@@ -197,7 +199,10 @@ export class Header extends PureComponent {
                             style={{paddingLeft: (level * 18) + 'px'}}
                             >
                             <div className={theme.header__labelWrapper}>
-                                <IconComponent icon={icon || 'question'} label={iconLabel} className={theme.header__icon}/>
+                                {customIconComponent ?
+                                  customIconComponent :
+                                  <IconComponent icon={icon || 'question'} label={iconLabel} className={theme.header__icon} />
+                                }
                                 <span {...rest} id={labelIdentifier} className={theme.header__label} onClick={onLabelClick} data-neos-integrational-test="tree__item__nodeHeader__itemLabel">
                                     {label}
                                 </span>

--- a/packages/react-ui-components/src/Tree/node.js
+++ b/packages/react-ui-components/src/Tree/node.js
@@ -200,8 +200,8 @@ export class Header extends PureComponent {
                             >
                             <div className={theme.header__labelWrapper}>
                                 {customIconComponent ?
-                                  customIconComponent :
-                                  <IconComponent icon={icon || 'question'} label={iconLabel} className={theme.header__icon} />
+                                    customIconComponent :
+                                    <IconComponent icon={icon || 'question'} label={iconLabel} className={theme.header__icon} />
                                 }
                                 <span {...rest} id={labelIdentifier} className={theme.header__label} onClick={onLabelClick} data-neos-integrational-test="tree__item__nodeHeader__itemLabel">
                                     {label}


### PR DESCRIPTION
This change will add some icons on top of the nodetype icon in the tree to visualize a `hidden` and `hiddenBefore/After` status.

Resolves #1500 
Resolves #1895 