### PR TITLE
BUGFIX: Integer validator with trailing chars

### DIFF
--- a/packages/neos-ui-validators/src/Integer/index.js
+++ b/packages/neos-ui-validators/src/Integer/index.js
@@ -7,7 +7,13 @@ import I18n from '@neos-project/neos-ui-i18n';
 const Integer = value => {
     const number = parseInt(value, 10);
 
-    if (value !== null && value !== undefined && value.length !== 0 && !Number.isSafeInteger(number)) {
+    console.log('value', value, 'should be', /^[0-9-]+$/.test(value))
+
+    if (value !== null &&
+        value !== undefined &&
+        value.length !== 0 &&
+        !(/^[0-9-]+$/.test(value)) &&
+        !Number.isSafeInteger(number)) {
         return <I18n id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected"/>;
     }
     return null;

--- a/packages/neos-ui-validators/src/Integer/index.js
+++ b/packages/neos-ui-validators/src/Integer/index.js
@@ -1,19 +1,20 @@
 import React from 'react';
 import I18n from '@neos-project/neos-ui-i18n';
 
+const isNotEmpty = value => {
+    return value !== null && value !== undefined && value.length !== 0;
+};
+
 /**
  * Checks if the given value is a valid Integer number
  */
 const Integer = value => {
     const number = parseInt(value, 10);
 
-    console.log('value', value, 'should be', /^[0-9-]+$/.test(value))
-
-    if (value !== null &&
-        value !== undefined &&
-        value.length !== 0 &&
-        !(/^[0-9-]+$/.test(value)) &&
-        !Number.isSafeInteger(number)) {
+    if (isNotEmpty(value) &&
+        (!Number.isSafeInteger(number) ||
+        // if the value contains other characters than '-' or a digit it's not valid
+        !(/^[\d-]+$/.test(value)))) {
         return <I18n id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected"/>;
     }
     return null;

--- a/packages/neos-ui-validators/src/Integer/index.spec.js
+++ b/packages/neos-ui-validators/src/Integer/index.spec.js
@@ -41,3 +41,7 @@ test('emptyish should pass', () => {
     expect(integerValidator(undefined)).toBe(null);
     expect(integerValidator('')).toBe(null);
 });
+
+test('Number with trailing chars should not be a valid integer', () => {
+    expect(integerValidator('1w')).not.toBe(null);
+});

--- a/packages/neos-ui-validators/src/Integer/index.spec.js
+++ b/packages/neos-ui-validators/src/Integer/index.spec.js
@@ -45,3 +45,7 @@ test('emptyish should pass', () => {
 test('Number with trailing chars should not be a valid integer', () => {
     expect(integerValidator('1w')).not.toBe(null);
 });
+
+test('Number with trailing chars should not be a valid integer(paradox  test case)', () => {
+    expect(integerValidator('1w')).toBe(null);
+});

--- a/packages/neos-ui-validators/src/Integer/index.spec.js
+++ b/packages/neos-ui-validators/src/Integer/index.spec.js
@@ -43,9 +43,13 @@ test('emptyish should pass', () => {
 });
 
 test('Number with trailing chars should not be a valid integer', () => {
-    expect(integerValidator('1w')).not.toBe(null);
+    expect(integerValidator('1a')).not.toBe(null);
 });
 
-test('Number with trailing chars should not be a valid integer(paradox  test case)', () => {
-    expect(integerValidator('1w')).toBe(null);
+test('Number with leading chars should not be a valid integer', () => {
+    expect(integerValidator('a1')).not.toBe(null);
+});
+
+test('Number with chars inside should not be a valid integer', () => {
+    expect(integerValidator('1a1')).not.toBe(null);
 });


### PR DESCRIPTION
closes #2080
So - the error should be somewhere else, not in the validator itself as the test is running through.

Edit:
There is a paradox test case, can someone explain this behaviour?

Ok found it, tests are running but doesn't think these are tests, tests-runner think's tests should be one level deeper:

```
$ yarn jest -- -w 2 --coverage                                                                                                                                                                                                               
$ NODE_ENV=test jest -w 2 --coverage                                                                                                                                                                                                         
No tests found                                                                                                                                                                                                                               
  32 files checked.                                                                                                                                                                                                                          
  roots: /home/maex/projects/contrib/neos-base-distribution/Packages/Application/Neos.Neos.Ui/packages/neos-ui-validators - 32 matches                                                                                                       
  testMatch: ./src/**/?(*.)spec.js - 0 matches                                                                                                                                                                                               
  testPathIgnorePatterns: /node_modules/ - 32 matches\
```

propbably some issue with:  https://github.com/neos/neos-ui/blob/master/packages/jest-preset-neos-ui/jest-preset.json#L18