### PR TITLE
BUGFIX: Don't try to get policies for removed nodes

### DIFF
--- a/packages/neos-ui/src/Sagas/CR/Policies/index.js
+++ b/packages/neos-ui/src/Sagas/CR/Policies/index.js
@@ -12,10 +12,11 @@ export function * watchNodeInformationChanges() {
 
         const nodesWithoutPolicies = Object.keys(nodeMap).filter(contextPath => {
             const node = selectors.CR.Nodes.nodeByContextPath(state)(contextPath);
-            const isFullyLoaded = $get('isFullyLoaded', node);
-            if (!isFullyLoaded) {
+
+            if (!$get('isFullyLoaded', node) || $get('properties._removed', node)) {
                 return false;
             }
+
             const policyInfo = $get('policy', node);
             return (!policyInfo);
         });


### PR DESCRIPTION
Due to the property mapping the request would fail for
removed nodes but we actually don't even need the policies
for those so I just filter them before requesting.
