### PR TITLE
BUGFIX: Fix priviege class inheritance check

### DIFF
--- a/Classes/Service/NodePolicyService.php
+++ b/Classes/Service/NodePolicyService.php
@@ -53,7 +53,7 @@ class NodePolicyService
         foreach ($policyService->getPrivilegeTargets() as $privilegeTarget) {
             $usedPrivilegeClassNames[$privilegeTarget->getPrivilegeClassName()] = true;
             foreach (class_parents($privilegeTarget->getPrivilegeClassName()) as $parentPrivilege) {
-                if (is_a($parentPrivilege, PrivilegeInterface::class)) {
+                if (is_a($parentPrivilege, PrivilegeInterface::class, true)) {
                     $usedPrivilegeClassNames[$parentPrivilege] = true;
                 }
             }


### PR DESCRIPTION
The $parentPrivilege is just class name here, so
is_a always returns false. Setting the third parameter
to true also accepts class names as object.