### PR TITLE
BUGFIX: Add missing container for textInput

### DIFF
--- a/packages/react-ui-components/src/TextInput/__snapshots__/textInput.spec.tsx.snap
+++ b/packages/react-ui-components/src/TextInput/__snapshots__/textInput.spec.tsx.snap
@@ -1,12 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<TextInput/> should render correctly. 1`] = `
-<input
-  aria-disabled="false"
-  aria-multiline="false"
-  className="textInputClassName fooClassName"
-  onChange={[Function]}
-  onKeyPress={[Function]}
-  role="textbox"
-/>
+<div>
+  <input
+    aria-disabled="false"
+    aria-multiline="false"
+    className="textInputClassName fooClassName"
+    onChange={[Function]}
+    onKeyPress={[Function]}
+    role="textbox"
+  />
+</div>
 `;

--- a/packages/react-ui-components/src/TextInput/textInput.tsx
+++ b/packages/react-ui-components/src/TextInput/textInput.tsx
@@ -101,19 +101,21 @@ class TextInput extends PureComponent<TextInputProps> {
         };
 
         return (
-            <input
-                {...rest}
-                className={classNames}
-                role="textbox"
-                aria-multiline="false"
-                aria-disabled={disabled ? 'true' : 'false'}
-                type={type}
-                placeholder={placeholder}
-                disabled={disabled}
-                onChange={this.handleValueChange}
-                onKeyPress={this.handleKeyPress}
-                ref={inputRef}
-                />
+            <div className={containerClassName}>
+                <input
+                    {...rest}
+                    className={classNames}
+                    role="textbox"
+                    aria-multiline="false"
+                    aria-disabled={disabled ? 'true' : 'false'}
+                    type={type}
+                    placeholder={placeholder}
+                    disabled={disabled}
+                    onChange={this.handleValueChange}
+                    onKeyPress={this.handleKeyPress}
+                    ref={inputRef}
+                    />
+                </div>
         );
     }
 }


### PR DESCRIPTION
Fixes regression from the typescript migration. The wrapping
div container was missing.

Fixes: #2239