### PR TITLE
FEATURE: make nodeCreationWorkflow more extensible

### DIFF
--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.js
@@ -95,11 +95,15 @@ const commenceRemoval = createAction(COMMENCE_REMOVAL, contextPath => contextPat
  * Start node creation workflow
  *
  * @param {String} referenceNodeContextPath The context path of the referenceNode
- * @param {String} referenceNodeFusionPath The fusion path of the referenceNode
+ * @param {String} referenceNodeFusionPath (optional) The fusion path of the referenceNode
+ * @param {String} preferredMode (optional) The default mode to use in the nodetype selection dialog. Currently not used withing the system but may be useful for extensibility.
+ * @param {String} nodeType (optional) If set, then the select nodetype step would be skipped completely. Currently not used withing the system but may be useful for extensibility.
  */
-const commenceCreation = createAction(COMMENCE_CREATION, (referenceNodeContextPath, referenceNodeFusionPath) => ({
+const commenceCreation = createAction(COMMENCE_CREATION, (referenceNodeContextPath, referenceNodeFusionPath, preferredMode = 'after', nodeType = null) => ({
     referenceNodeContextPath,
-    referenceNodeFusionPath
+    referenceNodeFusionPath,
+    preferredMode,
+    nodeType
 }));
 
 /**

--- a/packages/neos-ui-redux-store/src/UI/SelectNodeTypeModal/index.js
+++ b/packages/neos-ui-redux-store/src/UI/SelectNodeTypeModal/index.js
@@ -5,6 +5,8 @@ import {$set} from 'plow-js';
 import {handleActions} from '@neos-project/utils-redux';
 import {actionTypes as system} from '../../System/index';
 
+const PREFERRED_MODE_DEFAULT = 'after';
+
 const OPEN = '@neos/neos-ui/UI/SelectNodeTypeModal/OPEN';
 const CANCEL = '@neos/neos-ui/UI/SelectNodeTypeModal/CANCEL';
 const APPLY = '@neos/neos-ui/UI/SelectNodeTypeModal/APPLY';
@@ -18,7 +20,13 @@ export const actionTypes = {
     APPLY
 };
 
-const open = createAction(OPEN, referenceNodeContextPath => referenceNodeContextPath);
+/**
+ * Opens the select nodetype modal.
+ *
+ * @param {string} referenceNodeContextPath ContextPath of the node relative to which the new node ought to be created
+ * @param {string} preferredMode (optional) Allows to override the default insertion mode. Currently not used in the system, but useful for extensibility.
+ */
+const open = createAction(OPEN, (referenceNodeContextPath, preferredMode = PREFERRED_MODE_DEFAULT) => ({referenceNodeContextPath, preferredMode}));
 const cancel = createAction(CANCEL);
 const apply = createAction(APPLY, (mode, nodeType) => ({mode, nodeType}));
 
@@ -39,20 +47,24 @@ export const reducer = handleActions({
         'ui.selectNodeTypeModal',
         new Map({
             isOpen: false,
-            referenceNodeContextPath: ''
+            referenceNodeContextPath: '',
+            preferredMode: PREFERRED_MODE_DEFAULT
         })
     ),
-    [OPEN]: referenceNodeContextPath =>
+    [OPEN]: ({referenceNodeContextPath, preferredMode}) =>
         $set('ui.selectNodeTypeModal', new Map({
             isOpen: true,
-            referenceNodeContextPath
+            referenceNodeContextPath,
+            preferredMode
         })),
     [CANCEL]: () => $set('ui.selectNodeTypeModal', new Map({
         isOpen: false,
-        referenceNodeContextPath: ''
+        referenceNodeContextPath: '',
+        preferredMode: PREFERRED_MODE_DEFAULT
     })),
     [APPLY]: () => $set('ui.selectNodeTypeModal', new Map({
         isOpen: false,
-        referenceNodeContextPath: ''
+        referenceNodeContextPath: '',
+        preferredMode: PREFERRED_MODE_DEFAULT
     }))
 });

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
@@ -15,7 +15,13 @@ import NodeTypeGroupPanel from './nodeTypeGroupPanel';
 import NodeTypeFilter from './nodeTypeFilter';
 import style from './style.css';
 
-const calculateInitialMode = (allowedSiblingNodeTypes, allowedChildNodeTypes) => {
+const calculateInitialMode = (allowedSiblingNodeTypes, allowedChildNodeTypes, preferredMode) => {
+    if (
+        ((preferredMode === 'before' || preferredMode === 'after') && allowedSiblingNodeTypes.length) ||
+        (preferredMode === 'into' && allowedChildNodeTypes.length)
+    ) {
+        return preferredMode;
+    }
     if (allowedSiblingNodeTypes.length) {
         return 'after';
     }
@@ -43,6 +49,7 @@ const calculateInitialMode = (allowedSiblingNodeTypes, allowedChildNodeTypes) =>
 
         return {
             isOpen: $get('ui.selectNodeTypeModal.isOpen', state),
+            preferredMode: $get('ui.selectNodeTypeModal.preferredMode', state),
             allowedSiblingNodeTypes,
             allowedChildNodeTypes
         };
@@ -54,6 +61,7 @@ const calculateInitialMode = (allowedSiblingNodeTypes, allowedChildNodeTypes) =>
 export default class SelectNodeType extends PureComponent {
     static propTypes = {
         isOpen: PropTypes.bool.isRequired,
+        preferredMode: PropTypes.string,
         nodeTypesRegistry: PropTypes.object.isRequired,
         allowedSiblingNodeTypes: PropTypes.array,
         allowedChildNodeTypes: PropTypes.array,
@@ -65,7 +73,8 @@ export default class SelectNodeType extends PureComponent {
         filterSearchTerm: '',
         insertMode: calculateInitialMode(
             this.props.allowedSiblingNodeTypes,
-            this.props.allowedChildNodeTypes
+            this.props.allowedChildNodeTypes,
+            this.props.preferredMode
         ),
         activeHelpMessageGroupPanel: '',
         showHelpMessageFor: ''
@@ -77,7 +86,8 @@ export default class SelectNodeType extends PureComponent {
             this.setState({
                 insertMode: calculateInitialMode(
                     nextProps.allowedSiblingNodeTypes,
-                    nextProps.allowedChildNodeTypes
+                    nextProps.allowedChildNodeTypes,
+                    nextProps.preferredMode
                 )
             });
         }


### PR DESCRIPTION
This feature adds two more (optional) arguments to `commenceNodeCreation` action creator, which allow to specify the desired insertion mode and allow to skip the step of nodetype selection completely.

E.g. `commenceNodeCreation(contextPath, fusionPath, 'into', 'Vendor:News');`.

Usage example: https://github.com/psmb/Psmb.FlatNav/pull/13/commits/0c869ba05cd783a9396891f694577178c1eec539