### PR TITLE
 TASK: load all modals from the registry automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "lodash.omit": "^4.5.0",
     "lodash.sortby": "^4.7.0",
     "lodash.throttle": "^4.1.1",
+    "lodash.upperfirst": "^4.3.0",
     "lodash.unescape": "4.0.1",
     "moment": "^2.20.1",
     "monet": "^0.8.10",

--- a/packages/build-essentials/package.json
+++ b/packages/build-essentials/package.json
@@ -29,6 +29,7 @@
     "cross-env": "^5.1.3",
     "eslint": "^5.3.0",
     "extract-text-webpack-plugin": "^3.0.2",
+    "lodash.upperfirst": "^4.3.0",
     "postcss-css-variables": "^0.9.0",
     "postcss-hexrgba": "^1.0.0",
     "postcss-import": "^11.0.0",

--- a/packages/neos-ui/src/Containers/Modals/index.js
+++ b/packages/neos-ui/src/Containers/Modals/index.js
@@ -13,27 +13,11 @@ export default class Modals extends PureComponent {
     render() {
         const {containerRegistry} = this.props;
 
-        const DiscardDialog = containerRegistry.get('Modals/DiscardDialog');
-        const DeleteNodeModal = containerRegistry.get('Modals/DeleteNodeModal');
-        const InsertModeModal = containerRegistry.get('Modals/InsertModeModal');
-        const KeyboardShortcutModal = containerRegistry.get('Modals/KeyboardShortcutModal');
-        const SelectNodeTypeModal = containerRegistry.get('Modals/SelectNodeTypeModal');
-        const NodeCreationDialog = containerRegistry.get('Modals/NodeCreationDialog');
-        const NodeVariantCreationDialog = containerRegistry.get('Modals/NodeVariantCreationDialog');
-        const ReloginDialog = containerRegistry.get('Modals/ReloginDialog');
-        const UnappliedChangesDialog = containerRegistry.get('Modals/UnappliedChangesDialog');
+        const modals = containerRegistry.getChildren('Modals');
 
         return (
             <div>
-                <DiscardDialog/>
-                <DeleteNodeModal/>
-                <InsertModeModal/>
-                <KeyboardShortcutModal />
-                <SelectNodeTypeModal/>
-                <NodeCreationDialog/>
-                <NodeVariantCreationDialog/>
-                <ReloginDialog/>
-                <UnappliedChangesDialog/>
+                {modals.map((Component, key) => <Component key={key} />)}
             </div>
         );
     }


### PR DESCRIPTION
The modals are now automatically loaded from the registry, which allows to create custom modals from 3rd-party plugins.

Can be used like this: https://github.com/Flowpack/restrict-creation/blob/master/Resources/Private/RestrictCreation/src/manifest.js#L17