### PR TITLE
BUGFIX: Prevent data loss in change saga

### DIFF
--- a/packages/neos-ui/src/Sagas/Changes/index.js
+++ b/packages/neos-ui/src/Sagas/Changes/index.js
@@ -1,5 +1,4 @@
 import {take, race, put, call, select} from 'redux-saga/effects';
-import {delay} from 'redux-saga';
 import {$get} from 'plow-js';
 
 import {actionTypes, actions, selectors} from '@neos-project/neos-ui-redux-store';

--- a/packages/neos-ui/src/Sagas/Changes/index.js
+++ b/packages/neos-ui/src/Sagas/Changes/index.js
@@ -38,7 +38,7 @@ export function * watchPersist() {
     while (true) {
         const {action} = yield race({
             action: take(actionTypes.Changes.PERSIST),
-            time: call(delay, 1500)
+            saveFinished: take(actionTypes.UI.Remote.FINISH_SAVING)
         });
 
         if (action) {
@@ -52,4 +52,3 @@ export function * watchPersist() {
         }
     }
 }
-


### PR DESCRIPTION
The previous behavior left a window in which a change could be lost
(up to 1.5sec) due to waiting for the next opportunity to save.
Now pending changes are submitted to the server as soon as the last
save request finished. This should minimize the risk especially
in conjunction with disabling the publish button while chnages
are being persisted.

Fixes: #1933
