### PR TITLE
BUGFIX: Set css-class to snapshot

### DIFF
--- a/packages/react-ui-components/src/Dialog/__snapshots__/dialog.spec.js.snap
+++ b/packages/react-ui-components/src/Dialog/__snapshots__/dialog.spec.js.snap
@@ -19,7 +19,9 @@ exports[`<Dialog/> should render correctly. 1`] = `
           onClick={[Function]}
         />
         <div />
-        <div>
+        <div
+          className="dialog__body"
+        >
           Foo children
         </div>
         <div>

--- a/packages/react-ui-components/src/Dialog/dialog.js
+++ b/packages/react-ui-components/src/Dialog/dialog.js
@@ -90,7 +90,7 @@ export class DialogWithoutEscape extends PureComponent {
             [className]: className && className.length
         });
         const finalClassNameBody = mergeClassNames({
-            [theme.dialog__body]: true,
+            [theme.dialog__body]: Boolean(theme.dialog__body), // set only if it's not a faulty value
             'dialog__body': true
         });
 


### PR DESCRIPTION
and only add theme class if it's not a faulty value - otherwise it will
be undefined.

Maybe there are some other places where this would be good to do.

Should repair master, failed since merge of 6eed65fc771b5f993d30bcb597e3ff80301659ba

