### PR TITLE
BUGFIX: Fix content menu item link in backend

### DIFF
--- a/Resources/Private/Fusion/Backend/Root.fusion
+++ b/Resources/Private/Fusion/Backend/Root.fusion
@@ -193,7 +193,7 @@ backend = Neos.Fusion:Template {
             label = 'Neos.Neos:Main:content'
             icon = 'file'
             uri = Neos.Neos:NodeUri {
-                node = ${sitesForMenu[0]}
+                node = ${site}
             }
             target = 'ContentCanvas'
 

--- a/Resources/Private/Fusion/Backend/Root.fusion
+++ b/Resources/Private/Fusion/Backend/Root.fusion
@@ -193,7 +193,7 @@ backend = Neos.Fusion:Template {
             label = 'Neos.Neos:Main:content'
             icon = 'file'
             uri = Neos.Neos:NodeUri {
-                node = ${q(site).parent().children().get(0)}
+                node = ${sitesForMenu[0]}
             }
             target = 'ContentCanvas'
 


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!
-->

**What I did**

Using [neos-multisitehelper](http://github.com/flownative/neos-multisitehelper), I can limit users to certain sites in a single Neos installation. This then leads to a problem in the backend.

The left-side menu contains the "Content" entry. This header, by default, links to the first available site in the installation. If, however, the current user does not have access to this first site, an error is thrown.

This pull request fixes this issue.

**How I did it**

Use the `sitesForMenu` variable instead of a FlowQuery operation.

**How to verify it**

1. Create a multisite setup (using [neos-multisitehelper](http://github.com/flownative/neos-multisitehelper) and [neos-multisitekickstarter](http://github.com/flownative/neos-multisitekickstarter)).
2. Create two sites.
3. Assign two users to one of each of the sites.
4. Log in to the backend as the user that can access only the second site.
5. With the changes, no error will be thrown.

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
