### PR TITLE
FEATURE: Dynamically hide properties in the inspector

### DIFF
--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
@@ -149,6 +149,7 @@ export default class NodeTypesRegistry extends SynchronousRegistry {
                                         editor: $get('ui.inspector.editor'),
                                         editorOptions: $get('ui.inspector.editorOptions'),
                                         position: $get('ui.inspector.position'),
+                                        hidden: $get('ui.inspector.hidden'),
                                         helpMessage: $get('ui.help.message'),
                                         helpThumbnail: $get('ui.help.thumbnail')
                                     }),

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.js
@@ -48,7 +48,7 @@ export default class PropertyGroup extends PureComponent {
                         const itemType = $get('type', item);
                         const label = $get('label', item) || '';
 
-                        if (itemType === 'editor') {
+                        if (itemType === 'editor' && $get('hidden', item) !== true) {
                             return (
                                 <InspectorEditorEnvelope
                                     key={$get('contextPath', node) + itemId}

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.js
@@ -48,7 +48,7 @@ export default class PropertyGroup extends PureComponent {
                         const itemType = $get('type', item);
                         const label = $get('label', item) || '';
 
-                        if ($get('hidden', item) !== true) {
+                        if ($get('hidden', item)) {
                             return null;
                         }
                         if (itemType === 'editor') {

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.js
@@ -48,7 +48,10 @@ export default class PropertyGroup extends PureComponent {
                         const itemType = $get('type', item);
                         const label = $get('label', item) || '';
 
-                        if (itemType === 'editor' && $get('hidden', item) !== true) {
+                        if ($get('hidden', item) !== true) {
+                            return null;
+                        }
+                        if (itemType === 'editor') {
                             return (
                                 <InspectorEditorEnvelope
                                     key={$get('contextPath', node) + itemId}


### PR DESCRIPTION
Resolves: #1682

**What I did**

Added a property `hidden` to the inspector configuration for dynamically hiding editors in the inspector. See issue #1682.

**How to verify it**

For example add two properties to a Node Type, e.g.:

```
foo:
  type: boolean
  defaultValue: true
  ui:
    label: 'A totally unnecessary property'
    inspector:
      group: 'image'
image:
  type: 'Neos\Media\Domain\Model\ImageInterface'
  ui:
    label: 'Image'
    inspector:
      group: 'image'
      hidden: 'ClientEval:node.properties.foo ? true : true'
```

The editor for the property image will only be shown if `foo` ist set to `true`:

![45105453-8f932100-b134-11e8-9f36-981d12943eb4](https://user-images.githubusercontent.com/16836984/45150330-df70f700-b1cb-11e8-89a1-039fdfbbd27a.gif)
