### PR TITLE
FEATURE: Render help message from yaml file

### DIFF
--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
@@ -133,7 +133,8 @@ export default class NodeTypesRegistry extends SynchronousRegistry {
                                         label: $get('ui.label'),
                                         editor: $get('ui.inspector.editor'),
                                         editorOptions: $get('ui.inspector.editorOptions'),
-                                        position: $get('ui.inspector.position')
+                                        position: $get('ui.inspector.position'),
+                                        helpMessage: $get('ui.help.message')
                                     }),
                                     properties.filter(p => $get('ui.inspector.group', p) === group.id)
                                 ),
@@ -144,7 +145,8 @@ export default class NodeTypesRegistry extends SynchronousRegistry {
                                         label: $get('label'),
                                         view: $get('view'),
                                         viewOptions: $get('viewOptions'),
-                                        position: $get('position')
+                                        position: $get('position'),
+                                        helpMessage: $get('helpMessage')
                                     }),
                                     views.filter(v => $get('group', v) === group.id)
                                 )

--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
@@ -134,7 +134,8 @@ export default class NodeTypesRegistry extends SynchronousRegistry {
                                         editor: $get('ui.inspector.editor'),
                                         editorOptions: $get('ui.inspector.editorOptions'),
                                         position: $get('ui.inspector.position'),
-                                        helpMessage: $get('ui.help.message')
+                                        helpMessage: $get('ui.help.message'),
+                                        helpThumbnail: $get('ui.help.thumbnail')
                                     }),
                                     properties.filter(p => $get('ui.inspector.group', p) === group.id)
                                 ),

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -70,7 +70,7 @@ export default class EditorEnvelope extends PureComponent {
         const {label} = this.props;
 
         return (
-            <Label htmlFor={this.generateIdentifier()}>
+            <Label className={style.envelope__label} htmlFor={this.generateIdentifier()}>
                 <I18n id={label}/>
                 {this.renderHelpIcon()}
             </Label>

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -21,15 +21,8 @@ export default class EditorEnvelope extends PureComponent {
         identifier: PropTypes.string.isRequired,
         label: PropTypes.string.isRequired,
         editor: PropTypes.string.isRequired,
-        options: PropTypes.object,
-        value: PropTypes.any,
-        renderSecondaryInspector: PropTypes.func,
         editorRegistry: PropTypes.object.isRequired,
-        validationErrors: PropTypes.array,
-        onEnterKey: PropTypes.func,
-        helpMessage: PropTypes.string,
-
-        commit: PropTypes.func.isRequired
+        helpMessage: PropTypes.string
     };
 
     generateIdentifier() {

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -92,7 +92,7 @@ export default class EditorEnvelope extends PureComponent {
         return (
             <Tooltip className={style.envelope__tooltip}>
                 {this.props.helpMessage ? this.props.helpMessage : ''}
-                {this.props.helpThumbnail ? <img className={style.envelope__tooltip__image} src={this.props.helpThumbnail} /> : ''}
+                {this.props.helpThumbnail ? <img src={this.props.helpThumbnail} /> : ''}
             </Tooltip>
         );
     }

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -24,10 +24,17 @@ export default class EditorEnvelope extends PureComponent {
     static propTypes = {
         identifier: PropTypes.string.isRequired,
         label: PropTypes.string.isRequired,
+        options: PropTypes.object,
+        value: PropTypes.any,
+        renderSecondaryInspector: PropTypes.func,
         editor: PropTypes.string.isRequired,
         editorRegistry: PropTypes.object.isRequired,
+        validationErrors: PropTypes.array,
+        onEnterKey: PropTypes.func,
         helpMessage: PropTypes.string,
-        helpThumbnail: PropTypes.string
+        helpThumbnail: PropTypes.string,
+
+        commit: PropTypes.func.isRequired
     };
 
     generateIdentifier() {

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -13,6 +13,10 @@ import {Icon} from '@neos-project/react-ui-components';
 export default class EditorEnvelope extends PureComponent {
     state = {};
 
+    static defaultProps = {
+        helpMessage: ''
+    };
+
     static propTypes = {
         identifier: PropTypes.string.isRequired,
         label: PropTypes.string.isRequired,

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -1,6 +1,7 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import Label from '@neos-project/react-ui-components/src/Label/';
+import {Tooltip} from '@neos-project/react-ui-components';
 import I18n from '@neos-project/neos-ui-i18n';
 import {neos} from '@neos-project/neos-ui-decorators';
 import style from './style.css';
@@ -11,10 +12,13 @@ import {Icon} from '@neos-project/react-ui-components';
     editorRegistry: globalRegistry.get('inspector').get('editors')
 }))
 export default class EditorEnvelope extends PureComponent {
-    state = {};
+    state = {
+        showTooltip: false
+    };
 
     static defaultProps = {
-        helpMessage: ''
+        helpMessage: '',
+        helpThumbnail: ''
     };
 
     static propTypes = {
@@ -22,7 +26,8 @@ export default class EditorEnvelope extends PureComponent {
         label: PropTypes.string.isRequired,
         editor: PropTypes.string.isRequired,
         editorRegistry: PropTypes.object.isRequired,
-        helpMessage: PropTypes.string
+        helpMessage: PropTypes.string,
+        helpThumbnail: PropTypes.string
     };
 
     generateIdentifier() {
@@ -77,10 +82,25 @@ export default class EditorEnvelope extends PureComponent {
         );
     }
 
+    toggleTooltip = () => {
+        this.setState({
+            showTooltip: !this.state.showTooltip
+        });
+    };
+
+    renderTooltip() {
+        return (
+            <Tooltip className={style.envelope__tooltip}>
+                {this.props.helpMessage ? this.props.helpMessage : ''}
+                {this.props.helpThumbnail ? <img className={style.envelope__tooltip__image} src={this.props.helpThumbnail} /> : ''}
+            </Tooltip>
+        );
+    }
+
     renderHelpIcon() {
-        if (this.props.helpMessage) {
+        if (this.props.helpMessage || this.props.helpThumbnail) {
             return (
-                <span className={style.envelope__help}n>
+                <span role="button" onClick={this.toggleTooltip} className={style.envelope__tooltipButton}>
                     <Icon icon="question-circle" />
                 </span>
             );
@@ -99,8 +119,9 @@ export default class EditorEnvelope extends PureComponent {
 
         return (
             <div>
-                <span title={this.props.helpMessage}>
+                <span>
                     {this.renderLabel()}
+                    {this.state.showTooltip ? this.renderTooltip() : ''}
                 </span>
                 {this.renderEditorComponent()}
             </div>

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -5,6 +5,8 @@ import I18n from '@neos-project/neos-ui-i18n';
 import {neos} from '@neos-project/neos-ui-decorators';
 import style from './style.css';
 
+import {Icon} from '@neos-project/react-ui-components';
+
 @neos(globalRegistry => ({
     editorRegistry: globalRegistry.get('inspector').get('editors')
 }))
@@ -21,6 +23,7 @@ export default class EditorEnvelope extends PureComponent {
         editorRegistry: PropTypes.object.isRequired,
         validationErrors: PropTypes.array,
         onEnterKey: PropTypes.func,
+        helpMessage: PropTypes.string,
 
         commit: PropTypes.func.isRequired
     };
@@ -72,8 +75,21 @@ export default class EditorEnvelope extends PureComponent {
         return (
             <Label htmlFor={this.generateIdentifier()}>
                 <I18n id={label}/>
+                {this.renderHelpIcon()}
             </Label>
         );
+    }
+
+    renderHelpIcon() {
+        if (this.props.helpMessage) {
+            return (
+                <span className={style.envelope__help}n>
+                    <Icon icon="question-circle" />
+                </span>
+            );
+        }
+
+        return '';
     }
 
     render() {
@@ -86,7 +102,9 @@ export default class EditorEnvelope extends PureComponent {
 
         return (
             <div>
-                {this.renderLabel()}
+                <span title={this.props.helpMessage}>
+                    {this.renderLabel()}
+                </span>
                 {this.renderEditorComponent()}
             </div>
         );

--- a/packages/neos-ui-editors/src/EditorEnvelope/style.css
+++ b/packages/neos-ui-editors/src/EditorEnvelope/style.css
@@ -9,6 +9,12 @@
     justify-content: flex-start;
 }
 
-.envelope__help {
+.envelope__tooltipButton {
     padding-left: var(--spacing-Half);
+}
+
+.envelope__tooltip {
+    position: absolute;
+    z-index: var(--zIndex-NodeToolBar);
+    max-width: 100%;
 }

--- a/packages/neos-ui-editors/src/EditorEnvelope/style.css
+++ b/packages/neos-ui-editors/src/EditorEnvelope/style.css
@@ -2,3 +2,7 @@
     padding: .5em;
     border: 1px solid var(--colors-Error);
 }
+
+.envelope__help {
+    margin-left: var(--spacing-Half);
+}

--- a/packages/neos-ui-editors/src/EditorEnvelope/style.css
+++ b/packages/neos-ui-editors/src/EditorEnvelope/style.css
@@ -3,6 +3,12 @@
     border: 1px solid var(--colors-Error);
 }
 
+.envelope__label {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+}
+
 .envelope__help {
-    margin-left: var(--spacing-Half);
+    padding-left: var(--spacing-Half);
 }

--- a/packages/neos-ui/src/Containers/Modals/ReloginDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/ReloginDialog/index.js
@@ -115,7 +115,7 @@ export default class ReloginDialog extends PureComponent {
 
                     </Button>
                     {this.state.message ?
-                        <Tooltip error={true}>{this.state.message}</Tooltip> : null}
+                        <Tooltip asError={true}>{this.state.message}</Tooltip> : null}
 
                 </div>
             </Dialog>

--- a/packages/neos-ui/src/Containers/Modals/ReloginDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/ReloginDialog/index.js
@@ -115,7 +115,7 @@ export default class ReloginDialog extends PureComponent {
 
                     </Button>
                     {this.state.message ?
-                        <Tooltip>{this.state.message}</Tooltip> : null}
+                        <Tooltip error={true}>{this.state.message}</Tooltip> : null}
 
                 </div>
             </Dialog>

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeItem.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeItem.js
@@ -27,14 +27,6 @@ class NodeTypeItem extends PureComponent {
         }).isRequired
     };
 
-    renderHelpIcon = () => {
-        return (
-            <span className={style.nodeType__help}n>
-                <Icon icon="question-circle" />
-            </span>
-        );
-    }
-
     render() {
         const {ui} = this.props.nodeType;
         const icon = $get('icon', ui);
@@ -49,9 +41,11 @@ class NodeTypeItem extends PureComponent {
                 onClick={this.handleNodeTypeClick}
                 title={helpMessage ? helpMessage : ''}
                 >
-                {icon && <Icon icon={icon} className={style.nodeType__icon} padded="right"/>}
-                <I18n id={label} fallback={label}/>
-                {helpMessage ? this.renderHelpIcon() : null}
+                <span>
+                    {icon && <Icon icon={icon} className={style.nodeType__icon} padded="right"/>}
+                    <I18n id={label} fallback={label}/>
+                </span>
+                {helpMessage ? <Icon icon="question-circle" /> : null}
             </Button>
         );
     }

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeItem.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeItem.js
@@ -27,10 +27,19 @@ class NodeTypeItem extends PureComponent {
         }).isRequired
     };
 
+    renderHelpIcon = () => {
+        return (
+            <span className={style.nodeType__help}n>
+                <Icon icon="question-circle" />
+            </span>
+        );
+    }
+
     render() {
         const {ui} = this.props.nodeType;
         const icon = $get('icon', ui);
         const label = $get('label', ui);
+        const helpMessage = $get('help.message', ui);
 
         return (
             <Button
@@ -38,9 +47,11 @@ class NodeTypeItem extends PureComponent {
                 style="clean"
                 className={style.nodeType}
                 onClick={this.handleNodeTypeClick}
+                title={helpMessage ? helpMessage : ''}
                 >
                 {icon && <Icon icon={icon} className={style.nodeType__icon} padded="right"/>}
                 <I18n id={label} fallback={label}/>
+                {helpMessage ? this.renderHelpIcon() : null}
             </Button>
         );
     }

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/style.css
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/style.css
@@ -1,7 +1,9 @@
 .nodeType {
-    flex: 0 1 auto;
     width: calc(100% / 3);
     text-align: left;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
 }
 .nodeType__icon {
     color: var(--colors-PrimaryBlue);
@@ -40,8 +42,4 @@
 
 .nodeTypeFilter__label {
     margin-right: var(--spacing-Half);
-}
-
-.nodeType__help {
-    float: right;
 }

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/style.css
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/style.css
@@ -41,3 +41,7 @@
 .nodeTypeFilter__label {
     margin-right: var(--spacing-Half);
 }
+
+.nodeType__help {
+    float: right;
+}

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/InspectorEditorEnvelope/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/InspectorEditorEnvelope/index.js
@@ -32,6 +32,7 @@ export default class InspectorEditorEnvelope extends PureComponent {
         options: PropTypes.object,
         renderSecondaryInspector: PropTypes.func.isRequired,
         validationErrors: PropTypes.array,
+        helpMessage: PropTypes.string,
 
         node: PropTypes.object.isRequired,
         commit: PropTypes.func.isRequired

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.js
@@ -60,6 +60,7 @@ export default class PropertyGroup extends PureComponent {
                                     commit={commit}
                                     onEnterKey={handleInspectorApply}
                                     helpMessage={$get('helpMessage', item)}
+                                    helpThumbnail={$get('helpThumbnail', item)}
                                     />);
                         }
                         if (itemType === 'view') {

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.js
@@ -46,6 +46,7 @@ export default class PropertyGroup extends PureComponent {
                     {items.map(item => {
                         const itemId = $get('id', item);
                         const itemType = $get('type', item);
+
                         if (itemType === 'editor') {
                             return (
                                 <InspectorEditorEnvelope
@@ -58,6 +59,7 @@ export default class PropertyGroup extends PureComponent {
                                     node={node}
                                     commit={commit}
                                     onEnterKey={handleInspectorApply}
+                                    helpMessage={$get('helpMessage', item)}
                                     />);
                         }
                         if (itemType === 'view') {

--- a/packages/react-ui-components/src/Tooltip/style.css
+++ b/packages/react-ui-components/src/Tooltip/style.css
@@ -14,7 +14,7 @@
     border-bottom: var(--spacing-Half) solid var(--colors-ContrastNeutral);
 }
 
-.tooltip--error .tooltip--arrow {
+.tooltip--asError .tooltip--arrow {
     border-bottom: var(--spacing-Half) solid var(--colors-Error);
 }
 
@@ -25,6 +25,6 @@
     color: white;
 }
 
-.tooltip--error .tooltip--inner {
+.tooltip--asError .tooltip--inner {
     background: var(--colors-Error);
 }

--- a/packages/react-ui-components/src/Tooltip/style.css
+++ b/packages/react-ui-components/src/Tooltip/style.css
@@ -11,12 +11,20 @@
     margin-left: -var(--spacing-Half);
     border-left: var(--spacing-Half) solid transparent;
     border-right: var(--spacing-Half) solid transparent;
+    border-bottom: var(--spacing-Half) solid var(--colors-ContrastNeutral);
+}
+
+.tooltip--error .tooltip--arrow {
     border-bottom: var(--spacing-Half) solid var(--colors-Error);
 }
 
 .tooltip--inner {
     position: relative;
     padding: var(--spacing-Half);
-    background: var(--colors-Error);
+    background: var(--colors-ContrastNeutral);
     color: white;
+}
+
+.tooltip--error .tooltip--inner {
+    background: var(--colors-Error);
 }

--- a/packages/react-ui-components/src/Tooltip/tooltip.js
+++ b/packages/react-ui-components/src/Tooltip/tooltip.js
@@ -7,12 +7,12 @@ const Tooltip = props => {
         children,
         className,
         theme,
-        error,
+        asError,
         ...rest
     } = props;
     const classNames = mergeClassNames({
         [theme.tooltip]: true,
-        [theme['tooltip--error']]: error,
+        [theme['tooltip--asError']]: asError,
         [className]: className && className.length
     });
 
@@ -44,7 +44,7 @@ Tooltip.propTypes = {
     /**
      * Whether this tooltip should indicate an error or not
      */
-    error: PropTypes.bool
+    asError: PropTypes.bool
 };
 
 export default Tooltip;

--- a/packages/react-ui-components/src/Tooltip/tooltip.js
+++ b/packages/react-ui-components/src/Tooltip/tooltip.js
@@ -7,10 +7,12 @@ const Tooltip = props => {
         children,
         className,
         theme,
+        error,
         ...rest
     } = props;
     const classNames = mergeClassNames({
         [theme.tooltip]: true,
+        [theme['tooltip--error']]: error,
         [className]: className && className.length
     });
 
@@ -37,7 +39,12 @@ Tooltip.propTypes = {
     /**
      * An optional css theme to be injected.
      */
-    theme: PropTypes.object
+    theme: PropTypes.object,
+
+    /**
+     * Whether this tooltip should indicate an error or not
+     */
+    error: PropTypes.bool
 };
 
 export default Tooltip;


### PR DESCRIPTION
This currently shows a help icon in the NodeCreateionDialog and inspector property if a help definition exists in the yaml file and sets the title of this element to the help message.
Thus means if you hover this item you will see the help message.

closes  #1694

New:
![screenshot_2018-06-27 viii the queen s croquet-ground - the book - neos demo site](https://user-images.githubusercontent.com/12071529/41982426-ad4acd28-7a2b-11e8-97d8-8827dcdf666b.png)
![screenshot_2018-06-27 viii the queen s croquet-ground - the book - neos demo site 1](https://user-images.githubusercontent.com/12071529/41982427-ad7b394a-7a2b-11e8-9a21-58b11fc275a2.png)

Old:
![screenshot_2018-06-27 viii the queen s croquet-ground - the book - neos demo site 2](https://user-images.githubusercontent.com/12071529/41982776-91aa220c-7a2c-11e8-80d2-27ff4559caaf.png)
![screenshot_2018-06-27 viii the queen s croquet-ground - the book - neos demo site 3](https://user-images.githubusercontent.com/12071529/41982841-ba04d5ee-7a2c-11e8-9d23-ac1dc644bfca.png)

