### PR TITLE
BUGFIX: Use UTC date for dateOnly DateInput

### DIFF
--- a/packages/react-ui-components/src/DateInput/__snapshots__/dateInput.spec.js.snap
+++ b/packages/react-ui-components/src/DateInput/__snapshots__/dateInput.spec.js.snap
@@ -63,3 +63,68 @@ exports[`<DateInput/> should render correctly. 1`] = `
   </Component>
 </div>
 `;
+
+exports[`<DateInput/> should set "utc" on DatePickerComponent if "dateOnly" prop is set. 1`] = `
+<div
+  className=""
+>
+  <div
+    className="undefined"
+  >
+    <button
+      className=""
+      onClick={[Function]}
+    >
+      <Component
+        icon="far calendar-alt"
+      />
+    </button>
+    <div>
+      <div
+        className=""
+        onClick={[Function]}
+        role="presentation"
+      />
+      <input
+        onFocus={[Function]}
+        readOnly={true}
+        type="datetime"
+        value=""
+      />
+    </div>
+    <button
+      className=""
+      onClick={[Function]}
+    >
+      <Component
+        icon="times"
+      />
+    </button>
+  </div>
+  <Component
+    isOpened={false}
+  >
+    <button
+      onClick={[Function]}
+    />
+    <Component
+      dateFormat={true}
+      onChange={[Function]}
+      open={true}
+      timeConstraints={
+        Object {
+          "minutes": Object {
+            "step": 5,
+          },
+        }
+      }
+      timeFormat={false}
+      utc={true}
+    />
+    <Component
+      onClick={[Function]}
+      style="brand"
+    />
+  </Component>
+</div>
+`;

--- a/packages/react-ui-components/src/DateInput/dateInput.js
+++ b/packages/react-ui-components/src/DateInput/dateInput.js
@@ -196,6 +196,7 @@ export class DateInput extends PureComponent {
                         open={true}
                         defaultValue={value}
                         dateFormat={!timeOnly}
+                        utc={dateOnly}
                         locale={locale}
                         timeFormat={!dateOnly}
                         onChange={this.handleChange}
@@ -240,7 +241,11 @@ export class DateInput extends PureComponent {
         this.setState({
             isOpen: false
         }, () => {
-            this.props.onChange(moment().toDate());
+            let date = moment().toDate();
+            if (this.props.dateOnly) {
+                date = moment().utc().startOf('day').toDate();
+            }
+            this.props.onChange(date);
         });
     }
 

--- a/packages/react-ui-components/src/DateInput/dateInput.spec.js
+++ b/packages/react-ui-components/src/DateInput/dateInput.spec.js
@@ -84,4 +84,31 @@ describe('<DateInput/>', () => {
         expect(onChange.mock.calls.length).toBe(1);
         expect(onChange.mock.calls[0][0].toTimeString()).toBe(date.toTimeString());
     });
+
+    it('should set "utc" on DatePickerComponent if "dateOnly" prop is set.', () => {
+        const wrapper = shallow(<DateInput {...props} dateOnly={true}/>);
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should call "onChange" with beginning of day in UTC for todays date if "dateOnly" is set.', () => {
+        const onChange = jest.fn();
+        const wrapper = shallow(<DateInput {...props} dateOnly={true} onChange={onChange}/>);
+        const btn = wrapper.find('button').at(2);
+        const date = new Date();
+
+        wrapper.setState({isOpen: true});
+        btn.simulate('click');
+
+        expect(onChange.mock.calls.length).toBe(1);
+
+        const receivedDate = onChange.mock.calls[0][0];
+        expect(receivedDate.getUTCDate()).toBe(date.getDate());
+        expect(receivedDate.getUTCMonth()).toBe(date.getMonth());
+        expect(receivedDate.getUTCFullYear()).toBe(date.getFullYear());
+        expect(receivedDate.getUTCHours()).toBe(0);
+        expect(receivedDate.getUTCMinutes()).toBe(0);
+        expect(receivedDate.getUTCSeconds()).toBe(0);
+        expect(receivedDate.getUTCMilliseconds()).toBe(0);
+    });
 });

--- a/packages/react-ui-components/src/DateInput/index.story.js
+++ b/packages/react-ui-components/src/DateInput/index.story.js
@@ -16,6 +16,23 @@ storiesOf('DateInput', module)
                     onChange={action('onChange')}
                     dateOnly={boolean('Date only', false)}
                     timeOnly={boolean('Time only', false)}
+                    todayLabel="Today"
+                    />
+            </StoryWrapper>
+        ),
+        {inline: true, source: false}
+    )
+    .addWithInfo(
+        'dateOnly',
+        'Date only DateInput selector.',
+        () => (
+            <StoryWrapper>
+                <DateInput
+                    placeholder={text('Placeholder', 'No date set')}
+                    onChange={action('onChange')}
+                    dateOnly={boolean('Date only', true)}
+                    timeOnly={boolean('Time only', false)}
+                    todayLabel="Today"
                     />
             </StoryWrapper>
         ),


### PR DESCRIPTION
**What I did**

* Add utc prop to react-datetime if dateOnly is set
* Today button will use start of day in UTC if dateOnly is set

**How to verify it**

* Open storybook and test the DateInput stories
* Run tests

Relates #2147 