### PR TITLE
BUGFIX: Move slick vanilla styles to HostOnlyStyles

### DIFF
--- a/packages/neos-ui/src/Containers/EditModePanel/Panel/index.js
+++ b/packages/neos-ui/src/Containers/EditModePanel/Panel/index.js
@@ -1,11 +1,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import Slider from 'react-slick';
-
-/* eslint-disable no-unused-vars */
-import SlickStyles from './slick-styles.vanilla-css';
-/* eslint-enable no-unused-vars */
-
 import Button from '@neos-project/react-ui-components/src/Button/index';
 import IconComponent from '@neos-project/react-ui-components/src/Icon/index';
 import I18n from '@neos-project/neos-ui-i18n';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,10 @@ module.exports = merge(
             Host: [
                 './packages/neos-ui/src/index.js'
             ],
-            HostOnlyStyles: './packages/neos-ui/src/styleHostOnly.css',
+            HostOnlyStyles: [
+                './packages/neos-ui/src/styleHostOnly.css',
+                './packages/neos-ui/src/Containers/EditModePanel/Panel/slick-styles.vanilla-css'
+            ],
             Guest: [
                 './polyfills.js',
                 './packages/neos-ui-ckeditor-bindings/src/index.js'


### PR DESCRIPTION
The slick slider styles should no longer affect sliders within the guest frame

resolves: #1538 