### PR TITLE
TASK: lazily expose node variants information

### DIFF
--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -21,6 +21,7 @@ use Neos\Flow\Mvc\ResponseInterface;
 use Neos\Flow\Mvc\View\JsonView;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Neos\Domain\Service\ContentContextFactory;
+use Neos\Neos\Domain\Service\ContentDimensionPresetSourceInterface;
 use Neos\Neos\Service\PublishingService;
 use Neos\Neos\Service\UserService;
 use Neos\Neos\Ui\ContentRepository\Service\NodeService;
@@ -112,6 +113,12 @@ class BackendServiceController extends ActionController
      * @var NodeClipboard
      */
     protected $clipboard;
+
+    /**
+     * @Flow\Inject
+     * @var ContentDimensionPresetSourceInterface
+     */
+    protected $contentDimensionsPresetSource;
 
     /**
      * Set the controller context on the feedback collection after the controller
@@ -393,23 +400,49 @@ class BackendServiceController extends ActionController
     /**
      * @throws \Neos\Flow\Mvc\Exception\NoSuchArgumentException
      */
-    public function initializeGetPolicyInformationAction()
+    public function initializeGetLazyNodeDataAction()
     {
         $this->arguments->getArgument('nodes')->getPropertyMappingConfiguration()->allowAllProperties();
     }
 
     /**
+     * Fetches all the node information that can be lazy-loaded
+     *
      * @param array<NodeInterface> $nodes
      */
-    public function getPolicyInformationAction(array $nodes)
+    public function getLazyNodeDataAction(array $nodes)
     {
         $result = [];
         /** @var NodeInterface $node */
         foreach ($nodes as $node) {
-            $result[$node->getContextPath()] = ['policy' => $this->nodePolicyService->getNodePolicyInformation($node)];
+            $otherNodeVariants = array_values(array_filter(array_map(function ($node) {
+                return $this->getCurrentDimensionPresetIdentifiersForNode($node);
+            }, $node->getOtherNodeVariants())));
+            $result[$node->getContextPath()] = [
+                'policy' => $this->nodePolicyService->getNodePolicyInformation($node),
+                'dimensions' => $this->getCurrentDimensionPresetIdentifiersForNode($node),
+                'otherNodeVariants' => $otherNodeVariants
+            ];
         }
 
         $this->view->assign('value', $result);
+    }
+
+    /**
+     * Gets an array of current preset identifiers for each dimension of the give node
+     *
+     * @param NodeInterface $node
+     * @return array
+     */
+    protected function getCurrentDimensionPresetIdentifiersForNode($node)
+    {
+        $targetPresets = $this->contentDimensionsPresetSource->findPresetsByTargetValues($node->getDimensions());
+        $presetCombo = [];
+        foreach ($targetPresets as $dimensionName => $presetConfig) {
+            $fullPresetConfig = $this->contentDimensionsPresetSource->findPresetByDimensionValues($dimensionName, $presetConfig['values']);
+            $presetCombo[$dimensionName] = $fullPresetConfig['identifier'];
+        }
+        return $presetCombo;
     }
 
     /**

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -410,7 +410,7 @@ class BackendServiceController extends ActionController
      *
      * @param array<NodeInterface> $nodes
      */
