### PR TITLE
BUGFIX: Don't re-generate nodeNames on move if not needed.

### DIFF
--- a/Classes/Domain/Model/Changes/AbstractMove.php
+++ b/Classes/Domain/Model/Changes/AbstractMove.php
@@ -73,12 +73,12 @@ abstract class AbstractMove extends AbstractStructuralChange
      *
      * @param NodeInterface $parentNode
      * @param NodeInterface $node
-     * @return string
+     * @return string|null
      */
     protected function generateUniqueNodeNameIfNeeded(NodeInterface $parentNode, NodeInterface $node)
     {
         if ($this->contentRepositoryNodeService->nodePathAvailableForNode($parentNode->getPath() . $node->getName(), $node)) {
-            return $node->getName();
+            return null;
         }
 
         return $this->generateUniqueNodeName($parentNode);

--- a/Classes/Domain/Model/Changes/AbstractMove.php
+++ b/Classes/Domain/Model/Changes/AbstractMove.php
@@ -73,7 +73,7 @@ abstract class AbstractMove extends AbstractStructuralChange
      *
      * @param NodeInterface $parentNode
      * @param NodeInterface $node
-     * @return string|null
+     * @return string|null If the current name can be used, null is returned
      */
     protected function generateUniqueNodeNameIfNeeded(NodeInterface $parentNode, NodeInterface $node)
     {

--- a/Classes/Domain/Model/Changes/AbstractMove.php
+++ b/Classes/Domain/Model/Changes/AbstractMove.php
@@ -69,7 +69,7 @@ abstract class AbstractMove extends AbstractStructuralChange
     }
 
     /**
-     * Generate a unique node name for the copied node if needed
+     * Generate a (new) unique node name for the copied node if the current name is in use already
      *
      * @param NodeInterface $parentNode
      * @param NodeInterface $node

--- a/Classes/Domain/Model/Changes/AbstractMove.php
+++ b/Classes/Domain/Model/Changes/AbstractMove.php
@@ -67,4 +67,20 @@ abstract class AbstractMove extends AbstractStructuralChange
         return $this->contentRepositoryNodeService
             ->generateUniqueNodeName($parentNode->getPath());
     }
+
+    /**
+     * Generate a unique node name for the copied node if needed
+     *
+     * @param NodeInterface $parentNode
+     * @param NodeInterface $node
+     * @return string
+     */
+    protected function generateUniqueNodeNameIfNeeded(NodeInterface $parentNode, NodeInterface $node)
+    {
+        if ($this->contentRepositoryNodeService->nodePathAvailableForNode($parentNode->getPath() . $node->getName(), $node)) {
+            return $node->getName();
+        }
+
+        return $this->generateUniqueNodeName($parentNode);
+    }
 }

--- a/Classes/Domain/Model/Changes/AbstractMove.php
+++ b/Classes/Domain/Model/Changes/AbstractMove.php
@@ -77,7 +77,7 @@ abstract class AbstractMove extends AbstractStructuralChange
      */
     protected function generateUniqueNodeNameIfNeeded(NodeInterface $parentNode, NodeInterface $node)
     {
-        if ($this->contentRepositoryNodeService->nodePathAvailableForNode($parentNode->getPath() . $node->getName(), $node)) {
+        if ($this->contentRepositoryNodeService->nodePathAvailableForNode($parentNode->getPath() . '/' . $node->getName(), $node)) {
             return null;
         }
 

--- a/Classes/Domain/Model/Changes/MoveAfter.php
+++ b/Classes/Domain/Model/Changes/MoveAfter.php
@@ -43,7 +43,7 @@ class MoveAfter extends AbstractMove
             $before = self::cloneNodeWithNodeData($this->getSubject());
             $parent = $before->getParent();
 
-            $nodeName = $this->generateUniqueNodeName($this->getSiblingNode()->getParent());
+            $nodeName = $this->generateUniqueNodeNameIfNeeded($this->getSiblingNode()->getParent(), $this->getSubject());
             $this->getSubject()->moveAfter($this->getSiblingNode(), $nodeName);
 
             $updateParentNodeInfo = new UpdateNodeInfo();

--- a/Classes/Domain/Model/Changes/MoveBefore.php
+++ b/Classes/Domain/Model/Changes/MoveBefore.php
@@ -44,7 +44,7 @@ class MoveBefore extends AbstractMove
             $before = self::cloneNodeWithNodeData($this->getSubject());
             $parent = $before->getParent();
 
-            $nodeName = $this->generateUniqueNodeName($this->getSiblingNode()->getParent());
+            $nodeName = $this->generateUniqueNodeNameIfNeeded($this->getSiblingNode()->getParent(), $this->getSubject());
             $this->getSubject()->moveBefore($this->getSiblingNode(), $nodeName);
 
             $updateParentNodeInfo = new UpdateNodeInfo();

--- a/Classes/Domain/Model/Changes/MoveInto.php
+++ b/Classes/Domain/Model/Changes/MoveInto.php
@@ -82,7 +82,7 @@ class MoveInto extends AbstractMove
             $before = self::cloneNodeWithNodeData($this->getSubject());
             $parent = $before->getParent();
 
-            $nodeName = $this->generateUniqueNodeName($this->getParentNode());
+            $nodeName = $this->generateUniqueNodeNameIfNeeded($this->getParentNode(), $this->getSubject());
             $this->getSubject()->moveInto($this->getParentNode(), $nodeName);
 
             $updateParentNodeInfo = new UpdateNodeInfo();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5269,12 +5269,11 @@ event-emitter@~0.3.5:
     es5-ext "~0.10.14"
 
 event-stream@^3.3.0:
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.6.tgz#cac1230890e07e73ec9cacd038f60a5b66173eef"
-  integrity sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.5.tgz#e5dd8989543630d94c6cf4d657120341fa31636b"
+  integrity sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==
   dependencies:
     duplexer "^0.1.1"
-    flatmap-stream "^0.1.0"
     from "^0.1.7"
     map-stream "0.0.7"
     pause-stream "^0.0.11"
@@ -5748,11 +5747,6 @@ flat-cache@^1.2.1:
     del "^2.0.2"
     graceful-fs "^4.1.2"
     write "^0.2.1"
-
-flatmap-stream@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/flatmap-stream/-/flatmap-stream-0.1.0.tgz#ed54e01422cd29281800914fcb968d58b685d5f1"
-  integrity sha512-Nlic4ZRYxikqnK5rj3YoxDVKGGtUjcNDUtvQ7XsdGLZmMwdUYnXf10o1zcXtzEZTBgc6GxeRpQxV/Wu3WPIIHA==
 
 flatten@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Partially rolling back changes from #2098 because of issues like #2258, neos/neos-development-collection#2284 and neos/neos-development-collection#2282.