### PR TITLE
FEATURE: Remember collapsed state of menu groups

### DIFF
--- a/packages/neos-ui-redux-store/src/UI/Drawer/index.js
+++ b/packages/neos-ui-redux-store/src/UI/Drawer/index.js
@@ -1,5 +1,5 @@
 import {createAction} from 'redux-actions';
-import Immutable from 'immutable';
+import {Map} from 'immutable';
 import {$toggle, $get, $set} from 'plow-js';
 
 import {handleActions} from '@neos-project/utils-redux';
@@ -8,13 +8,15 @@ import {actionTypes as system} from '../../System/index';
 
 const TOGGLE = '@neos/neos-ui/UI/Drawer/TOGGLE';
 const HIDE = '@neos/neos-ui/UI/Drawer/HIDE';
+const TOGGLE_MENU_GROUP = '@neos/neos-ui/UI/Drawer/TOGGLE_MENU_GROUP';
 
 //
 // Export the action types
 //
 export const actionTypes = {
     TOGGLE,
-    HIDE
+    HIDE,
+    TOGGLE_MENU_GROUP
 };
 
 /**
@@ -27,24 +29,34 @@ const toggle = createAction(TOGGLE);
  */
 const hide = createAction(HIDE);
 
+/**
+ * Toggles collapsed state of a menu group.
+ */
+const toggleMenuGroup = createAction(TOGGLE_MENU_GROUP, menuGroup => ({menuGroup}));
+
 //
 // Export the actions
 //
 export const actions = {
     toggle,
-    hide
+    hide,
+    toggleMenuGroup
 };
 
 //
 // Export the reducer
 //
 export const reducer = handleActions({
-    [system.INIT]: payload => $set(
+    [system.INIT]: state => $set(
         'ui.drawer',
-        Immutable.fromJS($get('ui.drawer', payload) ? $get('ui.drawer', payload) : {isHidden: true})
+        new Map({
+            isHidden: $get('ui.drawer.isHidden', state) ? $get('ui.drawer.isHidden', state) : false,
+            collapsedMenuGroups: $get('ui.drawer.collapsedMenuGroups', state) ? $get('ui.drawer.collapsedMenuGroups', state) : ['content']
+        })
     ),
     [TOGGLE]: () => $toggle('ui.drawer.isHidden'),
-    [HIDE]: () => $set('ui.drawer.isHidden', true)
+    [HIDE]: () => $set('ui.drawer.isHidden', true),
+    [TOGGLE_MENU_GROUP]: ({menuGroup}) => $toggle('ui.drawer.collapsedMenuGroups', menuGroup)
 });
 
 //

--- a/packages/neos-ui-redux-store/src/UI/Drawer/index.spec.js
+++ b/packages/neos-ui-redux-store/src/UI/Drawer/index.spec.js
@@ -8,12 +8,14 @@ test(`should export actionTypes`, () => {
     expect(actionTypes).not.toBe(undefined);
     expect(typeof (actionTypes.TOGGLE)).toBe('string');
     expect(typeof (actionTypes.HIDE)).toBe('string');
+    expect(typeof (actionTypes.TOGGLE_MENU_GROUP)).toBe('string');
 });
 
 test(`should export action creators`, () => {
     expect(actions).not.toBe(undefined);
     expect(typeof (actions.toggle)).toBe('function');
     expect(typeof (actions.hide)).toBe('function');
+    expect(typeof (actions.toggleMenuGroup)).toBe('function');
 });
 
 test(`should export a reducer`, () => {
@@ -67,4 +69,35 @@ test(`The "hide" action should set the "isHidden" key to "true".`, () => {
 
     expect(nextState1.get('ui').get('drawer').get('isHidden')).toBe(true);
     expect(nextState2.get('ui').get('drawer').get('isHidden')).toBe(true);
+});
+
+test(`The reducer should initially mark the menu group "content" as collapsed.`, () => {
+    const state = new Map({});
+    const nextState = reducer(state, {
+        type: system.INIT
+    });
+
+    expect(nextState.get('ui').get('drawer').get('collapsedMenuGroups').includes('content')).toBe(true);
+});
+
+test(`The "toggleMenuGroup" action should add or remove given group from "collapsedMenuGroups".`, () => {
+    const state = Immutable.fromJS({
+        ui: {
+            drawer: {
+                collapsedMenuGroups: []
+            }
+        }
+    });
+    const nextState1 = reducer(state, actions.toggleMenuGroup('content'));
+    const nextState2 = reducer(nextState1, actions.toggleMenuGroup('management'));
+    const nextState3 = reducer(nextState2, actions.toggleMenuGroup('content'));
+    const nextState4 = reducer(nextState3, actions.toggleMenuGroup('management'));
+
+    expect(nextState1.get('ui').get('drawer').get('collapsedMenuGroups').includes('content')).toBe(true);
+    expect(nextState2.get('ui').get('drawer').get('collapsedMenuGroups').includes('content')).toBe(true);
+    expect(nextState2.get('ui').get('drawer').get('collapsedMenuGroups').includes('management')).toBe(true);
+    expect(nextState3.get('ui').get('drawer').get('collapsedMenuGroups').includes('content')).toBe(false);
+    expect(nextState3.get('ui').get('drawer').get('collapsedMenuGroups').includes('management')).toBe(true);
+    expect(nextState4.get('ui').get('drawer').get('collapsedMenuGroups').includes('content')).toBe(false);
+    expect(nextState4.get('ui').get('drawer').get('collapsedMenuGroups').includes('management')).toBe(false);
 });

--- a/packages/neos-ui/src/Containers/Drawer/MenuItemGroup/index.js
+++ b/packages/neos-ui/src/Containers/Drawer/MenuItemGroup/index.js
@@ -17,6 +17,8 @@ export default class MenuItemGroup extends PureComponent {
         label: PropTypes.string.isRequired,
         uri: PropTypes.string.isRequired,
         target: PropTypes.string,
+        collapsed: PropTypes.bool.isRequired,
+        handleMenuGroupToggle: PropTypes.func.isRequired,
 
         children: PropTypes.arrayOf(
             PropTypes.shape({
@@ -24,7 +26,7 @@ export default class MenuItemGroup extends PureComponent {
                 label: PropTypes.string.isRequired,
                 uri: PropTypes.string,
                 target: PropTypes.string,
-                isActive: PropTypes.bool.isReqired,
+                isActive: PropTypes.bool.isRequired,
                 skipI18n: PropTypes.bool
             })
         ),
@@ -40,7 +42,7 @@ export default class MenuItemGroup extends PureComponent {
     }
 
     render() {
-        const {label, icon, children, onChildClick, target, uri} = this.props;
+        const {label, icon, children, onChildClick, target, uri, collapsed, handleMenuGroupToggle} = this.props;
 
         const headerButton = (
             <Button
@@ -58,7 +60,7 @@ export default class MenuItemGroup extends PureComponent {
         const header = (target === TARGET_WINDOW ? <a href={uri}>{headerButton}</a> : headerButton);
 
         return (
-            <ToggablePanel isOpen={true} style="condensed" className={style.drawer__menuItem}>
+            <ToggablePanel onPanelToggle={handleMenuGroupToggle} isOpen={!collapsed} style="condensed" className={style.drawer__menuItem}>
                 <ToggablePanel.Header className={style.drawer__menuItem__header}>
                     {header}
                 </ToggablePanel.Header>

--- a/packages/neos-ui/src/Containers/Drawer/index.js
+++ b/packages/neos-ui/src/Containers/Drawer/index.js
@@ -12,15 +12,20 @@ import style from './style.css';
 import {TARGET_WINDOW, TARGET_CONTENT_CANVAS, THRESHOLD_MOUSE_LEAVE} from './constants';
 
 @connect($transform({
-    isHidden: $get('ui.drawer.isHidden')
+    isHidden: $get('ui.drawer.isHidden'),
+    collapsedMenuGroups: $get('ui.drawer.collapsedMenuGroups')
 }), {
     hideDrawer: actions.UI.Drawer.hide,
+    toggleMenuGroup: actions.UI.Drawer.toggleMenuGroup,
     setContentCanvasSrc: actions.UI.ContentCanvas.setSrc
 })
 export default class Drawer extends PureComponent {
     static propTypes = {
         isHidden: PropTypes.bool.isRequired,
+        collapsedMenuGroups: PropTypes.array.isRequired,
+
         hideDrawer: PropTypes.func.isRequired,
+        toggleMenuGroup: PropTypes.func.isRequired,
         setContentCanvasSrc: PropTypes.func.isRequired,
 
         menuData: PropTypes.objectOf(
@@ -96,7 +101,7 @@ export default class Drawer extends PureComponent {
     }
 
     render() {
-        const {isHidden, menuData} = this.props;
+        const {isHidden, menuData, collapsedMenuGroups, toggleMenuGroup} = this.props;
         const classNames = mergeClassNames({
             [style.drawer]: true,
             [style['drawer--isHidden']]: isHidden
@@ -113,12 +118,14 @@ export default class Drawer extends PureComponent {
                 aria-hidden={isHidden ? 'true' : 'false'}
                 >
                 <div className={style.drawer__menuItemGroupsWrapper}>
-                    {!isHidden && Object.values(menuData).map((item, index) => (
+                    {!isHidden && Object.entries(menuData).map(([menuGroup, menuGroupConfiguration]) => (
                         <MenuItemGroup
-                            key={index}
+                            key={menuGroup}
                             onClick={this.handleMenuItemClick}
                             onChildClick={this.handleMenuItemClick}
-                            {...item}
+                            collapsed={Boolean(collapsedMenuGroups.includes(menuGroup))}
+                            handleMenuGroupToggle={() => toggleMenuGroup(menuGroup)}
+                            {...menuGroupConfiguration}
                             />
                     ))}
                 </div>

--- a/packages/neos-ui/src/localStorageMiddleware.js
+++ b/packages/neos-ui/src/localStorageMiddleware.js
@@ -12,7 +12,8 @@ const localStorageMiddleware = ({getState}) => {
     const persistentActionsPatterns = [
         '@neos/neos-ui/UI/LeftSideBar/TOGGLE',
         '@neos/neos-ui/UI/LeftSideBar/TOGGLE_CONTENT_TREE',
-        '@neos/neos-ui/UI/RightSidebar/TOGGLE'
+        '@neos/neos-ui/UI/RightSidebar/TOGGLE',
+        '@neos/neos-ui/UI/Drawer/TOGGLE_MENU_GROUP'
     ];
 
     return next => action => {
@@ -29,6 +30,9 @@ const localStorageMiddleware = ({getState}) => {
                 // TODO: figure out a more declarative way to manage this. Or just move all persistent state under "ui"
                 const persistentStateSubset = {
                     ui: {
+                        drawer: {
+                            collapsedMenuGroups: $get('ui.drawer.collapsedMenuGroups', state)
+                        },
                         leftSideBar: {
                             isHidden: $get('ui.leftSideBar.isHidden', state),
                             contentTree: {


### PR DESCRIPTION
**What I did**
Implemented state handling with local storage persisting for menu group collapsed states.

**How to verify it**
Check that the collapsed state of the menu groups is kept after re-opening the menu, even after reloading the UI.

