### PR TITLE
 BUGFIX: disable throttle on typing

### DIFF
--- a/packages/neos-ui-ckeditor-bindings/src/guestFrameApi.js
+++ b/packages/neos-ui-ckeditor-bindings/src/guestFrameApi.js
@@ -229,7 +229,7 @@ const createCKEditorAPI = CKEDITOR => {
                     handleUserInteraction();
                 });
 
-                editor.on('change', debounce(() => onChange(editor.getData()), 450, {maxWait: 5000}));
+                editor.on('change', debounce(() => onChange(editor.getData()), 350, {maxWait: 5000}));
             });
         }
     };

--- a/packages/neos-ui-ckeditor-bindings/src/guestFrameApi.js
+++ b/packages/neos-ui-ckeditor-bindings/src/guestFrameApi.js
@@ -1,4 +1,3 @@
-import throttle from 'lodash.throttle';
 import debounce from 'lodash.debounce';
 import removeTags from './ckeditor/removeTags';
 
@@ -230,7 +229,7 @@ const createCKEditorAPI = CKEDITOR => {
                     handleUserInteraction();
                 });
 
-                editor.on('change', debounce(throttle(() => onChange(editor.getData()), 1500), 150));
+                editor.on('change', debounce(() => onChange(editor.getData()), 450, {maxWait: 5000}));
             });
         }
     };

--- a/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
@@ -1,4 +1,3 @@
-import throttle from 'lodash.throttle';
 import debounce from 'lodash.debounce';
 import DecoupledEditor from '@ckeditor/ckeditor5-editor-decoupled/src/decouplededitor';
 
@@ -59,7 +58,7 @@ export const createEditor = ({propertyDomNode, propertyName, contextPath, editor
             });
 
             editor.model.document.on('change', () => handleUserInteractionCallback());
-            editor.model.document.on('change:data', debounce(throttle(() => persistChange({
+            editor.model.document.on('change:data', debounce(() => persistChange({
                 type: 'Neos.Neos.Ui:Property',
                 subject: contextPath,
                 payload: {
@@ -67,7 +66,7 @@ export const createEditor = ({propertyDomNode, propertyName, contextPath, editor
                     value: cleanupContentBeforeCommit(editor.getData()),
                     isInline: true
                 }
-            }), 1500), 150));
+            }), 450, {maxWait: 5000}));
         }).catch(e => console.error(e));
 };
 

--- a/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
@@ -66,7 +66,7 @@ export const createEditor = ({propertyDomNode, propertyName, contextPath, editor
                     value: cleanupContentBeforeCommit(editor.getData()),
                     isInline: true
                 }
-            }), 450, {maxWait: 5000}));
+            }), 350, {maxWait: 5000}));
         }).catch(e => console.error(e));
 };
 


### PR DESCRIPTION
Before this change, we had typing throttled to 1.5s, so if the editor would close or reload the page within that interval, the change would get lost.

This change replaces throttle+debounce with just debounce + maxWait to 5s to make sure that editors who type really fast without stopping would still have their content saved periodically.

The potential problem with this change is that if editor types one keystroke per 350ms for a long time, and if the backend for some reason would take longer than 350ms to process that change, a lot of changes would line up in the changes saga (but thanks to @kitsunet's change server would still not get spammed with requests, so that should be fine).