### PR TITLE
BUGFIX: Actually import and expose all editors for extensibility

### DIFF
--- a/packages/neos-ui/src/apiExposureMap.js
+++ b/packages/neos-ui/src/apiExposureMap.js
@@ -15,7 +15,7 @@ import HTML5Backend from 'react-dnd-html5-backend';
 import ReactUiComponents from '@neos-project/react-ui-components';
 import * as NeosUiReduxStore from '@neos-project/neos-ui-redux-store';
 import * as NeosUiDecorators from '@neos-project/neos-ui-decorators';
-import * as NeosUiEditors from '@neos-project/neos-ui-editors/src/EditorEnvelope/index';
+import * as NeosUiEditors from '@neos-project/neos-ui-editors/src/index';
 import * as UtilsRedux from '@neos-project/utils-redux';
 import NeosUiI18n from '@neos-project/neos-ui-i18n';
 import * as CkEditorApi from '@neos-project/neos-ui-ckeditor5-bindings/src/ckEditorApi';


### PR DESCRIPTION
In the bugfix PR #2257 it was planned to expose all editors to the
extensibility layer as was planned originally. Unfortunately the
import path for components was not changed resulting in a totally
broken state at the moment. This change tries to rectify the situation
by adjusting the path. It has been tried in a project that uses the
``LinkOption`` component in a custom editor, which would fail without
this change.
