### PR TITLE
BUGFIX: Use backend validators if available

### DIFF
--- a/Classes/Domain/Model/Changes/Property.php
+++ b/Classes/Domain/Model/Changes/Property.php
@@ -15,12 +15,14 @@ use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Domain\Service\NodeServiceInterface;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+use Neos\ContentRepository\Exception\NodeTypeNotFoundException;
 use Neos\Flow\Annotations as Flow;
 use Neos\Neos\Ui\Domain\Model\AbstractChange;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\ReloadContentOutOfBand;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
 use Neos\Neos\Ui\Domain\Model\RenderedNodeDomAddress;
 use Neos\Neos\Ui\Domain\Service\NodePropertyConversionService;
+use Neos\Neos\Ui\Service\NodePropertyValidationService;
 use Neos\Utility\ObjectAccess;
 
 /**
@@ -34,6 +36,12 @@ class Property extends AbstractChange
      * @var NodePropertyConversionService
      */
     protected $nodePropertyConversionService;
+
+    /**
+     * @Flow\Inject
+     * @var NodePropertyValidationService
+     */
+    protected $nodePropertyValidationService;
 
     /**
      * @Flow\Inject
@@ -168,13 +176,26 @@ class Property extends AbstractChange
         $propertyName = $this->getPropertyName();
         $nodeTypeProperties = $nodeType->getProperties();
 
-        return isset($nodeTypeProperties[$propertyName]);
+        if (!isset($nodeTypeProperties[$propertyName])) {
+            return false;
+        }
+
+        if (isset($nodeTypeProperties[$propertyName]['validation'])) {
+            foreach ($nodeTypeProperties[$propertyName]['validation'] as $validatorName => $validatorConfiguration) {
+                if ($this->nodePropertyValidationService->validate($this->value, $validatorName, $validatorConfiguration) === false) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     /**
      * Applies this change
      *
      * @return void
+     * @throws NodeTypeNotFoundException
      */
     public function apply()
     {

--- a/Classes/Service/NodePolicyService.php
+++ b/Classes/Service/NodePolicyService.php
@@ -1,6 +1,16 @@
 <?php
 namespace Neos\Neos\Ui\Service;
 
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\CreateNodePrivilege;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\CreateNodePrivilegeSubject;

--- a/Classes/Service/NodePropertyValidationService.php
+++ b/Classes/Service/NodePropertyValidationService.php
@@ -55,7 +55,7 @@ class NodePropertyValidationService
     protected function resolveValidator(string $validatorName, array $validatorConfiguration)
     {
         $nameParts = explode('/', $validatorName);
-        if (!$nameParts[0] === 'Neos.Neos') {
+        if ($nameParts[0] !== 'Neos.Neos') {
             $this->logger->log(sprintf('The custom frontend property validator %s" is used. This property is not validated in the backend.', $validatorName), LOG_INFO);
             return null;
         }

--- a/Classes/Service/NodePropertyValidationService.php
+++ b/Classes/Service/NodePropertyValidationService.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+namespace Neos\Neos\Ui\Service;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Validation\Validator\ValidatorInterface;
+
+/**
+ * @Flow\Scope("singleton")
+ */
+class NodePropertyValidationService
+{
+
+    /**
+     * @param $value
+     * @param string $validatorName
+     * @param array $validatorConfiguration
+     * @return bool
+     */
+    public function validate($value, string $validatorName, array $validatorConfiguration): bool
+    {
+        $validator = $this->resolveValidator($validatorName, $validatorConfiguration);
+
+        if ($validator === null) {
+            return true;
+        }
+
+        $result = $validator->validate($value);
+        return !$result->hasErrors();
+    }
+
+    /**
+     * @param string $validatorName
+     * @param array $validatorConfiguration
+     * @return ValidatorInterface|null
+     */
+    protected function resolveValidator(string $validatorName, array $validatorConfiguration): ?ValidatorInterface
+    {
+        $nameParts = explode('/', $validatorName);
+        if (!$nameParts[0] === 'Neos.Neos') {
+            return null;
+        }
+
+        $fullQualifiedValidatorClassName = '\\Neos\\Flow\\Validation\\Validator\\' . end($nameParts);
+
+        if (!class_exists($fullQualifiedValidatorClassName)) {
+            return null;
+        }
+
+        return new $fullQualifiedValidatorClassName($validatorConfiguration);
+    }
+}

--- a/Classes/Service/NodePropertyValidationService.php
+++ b/Classes/Service/NodePropertyValidationService.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Neos\Neos\Ui\Service;
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Log\SystemLoggerInterface;
 use Neos\Flow\Validation\Validator\ValidatorInterface;
 
 /**
@@ -21,6 +22,12 @@ use Neos\Flow\Validation\Validator\ValidatorInterface;
  */
 class NodePropertyValidationService
 {
+
+    /**
+     * @Flow\Inject
+     * @var SystemLoggerInterface
+     */
+    protected $logger;
 
     /**
      * @param $value
@@ -45,16 +52,18 @@ class NodePropertyValidationService
      * @param array $validatorConfiguration
      * @return ValidatorInterface|null
      */
-    protected function resolveValidator(string $validatorName, array $validatorConfiguration): ?ValidatorInterface
+    protected function resolveValidator(string $validatorName, array $validatorConfiguration)
     {
         $nameParts = explode('/', $validatorName);
         if (!$nameParts[0] === 'Neos.Neos') {
+            $this->logger->log(sprintf('The custom frontend property validator %s" is used. This property is not validated in the backend.', $validatorName), LOG_INFO);
             return null;
         }
 
         $fullQualifiedValidatorClassName = '\\Neos\\Flow\\Validation\\Validator\\' . end($nameParts);
 
         if (!class_exists($fullQualifiedValidatorClassName)) {
+            $this->logger->log(sprintf('Could not find a backend validator fitting to the frontend validator "%s"', $validatorName), LOG_WARNING);
             return null;
         }
 

--- a/Tests/Functional/Service/NodePropertyValidationServiceTest.php
+++ b/Tests/Functional/Service/NodePropertyValidationServiceTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Neos\Ui\Tests\Functional\Service;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Validation\Validator\NotEmptyValidator;
+use Neos\Neos\Ui\Service\NodePropertyValidationService;
+
+class NodePropertyValidationServiceTest extends FunctionalTestCase
+{
+
+    /**
+     * @var NodePropertyValidationService
+     */
+    protected $nodePropertyValidationService;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $nodePropertyValidatorServiceProxy = $this->buildAccessibleProxy(NodePropertyValidationService::class);
+        $this->nodePropertyValidationService = $this->objectManager->get($nodePropertyValidatorServiceProxy);
+    }
+
+    /**
+     * @test
+     */
+    public function resolveValidator()
+    {
+        $validator = $this->nodePropertyValidationService->_call('resolveValidator', 'Neos.Neos/Validation/NotEmptyValidator', []);
+        $this->assertInstanceOf(NotEmptyValidator::class, $validator);
+    }
+
+    /**
+     * @test
+     */
+    public function validate()
+    {
+        $result = $this->nodePropertyValidationService->validate(
+            'test',
+            'Neos.Neos/Validation/StringLengthValidator',
+            ['minimum' => 1, 'maximum' => 255]);
+
+        $this->assertTrue($result);
+    }
+}


### PR DESCRIPTION
This change resolves the according flow validator to a configured
property validator. If it exists, it validates the result.
This is non braking, as it returns true, if the validator is not
found so custom validators are not affected.

Resolves: #2349, #2348 