### PR TITLE
WIP: FEATURE: add a splash-like loading experience & allow customization

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -133,6 +133,7 @@ class BackendController extends ActionController
         $this->view->assign('site', $siteNode);
         $this->view->assign('headScripts', $this->styleAndJavascriptInclusionService->getHeadScripts());
         $this->view->assign('headStylesheets', $this->styleAndJavascriptInclusionService->getHeadStylesheets());
+        $this->view->assign('splashScreenPartial', $this->settings['splashScreen']['partial']);
         $this->view->assign('sitesForMenu', $this->menuHelper->buildSiteList($this->getControllerContext()));
 
         $this->view->assign('interfaceLanguage', $this->userService->getInterfaceLanguage());

--- a/Classes/Domain/Service/StyleAndJavascriptInclusionService.php
+++ b/Classes/Domain/Service/StyleAndJavascriptInclusionService.php
@@ -55,15 +55,15 @@ class StyleAndJavascriptInclusionService
 
     public function getHeadScripts()
     {
-        return $this->build($this->javascriptResources, function ($uri) {
-            return '<script src="' . $uri . '"></script>';
+        return $this->build($this->javascriptResources, function ($uri, $defer) {
+            return '<script src="' . $uri . '" ' . $defer . '></script>';
         });
     }
 
     public function getHeadStylesheets()
     {
-        return $this->build($this->stylesheetResources, function ($uri) {
-            return '<link rel="stylesheet" href="' . $uri . '" />';
+        return $this->build($this->stylesheetResources, function ($uri, $defer) {
+            return '<link rel="stylesheet" href="' . $uri . '" ' . $defer . '/>';
         });
     }
 
@@ -86,7 +86,8 @@ class StyleAndJavascriptInclusionService
                 $resourceExpression = $this->resourceManager->getPublicPackageResourceUriByPath($resourceExpression);
             }
             $finalUri = $hash ? $resourceExpression . '?' . $hash : $resourceExpression;
-            $result .= $builderForLine($finalUri);
+            $defer = key_exists('defer', $element) && $element['defer'] ? 'defer ' : '';
+            $result .= $builderForLine($finalUri, $defer);
         }
 
         return $result;

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -25,6 +25,9 @@ Neos:
         Neos.Neos.Ui: true
     Ui:
 
+      splashScreen:
+        partial: 'SplashScreen'
+
       # API: "start 100" and smaller numbers; "no numbers", ...
       resources:
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -32,9 +32,11 @@ Neos:
           'Neos.Neos.UI:Vendor':
             resource: '${"resource://" + Neos.Ui.StaticResources.compiledResourcePackage() + "/Public/JavaScript/Vendor.js"}'
             position: 'start 1000'
+            defer: true
           'Neos.Neos.UI:Host':
             resource: '${"resource://" + Neos.Ui.StaticResources.compiledResourcePackage() + "/Public/JavaScript/Host.js"}'
             position: 'start 900'
+            defer: true
 
         stylesheets:
           'Neos.Neos.UI:Host':

--- a/Resources/Private/Fusion/Backend/Root.fusion
+++ b/Resources/Private/Fusion/Backend/Root.fusion
@@ -9,6 +9,7 @@ backend = Neos.Fusion:Template {
 
     headScripts = ${headScripts}
     headStylesheets = ${headStylesheets}
+    splashScreenPartial = ${splashScreenPartial}
 
     configuration = Neos.Fusion:RawArray {
         nodeTree = ${Configuration.setting('Neos.Neos.userInterface.navigateComponent.nodeTree')}

--- a/Resources/Private/Templates/Backend/Index.html
+++ b/Resources/Private/Templates/Backend/Index.html
@@ -11,6 +11,7 @@
         <script>_NEOS_UI_routes = {routes -> f:format.raw()};</script>
 
         {headStylesheets -> f:format.raw()}
+        {headScripts -> f:format.raw()}
     </head>
     <body>
         <div id="appContainer" data-csrf-token="{f:security.csrfToken()}" data-first-tab="{documentNodeUri}" data-env="{env}">
@@ -48,6 +49,5 @@
                 </svg>
             </div>
         </div>
-        {headScripts -> f:format.raw()}
     </body>
 </html>

--- a/Resources/Private/Templates/Backend/Index.html
+++ b/Resources/Private/Templates/Backend/Index.html
@@ -10,11 +10,44 @@
         <script>_NEOS_UI_initialState = {initialState -> f:format.raw()};</script>
         <script>_NEOS_UI_routes = {routes -> f:format.raw()};</script>
 
-        {headScripts -> f:format.raw()}
         {headStylesheets -> f:format.raw()}
     </head>
     <body>
         <div id="appContainer" data-csrf-token="{f:security.csrfToken()}" data-first-tab="{documentNodeUri}" data-env="{env}">
+            <style><![CDATA[
+                @keyframes color_change {
+                    0% {
+                        filter: drop-shadow(0 0 0 #03b6f0) opacity(25%);
+                    }
+                    100% {
+                        filter: drop-shadow(0 0 5px #03b6f0) opacity(100%);
+                    }
+                }
+
+                .loadingIcon {
+                    color: #03b6f0;
+                    animation-name: color_change;
+                    animation-duration: 1.2s;
+                    animation-iteration-count: infinite;
+                    animation-direction: alternate;
+                    animation-timing-function: ease-in-out;
+                }
+                .splash {
+                    width: 100vw;
+                    height: 100vh;
+                    background-color: black;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    font-size: 30px;
+                }
+            ]]></style>
+            <div class="splash">
+                <svg aria-hidden="true" data-prefix="fab" data-icon="neos" class="neos-svg-inline--fa neos-fa-neos fa-w-15 fa-3x loadingIcon" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 456 512" aria-label="Loading...">
+                    <path fill="currentColor" d="M387.44 512h-95.11L184.12 357.46v91.1L97.69 512H0V29.82L40.47 0h108.05l123.74 176.13V63.45L358.69 0h97.69v461.5L387.44 512zM10.77 35.27v460.72l72.01-52.88V193.95l215.49 307.69h84.79l52.35-38.17h-78.27L40.96 12.98 10.77 35.27zm82.54 466.61l80.04-58.78V342.06L93.55 227.7v220.94l-72.58 53.25h72.34zM52.63 10.77l310.6 442.57h82.37V10.77h-79.75v317.56L142.91 10.77H52.63zm230.4 180.88l72.01 102.81V15.93l-72.01 52.96v122.76z"/>
+                </svg>
+            </div>
         </div>
+        {headScripts -> f:format.raw()}
     </body>
 </html>

--- a/Resources/Private/Templates/Backend/Index.html
+++ b/Resources/Private/Templates/Backend/Index.html
@@ -15,39 +15,7 @@
     </head>
     <body>
         <div id="appContainer" data-csrf-token="{f:security.csrfToken()}" data-first-tab="{documentNodeUri}" data-env="{env}">
-            <style><![CDATA[
-                @keyframes color_change {
-                    0% {
-                        filter: drop-shadow(0 0 0 #03b6f0) opacity(25%);
-                    }
-                    100% {
-                        filter: drop-shadow(0 0 5px #03b6f0) opacity(100%);
-                    }
-                }
-
-                .loadingIcon {
-                    color: #03b6f0;
-                    animation-name: color_change;
-                    animation-duration: 1.2s;
-                    animation-iteration-count: infinite;
-                    animation-direction: alternate;
-                    animation-timing-function: ease-in-out;
-                }
-                .splash {
-                    width: 100vw;
-                    height: 100vh;
-                    background-color: black;
-                    display: flex;
-                    align-items: center;
-                    justify-content: center;
-                    font-size: 30px;
-                }
-            ]]></style>
-            <div class="splash">
-                <svg aria-hidden="true" data-prefix="fab" data-icon="neos" class="neos-svg-inline--fa neos-fa-neos fa-w-15 fa-3x loadingIcon" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 456 512" aria-label="Loading...">
-                    <path fill="currentColor" d="M387.44 512h-95.11L184.12 357.46v91.1L97.69 512H0V29.82L40.47 0h108.05l123.74 176.13V63.45L358.69 0h97.69v461.5L387.44 512zM10.77 35.27v460.72l72.01-52.88V193.95l215.49 307.69h84.79l52.35-38.17h-78.27L40.96 12.98 10.77 35.27zm82.54 466.61l80.04-58.78V342.06L93.55 227.7v220.94l-72.58 53.25h72.34zM52.63 10.77l310.6 442.57h82.37V10.77h-79.75v317.56L142.91 10.77H52.63zm230.4 180.88l72.01 102.81V15.93l-72.01 52.96v122.76z"/>
-                </svg>
-            </div>
+            <f:render partial="{splashScreenPartial}" />
         </div>
     </body>
 </html>

--- a/Resources/Private/Templates/Backend/Partials/SplashScreen.html
+++ b/Resources/Private/Templates/Backend/Partials/SplashScreen.html
@@ -1,0 +1,33 @@
+<style>
+    @keyframes color_change {
+        0% {
+            filter: drop-shadow(0 0 0 #00ADEE) opacity(25%);
+        }
+        100% {
+            filter: drop-shadow(0 0 5px #00ADEE) opacity(100%);
+        }
+    }
+
+    .loadingIcon {
+        color: #00ADEE;
+        animation-name: color_change;
+        animation-duration: 1.2s;
+        animation-iteration-count: infinite;
+        animation-direction: alternate;
+        animation-timing-function: ease-in-out;
+    }
+    .splash {
+        width: 100vw;
+        height: 100vh;
+        background-color: #222222;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 30px;
+    }
+</style>
+<div class="splash">
+    <svg aria-hidden="true" data-prefix="fab" data-icon="neos" class="neos-svg-inline--fa neos-fa-neos fa-w-15 fa-3x loadingIcon" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 456 512" aria-label="Loading...">
+        <path fill="currentColor" d="M387.44 512h-95.11L184.12 357.46v91.1L97.69 512H0V29.82L40.47 0h108.05l123.74 176.13V63.45L358.69 0h97.69v461.5L387.44 512zM10.77 35.27v460.72l72.01-52.88V193.95l215.49 307.69h84.79l52.35-38.17h-78.27L40.96 12.98 10.77 35.27zm82.54 466.61l80.04-58.78V342.06L93.55 227.7v220.94l-72.58 53.25h72.34zM52.63 10.77l310.6 442.57h82.37V10.77h-79.75v317.56L142.91 10.77H52.63zm230.4 180.88l72.01 102.81V15.93l-72.01 52.96v122.76z"/>
+    </svg>
+</div>

--- a/packages/neos-ui/src/index.js
+++ b/packages/neos-ui/src/index.js
@@ -21,8 +21,6 @@ import Root from './Containers/Root';
 import apiExposureMap from './apiExposureMap';
 import DelegatingReducer from './DelegatingReducer';
 
-import Icon from '@neos-project/react-ui-components/src/Icon/';
-
 const devToolsArePresent = typeof window === 'object' && typeof window.devToolsExtension !== 'undefined';
 const devToolsStoreEnhancer = () => devToolsArePresent ? window.devToolsExtension() : f => f;
 const sagaMiddleWare = createSagaMiddleware();
@@ -55,17 +53,6 @@ require('@neos-project/neos-ui-i18n/src/manifest');
 //
 function * application() {
     const appContainer = yield system.getAppContainer;
-
-    //
-    // We'll show just some loading screen,
-    // until we're good to go
-    //
-    ReactDOM.render(
-        <div style={{width: '100vw', height: '100vh', backgroundColor: 'black', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '30px'}}>
-            <Icon icon="circle-notch" label="Loading..." spin={true} size="2x"/>
-        </div>,
-        appContainer
-    );
 
     //
     // Initialize Neos JS API


### PR DESCRIPTION
# TODO

- [x] create default settings
- [x] allow customization 

**What I did**
While developing I noticed the rather stale loading experience of the Neos frontend.
I built a pretty simple animation for the Neos logo.
Also I noticed, that the user spends most of the time in front of a white screen while downloading, parsing and initially running the rather huge script files (I know, I am running the dev build, not production, but still..).

So I thought it would be nice to see this loading splash screen even before the scripts are being loaded.

The splash screen is a partial that is rendered inside the `app-container` wich will be overridden by React once the UI is ready to be rendered.
It is configurable in `Settings.yaml` of the Package:
```yaml
Neos:
    Neos:
        Ui:
            splashScreen:
                partial: 'SplashPartial'
```

**How I did it**
Added a splash screen to `index.html` that is the template for the page.
The splash and it's styles will be overwritten once React renders into the DOM.

We can also make this splash customizable through the `Settings.yaml`. (eg by setting the logo svg path or background color.. similar to the login screen customizations).

**How to verify it**
`flow server:run` -> open site with slow internet connection

![neosloadingsplash_logo_only 2018-10-19 15_18_12](https://user-images.githubusercontent.com/1615332/47220496-37e20980-d3b2-11e8-8f75-4e880f970df8.gif)
