### PR TITLE
TASK: Convert stripTags to Typescript

### DIFF
--- a/packages/utils-helpers/src/stripTags.js
+++ b/packages/utils-helpers/src/stripTags.js
@@ -1,4 +1,0 @@
-const stripTags = string => string && string.replace(/<\/?[^>]+(>|$)/g, '');
-const stripTagsEncoded = string => string && string.replace(/&lt;\/?[^&gt;]+(&gt;|$)/g, '');
-
-export {stripTags, stripTagsEncoded};

--- a/packages/utils-helpers/src/stripTags.spec.js
+++ b/packages/utils-helpers/src/stripTags.spec.js
@@ -19,3 +19,17 @@ test(`should return the same string if string does not contain html tags`, () =>
     const string = 'hello world';
     expect(stripTagsEncoded(string)).toEqual(string);
 });
+
+test(`stripTagsEncoded should throw a type error if parameter is not a string`, () => {
+    expect(() => stripTagsEncoded(undefined)).toThrow(TypeError);
+    expect(() => stripTagsEncoded(null)).toThrow(TypeError);
+    expect(() => stripTagsEncoded([])).toThrow(TypeError);
+    expect(() => stripTagsEncoded(1)).toThrow(TypeError);
+});
+
+test(`stripTags should throw a type error if parameter is not a string`, () => {
+    expect(() => stripTags(undefined)).toThrow(TypeError);
+    expect(() => stripTags(null)).toThrow(TypeError);
+    expect(() => stripTags([])).toThrow(TypeError);
+    expect(() => stripTags(1)).toThrow(TypeError);
+});

--- a/packages/utils-helpers/src/stripTags.ts
+++ b/packages/utils-helpers/src/stripTags.ts
@@ -1,0 +1,4 @@
+const stripTags = (value: string) : string => value.replace(/<\/?[^>]+(>|$)/g, '');
+const stripTagsEncoded = (value: string) : string => value.replace(/&lt;\/?[^&gt;]+(&gt;|$)/g, '');
+
+export {stripTags, stripTagsEncoded};


### PR DESCRIPTION
This converts the `stripTags` helper to Typescript and adds testcases.