### PR TITLE
BUGFIX: Dont throw a console.error when a label is not defined

### DIFF
--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.js
@@ -46,13 +46,14 @@ export default class PropertyGroup extends PureComponent {
                     {items.map(item => {
                         const itemId = $get('id', item);
                         const itemType = $get('type', item);
+                        const label = $get('label', item) || '';
 
                         if (itemType === 'editor') {
                             return (
                                 <InspectorEditorEnvelope
                                     key={$get('contextPath', node) + itemId}
                                     id={itemId}
-                                    label={$get('label', item)}
+                                    label={label}
                                     editor={$get('editor', item)}
                                     options={$get('editorOptions', item) && $get('editorOptions', item).toJS ? $get('editorOptions', item).toJS() : $get('editorOptions', item)}
                                     renderSecondaryInspector={renderSecondaryInspector}


### PR DESCRIPTION
Currently, an error is thrown when a Nodetype property definition has no label.
This PR prevents this.