### PR TITLE
BUGFIX: fix copy&pasting nodes across dimensions

### DIFF
--- a/Classes/FlowQueryOperations/NeosUiDefaultNodesOperation.php
+++ b/Classes/FlowQueryOperations/NeosUiDefaultNodesOperation.php
@@ -96,9 +96,11 @@ class NeosUiDefaultNodesOperation extends AbstractOperation
             $nodes[] = $documentNode;
         }
 
-        $clipboardNode = $this->propertyMapper->convert($clipboardNodeContextPath, NodeInterface::class);
-        if (!in_array($clipboardNode, $nodes)) {
-            $nodes[] = $clipboardNode;
+        if ($clipboardNodeContextPath) {
+            $clipboardNode = $this->propertyMapper->convert($clipboardNodeContextPath, NodeInterface::class);
+            if (!in_array($clipboardNode, $nodes)) {
+                $nodes[] = $clipboardNode;
+            }
         }
 
         $flowQuery->setContext($nodes);

--- a/Classes/FlowQueryOperations/NeosUiDefaultNodesOperation.php
+++ b/Classes/FlowQueryOperations/NeosUiDefaultNodesOperation.php
@@ -11,6 +11,8 @@ namespace Neos\Neos\Ui\FlowQueryOperations;
  * source code.
  */
 
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Property\PropertyMapper;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Eel\FlowQuery\Operations\AbstractOperation;
@@ -35,6 +37,12 @@ class NeosUiDefaultNodesOperation extends AbstractOperation
     protected static $priority = 100;
 
     /**
+     * @Flow\Inject
+     * @var PropertyMapper
+     */
+    protected $propertyMapper;
+
+    /**
      * {@inheritdoc}
      *
      * @param array (or array-like object) $context onto which this operation should be applied
@@ -55,7 +63,7 @@ class NeosUiDefaultNodesOperation extends AbstractOperation
     public function evaluate(FlowQuery $flowQuery, array $arguments)
     {
         list($siteNode, $documentNode) = $flowQuery->getContext();
-        list($baseNodeType, $loadingDepth, $toggledNodes) = $arguments;
+        list($baseNodeType, $loadingDepth, $toggledNodes, $clipboardNodeContextPath) = $arguments;
 
         // Collect all parents of documentNode up to siteNode
         $parents = [];
@@ -86,6 +94,11 @@ class NeosUiDefaultNodesOperation extends AbstractOperation
 
         if (!in_array($documentNode, $nodes)) {
             $nodes[] = $documentNode;
+        }
+
+        $clipboardNode = $this->propertyMapper->convert($clipboardNodeContextPath, NodeInterface::class);
+        if (!in_array($clipboardNode, $nodes)) {
+            $nodes[] = $clipboardNode;
         }
 
         $flowQuery->setContext($nodes);

--- a/packages/neos-ui-backend-connector/src/FlowQuery/Operations/NeosUiDefaultNodes/index.js
+++ b/packages/neos-ui-backend-connector/src/FlowQuery/Operations/NeosUiDefaultNodes/index.js
@@ -1,4 +1,4 @@
-export default () => (baseNodeType, loadingDepth, toggledNodes) => ({
+export default () => (baseNodeType, loadingDepth, toggledNodes, clipboardNodeContextPath) => ({
     type: 'neosUiDefaultNodes',
-    payload: [baseNodeType, loadingDepth, toggledNodes]
+    payload: [baseNodeType, loadingDepth, toggledNodes, clipboardNodeContextPath]
 });

--- a/packages/neos-ui/src/Sagas/CR/NodeOperations/reloadState.js
+++ b/packages/neos-ui/src/Sagas/CR/NodeOperations/reloadState.js
@@ -8,6 +8,7 @@ export default function * watchReloadState({configuration}) {
     yield takeLatest(actionTypes.CR.Nodes.RELOAD_STATE, function * reloadState(action) {
         const {q} = backend.get();
         const currentSiteNodeContextPath = yield select($get('cr.nodes.siteNode'));
+        const clipboardNodeContextPath = yield select($get('cr.nodes.clipboard'));
         const toggledNodes = yield select($get('ui.pageTree.toggled'));
         const siteNodeContextPath = $get('payload.siteNodeContextPath', action) || currentSiteNodeContextPath;
         const documentNodeContextPath = yield $get('payload.documentNodeContextPath', action) || select($get('ui.contentCanvas.contextPath'));
@@ -15,7 +16,8 @@ export default function * watchReloadState({configuration}) {
         const nodes = yield q([siteNodeContextPath, documentNodeContextPath]).neosUiDefaultNodes(
             configuration.nodeTree.presets.default.baseNodeType,
             configuration.nodeTree.loadingDepth,
-            toggledNodes.toJS()
+            toggledNodes.toJS(),
+            clipboardNodeContextPath
         ).getForTree();
         const nodeMap = nodes.reduce((nodeMap, node) => {
             nodeMap[$get('contextPath', node)] = node;


### PR DESCRIPTION
Fixes: #2000

It's necessary to have clipboard node in store in order to be able to paste it in different dimensions.