### PR TITLE
BUGFIX: fix options pallete of the LinkEditor

### DIFF
--- a/packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/LinkButton.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/LinkButton.js
@@ -93,8 +93,8 @@ export default class LinkButton extends PureComponent {
                             options={$get('linking', inlineEditorOptions)}
                             linkValue={this.getLinkValue()}
                             linkTitleValue={this.getLinkTitleValue()}
-                            linkRelValue={this.getLinkRelValue()}
-                            linkTargetValue={this.getLinkTargetValue()}
+                            linkRelNofollowValue={this.getLinkRelValue()}
+                            linkTargetBlankValue={this.getLinkTargetValue()}
                             onLinkChange={this.handleLinkChange}
                             onLinkTitleChange={this.handleLinkTitleChange}
                             onLinkRelChange={this.handleLinkRelChange}
@@ -120,10 +120,10 @@ export default class LinkButton extends PureComponent {
     }
 
     getLinkRelValue() {
-        return $get('linkRel', this.props.formattingUnderCursor) || '';
+        return $get('linkRelNofollow', this.props.formattingUnderCursor) || false;
     }
 
     getLinkTargetValue() {
-        return $get('linkTarget', this.props.formattingUnderCursor) || '';
+        return $get('linkTargetBlank', this.props.formattingUnderCursor) || false;
     }
 }

--- a/packages/neos-ui-editors/src/Library/LinkInput.js
+++ b/packages/neos-ui-editors/src/Library/LinkInput.js
@@ -38,7 +38,6 @@ const looksLikeExternalLink = link => {
 export default class LinkInput extends PureComponent {
     static propTypes = {
         i18nRegistry: PropTypes.object,
-        linkValue: PropTypes.string,
         options: PropTypes.shape({
             nodeTypes: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
             placeholder: PropTypes.string,
@@ -51,6 +50,10 @@ export default class LinkInput extends PureComponent {
             nodes: PropTypes.bool
         }),
         setFocus: PropTypes.bool,
+        linkValue: PropTypes.string,
+        linkTitleValue: PropTypes.string,
+        linkRelNofollowValue: PropTypes.bool,
+        linkTargetBlankValue: PropTypes.bool,
         onLinkChange: PropTypes.func.isRequired,
         onLinkRelChange: PropTypes.func,
         onLinkTargetChange: PropTypes.func,
@@ -317,7 +320,7 @@ export default class LinkInput extends PureComponent {
                         <div>
                             <TextInput
                                 id="__neos__linkEditor--title"
-                                value={$get('linkTitle', this.props.formattingUnderCursor) || ''}
+                                value={this.props.linkTitleValue || ''}
                                 placeholder={this.props.i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__titlePlaceholder', 'Enter link title')}
                                 onChange={value => {
                                     this.props.onLinkTitleChange(value);
@@ -331,7 +334,7 @@ export default class LinkInput extends PureComponent {
                             <label>
                                 <CheckBox
                                     onChange={this.props.onLinkTargetChange}
-                                    isChecked={$get('linkTargetBlank', this.props.formattingUnderCursor) || false}
+                                    isChecked={this.props.linkTargetBlankValue || false}
                                 /> {this.props.i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__targetBlank', 'Open in new window')}
                             </label>
                         </div>)}
@@ -340,7 +343,7 @@ export default class LinkInput extends PureComponent {
                             <label>
                                 <CheckBox
                                     onChange={this.props.onLinkRelChange}
-                                    isChecked={$get('linkRelNofollow', this.props.formattingUnderCursor) || false}
+                                    isChecked={this.props.linkRelNofollowValue || false}
                                 /> {this.props.i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__noFollow', 'No follow')}
                             </label>
                         </div>)}


### PR DESCRIPTION
How to test: go to the advanced options palette of the CKE5 link editor and try to toggle options.