### PR TITLE
BUGFIX: fix focusing nodes in FF

### DIFF
--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -17,16 +17,12 @@ import {
 import style from './style.css';
 
 //
-// Polyfil for event path
-// see: https://stackoverflow.com/questions/39245488/event-path-undefined-with-firefox-and-vue-js
-// TODO: extract into helpers if needed elsewhere
+// Get all parent elements of the event target.
+//
+// It's not possible to use `event.composedPath()` here because
+// it doesn't work in FF with past events stored in a closure.
 //
 const eventPath = event => {
-    const eventPath = event.path || (event.composedPath && event.composedPath());
-    if (eventPath) {
-        return eventPath;
-    }
-
     let element = event.target;
     const path = [];
 


### PR DESCRIPTION
For some weird reason FF returns empty composedPath for event which happened in the past and were stored in a closure.
Let's be safe and just use all parents, it's super quick anyways.