### PR TITLE
FEATURE: Asynchronously load policy information for nodes

### DIFF
--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -23,6 +23,7 @@ use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Neos\Domain\Service\ContentContextFactory;
 use Neos\Neos\Service\PublishingService;
 use Neos\Neos\Service\UserService;
+use Neos\Neos\TypeConverter\NodeConverter;
 use Neos\Neos\Ui\ContentRepository\Service\NodeService;
 use Neos\Neos\Ui\ContentRepository\Service\WorkspaceService;
 use Neos\Neos\Ui\Domain\Model\ChangeCollection;
@@ -35,6 +36,7 @@ use Neos\Neos\Ui\Domain\Model\Feedback\Operations\RemoveNode;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateWorkspaceInfo;
 use Neos\Neos\Ui\Domain\Model\FeedbackCollection;
+use Neos\Neos\Ui\Service\NodePolicyService;
 use Neos\Neos\Ui\Domain\Service\NodeTreeBuilder;
 use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
 use Neos\Neos\Ui\Fusion\Helper\WorkspaceHelper;
@@ -98,6 +100,12 @@ class BackendServiceController extends ActionController
      * @var UserService
      */
     protected $userService;
+
+    /**
+     * @Flow\Inject
+     * @var NodePolicyService
+     */
+    protected $nodePolicyService;
 
     /**
      * Set the controller context on the feedback collection after the controller
@@ -342,6 +350,29 @@ class BackendServiceController extends ActionController
     {
         $nodeTreeArguments->setControllerContext($this->controllerContext);
         $this->view->assign('value', $nodeTreeArguments->build($includeRoot));
+    }
+
+    /**
+     * @throws \Neos\Flow\Mvc\Exception\NoSuchArgumentException
+     */
+    public function initializeGetPolicyInformationAction()
+    {
+        $this->arguments->getArgument('nodes')->getPropertyMappingConfiguration()->allowAllProperties();
+    }
+
+    /**
+     * @param array<NodeInterface> $nodes
+     */
+    public function getPolicyInformationAction(array $nodes)
+    {
+        $result = [];
+        /** @var NodeInterface $node */
+        foreach ($nodes as $node)
+        {
+            $result[$node->getContextPath()] = ['policy' => $this->nodePolicyService->getNodePolicyInformation($node)];
+        }
+
+        $this->view->assign('value', $result);
     }
 
     /**

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -367,8 +367,7 @@ class BackendServiceController extends ActionController
     {
         $result = [];
         /** @var NodeInterface $node */
