### PR TITLE
BUGFIX: Limit out of band reloading to content-nodetypes

### DIFF
--- a/Classes/Domain/Model/Changes/Property.php
+++ b/Classes/Domain/Model/Changes/Property.php
@@ -202,7 +202,10 @@ class Property extends AbstractChange
 
             $reloadIfChangedConfigurationPath = sprintf('properties.%s.ui.reloadIfChanged', $propertyName);
             if (!$this->getIsInline() && $node->getNodeType()->getConfiguration($reloadIfChangedConfigurationPath)) {
-                if ($this->getNodeDomAddress() && $this->getNodeDomAddress()->getFusionPath() && $node->getParent()->getNodeType()->isOfType('Neos.Neos:ContentCollection')) {
+                if ($this->getNodeDomAddress() && $this->getNodeDomAddress()->getFusionPath()
+                    && $node->getNodeType()->isOfType('Neos.Neos:Content')
+                    && $node->getParent()->getNodeType()->isOfType('Neos.Neos:ContentCollection')
+                ) {
                     $reloadContentOutOfBand = new ReloadContentOutOfBand();
                     $reloadContentOutOfBand->setNode($node);
                     $reloadContentOutOfBand->setNodeDomAddress($this->getNodeDomAddress());


### PR DESCRIPTION
If a property with `reloadIfChanged` is used on document level an error occured when the ui tried out of band rendering on the root page in a non-default dimension. The configuration is strange but can occur easily via Mixins and Neos should behave better.

The reason for the error was that the ui checks the type of the parentNode as beeing a `ContentCollection` but did not validate wether the current node is `Content`. That lead to trying accessing the parentNode of the site-node which fails for the site-document in no default dimension because '/sites'  does not exist in all dimensions.

The solution is tho check wether the node is of type `Content` before checking the type of the parentNode beeing a `ContentCollection`.
