### PR TITLE
BUGFIX: Disallowed NodeTypes should be delivered as array

### DIFF
--- a/Classes/Service/NodePolicyService.php
+++ b/Classes/Service/NodePolicyService.php
@@ -117,7 +117,7 @@ class NodePolicyService
             return $nodeType->getName();
         };
 
-        return array_map($mapper, $disallowedNodeTypeObjects);
+        return array_values(array_map($mapper, $disallowedNodeTypeObjects));
     }
 
     /**


### PR DESCRIPTION
The UI expects the ``disallowedNodeTypes`` in policy information
as a simple array of strings. Due to the way `array_map` works in
PHP the keys of the array could be strings which would result in
a JSON object representation, breaking the UI.
