### PR TITLE
BUGFIX: Opening the Neos Backend with invalid node paths

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -116,6 +116,7 @@ class BackendController extends ActionController
     /**
      * Displays the backend interface
      *
+     * @Flow\IgnoreValidation("$node")
      * @param NodeInterface $node The node that will be displayed on the first tab
      * @return void
      */


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW PRs SHOULD TARGET 2.x BRANCH (unless they are not compatible with Neos 3.3)
-->


**What I did**

Remove the error resulting from invalid node paths, closes #2318.

**How I did it**

Ignore validation in BackendController->indexAction() for $node, as $node is not necessarily a valid object.

**How to verify it**

Open the backend with invalid node paths. You should be redirect to the next editable node or the site root node.

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