-        foreach ($nodes as $node)
-        {
+        foreach ($nodes as $node) {
             $result[$node->getContextPath()] = ['policy' => $this->nodePolicyService->getNodePolicyInformation($node)];
         }
 

--- a/Classes/Service/NodePolicyService.php
+++ b/Classes/Service/NodePolicyService.php
@@ -1,7 +1,6 @@
 <?php
 namespace Neos\Neos\Ui\Service;
 
-use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\CreateNodePrivilege;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\CreateNodePrivilegeSubject;
@@ -47,7 +46,7 @@ class NodePolicyService
      * @return array the key is a Privilege class name; the value is "true" if privileges are configured for this class name.
      * @Flow\CompileStatic
      */
-    public static function getUsedPrivilegeClassNames($objectManager)
+    public static function getUsedPrivilegeClassNames(ObjectManagerInterface $objectManager): array
     {
         $policyService = $objectManager->get(PolicyService::class);
         $usedPrivilegeClassNames = [];
@@ -86,12 +85,11 @@ class NodePolicyService
         if (!isset(self::getUsedPrivilegeClassNames($this->objectManager)[NodeTreePrivilege::class])) {
             return true;
         }
-        $hasNodeTreePrivilege = $this->privilegeManager->isGranted(
+
+        return $this->privilegeManager->isGranted(
             NodeTreePrivilege::class,
             new NodePrivilegeSubject($node)
         );
-
-        return $hasNodeTreePrivilege;
     }
 
     /**
@@ -116,11 +114,10 @@ class NodePolicyService
         $disallowedNodeTypeObjects = array_filter($this->nodeTypeManager->getNodeTypes(), $filter);
 
         $mapper = function ($nodeType) {
-            $nodeType->getName();
+            return $nodeType->getName();
         };
 
-        $disallowedNodeTypes = array_map($mapper, $disallowedNodeTypeObjects);
-        return $disallowedNodeTypes;
+        return array_map($mapper, $disallowedNodeTypeObjects);
     }
 
     /**

--- a/Classes/Service/NodePolicyService.php
+++ b/Classes/Service/NodePolicyService.php
@@ -114,7 +114,12 @@ class NodePolicyService
         };
 
         $disallowedNodeTypeObjects = array_filter($this->nodeTypeManager->getNodeTypes(), $filter);
-        $disallowedNodeTypes = array_map(function ($nodeType) {$nodeType->getName();}, $disallowedNodeTypeObjects);
+
+        $mapper = function ($nodeType) {
+            $nodeType->getName();
+        };
+
+        $disallowedNodeTypes = array_map($mapper, $disallowedNodeTypeObjects);
         return $disallowedNodeTypes;
     }
 

--- a/Configuration/Routes.Service.yaml
+++ b/Configuration/Routes.Service.yaml
@@ -53,3 +53,10 @@
     '@controller': 'BackendService'
     '@action': 'getWorkspaceInfo'
   httpMethods: ['GET']
+-
+  name: 'Get Policy Info'
+  uriPattern: 'get-policy-info'
+  defaults:
+    '@controller': 'BackendService'
+    '@action': 'getPolicyInformation'
+  httpMethods: ['POST']

--- a/Resources/Private/Fusion/Backend/Root.fusion
+++ b/Resources/Private/Fusion/Backend/Root.fusion
@@ -80,6 +80,9 @@ backend = Neos.Fusion:Template {
                 getWorkspaceInfo = Neos.Fusion:UriBuilder {
                     action = 'getWorkspaceInfo'
                 }
+                getPolicyInfo = Neos.Fusion:UriBuilder {
+                    action = 'getPolicyInformation'
+                }
             }
         }
         core = Neos.Fusion:RawArray {

--- a/packages/neos-ui-backend-connector/src/Endpoints/index.js
+++ b/packages/neos-ui-backend-connector/src/Endpoints/index.js
@@ -323,6 +323,19 @@ export default routes => {
         }
     })).then(response => fetchWithErrorHandling.parseJson(response));
 
+    const getPolicyInfo = nodeContextPaths => fetchWithErrorHandling.withCsrfToken(csrfToken => {
+        return {
+            url: routes.ui.service.getPolicyInfo,
+            method: 'POST',
+            credentials: 'include',
+            body: JSON.stringify({nodes: nodeContextPaths}),
+            headers: {
+                'X-Flow-Csrftoken': csrfToken,
+                'Content-Type': 'application/json'
+            }
+        };
+    }).then(response => fetchWithErrorHandling.parseJson(response));
+
     const dataSource = (dataSourceIdentifier, dataSourceUri, params = {}) => fetchWithErrorHandling.withCsrfToken(() => ({
         url: urlWithParams(dataSourceUri || `${routes.core.service.dataSource}/${dataSourceIdentifier}`, params),
 
@@ -375,6 +388,7 @@ export default routes => {
         dataSource,
         getJsonResource,
         getWorkspaceInfo,
+        getPolicyInfo,
         tryLogin,
         contentDimensions
     };

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -2,6 +2,7 @@ import {takeEvery, put, select} from 'redux-saga/effects';
 import {$get} from 'plow-js';
 
 import {selectors, actions, actionTypes} from '@neos-project/neos-ui-redux-store';
+import backend from '@neos-project/neos-ui-backend-connector';
 import {requestIdleCallback} from '@neos-project/utils-helpers';
 
 import initializeContentDomNode from './initializeContentDomNode';
@@ -51,7 +52,7 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
         [documentInformation.metaData.contextPath]: documentInformation.metaData.documentNodeSerialization
     });
 
-    yield put(actions.CR.Nodes.add(nodes));
+    yield put(actions.CR.Nodes.mergeFromGuestFrame(nodes));
 
     // Remove the inline scripts after initialization
     Array.prototype.forEach.call(guestFrameWindow.document.querySelectorAll('script[data-neos-nodedata]'), element => element.parentElement.removeChild(element));

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -51,7 +51,7 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
         [documentInformation.metaData.contextPath]: documentInformation.metaData.documentNodeSerialization
     });
 
-    yield put(actions.CR.Nodes.mergeFromGuestFrame(nodes));
+    yield put(actions.CR.Nodes.merge(nodes));
 
     // Remove the inline scripts after initialization
     Array.prototype.forEach.call(guestFrameWindow.document.querySelectorAll('script[data-neos-nodedata]'), element => element.parentElement.removeChild(element));

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -2,7 +2,6 @@ import {takeEvery, put, select} from 'redux-saga/effects';
 import {$get} from 'plow-js';
 
 import {selectors, actions, actionTypes} from '@neos-project/neos-ui-redux-store';
-import backend from '@neos-project/neos-ui-backend-connector';
 import {requestIdleCallback} from '@neos-project/utils-helpers';
 
 import initializeContentDomNode from './initializeContentDomNode';

--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.js
@@ -26,7 +26,6 @@ const PASTE = '@neos/neos-ui/CR/Nodes/PASTE';
 const HIDE = '@neos/neos-ui/CR/Nodes/HIDE';
 const SHOW = '@neos/neos-ui/CR/Nodes/SHOW';
 const UPDATE_URI = '@neos/neos-ui/CR/Nodes/UPDATE_URI';
-const MERGE_FROM_GUEST_FRAME = '@neos/neos-ui/CR/Nodes/MERGE_FROM_GUEST_FRAME';
 
 //
 // Export the action types
@@ -34,7 +33,6 @@ const MERGE_FROM_GUEST_FRAME = '@neos/neos-ui/CR/Nodes/MERGE_FROM_GUEST_FRAME';
 export const actionTypes = {
     ADD,
     MERGE,
-    MERGE_FROM_GUEST_FRAME,
     FOCUS,
     UNFOCUS,
     COMMENCE_CREATION,
@@ -68,12 +66,6 @@ const add = createAction(ADD, nodeMap => ({nodeMap}));
  * @param {Object} nodeMap A map of nodes, with contextPaths as key
  */
 const merge = createAction(MERGE, nodeMap => ({nodeMap}));
-
-/**
- * Specific action for node information coming from the guest frame,
- * to be able to trigger more specific sagas based on that information.
- */
-const mergeFromGuestFrame = createAction(MERGE_FROM_GUEST_FRAME, nodeMap => ({nodeMap}));
 
 /**
  * Marks a node as focused
@@ -292,30 +284,6 @@ export const reducer = handleActions({
         return $all(...transformations, state);
     },
     [MERGE]: ({nodeMap}) => $all(
-        ...Object.keys(nodeMap).map(contextPath => $merge(
-            ['cr', 'nodes', 'byContextPath', contextPath],
-            Immutable.fromJS(
-                //
-                // the data is passed from *the guest iFrame*. Because of this, at least in Chrome, Immutable.fromJS() does not do anything;
-                // as the object has a different prototype than the default "Object". For this reason, we need to JSON-encode-and-decode
-                // the data, to scope it relative to *this* frame.
-                //
-                JSON.parse(JSON.stringify(nodeMap[contextPath]))
-            )
-        )),
-        ...Object.keys(nodeMap).filter(contextPath => contextPath.children !== undefined).map(contextPath => $set(
-            ['cr', 'nodes', 'byContextPath', contextPath, 'children'],
-            Immutable.fromJS(
-                //
-                // the data is passed from *the guest iFrame*. Because of this, at least in Chrome, Immutable.fromJS() does not do anything;
-                // as the object has a different prototype than the default "Object". For this reason, we need to JSON-encode-and-decode
-                // the data, to scope it relative to *this* frame.
-                //
-                JSON.parse(JSON.stringify(nodeMap[contextPath].children))
-            )
-        )),
-    ),
-    [MERGE_FROM_GUEST_FRAME]: ({nodeMap}) => $all(
         ...Object.keys(nodeMap).map(contextPath => $merge(
             ['cr', 'nodes', 'byContextPath', contextPath],
             Immutable.fromJS(

--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.js
@@ -194,7 +194,6 @@ const updateUri = createAction(UPDATE_URI, (oldUriFragment, newUriFragment) => (
 export const actions = {
     add,
     merge,
-    mergeFromGuestFrame,
     focus,
     unFocus,
     commenceCreation,

--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.js
@@ -315,7 +315,7 @@ export const reducer = handleActions({
             )
         )),
     ),
-    [MERGE_FROM_GUEST_FRAME]: ({ nodeMap }) => $all(
+    [MERGE_FROM_GUEST_FRAME]: ({nodeMap}) => $all(
         ...Object.keys(nodeMap).map(contextPath => $merge(
             ['cr', 'nodes', 'byContextPath', contextPath],
             Immutable.fromJS(

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
@@ -231,8 +231,8 @@ export const PageTreeToolbar = withNodeTypesRegistry(connect(
                 subject: clipboardNodeContextPath,
                 reference: focusedNodeContextPath
             });
-            const canBeDeleted = $get('policy.canRemove', focusedNode);
-            const canBeEdited = $get('policy.canEdit', focusedNode);
+            const canBeDeleted = $get('policy.canRemove', focusedNode) || false;
+            const canBeEdited = $get('policy.canEdit', focusedNode) || false;
             const visibilityCanBeToggled = !$contains('_hidden', 'policy.disallowedProperties', focusedNode);
             const clipboardMode = $get('cr.nodes.clipboardMode', state);
             const isCut = focusedNodeContextPath === clipboardNodeContextPath && clipboardMode === 'Move';

--- a/packages/neos-ui/src/Sagas/CR/Policies/index.js
+++ b/packages/neos-ui/src/Sagas/CR/Policies/index.js
@@ -1,0 +1,53 @@
+import {select, take, put} from 'redux-saga/effects';
+import {$get} from 'plow-js';
+import {actions, actionTypes, selectors} from '@neos-project/neos-ui-redux-store';
+import backend from '@neos-project/neos-ui-backend-connector';
+
+export function * watchNodeFocus() {
+    const {endpoints} = backend.get();
+    let runningRequests = [];
+    while (true) {
+        const action = yield take([actionTypes.UI.ContentCanvas.SET_CONTEXT_PATH, actionTypes.CR.Nodes.FOCUS]);
+        const {contextPath} = action.payload;
+        if (runningRequests.includes(contextPath)) {
+            continue;
+        }
+
+        runningRequests.push(contextPath);
+
+        const getNodeByContextPathSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector(contextPath);
+        const node = select(getNodeByContextPathSelector);
+        const policyInfo = $get('policy', node);
+        if (policyInfo && policyInfo !== false) {
+            runningRequests = runningRequests.filter(item => item !== contextPath);
+            continue;
+        }
+
+        const policyData = yield endpoints.getPolicyInfo([contextPath]);
+        runningRequests = runningRequests.filter(item => item !== contextPath);
+        yield put(actions.CR.Nodes.merge(policyData));
+    }
+}
+
+export function * watchMergeFromGuestFrame() {
+    const {endpoints} = backend.get();
+    while (true) {
+        const action = yield take(actionTypes.CR.Nodes.MERGE_FROM_GUEST_FRAME);
+        const {nodeMap} = action.payload;
+
+        const nodesWithoutPolicies = Object.keys(nodeMap).filter(contextPath => {
+            const getNodeByContextPathSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector(contextPath);
+            const node = select(getNodeByContextPathSelector);
+            const policyInfo = $get('policy', node);
+            return (!policyInfo || policyInfo === false);
+        });
+
+        if (nodesWithoutPolicies.length === 0) {
+            continue;
+        }
+
+        const policyData = yield endpoints.getPolicyInfo(nodesWithoutPolicies);
+        yield put(actions.CR.Nodes.merge(policyData));
+    }
+}
+

--- a/packages/neos-ui/src/Sagas/CR/Policies/index.js
+++ b/packages/neos-ui/src/Sagas/CR/Policies/index.js
@@ -39,7 +39,7 @@ export function * watchMergeFromGuestFrame() {
             const getNodeByContextPathSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector(contextPath);
             const node = select(getNodeByContextPathSelector);
             const policyInfo = $get('policy', node);
-            return (!policyInfo || policyInfo === false);
+            return (!policyInfo);
         });
 
         if (nodesWithoutPolicies.length === 0) {

--- a/packages/neos-ui/src/Sagas/CR/Policies/index.js
+++ b/packages/neos-ui/src/Sagas/CR/Policies/index.js
@@ -3,41 +3,19 @@ import {$get} from 'plow-js';
 import {actions, actionTypes, selectors} from '@neos-project/neos-ui-redux-store';
 import backend from '@neos-project/neos-ui-backend-connector';
 
-export function * watchNodeFocus() {
-    const {endpoints} = backend.get();
-    let runningRequests = [];
-    while (true) {
-        const action = yield take([actionTypes.UI.ContentCanvas.SET_CONTEXT_PATH, actionTypes.CR.Nodes.FOCUS]);
-        const {contextPath} = action.payload;
-        if (runningRequests.includes(contextPath)) {
-            continue;
-        }
-
-        runningRequests.push(contextPath);
-
-        const getNodeByContextPathSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector(contextPath);
-        const node = select(getNodeByContextPathSelector);
-        const policyInfo = $get('policy', node);
-        if (policyInfo && policyInfo !== false) {
-            runningRequests = runningRequests.filter(item => item !== contextPath);
-            continue;
-        }
-
-        const policyData = yield endpoints.getPolicyInfo([contextPath]);
-        runningRequests = runningRequests.filter(item => item !== contextPath);
-        yield put(actions.CR.Nodes.merge(policyData));
-    }
-}
-
-export function * watchMergeFromGuestFrame() {
+export function * watchNodeInformationChanges() {
     const {endpoints} = backend.get();
     while (true) {
-        const action = yield take(actionTypes.CR.Nodes.MERGE_FROM_GUEST_FRAME);
+        const action = yield take([actionTypes.CR.Nodes.MERGE, actionTypes.CR.Nodes.ADD]);
         const {nodeMap} = action.payload;
+        const state = yield select();
 
         const nodesWithoutPolicies = Object.keys(nodeMap).filter(contextPath => {
-            const getNodeByContextPathSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector(contextPath);
-            const node = select(getNodeByContextPathSelector);
+            const node = selectors.CR.Nodes.nodeByContextPath(state)(contextPath);
+            const isFullyLoaded = $get('isFullyLoaded', node);
+            if (!isFullyLoaded) {
+                return false;
+            }
             const policyInfo = $get('policy', node);
             return (!policyInfo);
         });

--- a/packages/neos-ui/src/Sagas/CR/Policies/index.spec.js
+++ b/packages/neos-ui/src/Sagas/CR/Policies/index.spec.js
@@ -1,0 +1,3 @@
+test(`write tests`, () => {
+    expect(true).toBe(true);
+});

--- a/packages/neos-ui/src/Sagas/UI/ContentTree/index.js
+++ b/packages/neos-ui/src/Sagas/UI/ContentTree/index.js
@@ -24,7 +24,7 @@ export function * watchReloadTree({globalRegistry}) {
 
         yield put(actions.UI.ContentTree.stopLoading());
 
-        yield put(actions.CR.Nodes.add(self.concat(directChildNodes, consecutiveChildNodes).reduce((result, node) => {
+        yield put(actions.CR.Nodes.merge(self.concat(directChildNodes, consecutiveChildNodes).reduce((result, node) => {
             result[node.contextPath] = node;
             return result;
         }, {})));

--- a/packages/neos-ui/src/Sagas/UI/PageTree/index.js
+++ b/packages/neos-ui/src/Sagas/UI/PageTree/index.js
@@ -98,7 +98,7 @@ export function * watchCurrentDocument({configuration}) {
             if (!node) {
                 yield put(actions.UI.PageTree.setAsLoading(siteNodeContextPath));
                 const nodes = yield q(parentContextPath).get();
-                yield put(actions.CR.Nodes.add(nodes.reduce((nodeMap, node) => {
+                yield put(actions.CR.Nodes.merge(nodes.reduce((nodeMap, node) => {
                     nodeMap[$get('contextPath', node)] = node;
                     return nodeMap;
                 }, {})));

--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -246,7 +246,7 @@ manifest('main', {}, globalRegistry => {
     // When the server has updated node info, apply it to the store
     //
     serverFeedbackHandlers.set('Neos.Neos.Ui:UpdateNodeInfo/Main', (feedbackPayload, {store}) => {
-        store.dispatch(actions.CR.Nodes.add(feedbackPayload.byContextPath));
+        store.dispatch(actions.CR.Nodes.merge(feedbackPayload.byContextPath));
     });
 
     //

--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -246,7 +246,7 @@ manifest('main', {}, globalRegistry => {
     // When the server has updated node info, apply it to the store
     //
     serverFeedbackHandlers.set('Neos.Neos.Ui:UpdateNodeInfo/Main', (feedbackPayload, {store}) => {
-        store.dispatch(actions.CR.Nodes.merge(feedbackPayload.byContextPath));
+        store.dispatch(actions.CR.Nodes.add(feedbackPayload.byContextPath));
     });
 
     //

--- a/packages/neos-ui/src/manifest.sagas.js
+++ b/packages/neos-ui/src/manifest.sagas.js
@@ -5,6 +5,7 @@ import * as browser from './Sagas/Browser/index';
 import * as changes from './Sagas/Changes/index';
 import * as crContentDimensions from './Sagas/CR/ContentDimensions/index';
 import * as crNodeOperations from './Sagas/CR/NodeOperations/index';
+import * as crPolicies from './Sagas/CR/Policies/index';
 import * as publish from './Sagas/Publish/index';
 import * as serverFeedback from './Sagas/ServerFeedback/index';
 import * as uiContentCanvas from './Sagas/UI/ContentCanvas/index';
@@ -40,6 +41,9 @@ manifest('main.sagas', {}, globalRegistry => {
     sagasRegistry.set('neos-ui/CR/NodeOperations/showNode', {saga: crNodeOperations.showNode});
     sagasRegistry.set('neos-ui/CR/NodeOperations/removeNodeIfConfirmed', {saga: crNodeOperations.removeNodeIfConfirmed});
     sagasRegistry.set('neos-ui/CR/NodeOperations/reloadState', {saga: crNodeOperations.reloadState});
+
+    sagasRegistry.set('neos-ui/CR/Policies/watchNodeFocus', {saga: crPolicies.watchNodeFocus});
+    sagasRegistry.set('neos-ui/CR/Policies/watchMergeFromGuestFrame', {saga: crPolicies.watchMergeFromGuestFrame});
 
     sagasRegistry.set('neos-ui/Publish/watchChangeBaseWorkspace', {saga: publish.watchChangeBaseWorkspace});
     sagasRegistry.set('neos-ui/Publish/discardIfConfirmed', {saga: publish.discardIfConfirmed});

--- a/packages/neos-ui/src/manifest.sagas.js
+++ b/packages/neos-ui/src/manifest.sagas.js
@@ -42,8 +42,7 @@ manifest('main.sagas', {}, globalRegistry => {
     sagasRegistry.set('neos-ui/CR/NodeOperations/removeNodeIfConfirmed', {saga: crNodeOperations.removeNodeIfConfirmed});
     sagasRegistry.set('neos-ui/CR/NodeOperations/reloadState', {saga: crNodeOperations.reloadState});
 
-    sagasRegistry.set('neos-ui/CR/Policies/watchNodeFocus', {saga: crPolicies.watchNodeFocus});
-    sagasRegistry.set('neos-ui/CR/Policies/watchMergeFromGuestFrame', {saga: crPolicies.watchMergeFromGuestFrame});
+    sagasRegistry.set('neos-ui/CR/Policies/watchNodeInformationChanges', {saga: crPolicies.watchNodeInformationChanges});
 
     sagasRegistry.set('neos-ui/Publish/watchChangeBaseWorkspace', {saga: publish.watchChangeBaseWorkspace});
     sagasRegistry.set('neos-ui/Publish/discardIfConfirmed', {saga: publish.discardIfConfirmed});


### PR DESCRIPTION
Avoid evaluating policies when fetching node information from
server in order to improve performance of loading/display of nodes.

Policies for Documents are only fetched when the respective node is
selected in the tree. Policies for content nodes are fetched after
the page is loaded in the iframe.

Related: #1579
Fixes: #1646