### PR TITLE
BUGFIX: replace some exceptions with console errors to make UI feel more robust

### DIFF
--- a/packages/neos-ui-extensibility/src/registry/SynchronousRegistry.js
+++ b/packages/neos-ui-extensibility/src/registry/SynchronousRegistry.js
@@ -46,7 +46,7 @@ export default class SynchronousRegistry extends AbstractRegistry {
     get(key) {
         if (typeof key !== 'string') {
             console.error('Key must be a string');
-            return null;
+            return false;
         }
         const result = this._registry.find(item => item.key === key);
         return result ? result.value : false;
@@ -90,7 +90,7 @@ export default class SynchronousRegistry extends AbstractRegistry {
     has(key) {
         if (typeof key !== 'string') {
             console.error('Key must be a string');
-            return null;
+            return false;
         }
         return this._registry.find(item => item.key === key) && true;
     }

--- a/packages/neos-ui-extensibility/src/registry/SynchronousRegistry.js
+++ b/packages/neos-ui-extensibility/src/registry/SynchronousRegistry.js
@@ -45,7 +45,8 @@ export default class SynchronousRegistry extends AbstractRegistry {
      */
     get(key) {
         if (typeof key !== 'string') {
-            throw new Error('Key must be a string');
+            console.error('Key must be a string');
+            return null;
         }
         const result = this._registry.find(item => item.key === key);
         return result ? result.value : false;
@@ -88,7 +89,8 @@ export default class SynchronousRegistry extends AbstractRegistry {
      */
     has(key) {
         if (typeof key !== 'string') {
-            throw new Error('Key must be a string');
+            console.error('Key must be a string');
+            return null;
         }
         return this._registry.find(item => item.key === key) && true;
     }

--- a/packages/neos-ui/src/Containers/SecondaryToolbar/index.js
+++ b/packages/neos-ui/src/Containers/SecondaryToolbar/index.js
@@ -39,14 +39,18 @@ export default class SecondaryToolbar extends PureComponent {
     };
 
     getToolbarComponent() {
-        const {containerRegistry, currentlyEditedPropertyName, hasFocusedContentNode} = this.props;
+        const {containerRegistry, currentlyEditedPropertyName, hasFocusedContentNode, nodeTypesRegistry, inlineEditorRegistry, focusedNodeTypeName} = this.props;
         const DimensionSwitcher = containerRegistry.get('SecondaryToolbar/DimensionSwitcher');
+
+        // Focused node is not yet in state, we need to wait a bit
+        if (!focusedNodeTypeName) {
+            return null;
+        }
 
         if (!hasFocusedContentNode && !currentlyEditedPropertyName) {
             return DimensionSwitcher;
         }
 
-        const {nodeTypesRegistry, inlineEditorRegistry, focusedNodeTypeName} = this.props;
         const editorIdentifier = nodeTypesRegistry.getInlineEditorIdentifierForProperty(
             focusedNodeTypeName,
             currentlyEditedPropertyName


### PR DESCRIPTION
Fixes: #2057 #1898

We shouldn't be so strict about reading from registries (writing is a different topic), especially since we don't have a proper type system at our disposal.
That causes all sort of runtime exceptions that hit the editors on the head (surrounding them with error boundaries is another topic).

We, the developers would still see that something is wrong just by looking at the console output.