### PR TITLE
BUGFIX: Remove PHP 7.0 incompatible ``void`` return type

### DIFF
--- a/Classes/Aspects/AugmentationAspect.php
+++ b/Classes/Aspects/AugmentationAspect.php
@@ -221,7 +221,7 @@ class AugmentationAspect
      * @param NodeInterface $documentNode
      * @return void
      */
-    protected function appendNonRenderedContentNodeMetadata(NodeInterface $documentNode): void
+    protected function appendNonRenderedContentNodeMetadata(NodeInterface $documentNode)
     {
         if ($documentNode->getContext()->getWorkspace()->isPublicWorkspace()) {
             return;

--- a/Classes/Domain/Service/ConfigurationRenderingService.php
+++ b/Classes/Domain/Service/ConfigurationRenderingService.php
@@ -52,7 +52,7 @@ class ConfigurationRenderingService
      * @param array $context
      * @throws \Neos\Eel\Exception
      */
-    protected function computeConfigurationInternally(array &$adjustedConfiguration, array $context): void
+    protected function computeConfigurationInternally(array &$adjustedConfiguration, array $context)
     {
         foreach ($adjustedConfiguration as $key => &$value) {
             if (is_array($value)) {


### PR DESCRIPTION
Since Neos 3.3 still supports PHP 7.0, we can't make use of the ``void`` return type yet.