### PR TITLE
BUGFIX: Icon overlay in Image editor is too small for 2.x

### DIFF
--- a/packages/react-ui-components/src/Icon/style.css
+++ b/packages/react-ui-components/src/Icon/style.css
@@ -1,8 +1,8 @@
 .icon {
     composes: reset from './../reset.css';
     display: inline-block;
-    font: normal normal normal 14px/1 FontAwesome;
-    font-size: inherit;
+    font: normal normal normal FontAwesome;
+    font-size: 14px/1;
     text-rendering: auto;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
Has been already fixed in master but did not get the point with the branches so here the change for 2.x.

related: https://github.com/neos/neos-ui/pull/2331
fixes: #2331 