### PR TITLE
TASK: add node type to contentelement wrap

### DIFF
--- a/Classes/Aspects/AugmentationAspect.php
+++ b/Classes/Aspects/AugmentationAspect.php
@@ -146,6 +146,7 @@ class AugmentationAspect
         $attributes = $joinPoint->isMethodArgument('additionalAttributes') ? $joinPoint->getMethodArgument('additionalAttributes') : [];
         $attributes['data-__neos-node-contextpath'] = $node->getContextPath();
         $attributes['data-__neos-fusion-path'] = $fusionPath;
+        $attributes['data-__neos-node-nodetype'] = $node->getNodeType();
 
         $this->renderedNodes[$node->getIdentifier()] = $node;
 


### PR DESCRIPTION

This adds `data-__neos-node-nodetype="Acme.Site:NodeTypeName"` to the wrapping div so it is possible to filter for the NodeType in the here described https://neos.readthedocs.io/en/4.0/ExtendingNeos/InteractionWithTheNeosBackend.html?highlight=Neos.NodeCreated#javascript-events eventhandling without the integrator is forced to add NodeType information to the markup like in classnames.

So it it would be possible to get the NodeType name with something like 
`const nodeTypeName = event.detail.element.dataset.__neosNodeNodetype;`

I think it is not the most elegant way but as far I do remember there was a decision to not render the whole node so this solution would be a good comprimise.

Of course the documentation needs to be adjusted then as well.

https://github.com/neos/neos-ui/issues/1990