-    public function getLazyNodeDataAction(array $nodes)
+    public function getAdditionalNodeMetadataAction(array $nodes)
     {
         $result = [];
         /** @var NodeInterface $node */

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -400,7 +400,7 @@ class BackendServiceController extends ActionController
     /**
      * @throws \Neos\Flow\Mvc\Exception\NoSuchArgumentException
      */
-    public function initializeGetLazyNodeDataAction()
+    public function initializeGetAdditionalNodeMetadataAction()
     {
         $this->arguments->getArgument('nodes')->getPropertyMappingConfiguration()->allowAllProperties();
     }

--- a/Configuration/Routes.Service.yaml
+++ b/Configuration/Routes.Service.yaml
@@ -79,8 +79,8 @@
   httpMethods: ['GET']
 -
   name: 'Get Policy Info'
-  uriPattern: 'get-policy-info'
+  uriPattern: 'get-lazy-node-data'
   defaults:
     '@controller': 'BackendService'
-    '@action': 'getPolicyInformation'
+    '@action': 'getLazyNodeData'
   httpMethods: ['POST']

--- a/Configuration/Routes.Service.yaml
+++ b/Configuration/Routes.Service.yaml
@@ -78,9 +78,9 @@
     '@action': 'getWorkspaceInfo'
   httpMethods: ['GET']
 -
-  name: 'Get Policy Info'
-  uriPattern: 'get-lazy-node-data'
+  name: 'Get Additional Node Metadata'
+  uriPattern: 'get-additional-node-metadata'
   defaults:
     '@controller': 'BackendService'
-    '@action': 'getLazyNodeData'
+    '@action': 'getAdditionalNodeMetadata'
   httpMethods: ['POST']

--- a/Resources/Private/Fusion/Backend/Root.fusion
+++ b/Resources/Private/Fusion/Backend/Root.fusion
@@ -90,8 +90,8 @@ backend = Neos.Fusion:Template {
                 getWorkspaceInfo = Neos.Fusion:UriBuilder {
                     action = 'getWorkspaceInfo'
                 }
-                getPolicyInfo = Neos.Fusion:UriBuilder {
-                    action = 'getPolicyInformation'
+                getLazyNodeData = Neos.Fusion:UriBuilder {
+                    action = 'getLazyNodeData'
                 }
             }
         }

--- a/Resources/Private/Fusion/Backend/Root.fusion
+++ b/Resources/Private/Fusion/Backend/Root.fusion
@@ -90,8 +90,8 @@ backend = Neos.Fusion:Template {
                 getWorkspaceInfo = Neos.Fusion:UriBuilder {
                     action = 'getWorkspaceInfo'
                 }
-                getLazyNodeData = Neos.Fusion:UriBuilder {
-                    action = 'getLazyNodeData'
+                getAdditionalNodeMetadata = Neos.Fusion:UriBuilder {
+                    action = 'getAdditionalNodeMetadata'
                 }
             }
         }

--- a/packages/neos-ts-interfaces/src/index.ts
+++ b/packages/neos-ts-interfaces/src/index.ts
@@ -73,6 +73,8 @@ export interface Node {
     isFullyLoaded: boolean;
     uri: string;
     policy?: NodePolicy;
+    dimensions?: DimensionPresetCombination;
+    otherNodeVariants?: DimensionPresetCombination[];
 }
 
 // Type guard using duck-typing on some random properties to know if object is a Node

--- a/packages/neos-ui-backend-connector/src/Endpoints/index.ts
+++ b/packages/neos-ui-backend-connector/src/Endpoints/index.ts
@@ -16,7 +16,7 @@ export interface Routes {
             loadTree: string;
             flowQuery: string;
             getWorkspaceInfo: string;
-            getLazyNodeData: string;
+            getAdditionalNodeMetadata: string;
         };
     };
     core: {
@@ -475,9 +475,9 @@ export default (routes: Routes) => {
         }
     })).then(response => fetchWithErrorHandling.parseJson(response));
 
