### PR TITLE
TASK: Render help message below editor component

### DIFF
--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -158,10 +158,8 @@ export default class EditorEnvelope extends PureComponent {
                 <span>
                     {this.renderLabel()}
                 </span>
-
-                {this.state.showHelpmessage ? this.renderHelpmessage() : ''}
-
                 {this.renderEditorComponent()}
+                {this.state.showHelpmessage ? this.renderHelpmessage() : ''}
                 {validationErrors && validationErrors.length > 0 && <Tooltip renderInline asError><ul>{validationErrors.map((error, index) => <li key={index}>{error}</li>)}</ul></Tooltip>}
             </Fragment>
         );


### PR DESCRIPTION
Current:
![bildschirmfoto 2018-09-23 um 11 35 55](https://user-images.githubusercontent.com/769789/45926643-da2ede80-bf25-11e8-9890-79199193853c.png)

With this patch applied:
![bildschirmfoto 2018-09-23 um 11 37 56](https://user-images.githubusercontent.com/769789/45926644-ddc26580-bf25-11e8-9559-c184b27377c2.png)
