### PR TITLE
TASK: Rework Help Message in SelectNodeType Dialog

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
@@ -2,13 +2,10 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {$get} from 'plow-js';
-import ReactMarkdown from 'react-markdown';
 
 import {neos} from '@neos-project/neos-ui-decorators';
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 
-import Icon from '@neos-project/react-ui-components/src/Icon/';
-import IconButton from '@neos-project/react-ui-components/src/IconButton/';
 import Button from '@neos-project/react-ui-components/src/Button/';
 import Dialog from '@neos-project/react-ui-components/src/Dialog/';
 import I18n from '@neos-project/neos-ui-i18n';
@@ -70,6 +67,7 @@ export default class SelectNodeType extends PureComponent {
             this.props.allowedSiblingNodeTypes,
             this.props.allowedChildNodeTypes
         ),
+        activeHelpMessageGroupPanel: '',
         showHelpMessageFor: ''
     };
 
@@ -101,6 +99,19 @@ export default class SelectNodeType extends PureComponent {
 
         apply(insertMode, nodeType);
     };
+
+    handleCloseHelpMessage = () => {
+        this.setState({
+            showHelpMessageFor: ''
+        });
+    }
+
+    handleHelpMessage = (nodeType, groupPanel) => {
+        this.setState({
+            showHelpMessageFor: nodeType === this.state.showHelpMessageFor ? '' : nodeType,
+            activeHelpMessageGroupPanel: groupPanel
+        });
+    }
 
     getAllowedNodeTypesByCurrentInsertMode() {
         const {insertMode} = this.state;
@@ -154,48 +165,8 @@ export default class SelectNodeType extends PureComponent {
 
     handleNodeTypeFilterChange = filterSearchTerm => this.setState({filterSearchTerm});
 
-    renderHelpMessage = () => {
-        const {showHelpMessageFor} = this.state;
-        const {nodeTypesRegistry} = this.props;
-
-        const nodeType = nodeTypesRegistry.getNodeType(showHelpMessageFor);
-        const message = $get('ui.help.message', nodeType);
-
-        const icon = $get('ui.icon', nodeType);
-        const label = $get('ui.label', nodeType);
-
-        return (
-            <div className={style.helpMessage__wrapper}>
-                <div className={style.helpMessage}>
-                    <span className={style.helpMessage__label}>
-                        {icon && <Icon icon={icon} className={style.nodeType__icon} padded="right"/>}
-                        <I18n id={label} fallback={label}/>
-                    </span>
-                    <ReactMarkdown source={message} />
-                </div>
-
-                <IconButton className={style.helpMessage__closeButton} icon="times" onClick={() => this.handleCloseHelpMessage()} />
-            </div>
-        );
-    }
-
-    handleCloseHelpMessage = () => {
-        this.setState({
-            showHelpMessageFor: ''
-        });
-    }
-
-    handleHelpMessage = nodeType => {
-        this.setState({
-            showHelpMessageFor: nodeType === this.state.showHelpMessageFor ? '' : nodeType
-        });
-    }
-
     render() {
         const {isOpen} = this.props;
-        const {showHelpMessageFor} = this.state;
-
-        const showHelpMessage = showHelpMessageFor !== '';
 
         if (!isOpen) {
             return null;
@@ -203,7 +174,6 @@ export default class SelectNodeType extends PureComponent {
 
         return (
             <Dialog
-                className={showHelpMessage ? style.dialog__padded : ''}
                 actions={[this.renderCancelAction()]}
                 title={[this.renderSelectNodeTypeDialogHeader()]}
                 onRequestClose={this.handleCancel}
@@ -217,11 +187,13 @@ export default class SelectNodeType extends PureComponent {
                             group={group}
                             filterSearchTerm={this.state.filterSearchTerm}
                             onSelect={this.handleApply}
+                            showHelpMessageFor ={this.state.showHelpMessageFor}
+                            activeHelpMessageGroupPanel ={this.state.activeHelpMessageGroupPanel}
                             onHelpMessage={this.handleHelpMessage}
+                            onCloseHelpMessage={this.handleCloseHelpMessage}
                             />
                     </div>
                 ))}
-                {showHelpMessage ? this.renderHelpMessage() : null}
             </Dialog>
         );
     }

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeGroupPanel.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeGroupPanel.js
@@ -48,6 +48,27 @@ class NodeTypeGroupPanel extends PureComponent {
         i18nRegistry: PropTypes.object.isRequired
     };
 
+    componentDidUpdate() {
+        this.scrollIntoView();
+    }
+
+    scrollIntoView() {
+        const {
+            showHelpMessageFor,
+            activeHelpMessageGroupPanel,
+            group
+        } = this.props;
+
+        if (showHelpMessageFor !== '' && activeHelpMessageGroupPanel !== group.name) {
+            const helpMessage = document.querySelector('#nodeTypeGroupPanelhelpMessage');
+            const scrollParent = document.getElementById('neos-SelectNodeTypeDialog').querySelector('.dialog__body');
+
+            if (helpMessage && scrollParent && scrollParent.getBoundingClientRect().bottom < helpMessage.getBoundingClientRect().top + 100) {
+                scrollParent.scrollTop += helpMessage.getBoundingClientRect().bottom - scrollParent.getBoundingClientRect().bottom;
+            }
+        }
+    }
+
     renderHelpMessage = () => {
         const {
             i18nRegistry,
@@ -70,7 +91,7 @@ class NodeTypeGroupPanel extends PureComponent {
         }
 
         return (
-            <div className={style.helpMessage__wrapper}>
+            <div className={style.helpMessage__wrapper} id="nodeTypeGroupPanelhelpMessage">
                 <div className={style.helpMessage}>
                     <span className={style.helpMessage__label}>
                         {icon && <Icon icon={icon} className={style.nodeType__icon} padded="right"/>}

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeItem.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeItem.js
@@ -25,7 +25,8 @@ class NodeTypeItem extends PureComponent {
         nodeType: PropTypes.shape({
             name: PropTypes.string.isRequired,
             ui: PropTypes.object
-        }).isRequired
+        }).isRequired,
+        groupName: PropTypes.string.isRequired
     };
 
     render() {
@@ -33,7 +34,7 @@ class NodeTypeItem extends PureComponent {
         const icon = $get('icon', ui);
         const label = $get('label', ui);
         const helpMessage = $get('help.message', ui);
-        const {onHelpMessage} = this.props;
+        const {onHelpMessage, groupName} = this.props;
 
         return (
             <div className={style.nodeType}>
@@ -49,7 +50,7 @@ class NodeTypeItem extends PureComponent {
                         <I18n id={label} fallback={label}/>
                     </span>
                 </Button>
-                {helpMessage ? <IconButton className={style.nodeType__helpIcon} onClick={() => onHelpMessage(name)} icon="question-circle" /> : null}
+                {helpMessage ? <IconButton className={style.nodeType__helpIcon} onClick={() => onHelpMessage(name, groupName)} icon="question-circle" /> : null}
             </div>
         );
     }

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/style.css
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/style.css
@@ -1,7 +1,3 @@
-.dialog__padded {
-    padding-bottom: 80px;
-}
-
 .nodeType {
     width: calc(100% / 3);
     text-align: left;
@@ -45,20 +41,15 @@
 
 .helpMessage__wrapper {
     position: relative;
-    height: 120px;
+    width: 100%;
     background-color: var(--colors-ContrastDark);
+    clear: right;
 }
 
 .helpMessage {
-    position: absolute;
     background-color: var(--colors-ContrastDark);
-    left: 0;
-    right: 0;
-    bottom: 0;
     border-top: 1px solid var(--colors-ContrastDark);
     padding: var(--spacing-Full);
-    height: 120px;
-    overflow: scroll;
 }
 
 .helpMessage__label {
@@ -70,6 +61,13 @@
     right: 1px;
     top: 1px;
     background-color: var(--colors-ContrastDark);
+}
+
+.helpThumbnail {
+    float: right;
+    max-width: 342px;
+    margin-bottom: 16px;
+    margin-left: 16px;
 }
 /* TODO: refactor such typography things to Headline component */
 .groupHeader {

--- a/packages/react-ui-components/src/Dialog/dialog.js
+++ b/packages/react-ui-components/src/Dialog/dialog.js
@@ -89,6 +89,10 @@ class DialogWithoutEscape extends PureComponent {
             [theme['dialog--narrow']]: style === 'narrow',
             [className]: className && className.length
         });
+        const finalClassNameBody = mergeClassNames({
+            [theme.dialog__body]: true,
+            'dialog__body': true
+        });
 
         return (
             <Portal isOpened={isOpen}>
@@ -106,7 +110,7 @@ class DialogWithoutEscape extends PureComponent {
                                 {title}
                             </div>
 
-                            <div className={theme.dialog__body}>
+                            <div className={finalClassNameBody}>
                                 {children}
                             </div>
 


### PR DESCRIPTION
**What I did**

- Added support for translation

- Moved the help message from the bottom of the dialog to the bottom of the NodeType Groups

- Added support for thumbnails (currently just absolute paths - resource path resolving has to be done inside the neos package)

- Removed the fixed height of the message to improve display of thumbnails

**How I did it**

- Moved the help message part from index.js to nodeTypeGroupPanel.js

- Added an additional class to the Dialog component to query select the dialog body
- modified help css

**How to verify it**
- add help properties to a nodeType in your yaml (message + thumbnail with absolute path)

![ezgif com-video-to-gif-2](https://user-images.githubusercontent.com/17990673/44622228-d5d6bd80-a8b4-11e8-886b-f90c3e16537e.gif)

This fixes: #2086
and partly: #2088