### PR TITLE
TASK: Update @friendsofreactjs/react-css-themr

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.2.0",
     "@fortawesome/free-solid-svg-icons": "^5.2.0",
     "@fortawesome/react-fontawesome": "^0.1.1",
-    "@friendsofreactjs/react-css-themr": "^3.0.1",
+    "@friendsofreactjs/react-css-themr": "^3.3.2",
     "@neos-project/brand": "^1.1.0",
     "amator": "^1.0.1",
     "classnames": "^2.2.3",

--- a/packages/react-ui-components/package.json
+++ b/packages/react-ui-components/package.json
@@ -30,7 +30,7 @@
     "webpack-merge": "^4.1.1"
   },
   "peerDependencies": {
-    "@friendsofreactjs/react-css-themr": "^3.0.0",
+    "@friendsofreactjs/react-css-themr": "^3.3.2",
     "@neos-project/utils-redux": "^4.4.8",
     "classnames": "^2.2.3",
     "lodash.debounce": "^4.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -262,18 +262,11 @@
     "@ckeditor/ckeditor5-ui" "^11.0.0"
     "@ckeditor/ckeditor5-utils" "^10.2.0"
 
-"@ckeditor/ckeditor5-engine@^10.0.0", "@ckeditor/ckeditor5-engine@^10.1.0", "@ckeditor/ckeditor5-engine@^10.2.0":
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-10.2.0.tgz#f4cf448c0482233557f48d4b9a97baa571c0e9cc"
-  dependencies:
-    "@ckeditor/ckeditor5-utils" "^10.2.0"
-
-"@ckeditor/ckeditor5-engine@dimaip/ckeditor5-engine#iframe":
+"@ckeditor/ckeditor5-engine@^10.0.0", "@ckeditor/ckeditor5-engine@^10.1.0", "@ckeditor/ckeditor5-engine@^10.2.0", "@ckeditor/ckeditor5-engine@dimaip/ckeditor5-engine#iframe":
   version "10.2.0"
   resolved "https://codeload.github.com/dimaip/ckeditor5-engine/tar.gz/c0d426f95cc75d966fe11cf9f000f236213ff404"
   dependencies:
     "@ckeditor/ckeditor5-utils" "^10.2.0"
-    lodash-es "^4.17.10"
 
 "@ckeditor/ckeditor5-enter@^10.1.1":
   version "10.1.1"
@@ -436,9 +429,9 @@
     humps "^2.0.1"
     prop-types "^15.5.10"
 
-"@friendsofreactjs/react-css-themr@^3.0.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@friendsofreactjs/react-css-themr/-/react-css-themr-3.3.1.tgz#8ccb67027dd7640a43a8cc9320b2420355010e4f"
+"@friendsofreactjs/react-css-themr@^3.3.2":
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/@friendsofreactjs/react-css-themr/-/react-css-themr-3.3.2.tgz#03087b52a2bb0df15f4d27ac013dcab555a68dd0"
   dependencies:
     hoist-non-react-statics "^3.0.1"
     invariant "^2.2.4"
@@ -6996,7 +6989,7 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.17.10, lodash-es@^4.17.5, lodash-es@^4.2.1, lodash-es@~4.17.4:
+lodash-es@^4.17.5, lodash-es@^4.2.1, lodash-es@~4.17.4:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.10.tgz#62cd7104cdf5dd87f235a837f0ede0e8e5117e05"
 


### PR DESCRIPTION
Now using version 3.3.2 for possible typescript usage.
The issue #2102 needs the TS compatible version of @friendsofreactjs/react-css-themr. So this updates to the latest version.

Resolves: #2103 
