### PR TITLE
TASK: tslint now prohibits console.x and debugger

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -3,8 +3,8 @@
   "rules": {
     "interface-name": false,
     "member-ordering": false,
-    "no-console": false,
-    "no-debugger": false,
+    "no-console": true,
+    "no-debugger": true,
     "no-delete": true,
     "no-method-signature": true,
     "no-let": true,


### PR DESCRIPTION
**What I did**
I configured TSLint so that it prohibits `console.x` and `debugger`.

**How I did it**
I set the corresponding setting to true:
* `no-console: true`
* `no-debugger: true`

**How to verify it**
Use `console.log` in `.ts(x)` file and run `make lint`. It should fail with an error msg.
It should _not_ fail when running `make build-watch`. So you can still use `console` and `debugger` while developing.