### PR TITLE
Bugfix: Icon overlay in Image editor is too small

### DIFF
--- a/packages/react-ui-components/src/Icon/style.css
+++ b/packages/react-ui-components/src/Icon/style.css
@@ -1,8 +1,8 @@
 .icon {
     composes: reset from './../reset.css';
     display: inline-block;
-    font: normal normal normal 14px/1 FontAwesome;
-    font-size: inherit;
+    font: normal normal normal FontAwesome;
+    font-size: 14px/1;
     text-rendering: auto;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
The image editor icon was too small and the css class for the bigger icon (5x) did not work.
This patch extracts the font-size from the combined font style and make it work.

Fixes: #2313