### PR TITLE
TASK: Use correct json indentation in `react-ui-components`

### DIFF
--- a/packages/react-ui-components/.editorconfig
+++ b/packages/react-ui-components/.editorconfig
@@ -6,7 +6,7 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[*.{yml,yaml}]
+[*.{yml,yaml,json}]
 indent_size = 2
 
 [*.{md}]


### PR DESCRIPTION
The components have their own `.ediorconfig` which sets everything to 4
spaces by default but the `package.json` uses two spaces indentation.
The fallback to `[*]` overwrites the global one two space indentation
for `*.json`-files.

<!--
Thanks for your contribution, we appreciate it!
-->


**What I did**

Added the `json`-glob to the `.editorconfig` for the `react-ui-components`-package.

**How I did it**

With style.

**How to verify it**

Setup your editor to read the `.editorconfig` correctly and try to indent something in the `package.json` from the `react-ui-components`-package.

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->

