### PR TITLE
TASK: Add title attributes to secondarytoolbar components

### DIFF
--- a/packages/neos-ui/src/Containers/SecondaryToolbar/FullScreenButton/index.js
+++ b/packages/neos-ui/src/Containers/SecondaryToolbar/FullScreenButton/index.js
@@ -31,6 +31,7 @@ export default class FullScreenButton extends PureComponent {
                 className={style.fullScreenClose}
                 onClick={toggleFullScreen}
                 aria-label={i18nRegistry.translate('Neos.Neos:Main:deactivateFullscreen', 'Deactivate Fullscreen edit mode')}
+                title={i18nRegistry.translate('Neos.Neos:Main:deactivateFullscreen', 'Deactivate Fullscreen edit mode')}
                 />
             ) : (
                 <IconButton
@@ -38,6 +39,7 @@ export default class FullScreenButton extends PureComponent {
                     icon="expand"
                     onClick={toggleFullScreen}
                     aria-label={i18nRegistry.translate('Neos.Neos:Main:activateFullscreen', 'Activate Fullscreen edit mode')}
+                    title={i18nRegistry.translate('Neos.Neos:Main:activateFullscreen', 'Activate Fullscreen edit mode')}
                     />
             );
     }

--- a/packages/neos-ui/src/Containers/SecondaryToolbar/KeyboardShortcutButton/index.js
+++ b/packages/neos-ui/src/Containers/SecondaryToolbar/KeyboardShortcutButton/index.js
@@ -32,6 +32,7 @@ export default class KeyboardShortcutButton extends PureComponent {
             <IconButton
                 icon="keyboard"
                 aria-label={i18nRegistry.translate('Neos.Neos:Main:displayKeyboardShortcuts', 'Display Keyboard Shortcuts')}
+                title={i18nRegistry.translate('Neos.Neos:Main:displayKeyboardShortcuts', 'Display Keyboard Shortcuts')}
                 onClick={open}
                 />
         );

--- a/packages/neos-ui/src/Containers/SecondaryToolbar/PreviewButton/index.js
+++ b/packages/neos-ui/src/Containers/SecondaryToolbar/PreviewButton/index.js
@@ -36,6 +36,7 @@ export default class PreviewButton extends PureComponent {
                     target="neosPreview"
                     className={previewButtonClassNames}
                     aria-label={i18nRegistry.translate('Neos.Neos:Main:showPreview', 'Show Preview')}
+                    title={i18nRegistry.translate('Neos.Neos:Main:showPreview', 'Show Preview')}
                     >
                     <Icon icon="external-link-alt"/>
                 </a>


### PR DESCRIPTION
There are no title attributes on the secondary toolbar buttons so no description on hover.