### PR TITLE
BUGFIX: Declare defaultProps as static

### DIFF
--- a/packages/react-ui-components/src/MultiSelectBox/multiSelectBox.js
+++ b/packages/react-ui-components/src/MultiSelectBox/multiSelectBox.js
@@ -151,7 +151,7 @@ class MultiSelectBox extends PureComponent {
         MultiSelectBox_ListPreviewSortable: PropTypes.any.isRequired
     }
 
-    defaultProps = {
+    static defaultProps = {
         optionValueField: 'value',
         dndType: 'multiselect-box-value',
         allowEmpty: true,


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!
-->


**What I did**

Declared the `defaultProps`  of the `MultiSelectBox` as static properties

**How I did it**

with style

**How to verify it**

Declare a nodeype property e.g.

```
   test:
      type: array
      ui:
        label: 'test'
        inspector:
          group: 'general'
          editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
          editorOptions:
            values:
              test1:
                label: 'test1'
              test2:
                label: 'test2'
              test3:
                label: 'test3'
              test4:
                label: 'test4'
```

and try to choose an element in the select box

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->

closes #2042