### PR TITLE
TASK: reduce linter noise

### DIFF
--- a/packages/neos-ui-editors/src/Editors/Image/Components/PreviewScreen/index.js
+++ b/packages/neos-ui-editors/src/Editors/Image/Components/PreviewScreen/index.js
@@ -54,7 +54,7 @@ export default class PreviewScreen extends PureComponent {
                             className={(thumbnail ? style.cropArea__image : style['cropArea__image--placeholder'])}
                             src={thumbnail ? thumbnail.uri : '/_Resources/Static/Packages/Neos.Neos/Images/dummy-image.svg'}
                             style={thumbnail ? thumbnail.styles.thumbnail : {}}
-                            role="presentation"
+                            alt="thumbnail"
                             />
                     </div>
                 </div>

--- a/packages/neos-ui/src/Sagas/CR/NodeOperations/addNode.js
+++ b/packages/neos-ui/src/Sagas/CR/NodeOperations/addNode.js
@@ -107,6 +107,8 @@ export default function * addNode({globalRegistry}) {
                         }
                     }]));
                 }
+
+                default: return null;
             }
         });
     });

--- a/packages/neos-ui/src/Sagas/CR/NodeOperations/addNode.js
+++ b/packages/neos-ui/src/Sagas/CR/NodeOperations/addNode.js
@@ -107,8 +107,6 @@ export default function * addNode({globalRegistry}) {
                         }
                     }]));
                 }
-
-                default: return;
             }
         });
     });

--- a/packages/react-ui-components/src/ListPreviewElement/listPreviewElement.js
+++ b/packages/react-ui-components/src/ListPreviewElement/listPreviewElement.js
@@ -80,6 +80,7 @@ class ListPreviewElement extends PureComponent {
                 onMouseEnter={disabled ? noop : onMouseEnter}
                 onClick={disabled ? noop : onClick}
                 className={optionClassName}
+                role="button"
                 >
                 {Boolean(icon) && <Icon className={theme.listPreviewElement__icon} icon={icon}/>}
                 {children}

--- a/packages/react-ui-components/src/SelectBox_ListPreviewFlat/selectBox_ListPreviewFlat.js
+++ b/packages/react-ui-components/src/SelectBox_ListPreviewFlat/selectBox_ListPreviewFlat.js
@@ -74,6 +74,7 @@ export default class SelectBox_ListPreviewFlat extends PureComponent {
                     }
                 }}
                 role="option"
+                aria-selected={isHighlighted ? 'true' : 'false'}
                 className={theme.selectBox__item}
                 >
                 <ListPreviewElement

--- a/packages/react-ui-components/src/SelectBox_ListPreviewGrouped/selectBox_ListPreviewGrouped.js
+++ b/packages/react-ui-components/src/SelectBox_ListPreviewGrouped/selectBox_ListPreviewGrouped.js
@@ -115,6 +115,7 @@ export default class SelectBox_ListPreviewGrouped extends PureComponent {
                     }
                 }}
                 role="option"
+                aria-selected={isHighlighted ? 'true' : 'false'}
                 className={theme.selectBox__item}
                 >
                 <ListPreviewElement

--- a/packages/react-ui-components/src/Tree/node.js
+++ b/packages/react-ui-components/src/Tree/node.js
@@ -203,7 +203,14 @@ export class Header extends PureComponent {
                                         <IconComponent icon={icon || 'question'} label={iconLabel} />
                                     }
                                 </div>
-                                <span {...rest} id={labelIdentifier} className={theme.header__label} onClick={onLabelClick} data-neos-integrational-test="tree__item__nodeHeader__itemLabel">
+                                <span
+                                    {...rest}
+                                    id={labelIdentifier}
+                                    className={theme.header__label}
+                                    onClick={onLabelClick}
+                                    data-neos-integrational-test="tree__item__nodeHeader__itemLabel"
+                                    role="treeitem"
+                                >
                                     {label}
                                 </span>
                             </div>


### PR DESCRIPTION
This removes some warnings of the linter by adding aria-props.

There is one linter warning left: `warning  Method 'render' has a complexity of 25  complexity`
Which occurs in the file: `Neos.Neos.Ui/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js`.
However, this should be handled separately in my opinion.