### PR TITLE
BUGFIX: force re-render correcly when processing configuration

### DIFF
--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -139,7 +139,7 @@ export default class Inspector extends PureComponent {
         // Eval the view configuration
         this.preprocessViewConfiguration({node: nodeForContext});
         // Force re-render, since we were debounced
-        this.setState({});
+        this.forceUpdate();
     }, 250);
 
     handleCloseSecondaryInspector = () => {


### PR DESCRIPTION
`.setState` on `PureComponent` doesn't force a component update in case if some deep configuration value has changed.

This causes a bug, that the dependant(i.e. client-processed) properties don't get calculated correctly.