### PR TITLE
BUGFIX: reset index after filter when checking for policies

### DIFF
--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -253,7 +253,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
             return $this->$methodName($node, $controllerContext);
         };
 
-        return array_filter(array_map($mapper, $nodes));
+        return array_values(array_filter(array_map($mapper, $nodes)));
     }
 
     /**


### PR DESCRIPTION
The indexes of an array must be reset after filtering. This caused the result to be casted into object in JS, which broke the tree in effect.