### PR TITLE
TASK: add legacy aloha format migration and support both formats at the same time

### DIFF
--- a/Migrations/Code/Version20180907103800.php
+++ b/Migrations/Code/Version20180907103800.php
@@ -1,0 +1,94 @@
+<?php
+namespace Neos\Neos\Ui\Core\Migrations;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+use Neos\Flow\Configuration\ConfigurationManager;
+use Neos\Flow\Core\Migrations\AbstractMigration;
+
+/**
+ * Migrate RTE formatting configuration to new format
+ */
+class Version20180907103800 extends AbstractMigration
+{
+    /**
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return 'Neos.Neos-20180907103800';
+    }
+
+    /**
+     * @return void
+     */
+    public function up()
+    {
+        $this->processConfiguration(
+            'NodeTypes',
+            function (&$configuration) {
+                foreach ($configuration as &$nodeType) {
+                    if (isset($nodeType['properties'])) {
+                        foreach ($nodeType['properties'] as &$propertyConfiguration) {
+                            if (isset($propertyConfiguration['ui']['aloha'])) {
+                                $propertyConfiguration['ui']['inline']['editorOptions'] = $this->transformAlohaFormat($propertyConfiguration['ui']['aloha']);
+                                unset($propertyConfiguration['ui']['aloha']);
+                            }
+                        }
+                    }
+                }
+            },
+            true
+        );
+    }
+
+    /**
+     * Takes legacy aloha formatting and return editorOptions
+     * 
+     * @param array $aloha
+     * @return array $editorOptions
+     */
+    protected function transformAlohaFormat($aloha)
+    {
+        $editorOptions = [
+            'formatting' => []
+        ];
+        if (isset($aloha['format']) && is_array($aloha['format'])) {
+            $editorOptions['formatting'] = array_merge($editorOptions['formatting'], $aloha['format']);
+        }
+        if (isset($aloha['table']) && is_array($aloha['table'])) {
+            $editorOptions['formatting'] = array_merge($editorOptions['formatting'], $aloha['table']);
+        }
+        if (isset($aloha['link']) && is_array($aloha['link'])) {
+            $editorOptions['formatting'] = array_merge($editorOptions['formatting'], $aloha['link']);
+        }
+        if (isset($aloha['list']) && is_array($aloha['list'])) {
+            $editorOptions['formatting'] = array_merge($editorOptions['formatting'], $aloha['list']);
+        }
+        if (isset($aloha['alignment']) && is_array($aloha['alignment'])) {
+            $editorOptions['formatting'] = array_merge($editorOptions['formatting'], $aloha['alignment']);
+        }
+        if (isset($aloha['autoparagraph'])) {
+            $editorOptions['autoparagraph'] = $aloha['autoparagraph'];
+        }
+        if (isset($aloha['placeholder'])) {
+            $editorOptions['placeholder'] = $aloha['placeholder'];
+        }
+        if (isset($editorOptions['formatting']['b'])) {
+            $editorOptions['formatting']['strong'] = true;
+            unset($editorOptions['formatting']['b']);
+        }
+        if (isset($editorOptions['formatting']['i'])) {
+            $editorOptions['formatting']['em'] = true;
+            unset($editorOptions['formatting']['i']);
+        }
+        return $editorOptions;
+    }
+}

--- a/Migrations/Code/Version20180907103800.php
+++ b/Migrations/Code/Version20180907103800.php
@@ -89,6 +89,9 @@ class Version20180907103800 extends AbstractMigration
             $editorOptions['formatting']['em'] = true;
             unset($editorOptions['formatting']['i']);
         }
+        if ($editorOptions['formatting'] === []) {
+            unset($editorOptions['formatting']);
+        }
         return $editorOptions;
     }
 }

