### PR TITLE
Add fixed-width alignment for icons in SelectNodeType dialog

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeItem.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeItem.js
@@ -46,7 +46,9 @@ class NodeTypeItem extends PureComponent {
                     title={helpMessage ? helpMessage : ''}
                 >
                     <span>
-                        {icon && <Icon icon={icon} className={style.nodeType__icon} padded="right"/>}
+                        <span className={style.nodeType__iconWrapper}>
+                            {icon && <Icon icon={icon} className={style.nodeType__icon} padded="right"/>}
+                        </span>
                         <I18n id={label} fallback={label}/>
                     </span>
                 </Button>

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/style.css
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/style.css
@@ -21,6 +21,11 @@
     top: 40px;
 }
 
+.nodeType__iconWrapper {
+    width: 2em;
+    display: inline-block;
+    text-align: center;
+}
 .nodeType__icon {
     color: var(--colors-PrimaryBlue);
 


### PR DESCRIPTION
In the SelectNodeType dialog (that comes up when adding a document or content node), the icons in the list were not properly aligned. This PR fixes it, see screenshots.

Before:
![bildschirmfoto 2018-10-12 um 15 46 26](https://user-images.githubusercontent.com/3976405/46873062-0c9d6e80-ce36-11e8-956f-ad303b1fcea1.png)

After:
![bildschirmfoto 2018-10-12 um 15 46 15](https://user-images.githubusercontent.com/3976405/46873073-1030f580-ce36-11e8-82e0-67be1279b245.png)
