### PR TITLE
BUGFIX: Take care that the button margin is visible

### DIFF
--- a/packages/neos-ui/src/Containers/EditModePanel/Panel/index.js
+++ b/packages/neos-ui/src/Containers/EditModePanel/Panel/index.js
@@ -33,6 +33,17 @@ export default class Panel extends PureComponent {
         onPreviewModeClick: PropTypes.func.isRequired
     };
 
+    getButtonWrapperClassNames(currentIndex) {
+        const {modes, style} = this.props;
+        const amountOfModes = modes.length - 1;
+        const classNames = [style.editModePanel__buttonWrapper];
+        if (currentIndex === amountOfModes) {
+            classNames.push(style.editModePanel__lastButtonWrapper);
+        }
+
+        return classNames;
+    }
+
     render() {
         const {title, className, modes, current, currentMode, style, onPreviewModeClick} = this.props;
 
@@ -51,8 +62,8 @@ export default class Panel extends PureComponent {
             <div className={className}>
                 <p>{title} {currentMode && <b className={style.editModePanel__current}><I18n id={currentMode.title}/></b>}</p>
                 <Slider {...sliderSettings}>
-                    {modes.map(previewMode => (
-                        <div key={previewMode.id} className={style.editModePanel__buttonWrapper}>
+                    {modes.map((previewMode, index) => (
+                        <div key={previewMode.id} className={this.getButtonWrapperClassNames(index)}>
                             <Button
                                 isDisabled={previewMode.id === current}
                                 onClick={onPreviewModeClick(previewMode.id)}

--- a/packages/neos-ui/src/Containers/EditModePanel/Panel/index.js
+++ b/packages/neos-ui/src/Containers/EditModePanel/Panel/index.js
@@ -33,17 +33,6 @@ export default class Panel extends PureComponent {
         onPreviewModeClick: PropTypes.func.isRequired
     };
 
-    getButtonWrapperClassNames(currentIndex) {
-        const {modes, style} = this.props;
-        const amountOfModes = modes.length - 1;
-        const classNames = [style.editModePanel__buttonWrapper];
-        if (currentIndex === amountOfModes) {
-            classNames.push(style.editModePanel__lastButtonWrapper);
-        }
-
-        return classNames;
-    }
-
     render() {
         const {title, className, modes, current, currentMode, style, onPreviewModeClick} = this.props;
 
@@ -62,8 +51,8 @@ export default class Panel extends PureComponent {
             <div className={className}>
                 <p>{title} {currentMode && <b className={style.editModePanel__current}><I18n id={currentMode.title}/></b>}</p>
                 <Slider {...sliderSettings}>
-                    {modes.map((previewMode, index) => (
-                        <div key={previewMode.id} className={this.getButtonWrapperClassNames(index)}>
+                    {modes.map(previewMode => (
+                        <div key={previewMode.id} className={style.editModePanel__buttonWrapper}>
                             <Button
                                 isDisabled={previewMode.id === current}
                                 onClick={onPreviewModeClick(previewMode.id)}

--- a/packages/neos-ui/src/Containers/EditModePanel/style.css
+++ b/packages/neos-ui/src/Containers/EditModePanel/style.css
@@ -38,8 +38,8 @@
     margin-right: 1rem;
     white-space: nowrap;
 
-    &:last-child {
-        margin-right: 0;
+    &:.editModePanel__lastButtonWrapper {
+        margin-right: 1rem;
     }
 }
 

--- a/packages/neos-ui/src/Containers/EditModePanel/style.css
+++ b/packages/neos-ui/src/Containers/EditModePanel/style.css
@@ -37,10 +37,6 @@
 .editModePanel__buttonWrapper {
     margin-right: 1rem;
     white-space: nowrap;
-
-    &:.editModePanel__lastButtonWrapper {
-        margin-right: 1rem;
-    }
 }
 
 .editModePanel__current {


### PR DESCRIPTION
The buttons in the edit pane always overrides the margin-right.
So we now define a lastItem class that only resets the margin-right
for the last button in the edit pane.

Fixes: #1906 

