### PR TITLE
BUGFIX: getAllowed(Grand)ChildNodeTypes won't return abstract NodeTypes anymore

### DIFF
--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.js
@@ -55,13 +55,13 @@ export default class NodeTypesRegistry extends SynchronousRegistry {
     getAllowedChildNodeTypes(nodeTypeName) {
         const result = $get([nodeTypeName, 'nodeTypes'], this._constraints);
 
-        return Object.keys(result || []).filter(key => result[key]);
+        return Object.keys(result || []).filter(key => result[key] && this.has(key), this);
     }
 
     getAllowedGrandChildNodeTypes(nodeTypeName, childNodeName) {
         const result = $get([nodeTypeName, 'childNodes', childNodeName, 'nodeTypes'], this._constraints);
 
-        return Object.keys(result || []).filter(key => result[key]);
+        return Object.keys(result || []).filter(key => result[key] && this.has(key), this);
     }
 
     getAllowedNodeTypesTakingAutoCreatedIntoAccount(isSubjectNodeAutocreated, referenceParentName, referenceParentNodeType, referenceGrandParentNodeType, role) {

--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.spec.js
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.spec.js
@@ -5,10 +5,31 @@ test(`
     for a given node type`, () => {
     const nodeTypesRegistry = new NodeTypesRegistry(``);
 
+    nodeTypesRegistry.set('Neos.Neos.NodeTypes:Page', {
+        name: 'Neos.Neos.NodeTypes:Page',
+        label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label',
+        ui: {
+            label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label'
+        }
+    });
+    nodeTypesRegistry.set('Test:Page', {
+        name: 'Test:Page',
+        ui: {
+            label: 'The test page type'
+        }
+    });
+    nodeTypesRegistry.set('Test:Page2', {
+        name: 'Test:Page2',
+        ui: {
+            label: 'The test page type 2'
+        }
+    });
+
     nodeTypesRegistry.setConstraints({
         'Neos.Neos.NodeTypes:Page': {
             nodeTypes: {
                 'Neos.Neos.NodeTypes:Page': true,
+                'Test:Mixin': true,
                 'Test:Page': true,
                 'Test:Page2': true
             }
@@ -30,11 +51,32 @@ test(`
     node types for a given node type`, () => {
     const nodeTypesRegistry = new NodeTypesRegistry(``);
 
+    nodeTypesRegistry.set('Neos.Neos.NodeTypes:Page', {
+        name: 'Neos.Neos.NodeTypes:Page',
+        label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label',
+        ui: {
+            label: 'Neos.Neos.NodeTypes:NodeTypes.Page:ui.label'
+        }
+    });
+    nodeTypesRegistry.set('Test:Page', {
+        name: 'Test:Page',
+        ui: {
+            label: 'The test page type'
+        }
+    });
+    nodeTypesRegistry.set('Test:Page2', {
+        name: 'Test:Page2',
+        ui: {
+            label: 'The test page type 2'
+        }
+    });
+
     nodeTypesRegistry.setConstraints({
         'Neos.Neos.NodeTypes:Page': {
             childNodes: {
                 main: {
                     nodeTypes: {
+                        'Test:Mixin': true,
                         'Test:Page': true
                     }
                 }


### PR DESCRIPTION
**What I did**
If an abstract NodeType was allowed to be created as to another nodes constraints, but disallowed due to other policies (mentioned below), the "create node" buttons weren't deactivated.

**How I did it**
Add a check to `NodeTypesRegistry`s `getAllowedChildNodeTypes` and `getAllowedGrandChildNodeTypes` which checks if the NodeType is valid (i.e. not abstract) by looking it up in its own collection (the registry).

**How to verify it**
* `Node` with `NodeMixin`
* Document `ParentNode` with `constraints.nodetypes: [NodeMixin: true]`
* `CreateNodePrivilege` with `matcher: createdNodeIsOfType('Node')`, abstaining or denying

Now try to create a child node under the `ParentNode`. `Node` is theoretically allowed as child node due to being a NodeMixin, but blocked for the user due to the policy.
The create node button is not disabled due to it not knowing `NodeMixin` is abstract. But then the creation dialog does know it and won't display anyhing.