### PR TITLE
BUGFIX: Correctly export all editors for extensibility

### DIFF
--- a/packages/neos-ui-editors/src/index.js
+++ b/packages/neos-ui-editors/src/index.js
@@ -1,0 +1,96 @@
+import EditorEnvelope from './EditorEnvelope/index';
+
+import {
+    TextField,
+    TextArea,
+    Boolean,
+    DateTime,
+    Image,
+    SelectBox,
+    Link,
+    Reference,
+    References,
+    NodeType,
+    CodeMirror,
+    MasterPlugin,
+    AssetEditor,
+    PluginViews,
+    PluginView
+} from './Editors/index';
+
+import {
+    CodeMirrorWrap,
+    ImageCropper,
+    MediaDetailsScreen,
+    MediaSelectionScreen
+} from './SecondaryEditors/index';
+
+import AssetUpload from './Library/AssetUpload';
+import AssetOption from './Library/AssetOption';
+
+import LinkInput from './Library/LinkInput';
+import LinkOption from './Library/LinkOption';
+
+import NodeOption from './Library/NodeOption';
+
+export {
+    EditorEnvelope,
+
+    TextField,
+    TextArea,
+    Boolean,
+    DateTime,
+    Image,
+    SelectBox,
+    Link,
+    Reference,
+    References,
+    NodeType,
+    CodeMirror,
+    MasterPlugin,
+    AssetEditor,
+    PluginViews,
+    PluginView,
+
+    CodeMirrorWrap,
+    ImageCropper,
+    MediaDetailsScreen,
+    MediaSelectionScreen,
+
+    AssetUpload,
+    AssetOption,
+    LinkInput,
+    LinkOption,
+    NodeOption
+};
+
+export default {
+    EditorEnvelope,
+
+    TextField,
+    TextArea,
+    Boolean,
+    DateTime,
+    Image,
+    SelectBox,
+    Link,
+    Reference,
+    References,
+    NodeType,
+    CodeMirror,
+    MasterPlugin,
+    AssetEditor,
+    PluginViews,
+    PluginView,
+
+    CodeMirrorWrap,
+    ImageCropper,
+    MediaDetailsScreen,
+    MediaSelectionScreen,
+
+    AssetUpload,
+    AssetOption,
+    LinkInput,
+    LinkOption,
+    NodeOption
+};

--- a/packages/neos-ui-editors/src/manifest.js
+++ b/packages/neos-ui-editors/src/manifest.js
@@ -1,33 +1,9 @@
-import {
-    TextField,
-    TextArea,
-    Boolean,
-    DateTime,
-    Image,
-    SelectBox,
-    Link,
-    Reference,
-    References,
-    NodeType,
-    CodeMirror,
-    MasterPlugin,
-    AssetEditor,
-    PluginViews,
-    PluginView
-} from './Editors/index';
-import EditorEnvelope from './EditorEnvelope/index';
-
-import {
-    CodeMirrorWrap,
-    ImageCropper,
-    MediaDetailsScreen,
-    MediaSelectionScreen
-} from './SecondaryEditors/index';
+import * as Editors from './index';
 
 import manifest from '@neos-project/neos-ui-extensibility';
 import backend from '@neos-project/neos-ui-backend-connector';
 
