### PR TITLE
TASK: Adjust animation speed to make UI feel more responsive

### DIFF
--- a/packages/build-essentials/src/styles/styleConstants.js
+++ b/packages/build-essentials/src/styles/styleConstants.js
@@ -13,7 +13,7 @@ const config = {
     },
     transition: {
         fast: '.1s',
-        default: '.3s',
+        default: '.25s',
         slow: '.5s'
     },
     zIndex: {

--- a/packages/neos-ui/src/Containers/LeftSideBar/style.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/style.css
@@ -4,7 +4,7 @@
     flex-basis: 100%;
 
     padding-top: 41px;
-    transition: var(--transition-Default)  ease transform;
+    transition: var(--transition-Default) ease transform;
     will-change: transform;
 
     &:before,
@@ -30,7 +30,7 @@
 
 .leftSideBar__bottom {
     flex: 0 0 50%;
-    transition: flex-basis var(--transition-Slow), height var(--transition-Slow), overflow-y var(--transition-Slow);
+    transition: flex-basis var(--transition-Default), height var(--transition-Default), overflow-y var(--transition-Default);
     display: flex;
     flex-direction: column;
     min-height: 40px;

--- a/packages/neos-ui/src/Containers/SecondaryToolbar/style.css
+++ b/packages/neos-ui/src/Containers/SecondaryToolbar/style.css
@@ -13,7 +13,7 @@
     transition: var(--transition-Fast) ease-in-out;
 }
 .secondaryToolbar--isMovedDown {
-    transform: translateY(110px);  /* height of EditModePanel - 41px added */
+    transform: translateY(110px); /* height of EditModePanel - 41px added */
 }
 .secondaryToolbar--isFringeLeft {
     padding-left: 0;

--- a/packages/react-ui-components/src/ToggablePanel/style.css
+++ b/packages/react-ui-components/src/ToggablePanel/style.css
@@ -26,7 +26,7 @@
 .panel__contents {
     composes: reset from './../reset.css';
     padding: 0 var(--spacing-Full);
-    transition: var(--transition-Slow) ease padding;
+    transition: var(--transition-Default) ease padding;
 
     .panel--isOpen & {
         padding-top: 5px;

--- a/packages/react-ui-components/src/ToggablePanel/toggablePanel.js
+++ b/packages/react-ui-components/src/ToggablePanel/toggablePanel.js
@@ -287,7 +287,7 @@ export class Contents extends PureComponent {
         });
 
         return (
-            <Collapse isOpened={isPanelOpen}>
+            <Collapse isOpened={isPanelOpen} springConfig={{stiffness: 300, damping: 30}}>
                 <div className={finalClassName} aria-hidden={isPanelOpen ? 'false' : 'true'}>
                     {children}
                 </div>


### PR DESCRIPTION
**What I did**
Increases the transition speed of a couple animations to make the UI feel more responsive and avoid waiting on animations to finish.

**How to verify it**
Toggle collapsed state of inspector panels, menu groups and content tree.