### PR TITLE
BUGFIX: Inline editable placeholder text misaligned

### DIFF
--- a/packages/neos-ui-ckeditor5-bindings/src/plugins/neosPlaceholder.vanilla-css
+++ b/packages/neos-ui-ckeditor5-bindings/src/plugins/neosPlaceholder.vanilla-css
@@ -2,5 +2,4 @@
     color: #999;
     content: attr(data-neos-placeholder);
     cursor: text;
-    position: absolute;
 }


### PR DESCRIPTION
Ensures placeholder text for inline editable properties are aligned similar to inserted text.

Fixes #2166