### PR TITLE
BUGFIX: Load policies for tree nodes to allow moving and adding

### DIFF
--- a/packages/neos-ui/src/Sagas/CR/Policies/index.js
+++ b/packages/neos-ui/src/Sagas/CR/Policies/index.js
@@ -6,14 +6,14 @@ import backend from '@neos-project/neos-ui-backend-connector';
 export function * watchNodeInformationChanges() {
     const {endpoints} = backend.get();
     while (true) {
-        const action = yield take([actionTypes.CR.Nodes.MERGE, actionTypes.CR.Nodes.ADD]);
-        const {nodeMap} = action.payload;
+        const action = yield take([actionTypes.CR.Nodes.MERGE, actionTypes.CR.Nodes.ADD, actionTypes.CR.Nodes.SET_STATE]);
+        const nodeMap = (action.type === actionTypes.CR.Nodes.SET_STATE) ? action.payload.nodes : action.payload.nodeMap;
         const state = yield select();
 
         const nodesWithoutPolicies = Object.keys(nodeMap).filter(contextPath => {
             const node = selectors.CR.Nodes.nodeByContextPath(state)(contextPath);
 
-            if (!$get('isFullyLoaded', node) || $get('properties._removed', node)) {
+            if ($get('properties._removed', node)) {
                 return false;
             }
 


### PR DESCRIPTION
We need policies for all displayed tree nodes to allow the UI to
decide about creating above/below and also dragging in the tree.

Related: #1985
