### PR TITLE
BUGFIX: MediaDetailsScreen shows original asset

### DIFF
--- a/packages/neos-ui-editors/src/Editors/Image/index.js
+++ b/packages/neos-ui-editors/src/Editors/Image/index.js
@@ -189,7 +189,7 @@ export default class ImageEditor extends Component {
     handleThumbnailClicked = () => {
         const {secondaryEditorsRegistry} = this.props;
         const {component: MediaDetailsScreen} = secondaryEditorsRegistry.get('Neos.Neos/Inspector/Secondary/Editors/MediaDetailsScreen');
-        const imageIdentity = $get('__identity', this.props.value);
+        const imageIdentity = $get('originalAsset.__identity', this.props.value) || $get('__identity', this.props.value);
 
         if (imageIdentity) {
             this.props.renderSecondaryInspector('IMAGE_MEDIA_DETAILS', () => <MediaDetailsScreen onClose={this.handleCloseSecondaryScreen} imageIdentity={imageIdentity}/>);


### PR DESCRIPTION
In the media browser `ImageVariant`s are hidden, so we won't show them here either (but the original `Image`).

This may have a side effect on custom `AssetVariant`s. They will be turned into their original asset counterpart too. But since it is just for the `MediaDetailsScreen`, I think this won't be an issue for nearly everyone.