### PR TITLE
FEATURE: node variant selector

### DIFF
--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -190,10 +190,11 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
      * @param NodeInterface $node
      * @return array
      */
-    protected function getCurrentDimensionPresetIdentifiersForNode($node) {
+    protected function getCurrentDimensionPresetIdentifiersForNode($node)
+    {
         $targetPresets = $this->contentDimensionsPresetSource->findPresetsByTargetValues($node->getDimensions());
         $presetCombo = [];
-        foreach($targetPresets as $dimensionName => $presetConfig) {
+        foreach ($targetPresets as $dimensionName => $presetConfig) {
             $fullPresetConfig = $this->contentDimensionsPresetSource->findPresetByDimensionValues($dimensionName, $presetConfig['values']);
             $presetCombo[$dimensionName] = $fullPresetConfig['identifier'];
         }

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -264,6 +264,18 @@
 			<trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
 				<source>Unfocus Node</source>
 			</trans-unit>
+			<trans-unit id="NodeVariantsSelector.label" xml:space="preserve">
+				<source>Node variants</source>
+			</trans-unit>
+			<trans-unit id="NodeVariantsSelector.tooltip" xml:space="preserve">
+				<source>Use the dropdown to switch to other variants of the selected node</source>
+			</trans-unit>
+			<trans-unit id="NodeVariantsSelector.matchingTooltip" xml:space="preserve">
+				<source>The node dimensions of the selected node match the active dimension configuration, you may edit the node in place freely</source>
+			</trans-unit>
+			<trans-unit id="NodeVariantsSelector.shinethroughTooltip" xml:space="preserve">
+				<source>The selected node is a shine-through node from another dimension, you may want to switch to its original dimension to edit it there, editing it in-place would create a copy</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
@@ -1,4 +1,4 @@
-import {$get, $set} from 'plow-js';
+import {$get} from 'plow-js';
 import {createSelector, defaultMemoize} from 'reselect';
 
 import {getCurrentContentCanvasContextPath} from './../../UI/ContentCanvas/selectors';

--- a/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/selectors.js
@@ -1,4 +1,4 @@
-import {$get} from 'plow-js';
+import {$get, $set} from 'plow-js';
 import {createSelector, defaultMemoize} from 'reselect';
 
 import {getCurrentContentCanvasContextPath} from './../../UI/ContentCanvas/selectors';
@@ -145,6 +145,13 @@ export const focusedNodeTypeSelector = createSelector(
     ],
     focused =>
         $get('nodeType', focused)
+);
+
+export const focusedNodeVariantsSelector = createSelector(
+    [
+        focusedSelector
+    ],
+    focused => $get('otherNodeVariants', focused)
 );
 
 export const focusedNodeIdentifierSelector = createSelector(

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/SelectedElement/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/SelectedElement/index.js
@@ -65,13 +65,13 @@ export default class SelectedElement extends PureComponent {
         }
 
         const currentVariant = {
-            value: $get(['dimensions'], focusedNode).toJS(),
+            value: $get('dimensions', focusedNode).toJS(),
             label: (
                 <div>
                     {$get('matchesCurrentDimensions', focusedNode) ? (
-                        <Icon title="The node dimensions of the selected node match the active dimension configuration, you may edit the node in place freely" icon="check-circle" padded="right" color="primaryBlue" />
+                        <Icon title={i18nRegistry.translate('Neos.Neos.Ui:Main:NodeVariantsSelector.matchingTooltip')} icon="check-circle" padded="right" color="primaryBlue" />
                     ) : (
-                        <Icon title="The selected node is a shine-through node, you may want to switch to its original dimension to edit it there, editing in-place would create a copy" icon="exclamation-circle" padded="right" color="warn" />
+                        <Icon title={i18nRegistry.translate('Neos.Neos.Ui:Main:NodeVariantsSelector.shinethroughTooltip')} icon="exclamation-circle" padded="right" color="warn" />
                     )}
                     {contentDimensions.map((dimensionValue, dimensionName) => {
                         const dimensionPresetId = $get(['dimensions', dimensionName], focusedNode);
@@ -87,25 +87,35 @@ export default class SelectedElement extends PureComponent {
         const otherVariants = focusedNodeVariants.map(nodeVariant => {
             return {
                 value: nodeVariant.toJS(),
-                label: contentDimensions.map((dimensionValue, dimensionName) => {
-                    const dimensionPresetId = $get(dimensionName, nodeVariant);
-                    const presetLabel = $get([dimensionName, 'presets', dimensionPresetId, 'label'], contentDimensions);
-                    return (<span key={dimensionName} style={{marginRight: 20}}>
-                        <Icon icon={$get('icon', dimensionValue)} padded="right" />
-                        <I18n id={presetLabel} />
-                    </span>);
-                }).toArray()
+                label: (
+                    <div>
+                        {contentDimensions.map((dimensionValue, dimensionName) => {
+                            const dimensionPresetId = $get(dimensionName, nodeVariant);
+                            const presetLabel = $get([dimensionName, 'presets', dimensionPresetId, 'label'], contentDimensions);
+                            return (<span key={dimensionName} style={{marginRight: 20}}>
+                                <Icon icon={$get('icon', dimensionValue)} padded="right" />
+                                <I18n id={presetLabel} />
+                            </span>);
+                        }).toArray()}
+                    </div>
+                )
             };
         }).toArray();
         const nodeVariantOptions = [currentVariant, ...otherVariants];
 
         return (
             <div className={style.content}>
-                <label title="Switch to the other variants of the selected node" for="#__neos__nodeVariantsSelector" style={{marginBottom: 4, display: 'block'}}>Node variants</label>
+                <label
+                    title={i18nRegistry.translate('Neos.Neos.Ui:Main:NodeVariantsSelector.tooltip')}
+                    htmlFor="#__neos__nodeVariantsSelector"
+                    style={{marginBottom: 4, display: 'block'}}
+                    >
+                    <I18n id={'Neos.Neos.Ui:Main:NodeVariantsSelector.label'} />
+                </label>
                 <SelectBox
                     id="__neos__nodeVariantsSelector"
                     options={nodeVariantOptions}
-                    value={nodeVariantOptions[0].value}
+                    value={$get([0, 'value'], nodeVariantOptions)}
                     onValueChange={preset => this.props.selectPreset(preset)}
                 />
             </div>

--- a/packages/neos-ui/src/Containers/SecondaryToolbar/DimensionSwitcher/index.js
+++ b/packages/neos-ui/src/Containers/SecondaryToolbar/DimensionSwitcher/index.js
@@ -147,7 +147,7 @@ export default class DimensionSwitcher extends PureComponent {
     }
 
     handleApplyPresets = () => {
-        this.props.selectPreset(this.state.transientPresets);
+        this.props.selectPreset(this.getEffectivePresets());
         this.setState({isOpen: false, transientPresets: {}});
     }
 

--- a/packages/react-ui-components/src/SelectBox_CreateNew/selectBox_CreateNew.js
+++ b/packages/react-ui-components/src/SelectBox_CreateNew/selectBox_CreateNew.js
@@ -22,7 +22,10 @@ class SelectBox_CreateNew extends PureComponent {
         createNewLabel: PropTypes.string,
 
         // API with SelectBox
-        focusedValue: PropTypes.string,
+        focusedValue: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.object
+        ]).isRequired,
         onOptionFocus: PropTypes.func.isRequired
     }
 

--- a/packages/react-ui-components/src/SelectBox_Header/selectBox_Header.js
+++ b/packages/react-ui-components/src/SelectBox_Header/selectBox_Header.js
@@ -13,7 +13,10 @@ class SelectBox_Header extends PureComponent {
         // API with SelectBox
         option: PropTypes.shape({
             icon: PropTypes.string,
-            label: PropTypes.string.isRequired
+            label: PropTypes.oneOfType([
+                PropTypes.string,
+                PropTypes.object
+            ]).isRequired
         }),
         placeholder: PropTypes.string,
         placeholderIcon: PropTypes.string,

--- a/packages/react-ui-components/src/SelectBox_ListPreviewFlat/selectBox_ListPreviewFlat.js
+++ b/packages/react-ui-components/src/SelectBox_ListPreviewFlat/selectBox_ListPreviewFlat.js
@@ -20,7 +20,10 @@ export default class SelectBox_ListPreviewFlat extends PureComponent {
         // API with SelectBox
         optionValueAccessor: PropTypes.func.isRequired,
         onChange: PropTypes.func.isRequired,
-        focusedValue: PropTypes.string,
+        focusedValue: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.object
+        ]).isRequired,
         onOptionFocus: PropTypes.func,
 
         // ------------------------------

--- a/packages/react-ui-components/src/SelectBox_Option_SingleLine/selectBox_Option_SingleLine.js
+++ b/packages/react-ui-components/src/SelectBox_Option_SingleLine/selectBox_Option_SingleLine.js
@@ -7,7 +7,10 @@ import mergeClassNames from 'classnames';
 class SelectBox_Option_SingleLine extends PureComponent {
     static propTypes = {
         option: PropTypes.shape({
-            label: PropTypes.string.isRequired,
+            label: PropTypes.oneOfType([
+                PropTypes.string,
+                PropTypes.object
+            ]).isRequired,
             icon: PropTypes.string,
             disabled: PropTypes.bool
         }).isRequired,


### PR DESCRIPTION
This feature introduces a node variant selector which should help the editor to answer these questions:

1) Do I see a shine through node or a real thing? (the orange warning indicator)
2) Where does this node shine through from? (the first selectbox option, selected by default)
3) What other node variants are available? (the other selectbox options)
4) Quickly switch to those node variants (by selecting a node variant in selectbox)


TODO:

- [x] I18n
- [x] Adjust PropTypes

![peek 2018-10-08 10-11](https://user-images.githubusercontent.com/837032/46597135-93c1ae00-cae7-11e8-9f88-fb238bb10b0d.gif)
