### PR TITLE
TASK: upgrade mariadb version in Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 sudo: required
 addons:
-  mariadb: '10.2'
+  mariadb: '10.3'
   apt:
     sources:
      - google-chrome


### PR DESCRIPTION
Hopefully would fix this error in tests:

```
An exception occurred while executing 'CREATE TABLE flow3_resource_resourcepointer (hash VARCHAR(255) NOT NULL, PRIMARY KEY(hash)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB':
> SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 767 byt
```