### PR TITLE
TASK: Make help tooltips translatable

### DIFF
--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -13,7 +13,8 @@ import style from './style.css';
 import {Icon} from '@neos-project/react-ui-components';
 
 @neos(globalRegistry => ({
-    editorRegistry: globalRegistry.get('inspector').get('editors')
+    editorRegistry: globalRegistry.get('inspector').get('editors'),
+    i18nRegistry: globalRegistry.get('i18n')
 }))
 export default class EditorEnvelope extends PureComponent {
     state = {
@@ -34,6 +35,7 @@ export default class EditorEnvelope extends PureComponent {
         renderSecondaryInspector: PropTypes.func,
         editor: PropTypes.string.isRequired,
         editorRegistry: PropTypes.object.isRequired,
+        i18nRegistry: PropTypes.object.isRequired,
         validationErrors: PropTypes.array,
         onEnterKey: PropTypes.func,
         helpMessage: PropTypes.string,
@@ -108,11 +110,13 @@ export default class EditorEnvelope extends PureComponent {
     };
 
     renderHelpmessage() {
-        const {helpMessage, helpThumbnail, label} = this.props;
+        const {i18nRegistry, helpMessage, helpThumbnail, label} = this.props;
+
+        const translatedHelpMessage = i18nRegistry.translate(helpMessage);
 
         return (
             <Tooltip renderInline className={style.envelope__helpmessage}>
-                {helpMessage ? <ReactMarkdown source={helpMessage} /> : ''}
+                {helpMessage ? <ReactMarkdown source={translatedHelpMessage} /> : ''}
                 {helpThumbnail ? <img alt={label} src={helpThumbnail} /> : ''}
             </Tooltip>
         );


### PR DESCRIPTION
fixes: #1947

**What I did**
see title

**How I did it**
Used i18nRegistry to translate given help message

**How to verify it**
Create a property with
      ui:
        help:
          message: 'i18n'

Neos should show the translated value in the tool tip.

<img width="301" alt="bildschirmfoto 2018-08-20 um 21 35 20" src="https://user-images.githubusercontent.com/17990673/44362324-fd96e180-a4c0-11e8-8ec3-20675ded1820.png">


<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
