### PR TITLE
BUGFIX: Make custom icon classNames possible again

### DIFF
--- a/packages/react-ui-components/src/Icon/mapper.js
+++ b/packages/react-ui-components/src/Icon/mapper.js
@@ -489,11 +489,11 @@ const mapper = icon => {
      *  otherwise the mapping would'nt work for brand icons
      */
     if (icon.startsWith('fas fa-')) {
-        icon = icon.substr(7);
+        icon = icon.substr(7).split(' ')[0];
     }
 
     if (icon.startsWith('icon-')) {
-        icon = icon.substr(5);
+        icon = icon.substr(5).split(' ')[0];
     }
 
     icon = icon.trim();


### PR DESCRIPTION
Fixes: #1994 

**What I did**
Removed the custom className from the icon in the mapper method.

**How I did it**
.split(' ')[0]

**How to verify it**
Create a node with the icon 'fas fa-tag super-important'

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
