### PR TITLE
BUGFIX: disregard baseNodeType for search without preset

### DIFF
--- a/packages/neos-ui-sagas/src/UI/PageTree/index.js
+++ b/packages/neos-ui-sagas/src/UI/PageTree/index.js
@@ -140,7 +140,6 @@ export function * watchSearch({configuration}) {
         yield put(actions.UI.PageTree.setSearchResult(result));
 
         const {contextPath, query: searchQuery, filterNodeType} = action.payload;
-        const effectiveFilterNodeType = filterNodeType || configuration.nodeTree.presets.default.baseNodeType;
 
         yield put(actions.UI.PageTree.setAsLoading(contextPath));
         let matchingNodes = [];
@@ -150,7 +149,7 @@ export function * watchSearch({configuration}) {
             const query = q(contextPath);
 
             if (filterNodeType || searchQuery) {
-                matchingNodes = yield query.search(searchQuery, effectiveFilterNodeType).getForTreeWithParents();
+                matchingNodes = yield query.search(searchQuery, filterNodeType).getForTreeWithParents();
             } else {
                 const clipboardNodeContextPath = yield select($get('cr.nodes.clipboard'));
                 const toggledNodes = yield select($get('ui.pageTree.toggled'));


### PR DESCRIPTION
This PR fixes regression caused by https://github.com/neos/neos-ui/commit/9323ad3097f0acec8756cf3dfb0669af3e02d47d

Neos used to be able to search for all document nodes, disregarding `baseNodeType` setting. It makes a lot of sense, e.g. in projects where there are too many nodes to be shown in the tree at the same time, but yet you'd want to make them searchable.

An alternative could be to introduce a separate setting like `searchBaseNodeType` for tree presets, but I'd propose to start with restoring the original behavior, and introduce yet another setting if it would really be demanded by real projects.