### PR TITLE
BUGFIX: Properly reload the page tree if filter or search is reset #2130

### DIFF
--- a/packages/neos-ui-sagas/src/UI/PageTree/index.js
+++ b/packages/neos-ui-sagas/src/UI/PageTree/index.js
@@ -138,8 +138,8 @@ export function * watchSearch({configuration}) {
             } else {
                 const clipboardNodeContextPath = yield select($get('cr.nodes.clipboard'));
                 const toggledNodes = yield select($get('ui.pageTree.toggled'));
-                const documentNodeContextPath = yield $get('payload.documentNodeContextPath', action) || select($get('ui.contentCanvas.contextPath'));
-                
+                const documentNodeContextPath = yield select($get('ui.contentCanvas.contextPath'));
+
                 matchingNodes = yield q([contextPath, documentNodeContextPath]).neosUiDefaultNodes(
                     configuration.nodeTree.presets.default.baseNodeType,
                     configuration.nodeTree.loadingDepth,


### PR DESCRIPTION
Solves #2130: page tree is not properly reset after clearing filter or search.
