### PR TITLE
BUGFIX: Remove canEdit from allowedChildTypesSelector

### DIFF
--- a/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
@@ -205,7 +205,6 @@ export const getPathInNode = (state, contextPath, propertyPath) => {
 
 export const makeGetAllowedChildNodeTypesSelector = (nodeTypesRegistry, elevator = id => id) => createSelector(
     [
-        (state, {reference}) => getPathInNode(state, elevator(reference), 'policy.canEdit'),
         (state, {reference}) => getPathInNode(state, elevator(reference), 'policy.disallowedNodeTypes'),
         (state, {reference}) => getPathInNode(state, elevator(reference), 'isAutoCreated'),
         (state, {reference}) => getPathInNode(state, elevator(reference), 'name'),
@@ -213,11 +212,14 @@ export const makeGetAllowedChildNodeTypesSelector = (nodeTypesRegistry, elevator
         (state, {reference}) => getPathInNode(state, elevator(parentNodeContextPath(reference)), 'nodeType'),
         (state, {role}) => role
     ],
-    (canEdit, disallowedNodeTypes, ...args) => canEdit ?
-        nodeTypesRegistry
-            .getAllowedNodeTypesTakingAutoCreatedIntoAccount(...args)
-            .filter(nodeType => !disallowedNodeTypes.includes(nodeType)) :
-        []
+    (disallowedNodeTypes, ...args) => {
+        const allowedNodeTypesTakingAutoCreatedIntoAccount = nodeTypesRegistry
+            .getAllowedNodeTypesTakingAutoCreatedIntoAccount(...args);
+        return disallowedNodeTypes ?
+            allowedNodeTypesTakingAutoCreatedIntoAccount
+                .filter(nodeType => !disallowedNodeTypes.includes(nodeType)) :
+            allowedNodeTypesTakingAutoCreatedIntoAccount;
+    }
 );
 
 export const makeGetAllowedSiblingNodeTypesSelector = nodeTypesRegistry =>


### PR DESCRIPTION
**What I did**
Adding childNodes to a node which is not editable is allowed. So the UI has to respect that.

**How I did it**
Removed the check for `policy.canEdit`.

**How to verify it**
Add a child node to a node which is not editable (for you).