### PR TITLE
BUGFIX: Same image cannot be selected twice

### DIFF
--- a/packages/neos-ui-editors/src/Editors/Image/index.js
+++ b/packages/neos-ui-editors/src/Editors/Image/index.js
@@ -171,10 +171,16 @@ export default class ImageEditor extends Component {
     }
 
     handleMediaSelected = assetIdentifier => {
-        const {commit} = this.props;
+        const {commit, value} = this.props;
         const newAsset = {
             __identity: assetIdentifier
         };
+
+        // Same image selected as before?
+        if (value && value.__identity === assetIdentifier) {
+            this.handleCloseSecondaryScreen();
+            return;
+        }
 
         this.setState({
             image: null,


### PR DESCRIPTION
Just close the secondary inspector if you select the same image twice, closes #2367.