### PR TITLE
BUGFIX: Prevent NodeToolbar from crashing if focused node not in DOM

### DIFF
--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
@@ -69,9 +69,7 @@ export default class NodeToolbar extends PureComponent {
 
     componentDidMount() {
         this.iframeWindow.addEventListener('resize', this.debouncedUpdate);
-
         this.iframeWindow.addEventListener('scroll', this.debouncedSticky);
-
         this.iframeWindow.addEventListener('load', this.debouncedUpdate);
 
         this.scrollIntoView();

--- a/packages/neos-ui-guest-frame/src/InlineUI/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/index.js
@@ -4,7 +4,6 @@ import {connect} from 'react-redux';
 import {$transform, $get, $contains} from 'plow-js';
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {neos} from '@neos-project/neos-ui-decorators';
-import {findNodeInGuestFrame} from '@neos-project/neos-ui-guest-frame/src/dom';
 import NodeToolbar from './NodeToolbar/index';
 
 import style from './style.css';
@@ -49,7 +48,7 @@ export default class InlineUI extends PureComponent {
         const canBeEdited = $get('policy.canEdit', this.props.focusedNode) || false;
         const visibilityCanBeToggled = !$contains('_hidden', 'policy.disallowedProperties', this.props.focusedNode);
 
-        return (findNodeInGuestFrame(focusedNodeContextPath) &&
+        return (
             <div className={style.inlineUi} data-__neos__inline-ui="TRUE">
                 <NodeToolbar
                     shouldScrollIntoView={shouldScrollIntoView}

--- a/packages/neos-ui-guest-frame/src/InlineUI/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/index.js
@@ -4,6 +4,7 @@ import {connect} from 'react-redux';
 import {$transform, $get, $contains} from 'plow-js';
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {neos} from '@neos-project/neos-ui-decorators';
+
 import NodeToolbar from './NodeToolbar/index';
 
 import style from './style.css';

--- a/packages/neos-ui-guest-frame/src/InlineUI/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/index.js
@@ -48,10 +48,8 @@ export default class InlineUI extends PureComponent {
         const canBeDeleted = $get('policy.canRemove', this.props.focusedNode) || false;
         const canBeEdited = $get('policy.canEdit', this.props.focusedNode) || false;
         const visibilityCanBeToggled = !$contains('_hidden', 'policy.disallowedProperties', this.props.focusedNode);
-        // Check if focusedNode is in Guest frame to prevent errors (e.g. if still in store)
-        const focusedNodeInGuestFrame = findNodeInGuestFrame(focusedNodeContextPath) ? focused : {};
 
-        return (
+        return (findNodeInGuestFrame(focusedNodeContextPath) &&
             <div className={style.inlineUi} data-__neos__inline-ui="TRUE">
                 <NodeToolbar
                     shouldScrollIntoView={shouldScrollIntoView}
@@ -62,7 +60,7 @@ export default class InlineUI extends PureComponent {
                     canBeDeleted={canBeDeleted}
                     canBeEdited={canBeEdited}
                     visibilityCanBeToggled={visibilityCanBeToggled}
-                    {...focusedNodeInGuestFrame}
+                    {...focused}
                     />
             </div>
         );

--- a/packages/neos-ui-guest-frame/src/InlineUI/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/index.js
@@ -4,7 +4,7 @@ import {connect} from 'react-redux';
 import {$transform, $get, $contains} from 'plow-js';
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {neos} from '@neos-project/neos-ui-decorators';
-
+import {findNodeInGuestFrame} from '@neos-project/neos-ui-guest-frame/src/dom';
 import NodeToolbar from './NodeToolbar/index';
 
 import style from './style.css';
@@ -48,6 +48,8 @@ export default class InlineUI extends PureComponent {
         const canBeDeleted = $get('policy.canRemove', this.props.focusedNode) || false;
         const canBeEdited = $get('policy.canEdit', this.props.focusedNode) || false;
         const visibilityCanBeToggled = !$contains('_hidden', 'policy.disallowedProperties', this.props.focusedNode);
+        // Check if focusedNode is in Guest frame to prevent errors (e.g. if still in store)
+        const focusedNodeInGuestFrame = findNodeInGuestFrame(focusedNodeContextPath) ? focused : {};
 
         return (
             <div className={style.inlineUi} data-__neos__inline-ui="TRUE">
@@ -60,7 +62,7 @@ export default class InlineUI extends PureComponent {
                     canBeDeleted={canBeDeleted}
                     canBeEdited={canBeEdited}
                     visibilityCanBeToggled={visibilityCanBeToggled}
-                    {...focused}
+                    {...focusedNodeInGuestFrame}
                     />
             </div>
         );


### PR DESCRIPTION
If the document node was changed and the old focused element was still in the store (it is a racing condition between set_src and set_context_path actions), the NodeToolbar crashed because it could not find the old elements dimensions.

I added conditions to the InlineUI to check if the focused element is in the GuestframeWindow and also to the NodeToolbar to check if the nodeElement is set. I also updated the forceUpdate- and setState-calls to be cancelled if the component was unmounted during the debounce-delay

