### PR TITLE
BUGFIX: Editing in preview mode

### DIFF
--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -43,6 +43,15 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
     const inlineEditorRegistry = globalRegistry.get('inlineEditors');
     const guestFrameWindow = getGuestFrameWindow();
     const documentInformation = Object.assign({}, guestFrameWindow['@Neos.Neos.Ui:DocumentInformation']);
+
+    const state = store.getState();
+    const editPreviewMode = $get(['ui', 'editPreviewMode'], state);
+    const editPreviewModes = globalRegistry.get('frontendConfiguration').get('editPreviewModes');
+    const currentEditMode = editPreviewModes[editPreviewMode];
+    if (!currentEditMode.isEditingMode) {
+        return;
+    }
+
     const nodes = Object.assign({}, guestFrameWindow['@Neos.Neos.Ui:Nodes'], {
         [documentInformation.metaData.documentNode]: documentInformation.metaData.documentNodeSerialization
     });


### PR DESCRIPTION
**What I did**

Disable editing in preview mode by checking current editing mode in guest frame initialization, closes #2316. 

**How I did it**

Check current editing mode for "isEditingMode" in guest frame initialization. Hope this is the right place to do this.

**How to verify it**

Click on Edit / Preview and toggle the modes. You should not be able to inline edit your document in preview modes.