### PR TITLE
BUGFIX: Should not overwrite policy information on node add

### DIFF
--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -246,7 +246,7 @@ manifest('main', {}, globalRegistry => {
     // When the server has updated node info, apply it to the store
     //
     serverFeedbackHandlers.set('Neos.Neos.Ui:UpdateNodeInfo/Main', (feedbackPayload, {store}) => {
-        store.dispatch(actions.CR.Nodes.add(feedbackPayload.byContextPath));
+        store.dispatch(actions.CR.Nodes.merge(feedbackPayload.byContextPath));
     });
 
     //


### PR DESCRIPTION
We cannot use add as that would override policy information or
in general already loaded data. Merging the information results
in working inserts right after adding a node again.

Fixes: #1988
