### PR TITLE
BUGFIX: fix various edgecases regarding switching dimensions

### DIFF
--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
@@ -4,7 +4,7 @@ import {connect} from 'react-redux';
 import {$get} from 'plow-js';
 import mergeClassNames from 'classnames';
 
-import Tree from '@neos-project/react-ui-components/src/Tree/';
+import {Tree, Icon} from '@neos-project/react-ui-components';
 
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {dndTypes} from '@neos-project/neos-ui-constants';
@@ -91,7 +91,11 @@ export default class NodeTree extends PureComponent {
     render() {
         const {rootNode, ChildRenderer} = this.props;
         if (!rootNode) {
-            return (<div>...</div>);
+            return (
+                <div className={style.loader}>
+                    <Icon icon="spinner" spin={true} />
+                </div>
+            );
         }
 
         const classNames = mergeClassNames({

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/style.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/style.css
@@ -4,3 +4,6 @@
     flex: 1 0 0px;
     transition: var(--transition-Slow) ease height, overflow-y var(--transition-Slow);
 }
+.loader {
+    margin: var(--spacing-Half);
+}

--- a/packages/neos-ui/src/manifest.sagas.js
+++ b/packages/neos-ui/src/manifest.sagas.js
@@ -32,6 +32,7 @@ manifest('main.sagas', {}, globalRegistry => {
     sagasRegistry.set('neos-ui/Changes/watchPersist', {saga: changes.watchPersist});
 
     sagasRegistry.set('neos-ui/CR/ContentDimensions/watchSelectPreset', {saga: crContentDimensions.watchSelectPreset});
+    sagasRegistry.set('neos-ui/CR/ContentDimensions/watchSetActive', {saga: crContentDimensions.watchSetActive});
 
     sagasRegistry.set('neos-ui/CR/NodeOperations/addNode', {saga: crNodeOperations.addNode});
     sagasRegistry.set('neos-ui/CR/NodeOperations/copyAndPasteNode', {saga: crNodeOperations.copyAndPasteNode});


### PR DESCRIPTION
If user switched dimensions through inline navigation (and not dimensions selector), then switching dimensions with creating new nodes would be broken.

**Steps to reproduce**

1. Go to front page of the demo site, switch to Latvian via dimensions selector
2. Switch back to English via the site's language menu
3. Go to some other page, e.g. Downloads and switch language to Latvian via dimensions selector, click "Create and copy" (or whatever it's called)

That would end up with a failing ajax request + console errors, and nothing happening.

Also this PR fixes another problem:
1. Navigate to a different dimension via the site's language menu
2. State is not reloaded, e.g. tree doesn't have all needed nodes