### PR TITLE
BUGFIX: Stop hotkeys when editing shadow dom editables

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "lodash.upperfirst": "^4.3.0",
     "moment": "^2.20.1",
     "monet": "^0.8.10",
-    "mousetrap": "^1.6.1",
+    "mousetrap": "^1.6.3",
     "normalize.css": "^8.0.0",
     "plow-js": "^2.2.0",
     "prop-types": "^15.5.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9024,9 +9024,10 @@ moo@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"
 
-mousetrap@^1.6.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/mousetrap/-/mousetrap-1.6.2.tgz#caadd9cf886db0986fb2fee59a82f6bd37527587"
+mousetrap@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/mousetrap/-/mousetrap-1.6.3.tgz#80fee49665fd478bccf072c9d46bdf1bfed3558a"
+  integrity sha512-bd+nzwhhs9ifsUrC2tWaSgm24/oo2c83zaRyZQF06hYA6sANfsXHtnZ19AbbbDXCDzeH5nZBSQ4NvCjgD62tJA==
 
 mout@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
**What I did**

Prevent hotkeys from firing while editing a content editable or other editable element which is in the structure of a shadow dom.

**How I did it**

Updated Mousetrap from 1.6.1 to 1.6.3 which contains the fix.
