### PR TITLE
BUGFIX: Correctly check for allowed NodeTypes and properties

### DIFF
--- a/Classes/Service/NodePolicyService.php
+++ b/Classes/Service/NodePolicyService.php
@@ -105,7 +105,7 @@ class NodePolicyService
         }
 
         $filter = function ($nodeType) use ($node) {
-            return $this->privilegeManager->isGranted(
+            return !$this->privilegeManager->isGranted(
                 CreateNodePrivilege::class,
                 new CreateNodePrivilegeSubject($node, $nodeType)
             );
@@ -161,7 +161,7 @@ class NodePolicyService
         }
 
         $filter = function ($propertyName) use ($node) {
-            return $this->privilegeManager->isGranted(
+            return !$this->privilegeManager->isGranted(
                 EditNodePropertyPrivilege::class,
                 new PropertyAwareNodePrivilegeSubject($node, null, $propertyName)
             );


### PR DESCRIPTION
The filter should make sure that the collection of NodeTypes or
Node properties only contains those that are not allowed in the
end, which means the condition must be reversed to get the right
result.
