### PR TITLE
BUGFIX: EditNodePrivilege combined with EditNodePropertyPrivilege

### DIFF
--- a/Classes/Aspects/AugmentationAspect.php
+++ b/Classes/Aspects/AugmentationAspect.php
@@ -12,7 +12,6 @@ namespace Neos\Neos\Ui\Aspects;
  */
 
 use Neos\ContentRepository\Domain\Model\NodeInterface;
-use Neos\ContentRepository\Service\AuthorizationService;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Aop\JoinPointInterface;
 use Neos\Flow\Session\SessionInterface;
@@ -21,6 +20,7 @@ use Neos\Fusion\Service\HtmlAugmenter;
 use Neos\Neos\Domain\Service\ContentContext;
 use Neos\Neos\Ui\Domain\Service\UserLocaleService;
 use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
+use Neos\Neos\Ui\Service\NodePolicyService;
 
 /**
  * - Serialize all nodes related to the currently rendered document
@@ -31,12 +31,11 @@ use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
  */
 class AugmentationAspect
 {
-
     /**
      * @Flow\Inject
-     * @var AuthorizationService
+     * @var NodePolicyService
      */
-    protected $nodeAuthorizationService;
+    protected $nodePolicyService;
 
     /**
      * @Flow\Inject
@@ -202,15 +201,41 @@ class AugmentationAspect
 
     /**
      * @param NodeInterface $node
-     * @param boolean $renderCurrentDocumentMetadata
-     * @return boolean
+     * @param bool $renderCurrentDocumentMetadata
+     * @return bool
      */
-    protected function needsMetadata(NodeInterface $node, $renderCurrentDocumentMetadata)
+    protected function needsMetadata(NodeInterface $node, bool $renderCurrentDocumentMetadata): bool
     {
         /** @var $contentContext ContentContext */
         $contentContext = $node->getContext();
 
-        return ($contentContext->isInBackend() === true && ($renderCurrentDocumentMetadata === true || $this->nodeAuthorizationService->isGrantedToEditNode($node) === true));
+        if (!$contentContext->isInBackend()) {
+            return false;
+        }
+
+        if ($renderCurrentDocumentMetadata || $this->nodePolicyService->canEditNode($node)) {
+            return true;
+        }
+
+        $inlineEditableProperties = array_filter(
+            $node->getNodeType()->getProperties(),
+            function ($property) {
+                return $property['ui']['inlineEditable'] ?? false;
+            }
+        );
+
+        if ($inlineEditableProperties === []) {
+            return false;
+        }
+
+        $disallowedProperties = $this->nodePolicyService->getDisallowedProperties($node);
+        foreach ($inlineEditableProperties as $propertyName => $property) {
+            if (!in_array($propertyName, $disallowedProperties, true)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/Classes/Service/NodePolicyService.php
+++ b/Classes/Service/NodePolicyService.php
@@ -3,6 +3,7 @@ namespace Neos\Neos\Ui\Service;
 
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+use Neos\ContentRepository\Security\Authorization\Privilege\Node\EditNodePrivilege;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\EditNodePropertyPrivilege;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\NodePrivilegeSubject;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\PropertyAwareNodePrivilegeSubject;
@@ -11,6 +12,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Security\Authorization\Privilege\PrivilegeInterface;
 use Neos\Flow\Security\Authorization\PrivilegeManagerInterface;
+use Neos\Flow\Security\Context as SecurityContext;
 use Neos\Flow\Security\Policy\PolicyService;
 use Neos\Neos\Security\Authorization\Privilege\NodeTreePrivilege;
 
@@ -42,6 +44,12 @@ class NodePolicyService
      * @var ObjectManagerInterface
      */
     protected $objectManager;
+
+    /**
+     * @Flow\Inject
+     * @var SecurityContext
+     */
+    protected $securityContext;
 
     /**
      * @param ObjectManagerInterface $objectManager
@@ -127,6 +135,43 @@ class NodePolicyService
      */
     public function getDisallowedProperties(NodeInterface $node): array
     {
-        return $this->authorizationService->getDeniedNodePropertiesForEditing($node);
+        if ($this->canEditNode($node)) {
+            return $this->authorizationService->getDeniedNodePropertiesForEditing($node);
+        }
+
+        // If node editing was denied explicitly, property editing privilege can't overwrite
+        $privilegeSubject = new NodePrivilegeSubject($node);
+        foreach ($this->securityContext->getRoles() as $role) {
+            /** @var PrivilegeInterface[] $effectivePrivileges */
+            foreach ($role->getPrivilegesByType(EditNodePrivilege::class) as $privilege) {
+                if ($privilege->matchesSubject($privilegeSubject) && $privilege->isDenied()) {
+                    return array_keys($node->getNodeType()->getProperties());
+                }
+            }
+        }
+
+        // Matching node editing privileges only abstained
+        // Filter out node properties where editing is explicitly granted
+        $filter = function (string $propertyName) use ($node) {
+            $privilegeSubject = new PropertyAwareNodePrivilegeSubject($node, null, $propertyName);
+            $grants = 0;
+            foreach ($this->securityContext->getRoles() as $role) {
+                /** @var PrivilegeInterface[] $effectivePrivileges */
+                foreach ($role->getPrivilegesByType(EditNodePropertyPrivilege::class) as $privilege) {
+                    if ($privilege->matchesSubject($privilegeSubject)) {
+                        if ($privilege->isDenied()) {
+                            return true;
+                        }
+                        if ($privilege->isGranted()) {
+                            $grants++;
+                        }
+                    }
+                }
+            }
+
+            return $grants === 0;
+        };
+
+        return array_filter(array_keys($node->getNodeType()->getProperties()), $filter);
     }
 }

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/HideSelectedNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/HideSelectedNode/index.js
@@ -19,36 +19,35 @@ export default class HideSelectedNode extends PureComponent {
         hideNode: PropTypes.func.isRequired,
         showNode: PropTypes.func.isRequired,
         destructiveOperationsAreDisabled: PropTypes.bool.isRequired,
-        canBeEdited: PropTypes.bool.isRequired,
         visibilityCanBeToggled: PropTypes.bool.isRequired,
         i18nRegistry: PropTypes.object.isRequired
     };
 
     handleHideNode = () => {
-        const {node, hideNode, canBeEdited, visibilityCanBeToggled} = this.props;
+        const {node, hideNode, visibilityCanBeToggled} = this.props;
 
-        if (canBeEdited && visibilityCanBeToggled) {
+        if (visibilityCanBeToggled) {
             hideNode($get('contextPath', node));
         }
     }
 
     handleShowNode = () => {
-        const {node, showNode, canBeEdited, visibilityCanBeToggled} = this.props;
+        const {node, showNode, visibilityCanBeToggled} = this.props;
 
-        if (canBeEdited && visibilityCanBeToggled) {
+        if (visibilityCanBeToggled) {
             showNode($get('contextPath', node));
         }
     }
 
     render() {
-        const {className, node, destructiveOperationsAreDisabled, canBeEdited, visibilityCanBeToggled, i18nRegistry} = this.props;
+        const {className, node, destructiveOperationsAreDisabled, visibilityCanBeToggled, i18nRegistry} = this.props;
         const isHidden = $get('properties._hidden', node);
 
         return (
             <IconButton
                 className={className}
                 isActive={isHidden}
-                isDisabled={destructiveOperationsAreDisabled || !canBeEdited || !visibilityCanBeToggled}
+                isDisabled={destructiveOperationsAreDisabled || !visibilityCanBeToggled}
                 onClick={isHidden ? this.handleShowNode : this.handleHideNode}
                 icon="eye-slash"
                 hoverStyle="clean"

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -301,7 +301,7 @@ export default class Node extends PureComponent {
                     onToggle={this.handleNodeToggle}
                     onClick={this.handleNodeClick}
                     dragAndDropContext={this.getDragAndDropContext()}
-                    dragForbidden={$get('isAutoCreated', node)}
+                    dragForbidden={$get('isAutoCreated', node) && !$get('policy.canEdit', node)}
                     title={labelTitle}
                     />
                 {this.isCollapsed() ? null : (

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
@@ -62,17 +62,17 @@ export default class NodeTreeToolBar extends PureComponent {
     }
 
     handleHideNode = contextPath => {
-        const {hideNode, canBeEdited, visibilityCanBeToggled} = this.props;
+        const {hideNode, visibilityCanBeToggled} = this.props;
 
-        if (canBeEdited && visibilityCanBeToggled) {
+        if (visibilityCanBeToggled) {
             hideNode(contextPath);
         }
     }
 
     handleShowNode = contextPath => {
-        const {showNode, canBeEdited, visibilityCanBeToggled} = this.props;
+        const {showNode, visibilityCanBeToggled} = this.props;
 
-        if (canBeEdited && visibilityCanBeToggled) {
+        if (visibilityCanBeToggled) {
             showNode(contextPath);
         }
     }
@@ -151,7 +151,7 @@ export default class NodeTreeToolBar extends PureComponent {
                         i18nRegistry={i18nRegistry}
                         className={style.toolBar__btnGroup__btn}
                         focusedNodeContextPath={focusedNodeContextPath}
-                        isDisabled={destructiveOperationsAreDisabled || !canBeEdited || !visibilityCanBeToggled}
+                        isDisabled={destructiveOperationsAreDisabled || !visibilityCanBeToggled}
                         isHidden={isHidden}
                         onHide={this.handleHideNode}
                         onShow={this.handleShowNode}

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {$get, $contains} from 'plow-js';
+import {$contains, $get} from 'plow-js';
 import Tabs from '@neos-project/react-ui-components/src/Tabs/';
 
 import PropertyGroup from '../PropertyGroup/index';
@@ -19,10 +19,10 @@ export default class TabPanel extends PureComponent {
         handleInspectorApply: PropTypes.func
     };
 
-    isPropertyEnabled = ({id}) => {
+    isPropertyEnabled = property => {
         const {node} = this.props;
 
-        return !$contains(id, 'policy.disallowedProperties', node);
+        return !$contains($get('id', property), 'policy.disallowedProperties', node);
     };
 
     render() {

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -169,10 +169,10 @@ export default class Inspector extends PureComponent {
         }
     }
 
-    isPropertyEnabled = ({id}) => {
+    isPropertyEnabled = property => {
         const {focusedNode} = this.props;
 
-        return !$contains(id, 'policy.disallowedProperties', focusedNode);
+        return !$contains($get('id', property), 'policy.disallowedProperties', focusedNode);
     };
 
     /**


### PR DESCRIPTION
This PR contains multiple fixes to get to the point where the behavior of the UI corresponds to the behavior of the ContentRepository.

When you get an abstaining `EditNodePrivilege` (resulting in a "soft" DENY) in combination with an `EditNodePropertyPrivilege` GRANT, the UI ignores the latter and denies editing. The ContentRepository on the other hand (or rather Flows SecurityInterceptor) sees both privileges matching, one abstaining and the other granting, so it will allow access to the editProperty method.

The commit abc4c72310cadd5354a52f4a4114a892a7bffc0d isn't really connected that closely to this, but I stumbled upon it while fixing. If necessary, I'll extract it (or any other commit for that matter) into another PR.