### PR TITLE
BUGFIX: make the count validator work with the references editor in inspector

### DIFF
--- a/packages/neos-ui-validators/src/Count/index.js
+++ b/packages/neos-ui-validators/src/Count/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import I18n from '@neos-project/neos-ui-i18n';
 import logger from '@neos-project/utils-logger';
+import {List} from 'immutable';
 
 /**
  * Checks if the given value is an object or array
@@ -20,6 +21,9 @@ const Count = (value, validatorOptions) => {
         return <I18n id="content.inspector.validators.countValidator.notCountable"/>;
     }
 
+    if (value instanceof List) {
+        value = value.toJS();
+    }
     const {length} = Object.keys(value);
 
     if (length < minimum || length > maximum) {


### PR DESCRIPTION
**What I did**
If you are using the count validator for an references editor, in the node creation dialog everything is fine, but in the inspector there's always an error. In fact this error is there because the count validator counts the Object-keys of the value to check, and for the inspector this is always the same number because an object of the class List (from immutable.js) is used which always has the same length.

**How I did it**
By calling the method asJS() we get the array of the immutable list and thus have the proper countable element which we pass to the original count function. 

Here's the question though: Should we use asObject or asArray to get an object to count, or should the conversion be earlier than in the validator itself? I didn't really know if there is a better way, this is what worked in my tests.


**How to verify it**
* Create a nodetype with a property of the type references
* add the count validator to it and use e.g. min 1 and max 3
* without the fix the inspector always displays "should be between 1 and 3", with the fix it displays a valid (green) formfield
