### PR TITLE
BUGFIX: Add timeConstraints to snapshot 

### DIFF
--- a/packages/react-ui-components/src/DateInput/__snapshots__/dateInput.spec.js.snap
+++ b/packages/react-ui-components/src/DateInput/__snapshots__/dateInput.spec.js.snap
@@ -47,6 +47,13 @@ exports[`<DateInput/> should render correctly. 1`] = `
       dateFormat={true}
       onChange={[Function]}
       open={true}
+      timeConstraints={
+        Object {
+          "minutes": Object {
+            "step": 5,
+          },
+        }
+      }
       timeFormat={true}
     />
     <Component

--- a/yarn.lock
+++ b/yarn.lock
@@ -7631,7 +7631,7 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-"micromatch@github:jonschlinkert/micromatch#2.2.0":
+micromatch@jonschlinkert/micromatch#2.2.0:
   version "2.2.0"
   resolved "https://codeload.github.com/jonschlinkert/micromatch/tar.gz/5017fd78202e04c684cc31d3c2fb1f469ea222ff"
   dependencies:


### PR DESCRIPTION
Tests are currently broken becuase the jest snapshot wasn't updated after latest changes. 