-export default EditorEnvelope;
+export default Editors.EditorEnvelope;
 
 manifest('inspectorEditors', {}, globalRegistry => {
     const editorsRegistry = globalRegistry.get('inspector').get('editors');
@@ -40,66 +16,66 @@ manifest('inspectorEditors', {}, globalRegistry => {
     //
 
     editorsRegistry.set('Neos.Neos/Inspector/Editors/TextFieldEditor', {
-        component: TextField
+        component: Editors.TextField
     });
 
     editorsRegistry.set('Neos.Neos/Inspector/Editors/TextAreaEditor', {
-        component: TextArea
+        component: Editors.TextArea
     });
 
     editorsRegistry.set('Neos.Neos/Inspector/Editors/BooleanEditor', {
-        component: Boolean,
+        component: Editors.Boolean,
         hasOwnLabel: true
     });
 
     editorsRegistry.set('Neos.Neos/Inspector/Editors/DateTimeEditor', {
-        component: DateTime
+        component: Editors.DateTime
     });
 
     editorsRegistry.set('Neos.Neos/Inspector/Editors/ImageEditor', {
-        component: Image
+        component: Editors.Image
     });
 
     editorsRegistry.set('Neos.Neos/Inspector/Editors/SelectBoxEditor', {
-        component: SelectBox
+        component: Editors.SelectBox
     });
 
     editorsRegistry.set('Neos.Neos/Inspector/Editors/LinkEditor', {
-        component: Link
+        component: Editors.Link
     });
 
     editorsRegistry.set('Neos.Neos/Inspector/Editors/ReferenceEditor', {
-        component: Reference
+        component: Editors.Reference
     });
 
     editorsRegistry.set('Neos.Neos/Inspector/Editors/ReferencesEditor', {
-        component: References
+        component: Editors.References
     });
 
     editorsRegistry.set('Neos.Neos/Inspector/Editors/NodeTypeEditor', {
-        component: NodeType
+        component: Editors.NodeType
     });
 
     editorsRegistry.set('Neos.Neos/Inspector/Editors/CodeEditor', {
-        component: CodeMirror,
+        component: Editors.CodeMirror,
         hasOwnLabel: true
     });
 
     editorsRegistry.set('Neos.Neos/Inspector/Editors/AssetEditor', {
-        component: AssetEditor
+        component: Editors.AssetEditor
     });
 
     editorsRegistry.set('Neos.Neos/Inspector/Editors/MasterPluginEditor', {
-        component: MasterPlugin
+        component: Editors.MasterPlugin
     });
 
     editorsRegistry.set('Neos.Neos/Inspector/Editors/PluginViewsEditor', {
-        component: PluginViews,
+        component: Editors.PluginViews,
         hasOwnLabel: true
     });
 
     editorsRegistry.set('Neos.Neos/Inspector/Editors/PluginViewEditor', {
-        component: PluginView
+        component: Editors.PluginView
     });
 
     //
@@ -107,19 +83,19 @@ manifest('inspectorEditors', {}, globalRegistry => {
     //
 
     secondaryEditorsRegistry.set('Neos.Neos/Inspector/Secondary/Editors/CodeMirrorWrap', {
-        component: CodeMirrorWrap
+        component: Editors.CodeMirrorWrap
     });
 
     secondaryEditorsRegistry.set('Neos.Neos/Inspector/Secondary/Editors/ImageCropper', {
-        component: ImageCropper
+        component: Editors.ImageCropper
     });
 
     secondaryEditorsRegistry.set('Neos.Neos/Inspector/Secondary/Editors/MediaDetailsScreen', {
-        component: MediaDetailsScreen
+        component: Editors.MediaDetailsScreen
     });
 
     secondaryEditorsRegistry.set('Neos.Neos/Inspector/Secondary/Editors/MediaSelectionScreen', {
-        component: MediaSelectionScreen
+        component: Editors.MediaSelectionScreen
     });
 
     //

--- a/packages/neos-ui/src/apiExposureMap.js
+++ b/packages/neos-ui/src/apiExposureMap.js
@@ -15,7 +15,7 @@ import * as reactCssThemr from '@friendsofreactjs/react-css-themr';
 import ReactUiComponents from '@neos-project/react-ui-components';
 import * as NeosUiReduxStore from '@neos-project/neos-ui-redux-store';
 import * as NeosUiDecorators from '@neos-project/neos-ui-decorators';
-import EditorEnvelope from '@neos-project/neos-ui-editors/src/EditorEnvelope/index';
+import * as NeosUiEditors from '@neos-project/neos-ui-editors/src/EditorEnvelope/index';
 import * as UtilsRedux from '@neos-project/utils-redux';
 import NeosUiI18n from '@neos-project/neos-ui-i18n';
 import * as CkEditorApi from '@neos-project/neos-ui-ckeditor5-bindings/src/ckEditorApi';
@@ -96,7 +96,7 @@ export default {
         NeosUiBackendConnector,
         CkEditorApi,
         NeosUiDecorators,
-        NeosUiEditors: EditorEnvelope,
+        NeosUiEditors,
         NeosUiI18n,
         NeosUiReduxStore,
         NeosUiViews,


### PR DESCRIPTION
Makes sure the editors and their parts are exported to be used by
UI extensions.

Fixes: #2250
