### PR TITLE
TASK: export CKE5 in extensibility package

### DIFF
--- a/packages/neos-ui-extensibility/scripts/helpers/webpack.config.js
+++ b/packages/neos-ui-extensibility/scripts/helpers/webpack.config.js
@@ -59,6 +59,7 @@ module.exports = function (neosPackageJson) {
                 'redux-saga': '@neos-project/neos-ui-extensibility/src/shims/vendor/redux-saga/index',
                 'reselect': '@neos-project/neos-ui-extensibility/src/shims/vendor/reselect/index',
                 'react-css-themr': '@neos-project/neos-ui-extensibility/src/shims/vendor/react-css-themr/index',
+                'ckeditor5-exports': '@neos-project/neos-ui-extensibility/src/shims/vendor/ckeditor5-exports/index',
 
                 '@neos-project/react-ui-components': '@neos-project/neos-ui-extensibility/src/shims/neosProjectPackages/react-ui-components/index',
                 '@neos-project/neos-ui-backend-connector': '@neos-project/neos-ui-extensibility/src/shims/neosProjectPackages/neos-ui-backend-connector/index',

--- a/packages/neos-ui-extensibility/src/shims/vendor/ckeditor5-exports/index.js
+++ b/packages/neos-ui-extensibility/src/shims/vendor/ckeditor5-exports/index.js
@@ -1,0 +1,3 @@
+import readFromConsumerApi from '../../../readFromConsumerApi';
+
+module.exports = readFromConsumerApi('vendor')().CkEditor5;

--- a/packages/neos-ui/src/apiExposureMap.js
+++ b/packages/neos-ui/src/apiExposureMap.js
@@ -22,6 +22,57 @@ import * as CkEditorApi from '@neos-project/neos-ui-ckeditor5-bindings/src/ckEdi
 import NeosUiBackendConnectorDefault, * as NeosUiBackendConnector from '@neos-project/neos-ui-backend-connector';
 import * as NeosUiViews from '@neos-project/neos-ui-views';
 
+// We export most needed components from CKE5 to be used when making custom plugins.
+// It's not safe to just install CKE5 packages from the extension because then then "instanceof" checks will no longer work,
+// which would break CKE5 in some places.
+// Feel free to export more parts as needed.
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import Command from '@ckeditor/ckeditor5-core/src/command';
+
+import ModelDocument from '@ckeditor/ckeditor5-engine/src/model/document';
+import ModelDocumentFragment from '@ckeditor/ckeditor5-engine/src/model/documentfragment';
+import ModelDocumentSelection from '@ckeditor/ckeditor5-engine/src/model/documentselection';
+import ModelElement from '@ckeditor/ckeditor5-engine/src/model/element';
+import ModelNode from '@ckeditor/ckeditor5-engine/src/model/node';
+import ModelNodeList from '@ckeditor/ckeditor5-engine/src/model/nodelist';
+import ModelPosition from '@ckeditor/ckeditor5-engine/src/model/position';
+import ModelRange from '@ckeditor/ckeditor5-engine/src/model/range';
+import ModelSchema from '@ckeditor/ckeditor5-engine/src/model/schema';
+import ModelSelection from '@ckeditor/ckeditor5-engine/src/model/selection';
+import ModelText from '@ckeditor/ckeditor5-engine/src/model/text';
+import ModelTextProxy from '@ckeditor/ckeditor5-engine/src/model/textproxy';
+import ModelTreeWalker from '@ckeditor/ckeditor5-engine/src/model/treewalker';
+import ModelWriter from '@ckeditor/ckeditor5-engine/src/model/writer';
+
+import ViewAttributeElement from '@ckeditor/ckeditor5-engine/src/view/attributeelement';
+import ViewContainerElement from '@ckeditor/ckeditor5-engine/src/view/containerelement';
+import ViewDocument from '@ckeditor/ckeditor5-engine/src/view/document.js';
+import ViewDocumentFragment from '@ckeditor/ckeditor5-engine/src/view/documentfragment.js';
+import ViewDocumentSelection from '@ckeditor/ckeditor5-engine/src/view/documentselection.js';
+import ViewDOMConverter from '@ckeditor/ckeditor5-engine/src/view/domconverter.js';
+import ViewEditableElement from '@ckeditor/ckeditor5-engine/src/view/editableelement.js';
+import ViewElement from '@ckeditor/ckeditor5-engine/src/view/element.js';
+import ViewEmptyElement from '@ckeditor/ckeditor5-engine/src/view/emptyelement.js';
+import ViewFiller from '@ckeditor/ckeditor5-engine/src/view/filler.js';
+import ViewMatcher from '@ckeditor/ckeditor5-engine/src/view/matcher.js';
+import ViewNode from '@ckeditor/ckeditor5-engine/src/view/node.js';
+import ViewPlaceholder from '@ckeditor/ckeditor5-engine/src/view/placeholder.js';
+import ViewPosition from '@ckeditor/ckeditor5-engine/src/view/position.js';
+import ViewRange from '@ckeditor/ckeditor5-engine/src/view/range.js';
+import ViewRenderer from '@ckeditor/ckeditor5-engine/src/view/renderer';
+import ViewSelection from '@ckeditor/ckeditor5-engine/src/view/selection.js';
+import ViewText from '@ckeditor/ckeditor5-engine/src/view/text.js';
+import ViewTextProxy from '@ckeditor/ckeditor5-engine/src/view/textproxy.js';
+import ViewTreeWalker from '@ckeditor/ckeditor5-engine/src/view/treewalker.js';
+import ViewUIElement from '@ckeditor/ckeditor5-engine/src/view/uielement.js';
+import View from '@ckeditor/ckeditor5-engine/src/view/view.js';
+import ViewWriter from '@ckeditor/ckeditor5-engine/src/view/writer';
+
+import * as UpcastConverters from '@ckeditor/ckeditor5-engine/src/conversion/upcast-converters';
+import * as DowncastConverters from '@ckeditor/ckeditor5-engine/src/conversion/downcast-converters';
+
+const CkEditor5 = {Plugin, Command, UpcastConverters, DowncastConverters, ModelDocument, ModelDocumentFragment, ModelDocumentSelection, ModelElement, ModelNode, ModelNodeList, ModelPosition, ModelRange, ModelSchema, ModelSelection, ModelText, ModelTextProxy, ModelTreeWalker, ModelWriter, ViewAttributeElement, ViewContainerElement, ViewDocument, ViewDocumentFragment, ViewDocumentSelection, ViewDOMConverter, ViewEditableElement, ViewElement, ViewEmptyElement, ViewFiller, ViewMatcher, ViewNode, ViewPlaceholder, ViewPosition, ViewRange, ViewRenderer, ViewSelection, ViewText, ViewTextProxy, ViewTreeWalker, ViewUIElement, View, ViewWriter};
+
 export default {
     '@vendor': () => ({
         React,
@@ -36,7 +87,8 @@ export default {
         reduxSaga,
         reduxSagaEffects,
         reselect,
-        reactCssThemr
+        reactCssThemr,
+        CkEditor5
     }),
 
     '@NeosProjectPackages': () => ({


### PR DESCRIPTION
We can't just install CKE5 in parallel inside the plugin, as in that case `instaceof` checks inside CKE5 would stop working, so we need to expose the key CKE5 model classes.

Some less important utils can still be installed from npm, should be safe to duplicate them.

Usage example:

```
import {Command, Plugin, UpcastConverters, DowncastConverters, ModelRange as Range, ModelPosition as Position} from 'ckeditor5-exports';
```