### PR TITLE
BUGFIX: prevent selecting or uploading wrong image types in Image editor

### DIFF
--- a/packages/neos-ui-editors/src/Editors/Image/index.js
+++ b/packages/neos-ui-editors/src/Editors/Image/index.js
@@ -207,7 +207,7 @@ export default class ImageEditor extends Component {
         const {secondaryEditorsRegistry} = this.props;
         const {component: MediaSelectionScreen} = secondaryEditorsRegistry.get('Neos.Neos/Inspector/Secondary/Editors/MediaSelectionScreen');
 
-        this.props.renderSecondaryInspector('IMAGE_SELECT_MEDIA', () => <MediaSelectionScreen onComplete={this.handleMediaSelected}/>);
+        this.props.renderSecondaryInspector('IMAGE_SELECT_MEDIA', () => <MediaSelectionScreen type="images" onComplete={this.handleMediaSelected}/>);
     }
 
     handleOpenImageCropper = () => {

--- a/packages/neos-ui-editors/src/Library/AssetUpload.js
+++ b/packages/neos-ui-editors/src/Library/AssetUpload.js
@@ -111,6 +111,7 @@ export default class AssetUpload extends PureComponent {
                         ref={this.setDropzoneReference}
                         accept={accept}
                         onDropAccepted={multiple ? this.handleMultiUpload : this.handleUpload}
+                        onDropRejected={this.handleFileDialogCancel}
                         onFileDialogCancel={this.handleFileDialogCancel}
                         className={style.dropzone}
                         activeClassName={style['dropzone--isActive']}

--- a/packages/neos-ui-editors/src/SecondaryEditors/MediaSelectionScreen/index.js
+++ b/packages/neos-ui-editors/src/SecondaryEditors/MediaSelectionScreen/index.js
@@ -9,11 +9,16 @@ import style from './style.css';
 class MediaSelectionScreen extends PureComponent {
     static propTypes = {
         onComplete: PropTypes.func.isRequired,
-        neos: PropTypes.object.isRequired
+        neos: PropTypes.object.isRequired,
+        type: PropTypes.oneOf(['assets', 'images']).isRequired
+    };
+
+    static defaultProps = {
+        type: 'assets'
     };
 
     render() {
-        const {onComplete, neos} = this.props;
+        const {onComplete, neos, type} = this.props;
         window.NeosMediaBrowserCallbacks = {
             assetChosen: assetIdentifier => {
                 onComplete(assetIdentifier);
@@ -22,9 +27,8 @@ class MediaSelectionScreen extends PureComponent {
 
         const mediaBrowserUri = $get('routes.core.modules.mediaBrowser', neos);
 
-        // TODO: hard-coded url
         return (
-            <iframe src={mediaBrowserUri + '/assets.html'} className={style.iframe}/>
+            <iframe src={`${mediaBrowserUri}/${type}.html`} className={style.iframe}/>
         );
     }
 }


### PR DESCRIPTION
There were two faulty scenarios:
- from some Image editor, go to media library and pick a .pdf (or other non-image file). A scary exception would be thrown.
- from some Image editor, click upload button, change allowed file extension in file picker to all files, pick pdf file: the spinner would be infinitely loading.

With this change:
- if you go to media library from Image editor, it would only be possible to pick images, and not just any assets.
- if you fool the file picker to picking a wrong filetype, it will be rejected correctly.
