### PR TITLE
BUGFIX: Prevent backend inside of client frame in error case

### DIFF
--- a/Classes/Fusion/ExceptionHandler/PageExceptionHandler.php
+++ b/Classes/Fusion/ExceptionHandler/PageExceptionHandler.php
@@ -4,6 +4,7 @@ namespace Neos\Neos\Ui\Fusion\ExceptionHandler;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\ContentStream;
 use Neos\Flow\Http\Response;
+use Neos\Flow\Mvc\View\ViewInterface;
 use Neos\Flow\Utility\Environment;
 use Neos\FluidAdaptor\View\StandaloneView;
 use Neos\Fusion\Core\ExceptionHandlers\AbstractRenderingExceptionHandler;
@@ -40,6 +41,7 @@ class PageExceptionHandler extends AbstractRenderingExceptionHandler
      * @return string
      * @throws \Neos\Flow\Mvc\Exception\StopActionException
      * @throws \Neos\Flow\Security\Exception
+     * @throws \Neos\FluidAdaptor\Exception
      */
     protected function handle($fusionPath, \Exception $exception, $referenceCode)
     {
@@ -66,7 +68,7 @@ class PageExceptionHandler extends AbstractRenderingExceptionHandler
      * @param string $bodyContent
      * @return string
      */
-    protected function wrapHttpResponse(\Exception $exception, $bodyContent)
+    protected function wrapHttpResponse(\Exception $exception, string $bodyContent): string
     {
         $body = fopen('php://temp', 'rw');
         fputs($body, $bodyContent);
@@ -84,9 +86,10 @@ class PageExceptionHandler extends AbstractRenderingExceptionHandler
     /**
      * Prepare a Fluid view for rendering an error page with the Neos backend
      *
-     * @return StandaloneView
+     * @return ViewInterface
+     * @throws \Neos\FluidAdaptor\Exception
      */
-    protected function prepareFluidView()
+    protected function prepareFluidView(): ViewInterface
     {
         $fluidView = new StandaloneView();
         $fluidView->setControllerContext($this->runtime->getControllerContext());

--- a/Classes/Fusion/ExceptionHandler/PageExceptionHandler.php
+++ b/Classes/Fusion/ExceptionHandler/PageExceptionHandler.php
@@ -1,0 +1,98 @@
+<?php
+namespace Neos\Neos\Ui\Fusion\ExceptionHandler;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Http\ContentStream;
+use Neos\Flow\Http\Response;
+use Neos\Flow\Utility\Environment;
+use Neos\FluidAdaptor\View\StandaloneView;
+use Neos\Fusion\Core\ExceptionHandlers\AbstractRenderingExceptionHandler;
+use Neos\Fusion\Core\ExceptionHandlers\HtmlMessageHandler;
+use Neos\Neos\Fusion\ExceptionHandlers\PageHandler;
+use Neos\Neos\Ui\Fusion\Helper\ActivationHelper;
+
+/**
+ * A page exception handler for the new UI.
+ *
+ * FIXME: When the old UI is removed this handler needs to be untangled from the PageHandler as the parent functionality is no longer needed.
+ * FIXME: We should adapt rendering to requested "format" at some point
+ */
+class PageExceptionHandler extends AbstractRenderingExceptionHandler
+{
+    /**
+     * @Flow\Inject
+     * @var ActivationHelper
+     */
+    protected $activationHelper;
+
+    /**
+     * @Flow\Inject
+     * @var Environment
+     */
+    protected $environment;
+
+    /**
+     * Handle an exception by displaying an error message inside the Neos backend, if logged in and not displaying the live workspace.
+     *
+     * @param string $fusionPath path causing the exception
+     * @param \Exception $exception exception to handle
+     * @param integer $referenceCode
+     * @return string
+     * @throws \Neos\Flow\Mvc\Exception\StopActionException
+     * @throws \Neos\Flow\Security\Exception
+     */
+    protected function handle($fusionPath, \Exception $exception, $referenceCode)
+    {
+        if ($this->activationHelper->isLegacyBackendEnabled()) {
+            $handler = new PageHandler();
+            return $handler->handleRenderingException($fusionPath, $exception);
+        }
+
+        $handler = new HtmlMessageHandler($this->environment->getContext()->isDevelopment());
+        $handler->setRuntime($this->runtime);
+        $output = $handler->handleRenderingException($fusionPath, $exception);
+        $fluidView = $this->prepareFluidView();
+        $fluidView->assignMultiple([
+            'message' => $output
+        ]);
+
+        return $this->wrapHttpResponse($exception, $fluidView->render());
+    }
+
+    /**
+     * Renders an actual HTTP response including the correct status and cache control header.
+     *
+     * @param \Exception the exception
+     * @param string $bodyContent
+     * @return string
+     */
+    protected function wrapHttpResponse(\Exception $exception, $bodyContent)
+    {
+        $body = fopen('php://temp', 'rw');
+        fputs($body, $bodyContent);
+        rewind($body);
+
+        /** @var Response $response */
+        $response = (new Response())
+            ->withStatus($exception instanceof FlowException ? $exception->getStatusCode() : 500)
+            ->withBody(new ContentStream($body))
+            ->withHeader('Cache-Control', 'no-store');
+
+        return implode("\r\n", $response->renderHeaders()) . "\r\n\r\n" . $response->getContent();
+    }
+
+    /**
+     * Prepare a Fluid view for rendering an error page with the Neos backend
+     *
+     * @return StandaloneView
+     */
+    protected function prepareFluidView()
+    {
+        $fluidView = new StandaloneView();
+        $fluidView->setControllerContext($this->runtime->getControllerContext());
+        $fluidView->setFormat('html');
+        $fluidView->setTemplatePathAndFilename('resource://Neos.Neos.Ui/Private/Templates/Error/ErrorMessage.html');
+
+        return $fluidView;
+    }
+}

--- a/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -117,4 +117,6 @@ prototype(Neos.Neos:Page) {
         }
         node = ${node}
     }
+
+    @exceptionHandler = 'Neos\\Neos\\Ui\\Fusion\\ExceptionHandler\\PageExceptionHandler'
 }

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -1,1 +1,6 @@
 include: Prototypes/*.fusion
+
+root {
+    # Catch all unhandled exceptions at the root
+    @exceptionHandler = 'Neos\\Neos\\Ui\\Fusion\\ExceptionHandler\\PageExceptionHandler'
+}

--- a/Resources/Private/Templates/Error/ErrorMessage.html
+++ b/Resources/Private/Templates/Error/ErrorMessage.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Neos Error</title>
+    <link rel="stylesheet" href="{f:uri.resource(path: 'Styles/Error.css', package: 'Neos.Neos')}"/>
+</head>
+<body class="neos">
+    <div class="neos-error-screen">{message -> f:format.raw()}</div>
+</body>
+</html>


### PR DESCRIPTION
The old backend would show up inside the client frame in case a
rendering exception happened. The reason is the PageHandler in Neos
which just renders a (legacy) backend around the error message because
that was the only way the legacy backend could still work in case
of an error. This leads to the backend in backend problem and can be
avoided by a custom error handler for the new UI that replaces the
old one.
