### PR TITLE
TASK: Declare (only) Neos 3.3 compatibility

### DIFF
--- a/Build/Jenkins/release-neos-ui.sh
+++ b/Build/Jenkins/release-neos-ui.sh
@@ -22,19 +22,6 @@ cd $DIR/../../
 # go to $BRANCH
 git reset --hard origin/$BRANCH
 
-# download JQ if we don't have it yet, for manipulating composer.json
-if [ ! -f "jq-linux64" ]; then
-    wget https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-    chmod +x jq-linux64
-fi
-
-
-# update neos-ui-compiled version
-jq ".require[\"neos/neos-ui-compiled\"] = \"$VERSION || master\"" composer.json > composer.json.new
-rm composer.json
-mv composer.json.new composer.json
-rm jq-linux64
-
 # install yarn if not already
 path_to_yarn=$(which yarn)
 if [ -z "$path_to_yarn" ] ; then

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "GPL-3.0-or-later"
   ],
   "require": {
-    "neos/neos": "^3.3 || ^4.0 || dev-master",
+    "neos/neos": "^3.3",
     "neos/neos-ui-compiled": "self.version"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   ],
   "require": {
     "neos/neos": "^3.3 || ^4.0 || dev-master",
-    "neos/neos-ui-compiled": "1.4.1 || master"
+    "neos/neos-ui-compiled": "self.version"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Since Neos 4.x needs support for asset sources, this branch of the UI only supports Neos 3.3 (from now on).

This also makes `neos/neos-ui` require `neos/neos-ui-compiled` in the same version (using `self.version`). This eases the build process and keeps versioning simple(r).