### PR TITLE
!!! TASK: make CKE5 the default editor

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -95,7 +95,7 @@ Neos:
         legacy:
           enableUiSwitch: false
 
-        defaultInlineEditor: 'ckeditor'
+        defaultInlineEditor: 'ckeditor5'
 
       #################################
       # INTERNAL CONFIG (no API)


### PR DESCRIPTION
This PR marks CKeditor 4 integration as deprecated and makes CKeditor 5 the default editor.
You can still use CKeditor 4, but it will get removed with the next major release, perhaps in Neos 5.0.

In order to switch back to CKE4, add this to Settings.yaml:
```
Neos:
  Neos:
    Ui:
      defaultInlineEditor: 'ckeditor'
```

Known issues:

- custom CKE4 plugins won't work in CKE5, please get in touch with us for help how to rewrite then for CKE5
- https://github.com/neos/neos-ui/issues/2288