### PR TITLE
BUGFIX: Force re generation of moved node names

### DIFF
--- a/Classes/Domain/Model/Changes/AbstractMove.php
+++ b/Classes/Domain/Model/Changes/AbstractMove.php
@@ -13,10 +13,17 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
 
 use Neos\ContentRepository\Domain\Model\Node;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Service as ContentRepository;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\RemoveNode;
+use Neos\Flow\Annotations as Flow;
 
 abstract class AbstractMove extends AbstractStructuralChange
 {
+    /**
+     * @Flow\Inject
+     * @var ContentRepository\NodeServiceInterface
+     */
+    protected $contentRepositoryNodeService;
 
     /**
      * Perform finish tasks - needs to be called from inheriting class on `apply`
@@ -47,5 +54,17 @@ abstract class AbstractMove extends AbstractStructuralChange
             // do a best-effort clone
             return clone $node;
         }
+    }
+
+    /**
+     * Generate a unique node name for the copied node
+     *
+     * @param NodeInterface $parentNode
+     * @return string
+     */
+    protected function generateUniqueNodeName(NodeInterface $parentNode)
+    {
+        return $this->contentRepositoryNodeService
+            ->generateUniqueNodeName($parentNode->getPath());
     }
 }

--- a/Classes/Domain/Model/Changes/MoveAfter.php
+++ b/Classes/Domain/Model/Changes/MoveAfter.php
@@ -43,7 +43,8 @@ class MoveAfter extends AbstractMove
             $before = self::cloneNodeWithNodeData($this->getSubject());
             $parent = $before->getParent();
 
-            $this->getSubject()->moveAfter($this->getSiblingNode());
+            $nodeName = $this->generateUniqueNodeName($this->getSiblingNode()->getParent());
+            $this->getSubject()->moveAfter($this->getSiblingNode(), $nodeName);
 
             $updateParentNodeInfo = new UpdateNodeInfo();
             $updateParentNodeInfo->setNode($parent);

--- a/Classes/Domain/Model/Changes/MoveBefore.php
+++ b/Classes/Domain/Model/Changes/MoveBefore.php
@@ -44,7 +44,8 @@ class MoveBefore extends AbstractMove
             $before = self::cloneNodeWithNodeData($this->getSubject());
             $parent = $before->getParent();
 
-            $this->getSubject()->moveBefore($this->getSiblingNode());
+            $nodeName = $this->generateUniqueNodeName($this->getSiblingNode()->getParent());
+            $this->getSubject()->moveBefore($this->getSiblingNode(), $nodeName);
 
             $updateParentNodeInfo = new UpdateNodeInfo();
             $updateParentNodeInfo->setNode($parent);

--- a/Classes/Domain/Model/Changes/MoveInto.php
+++ b/Classes/Domain/Model/Changes/MoveInto.php
@@ -82,7 +82,8 @@ class MoveInto extends AbstractMove
             $before = self::cloneNodeWithNodeData($this->getSubject());
             $parent = $before->getParent();
 
-            $this->getSubject()->moveInto($this->getParentNode());
+            $nodeName = $this->generateUniqueNodeName($this->getParentNode());
+            $this->getSubject()->moveInto($this->getParentNode(), $nodeName);
 
             $updateParentNodeInfo = new UpdateNodeInfo();
             $updateParentNodeInfo->setNode($parent);


### PR DESCRIPTION
Like in https://github.com/neos/neos-ui/pull/2078 / https://github.com/neos/neos-ui/pull/2091 the problem exists in move actions too, but I've never seen it in real life.

**Important**: Before this PR's changes takes effect, the ContentRepository PR https://github.com/neos/neos-development-collection/pull/2161 needs to be merged too.
Without it does not break, but it changes nothing on the current behaviour if there is really a collision.