### PR TITLE
TAKS: Add return type to is email

### DIFF
--- a/packages/utils-helpers/src/isEmail.ts
+++ b/packages/utils-helpers/src/isEmail.ts
@@ -1,4 +1,4 @@
-const isEmail = (email: string) => {
+const isEmail = (email: string) : boolean => {
     const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
     return re.test(email.toLowerCase());
 };


### PR DESCRIPTION
This adds a return type to the `isEmail` function. 
As we are using Typescript there it should be done is as many places as possible to give us the whole power of TS.

