### PR TITLE
BUGFIX: remove defer from core JS assets

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -35,11 +35,9 @@ Neos:
           'Neos.Neos.UI:Vendor':
             resource: '${"resource://" + Neos.Ui.StaticResources.compiledResourcePackage() + "/Public/JavaScript/Vendor.js"}'
             position: 'start 1000'
-            defer: true
           'Neos.Neos.UI:Host':
             resource: '${"resource://" + Neos.Ui.StaticResources.compiledResourcePackage() + "/Public/JavaScript/Host.js"}'
             position: 'start 900'
-            defer: true
 
         stylesheets:
           'Neos.Neos.UI:Host':


### PR DESCRIPTION
We can't defer those, since currently our extensibility layer relies on JS code being loaded in the right order