### PR TITLE
FEATURE: Render help icon in BooleanEditor and CodeMirrorEditor

### DIFF
--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -78,7 +78,10 @@ export default class EditorEnvelope extends PureComponent {
             });
 
             return (
-                <EditorComponent className={classNames} id={this.generateIdentifier()} {...restProps} />
+                <EditorComponent className={classNames}
+                                 id={this.generateIdentifier()}
+                                 renderHelpIcon={this.renderHelpIcon.bind(this)}
+                                 {...restProps} />
             );
         }
 

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -79,9 +79,9 @@ export default class EditorEnvelope extends PureComponent {
 
             return (
                 <EditorComponent className={classNames}
-                                 id={this.generateIdentifier()}
-                                 renderHelpIcon={this.renderHelpIcon.bind(this)}
-                                 {...restProps} />
+                    id={this.generateIdentifier()}
+                    renderHelpIcon={this.renderHelpIcon.bind(this)}
+                    {...restProps} />
             );
         }
 

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -80,7 +80,7 @@ export default class EditorEnvelope extends PureComponent {
             return (
                 <EditorComponent className={classNames}
                     id={this.generateIdentifier()}
-                    renderHelpIcon={this.renderHelpIcon.bind(this)}
+                    renderHelpIcon={this.renderHelpIcon}
                     {...restProps} />
             );
         }
@@ -140,7 +140,7 @@ export default class EditorEnvelope extends PureComponent {
         );
     }
 
-    renderHelpIcon() {
+    renderHelpIcon = () => {
         if (this.props.helpMessage || this.props.helpThumbnail) {
             return (
                 <span role="button" onClick={this.toggleHelmpessage} className={style.envelope__tooltipButton}>

--- a/packages/neos-ui-editors/src/Editors/Boolean/index.js
+++ b/packages/neos-ui-editors/src/Editors/Boolean/index.js
@@ -39,7 +39,8 @@ const BooleanEditor = props => {
     });
 
     const finalClassName = mergeClassNames({
-        [style.boolean__disabled]: finalOptions.disabled
+        [style.boolean__disabled]: finalOptions.disabled,
+        [style.boolean__label]: true
     });
 
     return (
@@ -48,6 +49,7 @@ const BooleanEditor = props => {
                 <CheckBox id={identifier} isChecked={toBoolean(value)} isDisabled={finalOptions.disabled} onChange={commit}/>
                 <I18n id={label}/>
             </Label>
+            {props.renderHelpIcon ? props.renderHelpIcon() : ''}
         </div>
     );
 };
@@ -57,6 +59,7 @@ BooleanEditor.propTypes = {
     label: PropTypes.string.isRequired,
     value: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
     commit: PropTypes.func.isRequired,
+    renderHelpIcon: PropTypes.func,
     options: PropTypes.object
 };
 

--- a/packages/neos-ui-editors/src/Editors/Boolean/style.css
+++ b/packages/neos-ui-editors/src/Editors/Boolean/style.css
@@ -10,3 +10,8 @@
         margin-bottom: 0 !important;
     }
 }
+
+.boolean__label {
+    max-width: none;
+    display: inline;
+}

--- a/packages/neos-ui-editors/src/Editors/CodeMirror/index.js
+++ b/packages/neos-ui-editors/src/Editors/CodeMirror/index.js
@@ -23,7 +23,8 @@ export default class CodeMirror extends PureComponent {
         highlightingMode: PropTypes.string,
         value: PropTypes.string,
         secondaryEditorsRegistry: PropTypes.object.isRequired,
-        options: PropTypes.object
+        options: PropTypes.object,
+        renderHelpIcon: PropTypes.func
     };
 
     static defaultProps = {
@@ -43,6 +44,7 @@ export default class CodeMirror extends PureComponent {
                         <I18n id={label}/>
                     </Button>
                 </Label>
+                {this.props.renderHelpIcon ? this.props.renderHelpIcon() : ''}
             </div>
         );
     }

--- a/packages/neos-ui-editors/src/Editors/CodeMirror/style.css
+++ b/packages/neos-ui-editors/src/Editors/CodeMirror/style.css
@@ -1,3 +1,5 @@
 .codemirror__label {
     padding: 2px;
+    max-width: none;
+    display: inline;
 }


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW PRs SHOULD TARGET 2.x BRANCH (unless they are not compatible with Neos 3.3)
-->


**What I did**
This PR adds help icons that toggle the help messages to `BooleanEditor` and `CodeMirrorEditor` as outlined in #2249 

**How I did it**
The `renderHelpIcon` method of the `EditorEnvelope` is passed to the components.
This way inconsistencies between components is prevented since `EditorEnvelope` is always in charge of rendering the help icon.

**How to verify it**
Create a node type that uses a boolean property and a help message.
The following was used by me during development:

```yaml
'J6s.NeosPlayground:Test':
  superTypes:
    'Neos.Neos:Content': true

  ui:
    label: 'J6s.NeosPlayground:Test'
    inspector:
      groups:
        test:
          label: 'Testing'
          icon: 'icon-question'

  properties:

    string:
      type: string
      ui:
        label: String
        inspector:
          group: test
        help:
          message: string help

    checkbox:
      type: boolean
      ui:
        label: Checkbox
        inspector:
          group: test
        help:
          message: checkbox help

    'source':
      type: 'string'
      ui:
        help:
          message: code help
        label: 'CodeEditor'
        inspector:
          group: 'test'
          editor: 'Neos.Neos/Inspector/Editors/CodeEditor'
```

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->

Before: No help icons for checkbox and code
![before](https://user-images.githubusercontent.com/3374170/51789388-ac360100-2188-11e9-96cf-6e9243d0bdd9.gif)

After: New help icons:
![after](https://user-images.githubusercontent.com/3374170/51789392-b48e3c00-2188-11e9-8ea7-bf4873230025.gif)