### PR TITLE
TASK: Adjust responsibilities for validation result rendering

### DIFF
--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -67,7 +67,7 @@ export default class EditorEnvelope extends PureComponent {
             // We pass down a classname to render a highlight status on the editor field
             const classNames = mergeClassNames({
                 [style['envelope--highlight']]: highlight && !isInvalid,
-                [style['envelope--invalid']]: validationErrors
+                [style['envelope--invalid']]: validationErrors && validationErrors.length > 0
             });
 
             return (
@@ -149,7 +149,7 @@ export default class EditorEnvelope extends PureComponent {
                 </span>
 
                 {this.renderEditorComponent()}
-                {this.props.validationErrors && <Tooltip renderInline asError>{validationErrors}</Tooltip>}
+                {this.props.validationErrors && this.props.validationErrors.length > 0 && <Tooltip renderInline asError>{validationErrors}</Tooltip>}
             </Fragment>
         );
     }

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -149,7 +149,7 @@ export default class EditorEnvelope extends PureComponent {
                 </span>
 
                 {this.renderEditorComponent()}
-                {validationErrors && validationErrors.length > 0 && <Tooltip renderInline asError><ul>{validationErrors.map(error => <li>{error}</li>)}</ul></Tooltip>}
+                {validationErrors && validationErrors.length > 0 && <Tooltip renderInline asError><ul>{validationErrors.map((error, index) => <li key={index}>{error}</li>)}</ul></Tooltip>}
             </Fragment>
         );
     }

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -60,18 +60,17 @@ export default class EditorEnvelope extends PureComponent {
         if (editorDefinition && editorDefinition.component) {
             const EditorComponent = editorDefinition && editorDefinition.component;
 
-            const restProps = omit(this.props, ['validationErrors', 'highlight']);
-            const {highlight, validationErrors} = this.props;
-            const isInvalid = validationErrors && validationErrors.length > 1;
+            const {highlight, validationErrors, ...rest} = this.props;
+            const isInvalid = validationErrors && validationErrors.length > 0;
 
             // We pass down a classname to render a highlight status on the editor field
             const classNames = mergeClassNames({
                 [style['envelope--highlight']]: highlight && !isInvalid,
-                [style['envelope--invalid']]: validationErrors && validationErrors.length > 0
+                [style['envelope--invalid']]: isInvalid
             });
 
             return (
-                <EditorComponent className={classNames} id={this.generateIdentifier()} {...restProps} />
+                <EditorComponent className={classNames} id={this.generateIdentifier()} {...rest} />
             );
         }
 

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -23,7 +23,7 @@ export default class EditorEnvelope extends PureComponent {
     static defaultProps = {
         helpMessage: '',
         helpThumbnail: '',
-        highlight: false
+        highlight: true
     };
 
     static propTypes = {

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -23,7 +23,7 @@ export default class EditorEnvelope extends PureComponent {
     static defaultProps = {
         helpMessage: '',
         helpThumbnail: '',
-        highlight: true
+        highlight: false
     };
 
     static propTypes = {
@@ -149,7 +149,7 @@ export default class EditorEnvelope extends PureComponent {
                 </span>
 
                 {this.renderEditorComponent()}
-                {this.props.validationErrors && this.props.validationErrors.length > 0 && <Tooltip renderInline asError>{validationErrors}</Tooltip>}
+                {validationErrors && validationErrors.length > 0 && <Tooltip renderInline asError><ul>{validationErrors.map(error => <li>{error}</li>)}</ul></Tooltip>}
             </Fragment>
         );
     }

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -1,6 +1,5 @@
 import React, {PureComponent, Fragment} from 'react';
 import PropTypes from 'prop-types';
-import omit from 'lodash.omit';
 import mergeClassNames from 'classnames';
 
 import Label from '@neos-project/react-ui-components/src/Label/';

--- a/packages/neos-ui-editors/src/EditorEnvelope/style.css
+++ b/packages/neos-ui-editors/src/EditorEnvelope/style.css
@@ -1,8 +1,3 @@
-.envelope__error {
-    padding: .5em;
-    border: 1px solid var(--colors-Error);
-}
-
 .envelope__label {
     display: flex;
     flex-direction: row;
@@ -13,8 +8,16 @@
     padding-left: var(--spacing-Half);
 }
 
-.envelope__tooltip {
+.envelope__helpmessage {
     position: absolute;
     z-index: var(--zIndex-NodeToolBar);
     max-width: 100%;
+}
+.envelope--invalid {
+    outline: 2px solid var(--colors-Error) !important;
+    color: var(--colors-Error) !important;
+}
+
+.envelope--highlight {
+    outline: 2px solid var(--colors-Success);
 }

--- a/packages/neos-ui-editors/src/EditorEnvelope/style.css
+++ b/packages/neos-ui-editors/src/EditorEnvelope/style.css
@@ -14,8 +14,7 @@
     max-width: 100%;
 }
 .envelope--invalid {
-    outline: 2px solid var(--colors-Error) !important;
-    color: var(--colors-Error) !important;
+    outline: 2px solid var(--colors-Error);
 }
 
 .envelope--highlight {

--- a/packages/neos-ui-editors/src/Editors/AssetEditor/index.js
+++ b/packages/neos-ui-editors/src/Editors/AssetEditor/index.js
@@ -29,11 +29,10 @@ export default class AssetEditor extends PureComponent {
     static propTypes = {
         // The propertyName this editor is used for, coming from the inspector
         identifier: PropTypes.string,
-
+        className: PropTypes.string,
         value: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.arrayOf(PropTypes.string), PropTypes.arrayOf(PropTypes.object)]),
         options: PropTypes.object,
         searchOptions: PropTypes.array,
-        highlight: PropTypes.bool,
         placeholder: PropTypes.string,
         onSearchTermChange: PropTypes.func,
         commit: PropTypes.func.isRequired,
@@ -176,11 +175,12 @@ export default class AssetEditor extends PureComponent {
 
         const disabled = $get('options.disabled', this.props);
         const accept = $get('options.accept', this.props);
+        const {className} = this.props;
 
         if (this.props.options.multiple) {
             return (
                 <AssetUpload
-                    highlight={this.props.highlight}
+                    className={className}
                     multiple={true}
                     multipleData={this.props.value}
                     onAfterUpload={this.handleValuesChange}
@@ -198,7 +198,6 @@ export default class AssetEditor extends PureComponent {
                         placeholder={this.props.i18nRegistry.translate(this.props.placeholder)}
                         options={this.state.options || []}
                         values={this.getValues()}
-                        highlight={this.props.highlight}
                         onValuesChange={this.handleValuesChange}
                         displayLoadingIndicator={this.state.isLoading}
                         searchOptions={this.state.searchOptions}
@@ -214,7 +213,7 @@ export default class AssetEditor extends PureComponent {
         }
         return (
             <AssetUpload
-                highlight={this.props.highlight}
+                className={className}
                 multiple={false}
                 onAfterUpload={this.handleValueChange}
                 ref={this.setAssetUploadReference}
@@ -230,7 +229,6 @@ export default class AssetEditor extends PureComponent {
                     placeholder={this.props.i18nRegistry.translate(this.props.placeholder)}
                     options={this.props.value ? this.state.options : this.state.searchOptions}
                     value={this.getValue()}
-                    highlight={this.props.highlight}
                     onValueChange={this.handleValueChange}
                     displayLoadingIndicator={this.state.isLoading}
                     showDropDownToggle={false}

--- a/packages/neos-ui-editors/src/Editors/Boolean/index.js
+++ b/packages/neos-ui-editors/src/Editors/Boolean/index.js
@@ -30,29 +30,34 @@ const defaultOptions = {
 };
 
 const BooleanEditor = props => {
-    const {value, label, identifier, commit, options, highlight} = props;
+    const {value, label, identifier, commit, options, className} = props;
     const finalOptions = Object.assign({}, defaultOptions, options);
+
+    const wrapperClassName = mergeClassNames({
+        [className]: true,
+        [style.boolean__wrapper]: true
+    });
 
     const finalClassName = mergeClassNames({
         [style.boolean__disabled]: finalOptions.disabled
     });
 
     return (
-        <div>
+        <div className={wrapperClassName}>
             <Label htmlFor={identifier} className={finalClassName}>
-                <CheckBox id={identifier} highlight={highlight} isChecked={toBoolean(value)} isDisabled={finalOptions.disabled} onChange={commit}/>
+                <CheckBox id={identifier} isChecked={toBoolean(value)} isDisabled={finalOptions.disabled} onChange={commit}/>
                 <I18n id={label}/>
             </Label>
         </div>
     );
 };
 BooleanEditor.propTypes = {
+    className: PropTypes.string,
     identifier: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
     value: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
     commit: PropTypes.func.isRequired,
-    options: PropTypes.object,
-    highlight: PropTypes.bool
+    options: PropTypes.object
 };
 
 export default BooleanEditor;

--- a/packages/neos-ui-editors/src/Editors/Boolean/style.css
+++ b/packages/neos-ui-editors/src/Editors/Boolean/style.css
@@ -2,3 +2,11 @@
     opacity: .65;
     cursor: not-allowed;
 }
+
+.boolean__wrapper {
+    padding: 5px;
+
+    label {
+        margin-bottom: 0 !important;
+    }
+}

--- a/packages/neos-ui-editors/src/Editors/CodeMirror/index.js
+++ b/packages/neos-ui-editors/src/Editors/CodeMirror/index.js
@@ -6,14 +6,16 @@ import Button from '@neos-project/react-ui-components/src/Button/';
 import Icon from '@neos-project/react-ui-components/src/Icon/';
 import Label from '@neos-project/react-ui-components/src/Label/';
 import I18n from '@neos-project/neos-ui-i18n';
-
 import {neos} from '@neos-project/neos-ui-decorators';
+
+import style from './style.css';
 
 @neos(globalRegistry => ({
     secondaryEditorsRegistry: globalRegistry.get('inspector').get('secondaryEditors')
 }))
 export default class CodeMirror extends PureComponent {
     static propTypes = {
+        className: PropTypes.string,
         identifier: PropTypes.string.isRequired,
         renderSecondaryInspector: PropTypes.func.isRequired,
         commit: PropTypes.func.isRequired,
@@ -29,14 +31,14 @@ export default class CodeMirror extends PureComponent {
     };
 
     render() {
-        const {label, identifier} = this.props;
+        const {label, identifier, className} = this.props;
         const disabled = $get('options.disabled', this.props);
         const handleClick = () => disabled ? null : this.handleOpenCodeEditor;
 
         return (
             <div>
-                <Label htmlFor={identifier}>
-                    <Button disabled={disabled} onClick={handleClick()} style="brand">
+                <Label className={style.codemirror__label} htmlFor={identifier}>
+                    <Button className={className} disabled={disabled} onClick={handleClick()}>
                         <Icon icon="pencil" padded="right" style="lighter" title="Edit"/>
                         <I18n id={label}/>
                     </Button>

--- a/packages/neos-ui-editors/src/Editors/CodeMirror/index.js
+++ b/packages/neos-ui-editors/src/Editors/CodeMirror/index.js
@@ -38,7 +38,7 @@ export default class CodeMirror extends PureComponent {
         return (
             <div>
                 <Label className={style.codemirror__label} htmlFor={identifier}>
-                    <Button className={className} disabled={disabled} onClick={handleClick()}>
+                    <Button className={className} style="clean" disabled={disabled} onClick={handleClick()}>
                         <Icon icon="pencil" padded="right" style="lighter" title="Edit"/>
                         <I18n id={label}/>
                     </Button>

--- a/packages/neos-ui-editors/src/Editors/CodeMirror/style.css
+++ b/packages/neos-ui-editors/src/Editors/CodeMirror/style.css
@@ -1,0 +1,3 @@
+.codemirror__label {
+    padding: 2px;
+}

--- a/packages/neos-ui-editors/src/Editors/DateTime/index.js
+++ b/packages/neos-ui-editors/src/Editors/DateTime/index.js
@@ -17,26 +17,24 @@ class DateTime extends PureComponent {
     static propTypes = {
         value: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
         commit: PropTypes.func.isRequired,
-        highlight: PropTypes.bool,
+        className: PropTypes.string,
         placeholder: PropTypes.string,
         options: PropTypes.object,
         id: PropTypes.string,
         i18nRegistry: PropTypes.object,
-        interfaceLanguage: PropTypes.string,
-        validationErrors: PropTypes.array
+        interfaceLanguage: PropTypes.string
     }
 
     render() {
         const {
             id,
+            className,
             value,
             commit,
             placeholder,
             options,
             i18nRegistry,
-            highlight,
-            interfaceLanguage,
-            validationErrors
+            interfaceLanguage
         } = this.props;
         const mappedValue = (typeof value === 'string' && value.length) ? moment(value).toDate() : (value || undefined);
 
@@ -47,17 +45,16 @@ class DateTime extends PureComponent {
         return (
             <DateInput
                 id={id}
+                className={className}
                 value={mappedValue}
                 onChange={onChange}
                 labelFormat={convertPhpDateFormatToMoment(options.format)}
-                highlight={highlight}
                 dateOnly={!hasTimeFormat(options.format)}
                 timeOnly={!hasDateFormat(options.format)}
                 placeholder={placeholder || i18nRegistry.translate('content.inspector.editors.dateTimeEditor.noDateSet', '', {}, 'Neos.Neos', 'Main')}
                 todayLabel={i18nRegistry.translate('content.inspector.editors.dateTimeEditor.today', 'Today', {}, 'Neos.Neos', 'Main')}
                 applyLabel={i18nRegistry.translate('content.inspector.editors.dateTimeEditor.apply', 'Apply', {}, 'Neos.Neos', 'Main')}
                 locale={interfaceLanguage}
-                validationErrors={validationErrors}
                 disabled={options.disabled}
                 />
         );

--- a/packages/neos-ui-editors/src/Editors/Image/Components/PreviewScreen/index.js
+++ b/packages/neos-ui-editors/src/Editors/Image/Components/PreviewScreen/index.js
@@ -9,12 +9,12 @@ import style from './style.css';
 
 export default class PreviewScreen extends PureComponent {
     static propTypes = {
+        className: PropTypes.string,
         propertyName: PropTypes.string,
         image: PropTypes.object,
         afterUpload: PropTypes.func.isRequired,
         onClick: PropTypes.func.isRequired,
         isLoading: PropTypes.bool.isRequired,
-        highlight: PropTypes.bool,
         isUploadEnabled: PropTypes.bool.isRequired,
         disabled: PropTypes.bool,
         accept: PropTypes.string
@@ -25,11 +25,11 @@ export default class PreviewScreen extends PureComponent {
     }
 
     renderPreview() {
-        const {image, onClick, highlight, disabled} = this.props;
+        const {image, onClick, disabled, className} = this.props;
 
         const classNames = mergeClassNames({
+            [className]: true,
             [style.thumbnail]: true,
-            [style['thumbnail--highlight']]: highlight,
             [style['thumbnail--disabled']]: disabled
         });
 
@@ -37,8 +37,7 @@ export default class PreviewScreen extends PureComponent {
         const handleClick = () => disabled ? null : onClick;
 
         return (
-            <div
-                className={classNames}
+            <div className={classNames}
                 onClick={handleClick()}
                 role="button"
                 >
@@ -63,7 +62,7 @@ export default class PreviewScreen extends PureComponent {
     }
 
     render() {
-        const {afterUpload, isLoading, highlight, propertyName, isUploadEnabled, accept} = this.props;
+        const {afterUpload, isLoading, propertyName, isUploadEnabled, accept} = this.props;
 
         if (isUploadEnabled) {
             return (
@@ -71,7 +70,6 @@ export default class PreviewScreen extends PureComponent {
                     onAfterUpload={afterUpload}
                     isLoading={isLoading}
                     propertyName={propertyName}
-                    highlight={highlight}
                     ref={this.setAssetUploadReference}
                     imagesOnly={true}
                     accept={accept || 'image/*'}

--- a/packages/neos-ui-editors/src/Editors/Image/index.js
+++ b/packages/neos-ui-editors/src/Editors/Image/index.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {$set, $drop, $get} from 'plow-js';
+import mergeClassNames from 'classnames';
 
 import backend from '@neos-project/neos-ui-backend-connector';
 import {neos} from '@neos-project/neos-ui-decorators';
@@ -17,9 +18,7 @@ const DEFAULT_FEATURES = {
     upload: true
 };
 
-@neos(globalRegistry => ({
-    secondaryEditorsRegistry: globalRegistry.get('inspector').get('secondaryEditors')
-}))
+@neos(globalRegistry => ({secondaryEditorsRegistry: globalRegistry.get('inspector').get('secondaryEditors')}))
 export default class ImageEditor extends Component {
     state = {
         image: null,
@@ -33,9 +32,7 @@ export default class ImageEditor extends Component {
         identifier: PropTypes.string,
 
         value: PropTypes.oneOfType([
-            PropTypes.shape({
-                __identifier: PropTypes.string
-            }),
+            PropTypes.shape({__identifier: PropTypes.string}),
             PropTypes.string
         ]),
         // "hooks" are the hooks specified by commit()
@@ -46,7 +43,6 @@ export default class ImageEditor extends Component {
         secondaryEditorsRegistry: PropTypes.object.isRequired,
 
         options: PropTypes.object,
-        highlight: PropTypes.bool,
 
         // Public API:
         // I18N key
@@ -66,13 +62,9 @@ export default class ImageEditor extends Component {
             this.setState({
                 isAssetLoading: true
             }, () => {
-                this.loadImage = loadImageMetadata(this.props.value.__identity)
-                    .then(image => {
-                        this.setState({
-                            image,
-                            isAssetLoading: false
-                        });
-                    });
+                this.loadImage = loadImageMetadata(this.props.value.__identity).then(image => {
+                    this.setState({image, isAssetLoading: false});
+                });
             });
         }
 
@@ -93,30 +85,25 @@ export default class ImageEditor extends Component {
         //
         // Re-Load the image metadata in case a new image was selected.
         //
-        if (
-            nextProps.value &&
-            nextProps.value.__identity &&
-            nextProps.value.__identity !== (this.props.value && this.props.value.__identity)
-        ) {
-            loadImageMetadata(nextProps.value.__identity)
-                .then(image => {
-                    if (this._isMounted) {
-                        this.setState({
-                            image,
-                            isAssetLoading: false
-                        }, () => {
-                            // When forceCrop option is enabled and we were requested to do the force cropping...
-                            if (this.state.requestOpenImageCropper && $get('crop.aspectRatio.forceCrop', this.props.options)) {
-                                this.handleCloseSecondaryScreen();
-                                this.handleOpenImageCropper();
-                                this.setState({requestOpenImageCropper: false});
-                            } else if (this.state.isImageCropperOpen) {
-                                this.handleCloseSecondaryScreen();
-                                this.handleOpenImageCropper();
-                            }
-                        });
-                    }
-                });
+        if (nextProps.value && nextProps.value.__identity && nextProps.value.__identity !== (this.props.value && this.props.value.__identity)) {
+            loadImageMetadata(nextProps.value.__identity).then(image => {
+                if (this._isMounted) {
+                    this.setState({
+                        image,
+                        isAssetLoading: false
+                    }, () => {
+                        // When forceCrop option is enabled and we were requested to do the force cropping...
+                        if (this.state.requestOpenImageCropper && $get('crop.aspectRatio.forceCrop', this.props.options)) {
+                            this.handleCloseSecondaryScreen();
+                            this.handleOpenImageCropper();
+                            this.setState({requestOpenImageCropper: false});
+                        } else if (this.state.isImageCropperOpen) {
+                            this.handleCloseSecondaryScreen();
+                            this.handleOpenImageCropper();
+                        }
+                    });
+                }
+            });
         }
     }
 
@@ -127,10 +114,7 @@ export default class ImageEditor extends Component {
 
     afterUpload = uploadResult => {
         this.props.commit(uploadResult.object);
-        this.setState({
-            requestOpenImageCropper: true,
-            isAssetLoading: false
-        });
+        this.setState({requestOpenImageCropper: true, isAssetLoading: false});
     }
 
     handleMediaCrop = cropArea => {
@@ -147,9 +131,7 @@ export default class ImageEditor extends Component {
         };
         const nextimage = $set(CROP_IMAGE_ADJUSTMENT, cropAdjustments, image);
 
-        commit(value, {
-            'Neos.UI:Hook.BeforeSave.CreateImageVariant': nextimage
-        });
+        commit(value, {'Neos.UI:Hook.BeforeSave.CreateImageVariant': nextimage});
         this.setState({isImageCropperOpen: false});
     }
 
@@ -157,13 +139,10 @@ export default class ImageEditor extends Component {
         const {commit, value} = this.props;
         const {image} = this.state;
         const nextimage = resizeAdjustment ?
-            $set(RESIZE_IMAGE_ADJUSTMENT, resizeAdjustment, image) : $drop(RESIZE_IMAGE_ADJUSTMENT, image);
-        this.setState({
-            image: nextimage
-        });
-        commit(value, {
-            'Neos.UI:Hook.BeforeSave.CreateImageVariant': nextimage
-        });
+            $set(RESIZE_IMAGE_ADJUSTMENT, resizeAdjustment, image) :
+            $drop(RESIZE_IMAGE_ADJUSTMENT, image);
+        this.setState({image: nextimage});
+        commit(value, {'Neos.UI:Hook.BeforeSave.CreateImageVariant': nextimage});
     }
 
     handleCloseSecondaryScreen = () => {
@@ -171,7 +150,9 @@ export default class ImageEditor extends Component {
     }
 
     getValue() {
-        return this.props.value ? this.props.value : {};
+        return this.props.value ?
+            this.props.value :
+            {};
     }
 
     handleRemoveFile = () => {
@@ -187,7 +168,9 @@ export default class ImageEditor extends Component {
 
     handleMediaSelected = assetIdentifier => {
         const {commit} = this.props;
-        const newAsset = {__identity: assetIdentifier};
+        const newAsset = {
+            __identity: assetIdentifier
+        };
 
         this.setState({
             image: null,
@@ -205,12 +188,7 @@ export default class ImageEditor extends Component {
         const imageIdentity = $get('__identity', this.props.value);
 
         if (imageIdentity) {
-            this.props.renderSecondaryInspector('IMAGE_MEDIA_DETAILS', () =>
-                <MediaDetailsScreen
-                    onClose={this.handleCloseSecondaryScreen}
-                    imageIdentity={imageIdentity}
-                    />
-            );
+            this.props.renderSecondaryInspector('IMAGE_MEDIA_DETAILS', () => <MediaDetailsScreen onClose={this.handleCloseSecondaryScreen} imageIdentity={imageIdentity}/>);
         } else {
             this.handleChooseFile();
         }
@@ -225,76 +203,51 @@ export default class ImageEditor extends Component {
         const {secondaryEditorsRegistry} = this.props;
         const {component: MediaSelectionScreen} = secondaryEditorsRegistry.get('Neos.Neos/Inspector/Secondary/Editors/MediaSelectionScreen');
 
-        this.props.renderSecondaryInspector('IMAGE_SELECT_MEDIA', () =>
-            <MediaSelectionScreen onComplete={this.handleMediaSelected}/>
-        );
+        this.props.renderSecondaryInspector('IMAGE_SELECT_MEDIA', () => <MediaSelectionScreen onComplete={this.handleMediaSelected}/>);
     }
 
     handleOpenImageCropper = () => {
         const {secondaryEditorsRegistry} = this.props;
         const {component: ImageCropper} = secondaryEditorsRegistry.get('Neos.Neos/Inspector/Secondary/Editors/ImageCropper');
 
-        this.setState({isImageCropperOpen: true}, () => {
-            this.props.renderSecondaryInspector('IMAGE_CROP', () => <ImageCropper
-                sourceImage={Image.fromImageData(this.getUsedImage())}
-                options={this.props.options}
-                onComplete={this.handleMediaCrop}
-                />);
+        this.setState({
+            isImageCropperOpen: true
+        }, () => {
+            this.props.renderSecondaryInspector('IMAGE_CROP', () => <ImageCropper sourceImage={Image.fromImageData(this.getUsedImage())} options={this.props.options} onComplete={this.handleMediaCrop}/>);
         });
     }
 
     render() {
-        const {
-            isAssetLoading,
-            image
-        } = this.state;
-        const {highlight} = this.props;
+        const {isAssetLoading, image} = this.state;
+        const {className} = this.props;
         const disabled = $get('options.disabled', this.props);
         const accept = $get('options.accept', this.props);
 
-        return (
-            <div className={style.imageEditor}>
-                <PreviewScreen
-                    propertyName={this.props.identifier}
-                    ref={this.setPreviewScreenRef}
-                    image={this.getUsedImage()}
-                    isLoading={isAssetLoading}
-                    afterUpload={this.afterUpload}
-                    highlight={highlight}
-                    onClick={this.handleThumbnailClicked}
-                    isUploadEnabled={this.isFeatureEnabled('upload')}
-                    disabled={disabled}
-                    accept={accept}
-                    />
-                <Controls
-                    onChooseFromMedia={this.handleChooseFromMedia}
-                    onChooseFromLocalFileSystem={this.handleChooseFile}
-                    isUploadEnabled={this.isFeatureEnabled('upload')}
-                    isMediaBrowserEnabled={this.isFeatureEnabled('mediaBrowser')}
-                    onRemove={image ? this.handleRemoveFile : null}
-                    onCrop={image ? this.isFeatureEnabled('crop') && this.handleOpenImageCropper : null}
-                    disabled={disabled}
-                    />
-                {this.isFeatureEnabled('resize') && <ResizeControls
-                    onChange={this.handleResize}
-                    resizeAdjustment={$get(RESIZE_IMAGE_ADJUSTMENT, image)}
-                    imageDimensions={{
-                        width: $get('originalDimensions.width', image),
-                        height: $get('originalDimensions.height', image)
-                    }}
-                    disabled={disabled}
-                    />}
-            </div>
-        );
+        const classNames = mergeClassNames({
+            [style.imageEditor]: true
+        });
+        return (<div className={classNames}>
+            <PreviewScreen className={className} propertyName={this.props.identifier} ref={this.setPreviewScreenRef} image={this.getUsedImage()} isLoading={isAssetLoading} afterUpload={this.afterUpload} onClick={this.handleThumbnailClicked} isUploadEnabled={this.isFeatureEnabled('upload')} disabled={disabled} accept={accept}/>
+            <Controls onChooseFromMedia={this.handleChooseFromMedia} onChooseFromLocalFileSystem={this.handleChooseFile} isUploadEnabled={this.isFeatureEnabled('upload')} isMediaBrowserEnabled={this.isFeatureEnabled('mediaBrowser')} onRemove={image ?
+                    this.handleRemoveFile :
+                    null} onCrop={image ?
+                    this.isFeatureEnabled('crop') && this.handleOpenImageCropper :
+                    null} disabled={disabled}/> {
+                this.isFeatureEnabled('resize') && <ResizeControls onChange={this.handleResize} resizeAdjustment={$get(RESIZE_IMAGE_ADJUSTMENT, image)} imageDimensions={{
+                    width: $get('originalDimensions.width', image),
+                    height: $get('originalDimensions.height', image)
+                }} disabled={disabled}/>
+            }
+        </div>);
     }
 
     getUsedImage() {
-        return this.props.hooks ? this.props.hooks['Neos.UI:Hook.BeforeSave.CreateImageVariant'] : this.state.image;
+        return this.props.hooks ?
+            this.props.hooks['Neos.UI:Hook.BeforeSave.CreateImageVariant'] :
+            this.state.image;
     }
 
     setPreviewScreenRef = ref => {
         this.previewScreen = ref;
     }
-
-    handleDrop
 }

--- a/packages/neos-ui-editors/src/Editors/Link/index.js
+++ b/packages/neos-ui-editors/src/Editors/Link/index.js
@@ -21,9 +21,9 @@ import {isUri} from '@neos-project/utils-helpers';
 class LinkEditor extends PureComponent {
     static propTypes = {
         identifier: PropTypes.string.isRequired,
+        className: PropTypes.string,
         value: PropTypes.string,
         commit: PropTypes.func.isRequired,
-        highlight: PropTypes.bool,
         options: PropTypes.shape({
             nodeTypes: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
             placeholder: PropTypes.string,
@@ -131,15 +131,17 @@ class LinkEditor extends PureComponent {
     }
 
     render() {
+        const {className, value, i18nRegistry, options} = this.props;
+
         return (
             <SelectBox
-                options={this.props.value ? this.state.options : this.state.searchOptions}
+                className={className}
+                options={value ? this.state.options : this.state.searchOptions}
                 optionValueField="loaderUri"
-                highlight={this.props.highlight}
-                value={this.props.value}
+                value={value}
                 onValueChange={this.handleValueChange}
-                placeholder={this.props.i18nRegistry.translate(this.props.options.placeholder)}
-                loadingLabel={this.props.i18nRegistry.translate('loading', 'Loading', [], 'Neos.Neos', 'Main')}
+                placeholder={i18nRegistry.translate(this.props.options.placeholder)}
+                loadingLabel={i18nRegistry.translate('loading', 'Loading', [], 'Neos.Neos', 'Main')}
                 displayLoadingIndicator={this.state.isLoading}
                 displaySearchBox={true}
                 showDropDownToggle={false}
@@ -147,9 +149,9 @@ class LinkEditor extends PureComponent {
                 searchTerm={this.state.searchTerm}
                 onSearchTermChange={this.handleSearchTermChange}
                 ListPreviewElement={LinkOption}
-                noMatchesFoundLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}
-                searchBoxLeftToTypeLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
-                disabled={this.props.options.disabled}
+                noMatchesFoundLabel={i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}
+                searchBoxLeftToTypeLabel={i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
+                disabled={options.disabled}
                 />
         );
     }

--- a/packages/neos-ui-editors/src/Editors/MasterPlugin/index.js
+++ b/packages/neos-ui-editors/src/Editors/MasterPlugin/index.js
@@ -12,14 +12,13 @@ import {$transform, $get} from 'plow-js';
         i18nRegistry: globalRegistry.get('i18n')
     };
 })
-
 @connect($transform({
     activeContentDimensions: selectors.CR.ContentDimensions.active,
     personalWorkspace: selectors.CR.Workspaces.personalWorkspaceNameSelector
 }))
-
 class MasterPluginEditor extends React.PureComponent {
     static propTypes = {
+        className: PropTypes.string,
         id: PropTypes.string,
         value: PropTypes.string,
         commit: PropTypes.func.isRequired,
@@ -84,6 +83,7 @@ class MasterPluginEditor extends React.PureComponent {
 
         return (
             <SelectBox
+                className={this.props.className}
                 options={options}
                 value={this.props.value}
                 onValueChange={this.handleValueChange}

--- a/packages/neos-ui-editors/src/Editors/NodeType/index.js
+++ b/packages/neos-ui-editors/src/Editors/NodeType/index.js
@@ -2,6 +2,7 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {$get} from 'plow-js';
+import mergeClassNames from 'classnames';
 
 import SelectBox from '@neos-project/react-ui-components/src/SelectBox/';
 import {neos} from '@neos-project/neos-ui-decorators';
@@ -29,9 +30,9 @@ import style from './style.css';
 })
 export default class NodeType extends PureComponent {
     static propTypes = {
+        className: PropTypes.string,
         value: PropTypes.string.isRequired,
         commit: PropTypes.func.isRequired,
-        highlight: PropTypes.bool,
         options: PropTypes.object,
 
         isSiteNode: PropTypes.bool,
@@ -42,17 +43,22 @@ export default class NodeType extends PureComponent {
     }
 
     renderNoOptionsAvailable() {
-        const {value, nodeTypesRegistry, i18nRegistry} = this.props;
+        const {value, nodeTypesRegistry, i18nRegistry, className} = this.props;
+
+        const classNames = mergeClassNames({
+            [className]: true,
+            [style.noOptionsAvailable]: true
+        });
 
         return (
-            <div className={style.noOptionsAvailable}>
+            <div className={classNames}>
                 {i18nRegistry.translate($get('ui.label', nodeTypesRegistry.get(value)))}
             </div>
         );
     }
 
     render() {
-        const {value, commit, nodeTypesRegistry, allowedSiblingNodeTypesForFocusedNode, i18nRegistry, highlight, focusedNode, isSiteNode} = this.props;
+        const {value, className, commit, nodeTypesRegistry, allowedSiblingNodeTypesForFocusedNode, i18nRegistry, focusedNode, isSiteNode} = this.props;
         const disabled = $get('options.disabled', this.props);
 
         // Auto-created child nodes cannot change type
@@ -75,7 +81,7 @@ export default class NodeType extends PureComponent {
         }, []);
 
         if (nodeTypes.length) {
-            return <SelectBox options={nodeTypes} disabled={disabled} highlight={highlight} value={value} onValueChange={commit}/>;
+            return <SelectBox className={className} options={nodeTypes} disabled={disabled} value={value} onValueChange={commit}/>;
         }
 
         return this.renderNoOptionsAvailable();

--- a/packages/neos-ui-editors/src/Editors/PluginView/index.js
+++ b/packages/neos-ui-editors/src/Editors/PluginView/index.js
@@ -24,6 +24,7 @@ class PluginViewEditor extends React.PureComponent {
     static propTypes = {
         id: PropTypes.string,
         value: PropTypes.string,
+        className: PropTypes.string,
         commit: PropTypes.func.isRequired,
         i18nRegistry: PropTypes.object.isRequired,
         activeContentDimensions: PropTypes.object.isRequired,
@@ -99,6 +100,7 @@ class PluginViewEditor extends React.PureComponent {
         return (
             <SelectBox
                 options={options}
+                className={this.props.className}
                 value={this.props.value}
                 onValueChange={this.handleValueChange}
                 displayLoadingIndicator={isLoading}

--- a/packages/neos-ui-editors/src/Editors/PluginViews/index.js
+++ b/packages/neos-ui-editors/src/Editors/PluginViews/index.js
@@ -4,6 +4,7 @@ import backend from '@neos-project/neos-ui-backend-connector';
 import {neos} from '@neos-project/neos-ui-decorators';
 import {connect} from 'react-redux';
 import {selectors, actions} from '@neos-project/neos-ui-redux-store';
+import mergeClassNames from 'classnames';
 import {$transform} from 'plow-js';
 import style from './style.css';
 
@@ -24,6 +25,7 @@ import style from './style.css';
 class PluginViewsEditor extends React.PureComponent {
     static propTypes = {
         i18nRegistry: PropTypes.object.isRequired,
+        className: PropTypes.string,
         activeContentDimensions: PropTypes.object.isRequired,
         personalWorkspace: PropTypes.string,
         focusedNodeIdentifier: PropTypes.string.isRequired,
@@ -106,8 +108,14 @@ class PluginViewsEditor extends React.PureComponent {
     }
 
     render() {
+        const {className} = this.props;
+        const classNames = mergeClassNames({
+            [className]: true,
+            [style.pluginViewContainer]: true
+        });
+
         return (
-            <ul className={style.pluginViewContainer}>
+            <ul className={classNames}>
                 {this.renderViewListItems()}
             </ul>
         );

--- a/packages/neos-ui-editors/src/Editors/Reference/index.js
+++ b/packages/neos-ui-editors/src/Editors/Reference/index.js
@@ -14,9 +14,9 @@ import {neos} from '@neos-project/neos-ui-decorators';
 export default class ReferenceEditor extends PureComponent {
     static propTypes = {
         value: PropTypes.string,
+        className: PropTypes.string,
         options: PropTypes.array,
         searchOptions: PropTypes.array,
-        highlight: PropTypes.bool,
         placeholder: PropTypes.string,
         displayLoadingIndicator: PropTypes.bool,
         threshold: PropTypes.number,
@@ -32,26 +32,28 @@ export default class ReferenceEditor extends PureComponent {
     }
 
     render() {
+        const {className, value, i18nRegistry, threshold, options, displayLoadingIndicator, onSearchTermChange, onCreateNew, disabled} = this.props;
+
         return (<SelectBox
+            className={className}
             optionValueField="identifier"
             displaySearchBox={true}
             ListPreviewElement={NodeOption}
-            createNewLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:createNew')}
-            noMatchesFoundLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}
-            searchBoxLeftToTypeLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
-            placeholder={this.props.i18nRegistry.translate(this.props.placeholder)}
-            threshold={this.props.threshold}
-            options={this.props.options}
-            value={this.props.value}
-            highlight={this.props.highlight}
+            createNewLabel={i18nRegistry.translate('Neos.Neos:Main:createNew')}
+            noMatchesFoundLabel={i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}
+            searchBoxLeftToTypeLabel={i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
+            placeholder={i18nRegistry.translate(this.props.placeholder)}
+            threshold={threshold}
+            options={options}
+            value={value}
             onValueChange={this.handleValueChange}
-            loadingLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:loading')}
-            displayLoadingIndicator={this.props.displayLoadingIndicator}
+            loadingLabel={i18nRegistry.translate('Neos.Neos:Main:loading')}
+            displayLoadingIndicator={displayLoadingIndicator}
             showDropDownToggle={false}
             allowEmpty={true}
-            onSearchTermChange={this.props.onSearchTermChange}
-            onCreateNew={this.props.onCreateNew}
-            disabled={this.props.disabled}
+            onSearchTermChange={onSearchTermChange}
+            onCreateNew={onCreateNew}
+            disabled={disabled}
             />);
     }
 }

--- a/packages/neos-ui-editors/src/Editors/References/index.js
+++ b/packages/neos-ui-editors/src/Editors/References/index.js
@@ -17,7 +17,6 @@ export default class ReferencesEditor extends PureComponent {
         value: PropTypes.arrayOf(PropTypes.string),
         options: PropTypes.array,
         searchOptions: PropTypes.array,
-        highlight: PropTypes.bool,
         placeholder: PropTypes.string,
         displayLoadingIndicator: PropTypes.bool,
         threshold: PropTypes.number,
@@ -33,28 +32,30 @@ export default class ReferencesEditor extends PureComponent {
     }
 
     render() {
+        const {className, i18nRegistry, threshold, placeholder, options, value, displayLoadingIndicator, searchOptions, onSearchTermChange, onCreateNew, disabled} = this.props;
+
         return (<MultiSelectBox
+            className={className}
             dndType={dndTypes.MULTISELECT}
             optionValueField="identifier"
-            loadingLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:loading')}
+            loadingLabel={i18nRegistry.translate('Neos.Neos:Main:loading')}
             displaySearchBox={true}
             ListPreviewElement={NodeOption}
-            createNewLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:createNew')}
-            placeholder={this.props.i18nRegistry.translate(this.props.placeholder)}
-            threshold={this.props.threshold}
-            noMatchesFoundLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}
-            searchBoxLeftToTypeLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
-            options={this.props.options}
-            values={this.props.value}
-            highlight={this.props.highlight}
+            createNewLabel={i18nRegistry.translate('Neos.Neos:Main:createNew')}
+            placeholder={i18nRegistry.translate(placeholder)}
+            threshold={threshold}
+            noMatchesFoundLabel={i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}
+            searchBoxLeftToTypeLabel={i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
+            options={options}
+            values={value}
             onValuesChange={this.handleValueChange}
-            displayLoadingIndicator={this.props.displayLoadingIndicator}
+            displayLoadingIndicator={displayLoadingIndicator}
             showDropDownToggle={false}
             allowEmpty={true}
-            searchOptions={this.props.searchOptions}
-            onSearchTermChange={this.props.onSearchTermChange}
-            onCreateNew={this.props.onCreateNew}
-            disabled={this.props.disabled}
+            searchOptions={searchOptions}
+            onSearchTermChange={onSearchTermChange}
+            onCreateNew={onCreateNew}
+            disabled={disabled}
             />);
     }
 }

--- a/packages/neos-ui-editors/src/Editors/SelectBox/DataSourceBasedSelectBoxEditor.js
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/DataSourceBasedSelectBoxEditor.js
@@ -18,6 +18,7 @@ import {shouldDisplaySearchBox, searchOptions, processSelectBoxOptions} from './
 export default class DataSourceBasedSelectBoxEditor extends PureComponent {
     static propTypes = {
         commit: PropTypes.func.isRequired,
+        className: PropTypes.string,
         value: PropTypes.oneOfType([
             PropTypes.string,
             PropTypes.arrayOf(PropTypes.string)
@@ -45,7 +46,6 @@ export default class DataSourceBasedSelectBoxEditor extends PureComponent {
             )
 
         }).isRequired,
-        highlight: PropTypes.bool,
         i18nRegistry: PropTypes.object.isRequired,
         dataSourcesDataLoader: PropTypes.shape({
             resolveValue: PropTypes.func.isRequired
@@ -87,7 +87,7 @@ export default class DataSourceBasedSelectBoxEditor extends PureComponent {
     }
 
     render() {
-        const {commit, value, i18nRegistry, highlight} = this.props;
+        const {commit, value, i18nRegistry, className} = this.props;
         const options = Object.assign({}, this.constructor.defaultOptions, this.props.options);
 
         const processedSelectBoxOptions = processSelectBoxOptions(i18nRegistry, this.state.selectBoxOptions);
@@ -98,13 +98,13 @@ export default class DataSourceBasedSelectBoxEditor extends PureComponent {
 
         if (options.multiple) {
             return (<MultiSelectBox
+                className={className}
                 options={processedSelectBoxOptions}
                 values={value || []}
                 onValuesChange={commit}
                 loadingLabel={loadingLabel}
                 displayLoadingIndicator={this.state.isLoading}
                 placeholder={placeholder}
-                highlight={highlight}
                 allowEmpty={options.allowEmpty}
                 displaySearchBox={shouldDisplaySearchBox(options, processedSelectBoxOptions)}
                 searchOptions={searchOptions(this.state.searchTerm, processedSelectBoxOptions)}
@@ -117,13 +117,13 @@ export default class DataSourceBasedSelectBoxEditor extends PureComponent {
 
         // multiple = FALSE
         return (<SelectBox
+            className={className}
             options={this.state.searchTerm ? searchOptions(this.state.searchTerm, processedSelectBoxOptions) : processedSelectBoxOptions}
             value={value}
             onValueChange={commit}
             loadingLabel={loadingLabel}
             displayLoadingIndicator={this.state.isLoading}
             placeholder={placeholder}
-            highlight={highlight}
             allowEmpty={options.allowEmpty}
             displaySearchBox={shouldDisplaySearchBox(options, processedSelectBoxOptions)}
             onSearchTermChange={this.handleSearchTermChange}

--- a/packages/neos-ui-editors/src/Editors/SelectBox/SimpleSelectBoxEditor.js
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/SimpleSelectBoxEditor.js
@@ -12,7 +12,7 @@ export default class SimpleSelectBoxEditor extends PureComponent {
     static propTypes = {
         commit: PropTypes.func.isRequired,
         value: PropTypes.any,
-        highlight: PropTypes.bool,
+        className: PropTypes.string,
         options: PropTypes.shape({
             allowEmpty: PropTypes.bool,
             placeholder: PropTypes.string,
@@ -49,7 +49,7 @@ export default class SimpleSelectBoxEditor extends PureComponent {
     };
 
     render() {
-        const {commit, value, i18nRegistry, highlight} = this.props;
+        const {commit, value, i18nRegistry, className} = this.props;
         const options = Object.assign({}, this.constructor.defaultOptions, this.props.options);
 
         const processedSelectBoxOptions = processSelectBoxOptions(i18nRegistry, options.values);
@@ -61,10 +61,10 @@ export default class SimpleSelectBoxEditor extends PureComponent {
 
         if (options.multiple) {
             return (<MultiSelectBox
+                className={className}
                 options={processedSelectBoxOptions}
                 values={value || []}
                 onValuesChange={commit}
-                highlight={highlight}
                 placeholder={placeholder}
                 allowEmpty={allowEmpty}
                 displaySearchBox={shouldDisplaySearchBox(options, processedSelectBoxOptions)}
@@ -81,9 +81,9 @@ export default class SimpleSelectBoxEditor extends PureComponent {
         return (<SelectBox
             options={this.state.searchTerm ? searchOptions(this.state.searchTerm, processedSelectBoxOptions) : processedSelectBoxOptions}
             value={value}
+            className={className}
             onValueChange={commit}
             placeholder={placeholder}
-            highlight={highlight}
             allowEmpty={allowEmpty}
             displaySearchBox={shouldDisplaySearchBox(options, processedSelectBoxOptions)}
             onSearchTermChange={this.handleSearchTermChange}

--- a/packages/neos-ui-editors/src/Editors/TextArea/index.js
+++ b/packages/neos-ui-editors/src/Editors/TextArea/index.js
@@ -12,22 +12,21 @@ const defaultOptions = {
 };
 
 const TextAreaEditor = props => {
-    const {id, value, commit, highlight, options, validationErrors} = props;
+    const {id, value, commit, options, className} = props;
 
     const finalOptions = Object.assign({}, defaultOptions, options);
 
     return (<TextArea
         id={id}
         value={value}
+        className={className}
         onChange={commit}
-        highlight={highlight}
         disabled={finalOptions.disabled}
         maxLength={finalOptions.maxlength}
         readOnly={finalOptions.readonly}
         placeholder={finalOptions.placeholder}
         minRows={finalOptions.minRows}
         expandedRows={finalOptions.expandedRows}
-        validationErrors={validationErrors}
         />
     );
 };

--- a/packages/neos-ui-editors/src/Editors/TextField/index.js
+++ b/packages/neos-ui-editors/src/Editors/TextField/index.js
@@ -10,17 +10,14 @@ const defaultOptions = {
     maxlength: null,
     readonly: false
 };
-
 @neos(globalRegistry => ({
     i18nRegistry: globalRegistry.get('i18n')
 }))
-
 export default class TextField extends PureComponent {
     static propTypes = {
+        className: PropTypes.string,
         value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         commit: PropTypes.func.isRequired,
-        validationErrors: PropTypes.array,
-        highlight: PropTypes.bool,
         options: PropTypes.object,
         onKeyPress: PropTypes.func,
         onEnterKey: PropTypes.func,
@@ -34,20 +31,19 @@ export default class TextField extends PureComponent {
     };
 
     render() {
-        const {id, value, commit, validationErrors, options, i18nRegistry, highlight, onKeyPress, onEnterKey} = this.props;
+        const {id, value, className, commit, options, i18nRegistry, onKeyPress, onEnterKey} = this.props;
 
         // Placeholder text must be unescaped in case html entities were used
         const placeholder = options && options.placeholder && i18nRegistry.translate(unescape(options.placeholder));
         const finalOptions = Object.assign({}, defaultOptions, options);
 
         return (<TextInput
+            className={className}
             id={id}
             autoFocus={finalOptions.autoFocus}
             value={value}
             onChange={commit}
-            validationErrors={validationErrors}
             placeholder={placeholder}
-            highlight={highlight}
             onKeyPress={onKeyPress}
             onEnterKey={onEnterKey}
             disabled={finalOptions.disabled}

--- a/packages/neos-ui-editors/src/Library/AssetUpload.js
+++ b/packages/neos-ui-editors/src/Library/AssetUpload.js
@@ -19,6 +19,7 @@ export default class AssetUpload extends PureComponent {
     };
 
     static propTypes = {
+        className: PropTypes.string,
         propertyName: PropTypes.string,
         isLoading: PropTypes.bool.isRequired,
         onAfterUpload: PropTypes.func.isRequired,
@@ -79,11 +80,11 @@ export default class AssetUpload extends PureComponent {
     }
 
     render() {
-        const {isLoading, highlight, multiple, children, accept} = this.props;
+        const {isLoading, multiple, children, accept, className} = this.props;
 
         const classNames = mergeClassNames({
-            [style.thumbnail]: true,
-            [style['thumbnail--highlight']]: highlight
+            [className]: true,
+            [style.thumbnail]: true
         });
 
         return (
@@ -97,7 +98,7 @@ export default class AssetUpload extends PureComponent {
                     </div>
                 )}
                 {/* We should not remove Dropzone element when loading, as that would kill the upload */}
-                <div style={{display: isLoading ? 'none' : 'block'}}>
+                <div className={className} style={{display: isLoading ? 'none' : 'block'}}>
                     <Dropzone
                         ref={this.setDropzoneReference}
                         accept={accept}

--- a/packages/react-ui-components/src/CheckBox/checkBox.js
+++ b/packages/react-ui-components/src/CheckBox/checkBox.js
@@ -29,8 +29,8 @@ class CheckBox extends PureComponent {
          */
         theme: PropTypes.shape({
             checkbox: PropTypes.string,
-            checkbox__input: PropTypes.string,
-            checkbox__inputMirror: PropTypes.string,
+            checkbox__input: PropTypes.string, // eslint-disable-line
+            checkbox__inputMirror: PropTypes.string, // eslint-disable-line
             'checkbox__inputMirror--active': PropTypes.string
         }).isRequired
     };

--- a/packages/react-ui-components/src/CheckBox/checkBox.js
+++ b/packages/react-ui-components/src/CheckBox/checkBox.js
@@ -25,19 +25,13 @@ class CheckBox extends PureComponent {
         onChange: PropTypes.func,
 
         /**
-         * Highlight input
-         */
-        highlight: PropTypes.bool,
-
-        /**
          * An optional css theme to be injected.
          */
         theme: PropTypes.shape({
-            'checkbox': PropTypes.string,
-            'checkbox__input': PropTypes.string,
-            'checkbox__inputMirror': PropTypes.string,
-            'checkbox__inputMirror--active': PropTypes.string,
-            'checkbox__inputMirror--highlight': PropTypes.string
+            checkbox: PropTypes.string,
+            checkbox__input: PropTypes.string,
+            checkbox__inputMirror: PropTypes.string,
+            'checkbox__inputMirror--active': PropTypes.string
         }).isRequired
     };
 
@@ -55,7 +49,6 @@ class CheckBox extends PureComponent {
             isDisabled,
             className,
             theme,
-            highlight,
             ...rest
         } = this.props;
         const finalClassName = mergeClassNames({
@@ -65,9 +58,7 @@ class CheckBox extends PureComponent {
         });
         const mirrorClassNames = mergeClassNames({
             [theme.checkbox__inputMirror]: true,
-            [theme['checkbox__inputMirror--active']]: isChecked,
-            [theme['checkbox__inputMirror--highlight-checked']]: highlight && isChecked,
-            [theme['checkbox__inputMirror--highlight-unchecked']]: highlight && !isChecked
+            [theme['checkbox__inputMirror--active']]: isChecked
         });
 
         return (

--- a/packages/react-ui-components/src/CheckBox/style.css
+++ b/packages/react-ui-components/src/CheckBox/style.css
@@ -54,14 +54,6 @@
         transform: translateX(-50%) translateY(-50%);
     }
 }
-.checkbox__inputMirror--highlight-checked {
-    background: var(--colors-Success);
-    border-color: var(--colors-Success);
-    color: #fff;
-}
-.checkbox__inputMirror--highlight-unchecked {
-    border-color: var(--colors-Success);
-}
 .checkbox__disabled {
     opacity: .65;
     cursor: not-allowed;

--- a/packages/react-ui-components/src/DateInput/dateInput.js
+++ b/packages/react-ui-components/src/DateInput/dateInput.js
@@ -17,6 +17,11 @@ export class DateInput extends PureComponent {
         value: PropTypes.instanceOf(Date),
 
         /**
+         * Additional className to render into the wrapper div
+         */
+        className: PropTypes.string,
+
+        /**
          * An optional placeholder which will be rendered if no date was selected.
          */
         placeholder: PropTypes.string,
@@ -42,11 +47,6 @@ export class DateInput extends PureComponent {
         labelFormat: PropTypes.string,
 
         /**
-         * Highlight input
-         */
-        highlight: PropTypes.bool,
-
-        /**
          * Display only date picker
          */
         dateOnly: PropTypes.bool,
@@ -60,16 +60,6 @@ export class DateInput extends PureComponent {
          * Locale for the date picker (determines time format)
          */
         locale: PropTypes.string,
-
-        /**
-         * Static component dependencies which are injected from the outside (index.js)
-         */
-        TooltipComponent: PropTypes.any.isRequired,
-
-        /**
-         * An array of error messages
-         */
-        validationErrors: PropTypes.array,
 
         /**
          * Disable the DateInput
@@ -110,19 +100,17 @@ export class DateInput extends PureComponent {
             IconComponent,
             DatePickerComponent,
             CollapseComponent,
-            TooltipComponent,
             placeholder,
             theme,
             value,
+            className,
             id,
             todayLabel,
             applyLabel,
             labelFormat,
             dateOnly,
             timeOnly,
-            highlight,
             locale,
-            validationErrors,
             disabled
         } = this.props;
         const selectedDate = value ? moment(value).format(labelFormat) : '';
@@ -135,14 +123,9 @@ export class DateInput extends PureComponent {
             [theme.disabled]: disabled
         });
 
-        const renderedErrors = validationErrors && validationErrors.length > 0 && validationErrors.map((validationError, key) => {
-            return <div key={key}>{validationError}</div>;
-        });
-
         const calendarInputWrapper = mergeClassNames({
-            [theme.calendarInputWrapper]: true,
-            [theme['calendarInputWrapper--highlight']]: highlight,
-            [theme['calendarInputWrapper--invalid']]: validationErrors && validationErrors.length > 0
+            [className]: true,
+            [theme.calendarInputWrapper]: true
         });
 
         const calendarFakeInputMirror = mergeClassNames({
@@ -215,7 +198,6 @@ export class DateInput extends PureComponent {
                         {applyLabel}
                     </ButtonComponent>
                 </CollapseComponent>
-                {renderedErrors && <TooltipComponent>{renderedErrors}</TooltipComponent>}
             </div>
         );
     }

--- a/packages/react-ui-components/src/DateInput/index.js
+++ b/packages/react-ui-components/src/DateInput/index.js
@@ -13,11 +13,9 @@ import Button from './../Button/index';
 import Icon from './../Icon/index';
 import DatePicker from 'react-datetime';
 import Collapse from 'react-collapse';
-import Tooltip from '../Tooltip/index';
 
 export default injectProps({
     ButtonComponent: Button,
-    TooltipComponent: Tooltip,
     IconComponent: Icon,
     DatePickerComponent: DatePicker,
     CollapseComponent: Collapse

--- a/packages/react-ui-components/src/MultiSelectBox/multiSelectBox.js
+++ b/packages/react-ui-components/src/MultiSelectBox/multiSelectBox.js
@@ -189,8 +189,13 @@ export default class MultiSelectBox extends PureComponent {
 
         const optionValueAccessor = this.getOptionValueAccessor();
 
+        const classNames = mergeClassNames({
+            [className]: true,
+            [theme.wrapper]: true
+        });
+
         return (
-            <div className={theme.wrapper}>
+            <div className={classNames}>
                 <ul className={selectedOptionsClassNames}>
                     <MultiSelectBox_ListPreviewSortable
                         {...omit(this.props, ['theme'])}
@@ -199,8 +204,7 @@ export default class MultiSelectBox extends PureComponent {
                         />
                 </ul>
                 <SelectBox
-                    {...omit(this.props, ['theme'])}
-                    className={className}
+                    {...omit(this.props, ['theme', 'className'])}
                     options={filteredSearchOptions}
                     value=""
                     onValueChange={this.handleNewValueSelected}

--- a/packages/react-ui-components/src/MultiSelectBox/multiSelectBox.js
+++ b/packages/react-ui-components/src/MultiSelectBox/multiSelectBox.js
@@ -35,6 +35,11 @@ export default class MultiSelectBox extends PureComponent {
         ),
 
         /**
+         * Additional className wich will be applied
+         */
+        className: PropTypes.string,
+
+        /**
          * Field name specifying which field in a single "option" contains the "value"
          */
         optionValueField: PropTypes.string,
@@ -76,11 +81,6 @@ export default class MultiSelectBox extends PureComponent {
          * Limit height and show scrollbars if needed, defaults to true
          */
         scrollable: PropTypes.bool,
-
-        /**
-         * Should the MultiSelectBox be highlighted? (e.g. if the property was modified)
-         */
-        highlight: PropTypes.bool,
 
         /**
          * Component used for rendering the individual option elements; Usually this component uses "SelectBoxOption" internally for common styling.
@@ -150,7 +150,6 @@ export default class MultiSelectBox extends PureComponent {
         // ------------------------------
         theme: PropTypes.shape({/* eslint-disable quote-props */
             'selectedOptions': PropTypes.string,
-            'selectedOptions--highlight': PropTypes.string,
             'selectedOptions__item': PropTypes.string
         }).isRequired, /* eslint-enable quote-props */
 
@@ -175,18 +174,17 @@ export default class MultiSelectBox extends PureComponent {
             values,
             optionValueField,
             theme,
-            highlight,
             SelectBox,
             MultiSelectBox_ListPreviewSortable,
-            disabled
+            disabled,
+            className
         } = this.props;
 
         const filteredSearchOptions = (searchOptions || [])
             .filter(option => !(values && values.indexOf(option[optionValueField]) !== -1));
 
         const selectedOptionsClassNames = mergeClassNames({
-            [theme.selectedOptions]: true,
-            [theme['selectedOptions--highlight']]: highlight
+            [theme.selectedOptions]: true
         });
 
         const optionValueAccessor = this.getOptionValueAccessor();
@@ -202,8 +200,8 @@ export default class MultiSelectBox extends PureComponent {
                 </ul>
                 <SelectBox
                     {...omit(this.props, ['theme'])}
+                    className={className}
                     options={filteredSearchOptions}
-                    highlight={false}
                     value=""
                     onValueChange={this.handleNewValueSelected}
                     disabled={disabled}

--- a/packages/react-ui-components/src/MultiSelectBox/style.css
+++ b/packages/react-ui-components/src/MultiSelectBox/style.css
@@ -7,8 +7,3 @@
     padding-left: 0;
 
 }
-
-.selectedOptions--highlight {
-    outline: 2px solid var(--colors-Success);
-    margin-bottom: 2px;
-}

--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -39,6 +39,11 @@ export default class SelectBox extends PureComponent {
         ),
 
         /**
+         * Additional className wich will be applied
+         */
+        className: PropTypes.string,
+
+        /**
          * Field name specifying which field in a single "option" contains the "value"
          */
         optionValueField: PropTypes.string,
@@ -86,11 +91,6 @@ export default class SelectBox extends PureComponent {
          * Limit height and show scrollbars if needed, defaults to true
          */
         scrollable: PropTypes.bool,
-
-        /**
-         * Should the SelectBox be highlighted? (e.g. if the property was modified)
-         */
-        highlight: PropTypes.bool,
 
         /**
          * Component used for rendering the individual option elements; Usually this component uses "ListPreviewElement" internally for common styling.
@@ -149,7 +149,6 @@ export default class SelectBox extends PureComponent {
         // Theme & Dependencies
         // ------------------------------
         theme: PropTypes.shape({/* eslint-disable quote-props */
-            'wrapper--highlight': PropTypes.string,
             'selectBox__btn--noRightPadding': PropTypes.string
         }).isRequired, /* eslint-enable quote-props */
 
@@ -177,7 +176,6 @@ export default class SelectBox extends PureComponent {
         const {
             options,
             theme,
-            highlight,
             showDropDownToggle,
             threshold,
             displaySearchBox,
@@ -185,7 +183,7 @@ export default class SelectBox extends PureComponent {
             ListPreviewElement,
             plainInputMode,
             disabled,
-
+            className,
             DropDown,
             SelectBox_ListPreview
         } = this.props;
@@ -196,8 +194,8 @@ export default class SelectBox extends PureComponent {
         const isExpanded = disabled ? false : this.state.isExpanded;
 
         const headerClassName = mergeClassNames({
+            [className]: true,
             [theme.selectBox__btn]: true,
-            [theme['selectBox--highlight']]: highlight,
             [theme['selectBox__btn--noRightPadding']]: !showDropDownToggle,
             [theme['selectBox--disabled']]: disabled
         });

--- a/packages/react-ui-components/src/SelectBox/style.css
+++ b/packages/react-ui-components/src/SelectBox/style.css
@@ -3,10 +3,6 @@
     padding: 0;
 }
 
-.selectBox--highlight {
-    outline: 2px solid var(--colors-Success);
-}
-
 .selectBox {
     composes: reset from './../reset.css', dropDown from './../DropDown/style.css';
     position: relative;

--- a/packages/react-ui-components/src/TextArea/index.js
+++ b/packages/react-ui-components/src/TextArea/index.js
@@ -5,12 +5,4 @@ import TextArea from './textArea.js';
 
 const ThemedTextArea = themr(identifiers.textArea, style)(TextArea);
 
-//
-// Dependency injection
-//
-import injectProps from './../_lib/injectProps.js';
-import Tooltip from '../Tooltip/index';
-
-export default injectProps({
-    TooltipComponent: Tooltip
-})(ThemedTextArea);
+export default ThemedTextArea;

--- a/packages/react-ui-components/src/TextArea/textArea.js
+++ b/packages/react-ui-components/src/TextArea/textArea.js
@@ -11,16 +11,6 @@ class TextArea extends PureComponent {
 
     static propTypes = {
         /**
-         * Array of validation errors
-         */
-        validationErrors: PropTypes.array,
-
-        /**
-         * Highlight input
-         */
-        highlight: PropTypes.bool,
-
-        /**
          * An optional className to render on the textarea node.
          */
         className: PropTypes.string,
@@ -44,14 +34,9 @@ class TextArea extends PureComponent {
          * An optional css theme to be injected.
          */
         theme: PropTypes.shape({
-            'textArea': PropTypes.string,
+            textArea: PropTypes.string,
             'textArea--invalid': PropTypes.string
         }).isRequired,
-
-        /**
-         * Static component dependencies which are injected from the outside (index.js)
-         */
-        TooltipComponent: PropTypes.any.isRequired,
 
         /**
          * Optional number to set the minRows of the TextArea if not expanded
@@ -92,7 +77,6 @@ class TextArea extends PureComponent {
 
     render() {
         const {
-            TooltipComponent,
             placeholder,
             className,
             validationErrors,
@@ -106,12 +90,7 @@ class TextArea extends PureComponent {
         const classNames = mergeClassNames({
             [className]: className && className.length,
             [theme.textArea]: true,
-            [theme['textArea--invalid']]: validationErrors && validationErrors.length > 0,
-            [theme['textArea--highlight']]: highlight,
             [theme['textArea--disabled']]: disabled
-        });
-        const renderedErrors = validationErrors && validationErrors.length > 0 && validationErrors.map((validationError, key) => {
-            return <div key={key}>{validationError}</div>;
         });
 
         return (
@@ -128,7 +107,6 @@ class TextArea extends PureComponent {
                     onClick={this.handleOnClick}
                     minRows={this.state.isFocused ? expandedRows : minRows}
                     />
-                {renderedErrors && <TooltipComponent>{renderedErrors}</TooltipComponent>}
             </div>
         );
     }

--- a/packages/react-ui-components/src/TextArea/textArea.spec.js
+++ b/packages/react-ui-components/src/TextArea/textArea.spec.js
@@ -2,7 +2,6 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import toJson from 'enzyme-to-json';
 import TextareaAutoresize from 'react-textarea-autosize';
-import {createStubComponent} from './../_lib/testUtils.js';
 import {undecorated as TextArea} from './textArea.js';
 
 describe('<TextArea/>', () => {
@@ -10,8 +9,7 @@ describe('<TextArea/>', () => {
 
     beforeEach(() => {
         props = {
-            theme: {},
-            TooltipComponent: createStubComponent()
+            theme: {}
         };
     });
 

--- a/packages/react-ui-components/src/TextInput/index.js
+++ b/packages/react-ui-components/src/TextInput/index.js
@@ -5,12 +5,4 @@ import TextInput from './textInput.js';
 
 const ThemedTextInput = themr(identifiers.textInput, style)(TextInput);
 
-//
-// Dependency injection
-//
-import injectProps from './../_lib/injectProps.js';
-import Tooltip from '../Tooltip/index';
-
-export default injectProps({
-    TooltipComponent: Tooltip
-})(ThemedTextInput);
+export default ThemedTextInput;

--- a/packages/react-ui-components/src/TextInput/style.css
+++ b/packages/react-ui-components/src/TextInput/style.css
@@ -20,13 +20,6 @@
     font-weight: normal;
     color: var(--colors-ContrastBright);
 }
-.textInput--invalid {
-    outline: 2px solid var(--colors-Error) !important;
-    color: var(--colors-Error) !important;
-}
-.textInput--highlight {
-    outline: 2px solid var(--colors-Success);
-}
 
 .textInput--disabled {
     opacity: .65;

--- a/packages/react-ui-components/src/TextInput/textInput.js
+++ b/packages/react-ui-components/src/TextInput/textInput.js
@@ -36,16 +36,6 @@ class TextInput extends PureComponent {
         onBlur: PropTypes.func,
 
         /**
-         * An array of error messages
-         */
-        validationErrors: PropTypes.array,
-
-        /**
-         * Highlight input
-         */
-        highlight: PropTypes.bool,
-
-        /**
          * This prop controls if the CheckBox is disabled or not.
          */
         disabled: PropTypes.bool,
@@ -69,15 +59,8 @@ class TextInput extends PureComponent {
          * An optional css theme to be injected.
          */
         theme: PropTypes.shape({
-            'textInput': PropTypes.string,
-            'textInput--invalid': PropTypes.string,
-            'textInput--highlight': PropTypes.string
-        }).isRequired,
-
-        /**
-         * Static component dependencies which are injected from the outside (index.js)
-         */
-        TooltipComponent: PropTypes.any.isRequired
+            textInput: PropTypes.string
+        }).isRequired
     };
 
     componentDidMount() {
@@ -106,12 +89,9 @@ class TextInput extends PureComponent {
 
     render() {
         const {
-            TooltipComponent,
             placeholder,
             className,
-            validationErrors,
             theme,
-            highlight,
             containerClassName,
             disabled,
             type,
@@ -122,13 +102,7 @@ class TextInput extends PureComponent {
         const classNames = mergeClassNames({
             [className]: className && className.length,
             [theme.textInput]: true,
-            [theme['textInput--invalid']]: validationErrors && validationErrors.length > 0,
-            [theme['textInput--highlight']]: highlight,
             [theme['textInput--disabled']]: disabled
-        });
-
-        const renderedErrors = validationErrors && validationErrors.length > 0 && validationErrors.map((validationError, key) => {
-            return <div key={key}>{validationError}</div>;
         });
 
         const inputRef = el => {
@@ -150,7 +124,6 @@ class TextInput extends PureComponent {
                     onKeyPress={this.handleKeyPress}
                     ref={inputRef}
                     />
-                {renderedErrors && <TooltipComponent>{renderedErrors}</TooltipComponent>}
             </div>
         );
     }

--- a/packages/react-ui-components/src/TextInput/textInput.spec.js
+++ b/packages/react-ui-components/src/TextInput/textInput.spec.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import toJson from 'enzyme-to-json';
-import {createStubComponent} from './../_lib/testUtils.js';
 import TextInput from './textInput.js';
 
 describe('<TextInput/>', () => {
@@ -9,8 +8,7 @@ describe('<TextInput/>', () => {
 
     beforeEach(() => {
         props = {
-            theme: {},
-            TooltipComponent: createStubComponent()
+            theme: {}
         };
     });
 

--- a/packages/react-ui-components/src/Tooltip/style.css
+++ b/packages/react-ui-components/src/Tooltip/style.css
@@ -2,6 +2,10 @@
     position: absolute;
 }
 
+.tooltip--inline {
+    position: relative;
+}
+
 .tooltip--arrow {
     position: relative;
     top: 0;
@@ -11,7 +15,7 @@
     margin-left: -var(--spacing-Half);
     border-left: var(--spacing-Half) solid transparent;
     border-right: var(--spacing-Half) solid transparent;
-    border-bottom: var(--spacing-Half) solid var(--colors-ContrastNeutral);
+    border-bottom: var(--spacing-Half) solid var(--colors-ContrastDarkest);
 }
 
 .tooltip--asError .tooltip--arrow {
@@ -21,8 +25,9 @@
 .tooltip--inner {
     position: relative;
     padding: var(--spacing-Half);
-    background: var(--colors-ContrastNeutral);
+    background: var(--colors-ContrastDarkest);
     color: white;
+    box-shadow: 0px 0px 10px rgba(125, 125, 125, .2);
 }
 
 .tooltip--asError .tooltip--inner {

--- a/packages/react-ui-components/src/Tooltip/style.css
+++ b/packages/react-ui-components/src/Tooltip/style.css
@@ -1,5 +1,9 @@
 .tooltip {
     position: absolute;
+
+    ul  {
+        margin: 0;
+    }
 }
 
 .tooltip--inline {

--- a/packages/react-ui-components/src/Tooltip/tooltip.js
+++ b/packages/react-ui-components/src/Tooltip/tooltip.js
@@ -7,12 +7,14 @@ const Tooltip = props => {
         children,
         className,
         theme,
+        renderInline,
         asError,
         ...rest
     } = props;
     const classNames = mergeClassNames({
         [theme.tooltip]: true,
         [theme['tooltip--asError']]: asError,
+        [theme['tooltip--inline']]: renderInline,
         [className]: className && className.length
     });
 
@@ -37,6 +39,12 @@ Tooltip.propTypes = {
     children: PropTypes.node,
 
     /**
+     * If set to true the tooltip won't be positioned absolute but relative and
+     * show up inline
+     */
+    renderInline: PropTypes.bool,
+
+    /**
      * An optional css theme to be injected.
      */
     theme: PropTypes.object,
@@ -45,6 +53,10 @@ Tooltip.propTypes = {
      * Whether this tooltip should indicate an error or not
      */
     asError: PropTypes.bool
+};
+
+Tooltip.defaultProps = {
+    renderInline: false
 };
 
 export default Tooltip;


### PR DESCRIPTION
This change takes moves the validation result rendering to a central place into EditorEnvelope. Also core ui components like a select box or a textfield should not care about stuff like `isHighlighted` oder rendering validation results. Those options are removed and will be handled from `EditorEnvelope`

Resolves #1769  #1651 #1426 (as we render tooltip with validation inline)
