### PR TITLE
TASK: Render resource paths images in help tooltips

### DIFF
--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -109,15 +109,24 @@ export default class EditorEnvelope extends PureComponent {
         });
     };
 
+    getThumbnailSrc(thumbnail) {
+        if (thumbnail.substr(0, 11) === 'resource://') {
+            thumbnail = '/_Resources/Static/Packages/' + thumbnail.substr(11);
+        }
+
+        return thumbnail;
+    }
+
     renderHelpmessage() {
         const {i18nRegistry, helpMessage, helpThumbnail, label} = this.props;
 
         const translatedHelpMessage = i18nRegistry.translate(helpMessage);
+        const helpThumbnailSrc = this.getThumbnailSrc(helpThumbnail);
 
         return (
             <Tooltip renderInline className={style.envelope__helpmessage}>
                 {helpMessage ? <ReactMarkdown source={translatedHelpMessage} /> : ''}
-                {helpThumbnail ? <img alt={label} src={helpThumbnail} /> : ''}
+                {helpThumbnail ? <img alt={label} src={helpThumbnailSrc} className={style.envelope__helpThumbnail} /> : ''}
             </Tooltip>
         );
     }

--- a/packages/neos-ui-editors/src/EditorEnvelope/style.css
+++ b/packages/neos-ui-editors/src/EditorEnvelope/style.css
@@ -22,5 +22,5 @@
 }
 
 .envelope__helpThumbnail {
-	max-width: 100%;
+    max-width: 100%;
 }

--- a/packages/neos-ui-editors/src/EditorEnvelope/style.css
+++ b/packages/neos-ui-editors/src/EditorEnvelope/style.css
@@ -20,3 +20,7 @@
 .envelope--highlight {
     outline: 2px solid var(--colors-Success);
 }
+
+.envelope__helpThumbnail {
+	max-width: 100%;
+}


### PR DESCRIPTION
fixes: #1948

**What I did**
I added a helper Method which checks if the thumbnail is on a resource path and in case resolves it.
In addition I added a class to the image with style max-width: 100%

**How I did it**


**How to verify it**
Create a property with a help thumbnail.
Absolute URI and resource path should work now

<img width="298" alt="bildschirmfoto 2018-08-22 um 06 31 51" src="https://user-images.githubusercontent.com/17990673/44442894-198ba780-a5d5-11e8-9bf6-2a80f23202b4.png">
