### PR TITLE
BUGFIX: Update preview link on node creation and publishing #2173

### DIFF
--- a/packages/neos-ui-sagas/src/Publish/index.js
+++ b/packages/neos-ui-sagas/src/Publish/index.js
@@ -20,6 +20,14 @@ export function * watchPublish() {
                 const feedback = yield call(publish, nodeContextPaths, targetWorkspaceName);
                 yield put(actions.UI.Remote.finishPublishing());
                 yield put(actions.ServerFeedback.handleServerFeedback(feedback));
+
+                const documentNodeContextPath = yield select($get('ui.contentCanvas.contextPath'));
+                const documentNode = yield select(selectors.CR.Nodes.byContextPathSelector(documentNodeContextPath));
+                const documentUri = decodeURIComponent($get('uri', documentNode));
+                const documentUriFragment = documentUri.split('@')[0];
+                const previewUrl = documentUriFragment + '@' + targetWorkspaceName;
+
+                yield put(actions.UI.ContentCanvas.setPreviewUrl(previewUrl));
             } catch (error) {
                 console.error('Failed to publish', error);
             }


### PR DESCRIPTION
On publishing, generate preview link and update ContentCanvas by setting new preview url. Before, the preview button has not been updates, see: https://github.com/neos/neos-ui/issues/2173

I am not sure if this is the correct way to do it and I am open for your feedback. 