-    const getLazyNodeData = (nodeContextPaths: NodeContextPath) => fetchWithErrorHandling.withCsrfToken(csrfToken => {
+    const getAdditionalNodeMetadata = (nodeContextPaths: NodeContextPath) => fetchWithErrorHandling.withCsrfToken(csrfToken => {
         return {
-            url: routes.ui.service.getLazyNodeData,
+            url: routes.ui.service.getAdditionalNodeMetadata,
             method: 'POST',
             credentials: 'include',
             body: JSON.stringify({nodes: nodeContextPaths}),
@@ -487,7 +487,7 @@ export default (routes: Routes) => {
             }
         };
     }).then(response => fetchWithErrorHandling.parseJson(response))
-    .catch(reason => console.warn('Something went wrong with requesting lazy node information:', reason)); // tslint:disable-line no-console
+    .catch(reason => console.warn('Something went wrong with requesting additional node metadata:', reason)); // tslint:disable-line no-console
 
     const dataSource = (dataSourceIdentifier: string, dataSourceUri: string, params = {}) => fetchWithErrorHandling.withCsrfToken(() => ({
         url: urlWithParams(dataSourceUri || `${routes.core.service.dataSource}/${dataSourceIdentifier}`, params),
@@ -544,7 +544,7 @@ export default (routes: Routes) => {
         dataSource,
         getJsonResource,
         getWorkspaceInfo,
-        getLazyNodeData,
+        getAdditionalNodeMetadata,
         tryLogin,
         contentDimensions
     };

--- a/packages/neos-ui-backend-connector/src/Endpoints/index.ts
+++ b/packages/neos-ui-backend-connector/src/Endpoints/index.ts
@@ -16,7 +16,7 @@ export interface Routes {
             loadTree: string;
             flowQuery: string;
             getWorkspaceInfo: string;
-            getPolicyInfo: string;
+            getLazyNodeData: string;
         };
     };
     core: {
@@ -475,9 +475,9 @@ export default (routes: Routes) => {
         }
     })).then(response => fetchWithErrorHandling.parseJson(response));
 
-    const getPolicyInfo = (nodeContextPaths: NodeContextPath) => fetchWithErrorHandling.withCsrfToken(csrfToken => {
+    const getLazyNodeData = (nodeContextPaths: NodeContextPath) => fetchWithErrorHandling.withCsrfToken(csrfToken => {
         return {
-            url: routes.ui.service.getPolicyInfo,
+            url: routes.ui.service.getLazyNodeData,
             method: 'POST',
             credentials: 'include',
             body: JSON.stringify({nodes: nodeContextPaths}),
@@ -487,7 +487,7 @@ export default (routes: Routes) => {
             }
         };
     }).then(response => fetchWithErrorHandling.parseJson(response))
-    .catch(reason => console.warn('Something went wrong with requesting policy information:', reason)); // tslint:disable-line no-console
+    .catch(reason => console.warn('Something went wrong with requesting lazy node information:', reason)); // tslint:disable-line no-console
 
     const dataSource = (dataSourceIdentifier: string, dataSourceUri: string, params = {}) => fetchWithErrorHandling.withCsrfToken(() => ({
         url: urlWithParams(dataSourceUri || `${routes.core.service.dataSource}/${dataSourceIdentifier}`, params),
@@ -544,7 +544,7 @@ export default (routes: Routes) => {
         dataSource,
         getJsonResource,
         getWorkspaceInfo,
-        getPolicyInfo,
+        getLazyNodeData,
         tryLogin,
         contentDimensions
     };

--- a/packages/neos-ui-sagas/src/CR/Policies/index.js
+++ b/packages/neos-ui-sagas/src/CR/Policies/index.js
@@ -5,19 +5,19 @@ import backend from '@neos-project/neos-ui-backend-connector';
 
 let nodesCurrentlyProcessed = [];
 
-function * fetchPolicies(nodesWithoutPolicies) {
-    const nodesNotProcessed = nodesWithoutPolicies.filter(nodePath => !nodesCurrentlyProcessed.includes(nodePath));
+function * fetchLazyData(nodesWithoutLazyData) {
+    const nodesNotProcessed = nodesWithoutLazyData.filter(nodePath => !nodesCurrentlyProcessed.includes(nodePath));
     if (nodesNotProcessed.length === 0) {
         return;
     }
 
-    nodesCurrentlyProcessed.push(...nodesWithoutPolicies);
+    nodesCurrentlyProcessed.push(...nodesWithoutLazyData);
 
     const {endpoints} = backend.get();
-    const policyData = yield endpoints.getPolicyInfo(nodesWithoutPolicies);
-    if (policyData) {
-        yield put(actions.CR.Nodes.merge(policyData));
-        nodesCurrentlyProcessed = nodesCurrentlyProcessed.filter(nodePath => !nodesWithoutPolicies.includes(nodePath));
+    const lazyData = yield endpoints.getLazyNodeData(nodesWithoutLazyData);
+    if (lazyData) {
+        yield put(actions.CR.Nodes.merge(lazyData));
+        nodesCurrentlyProcessed = nodesCurrentlyProcessed.filter(nodePath => !nodesWithoutLazyData.includes(nodePath));
     }
 }
 
@@ -27,7 +27,7 @@ export function * watchNodeInformationChanges() {
         const nodeMap = (action.type === actionTypes.CR.Nodes.SET_STATE) ? action.payload.nodes : action.payload.nodeMap;
         const state = yield select();
 
-        const nodesWithoutPolicies = Object.keys(nodeMap).filter(contextPath => {
+        const nodesWithoutLazyData = Object.keys(nodeMap).filter(contextPath => {
             const node = selectors.CR.Nodes.nodeByContextPath(state)(contextPath);
 
             if ($get('properties._removed', node)) {
@@ -38,11 +38,11 @@ export function * watchNodeInformationChanges() {
             return (!policyInfo);
         });
 
-        if (nodesWithoutPolicies.length === 0) {
+        if (nodesWithoutLazyData.length === 0) {
             continue;
         }
 
-        yield fork(fetchPolicies, nodesWithoutPolicies);
+        yield fork(fetchLazyData, nodesWithoutLazyData);
     }
 }
 


### PR DESCRIPTION
Since #2164 got blocked, I extract the logic for loading node variant information into this PR, so it would be possible to experiment with node variants selector in a separate package.

I refactor `getPolicyInformationAction` into `getLazyNodeDataAction`, a place where we'd be able to fetch all node information, that is expensive to calculate and load, I'm sure it'd be useful in the future.