### PR TITLE
TASK: support span-like editable mode for CKE5

### DIFF
--- a/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
@@ -2,6 +2,16 @@ import throttle from 'lodash.throttle';
 import debounce from 'lodash.debounce';
 import DecoupledEditor from '@ckeditor/ckeditor5-editor-decoupled/src/decouplededitor';
 
+// We remove opening and closing span tags that are produced by the inlineMode plugin
+const cleanupContentBeforeCommit = content => {
+    if (content.match(/^<span>/) && content.match(/<\/span>$/)) {
+        return content
+            .replace(/^<span>/, '')
+            .replace(/<\/span>$/, '');
+    }
+    return content;
+};
+
 let currentEditor = null;
 let editorConfig = {};
 
@@ -54,7 +64,7 @@ export const createEditor = ({propertyDomNode, propertyName, contextPath, editor
                 subject: contextPath,
                 payload: {
                     propertyName,
-                    value: editor.getData(),
+                    value: cleanupContentBeforeCommit(editor.getData()),
                     isInline: true
                 }
             }), 1500), 150));

--- a/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
@@ -34,7 +34,8 @@ export const createEditor = ({propertyDomNode, propertyName, contextPath, editor
     const ckEditorConfig = editorConfig.configRegistry.getCkeditorConfig({
         editorOptions,
         userPreferences,
-        globalRegistry
+        globalRegistry,
+        propertyDomNode
     });
 
     DecoupledEditor

--- a/packages/neos-ui-ckeditor5-bindings/src/plugins/inlineMode.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/plugins/inlineMode.js
@@ -1,0 +1,21 @@
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+
+export default class InlineMode extends Plugin {
+    static get pluginName() {
+        return 'InlineMode';
+    }
+    init() {
+        const editor = this.editor;
+
+        // We map paragraph model into plain <span> element
+        editor.conversion.elementToElement({model: 'paragraph', view: 'span', converterPriority: 'high'});
+
+        // We redefine enter key to great soft breaks instead of paragraphs
+        editor.editing.view.document.on('enter', (evt, data) => {
+            editor.execute('shiftEnter');
+            data.preventDefault();
+            evt.stop();
+            editor.editing.view.scrollToTheSelection();
+        }, {priority: 'high'});
+    }
+}

--- a/packages/neos-ui-ckeditor5-bindings/src/plugins/neosPlaceholder.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/plugins/neosPlaceholder.js
@@ -16,6 +16,7 @@ const htmlIsEmptyish = data => {
     const a = (
         !value ||
         value === '<br>' ||
+        value === '<span>&nbsp;</span>' ||
         value === '<p>&nbsp;</p>' ||
         value === '<p>&nbsp;<br></p>' ||
         value === '<p><br></p>' ||


### PR DESCRIPTION
This feature disables creation of paragraphs for span and heading elements. Also it configures [enter] key to produce soft line breaks.

It's also possible to enable this mode with this config:

```
formatting:
  paragraph: false
```

Under the hood it works a bit hackishly: it re-maps paragraph model elements to `<span>` tags, and then removes the wrapping span in post-processing. There are other ways to do it, but this one is the most reliable one.
