### PR TITLE
BUGFIX: Add missing legacy formatting options

### DIFF
--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.ts
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.ts
@@ -314,6 +314,12 @@ export default class NodeTypesRegistry extends SynchronousRegistry<NodeType> {
         if ($get(['formatting', 'i'], mergedConfig)) {
             mergedConfig.formatting.em = true;
         }
+        if ($get(['formatting', 'u'], mergedConfig)) {
+            mergedConfig.formatting.underline = true;
+        }
+        if ($get(['formatting', 'del'], mergedConfig)) {
+            mergedConfig.formatting.strikethrough = true;
+        }
 
         return mergedConfig;
     }


### PR DESCRIPTION
Feature switches for formating options del / u were not converted to their new names.