### PR TITLE
BUGFIX: Use submodule path to check for availability

### DIFF
--- a/Resources/Private/Fusion/Backend/Root.fusion
+++ b/Resources/Private/Fusion/Backend/Root.fusion
@@ -254,7 +254,7 @@ backend = Neos.Fusion:Template {
 
                         @if {
                             isNotHiddenInMenu = ${!submodule.hideInMenu}
-                            isAvailable = ${Neos.Ui.Modules.isAvailable(submoduleName)}
+                            isAvailable = ${Neos.Ui.Modules.isAvailable(moduleName + '/' + submoduleName)}
                         }
                     }
                 }


### PR DESCRIPTION
The helper needs the full module path to check availability,
interestingly it apparently returns true for wrong paths,
that should be fixed in the future.
