### PR TITLE
BUGFIX: use mousedown event instead of click when focusing a node inline

### DIFF
--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -100,8 +100,16 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
         }
     };
 
-    getGuestFrameDocument().addEventListener('click', e => {
-        focusSelectedNode(e);
+    // We store the original mousedown event in order to prevent bugs like this: https://github.com/neos/neos-ui/issues/1934
+    let mouseDownEvent = null;
+    getGuestFrameDocument().addEventListener('mousedown', event => {
+        mouseDownEvent = event;
+    });
+    getGuestFrameDocument().addEventListener('mouseup', () => {
+        if (mouseDownEvent) {
+            focusSelectedNode(mouseDownEvent);
+        }
+        mouseDownEvent = null;
     });
 
     getGuestFrameDocument().addEventListener('keyup', e => {


### PR DESCRIPTION
Fixes: #1934

See the issue for description.

Alternative solution would be to stop using event delegation of click event, and attach it on actual editable dom nodes, but then we'd need to bind and unbind those events all the time, which is a mess.