### PR TITLE
TASK: Render markdown in help messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "react-image-crop": "^2.0.5",
     "react-immutable-proptypes": "^2.1.0",
     "react-keydown": "^1.9.4",
+    "react-markdown": "^3.3.4",
     "react-measure": "^1.4.7",
     "react-motion": "^0.5.0",
     "react-portal": "^3.1.0",

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -1,6 +1,7 @@
 import React, {PureComponent, Fragment} from 'react';
 import PropTypes from 'prop-types';
 import mergeClassNames from 'classnames';
+import ReactMarkdown from 'react-markdown';
 
 import Label from '@neos-project/react-ui-components/src/Label/';
 import {Tooltip} from '@neos-project/react-ui-components';
@@ -111,7 +112,7 @@ export default class EditorEnvelope extends PureComponent {
 
         return (
             <Tooltip renderInline className={style.envelope__helpmessage}>
-                {helpMessage ? helpMessage : ''}
+                {helpMessage ? <ReactMarkdown source={helpMessage} /> : ''}
                 {helpThumbnail ? <img alt={label} src={helpThumbnail} /> : ''}
             </Tooltip>
         );

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
@@ -2,6 +2,7 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {$get} from 'plow-js';
+import ReactMarkdown from 'react-markdown';
 
 import {neos} from '@neos-project/neos-ui-decorators';
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
@@ -170,7 +171,7 @@ export default class SelectNodeType extends PureComponent {
                         {icon && <Icon icon={icon} className={style.nodeType__icon} padded="right"/>}
                         <I18n id={label} fallback={label}/>
                     </span>
-                    {message}
+                    <ReactMarkdown source={message} />
                 </div>
 
                 <IconButton className={style.helpMessage__closeButton} icon="times" onClick={() => this.handleCloseHelpMessage()} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -9626,6 +9626,16 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
+react-markdown@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-3.3.4.tgz#4002599ad133c649923a49aedc06b2f3af2016b6"
+  dependencies:
+    prop-types "^15.6.1"
+    remark-parse "^5.0.0"
+    unified "^6.1.5"
+    unist-util-visit "^1.3.0"
+    xtend "^4.0.1"
+
 react-measure@^1.4.7:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/react-measure/-/react-measure-1.4.7.tgz#a1d2ca0dcfef04978b7ac263a765dcb6a0936fdb"
@@ -11782,7 +11792,7 @@ unherit@^1.0.4:
     inherits "^2.0.1"
     xtend "^4.0.1"
 
-unified@^6.0.0:
+unified@^6.0.0, unified@^6.1.5:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
   dependencies:
@@ -11842,7 +11852,7 @@ unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
 
-unist-util-visit@^1.1.0:
+unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.3.1.tgz#c019ac9337a62486be58531bc27e7499ae7d55c7"
   dependencies:


### PR DESCRIPTION
I added the [react-markdown](https://github.com/rexxars/react-markdown) library to convert Markdown into a React-Component and wrapped the `helpMessage` output with this component.

closes #1944 