--- a/Migrations/Code/Version20180907103800.php
+++ b/Migrations/Code/Version20180907103800.php
@@ -38,7 +38,8 @@ class Version20180907103800 extends AbstractMigration
                     if (isset($nodeType['properties'])) {
                         foreach ($nodeType['properties'] as &$propertyConfiguration) {
                             if (isset($propertyConfiguration['ui']['aloha'])) {
-                                $propertyConfiguration['ui']['inline']['editorOptions'] = $this->transformAlohaFormat($propertyConfiguration['ui']['aloha']);
+                                $editorOptions = $this->transformAlohaFormat($propertyConfiguration['ui']['aloha']);
+                                $propertyConfiguration['ui']['inline']['editorOptions'] = isset($propertyConfiguration['ui']['inline']['editorOptions']) ? array_merge_recursive($propertyConfiguration['ui']['inline']['editorOptions'], $editorOptions) : $editorOptions;
                                 unset($propertyConfiguration['ui']['aloha']);
                             }
                         }

--- a/Migrations/Code/Version20180907103800.php
+++ b/Migrations/Code/Version20180907103800.php
@@ -51,7 +51,7 @@ class Version20180907103800 extends AbstractMigration
 
     /**
      * Takes legacy aloha formatting and return editorOptions
-     * 
+     *
      * @param array $aloha
      * @return array $editorOptions
      */

--- a/Migrations/Code/Version20180907103800.php
+++ b/Migrations/Code/Version20180907103800.php
@@ -1,5 +1,5 @@
 <?php
-namespace Neos\Neos\Ui\Core\Migrations;
+namespace Neos\Flow\Core\Migrations;
 
 /*
  * This file is part of the Neos.Neos.Ui package.
@@ -11,7 +11,6 @@ namespace Neos\Neos\Ui\Core\Migrations;
  * source code.
  */
 use Neos\Flow\Configuration\ConfigurationManager;
-use Neos\Flow\Core\Migrations\AbstractMigration;
 
 /**
  * Migrate RTE formatting configuration to new format

--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
@@ -225,6 +225,13 @@ export default class NodeTypesRegistry extends SynchronousRegistry {
             return acc;
         }, {});
 
+        if ($get('formatting.b', legacyConfiguration)) {
+            legacyConfiguration.formatting.strong = true;
+        }
+        if ($get('formatting.i', legacyConfiguration)) {
+            legacyConfiguration.formatting.em = true;
+        }
+
         return inlineEditorOptions ? merge(legacyConfiguration, inlineEditorOptions) : legacyConfiguration;
     }
 

--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
@@ -199,7 +199,7 @@ export default class NodeTypesRegistry extends SynchronousRegistry {
      * Inline Editor Configuration looks as follows:
      *
      * formatting: // what formatting is enabled / disabled
-     *   b: true
+     *   strong: true
      *   a: true
      *   MyFormattingRule: {Configuration Object if needed}
      * placeholder: "Placeholder text"
@@ -207,6 +207,12 @@ export default class NodeTypesRegistry extends SynchronousRegistry {
      */
     getInlineEditorOptionsForProperty(nodeTypeName, propertyName) {
         const nodeType = this.get(nodeTypeName);
+
+        const defautlInlineEditorOptions = {
+            formatting: {},
+            placeholder: '',
+            autoparagraph: false
+        };
 
         const inlineEditorOptions = $get(['properties', propertyName, 'ui', 'inline', 'editorOptions'], nodeType) || {};
 
@@ -221,7 +227,7 @@ export default class NodeTypesRegistry extends SynchronousRegistry {
             return acc;
         }, {});
 
-        const mergedConfig = merge(legacyConfiguration, inlineEditorOptions);
+        const mergedConfig = merge(defautlInlineEditorOptions, legacyConfiguration, inlineEditorOptions);
 
         if ($get('formatting.b', mergedConfig)) {
             mergedConfig.formatting.strong = true;

--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
@@ -208,14 +208,10 @@ export default class NodeTypesRegistry extends SynchronousRegistry {
     getInlineEditorOptionsForProperty(nodeTypeName, propertyName) {
         const nodeType = this.get(nodeTypeName);
 
-        const inlineEditorOptions = $get(['properties', propertyName, 'ui', 'inline', 'editorOptions'], nodeType);
+        const inlineEditorOptions = $get(['properties', propertyName, 'ui', 'inline', 'editorOptions'], nodeType) || {};
 
         // OLD variant of configuration
-        const legacyConfiguration = $get(['properties', propertyName, 'ui', 'aloha'], nodeType);
-
-        if (inlineEditorOptions && !legacyConfiguration) {
-            return inlineEditorOptions;
-        }
+        const legacyConfiguration = $get(['properties', propertyName, 'ui', 'aloha'], nodeType) || {};
 
         legacyConfiguration.formatting = [].concat(
             ...['format', 'link', 'list', 'table', 'alignment']
@@ -225,14 +221,16 @@ export default class NodeTypesRegistry extends SynchronousRegistry {
             return acc;
         }, {});
 
-        if ($get('formatting.b', legacyConfiguration)) {
-            legacyConfiguration.formatting.strong = true;
+        const mergedConfig = merge(legacyConfiguration, inlineEditorOptions);
+
+        if ($get('formatting.b', mergedConfig)) {
+            mergedConfig.formatting.strong = true;
         }
-        if ($get('formatting.i', legacyConfiguration)) {
-            legacyConfiguration.formatting.em = true;
+        if ($get('formatting.i', mergedConfig)) {
+            mergedConfig.formatting.em = true;
         }
 
-        return inlineEditorOptions ? merge(legacyConfiguration, inlineEditorOptions) : legacyConfiguration;
+        return mergedConfig;
     }
 
     isInlineEditable(nodeTypeName) {


### PR DESCRIPTION
This PR provides a core migration from old Aloha NodeTypes.yaml format to the new one, but also allows both formats to exist at the same time.

The old aloha format and the new format are supported at the same time, the new format takes precedence.