### PR TITLE
FEATURE: Allow redux store extensibility

### DIFF
--- a/packages/neos-ui-redux-store/src/index.ts
+++ b/packages/neos-ui-redux-store/src/index.ts
@@ -27,7 +27,9 @@ export const reducer = combineReducers({
     cr: CR.reducer,
     system: System.reducer,
     ui: UI.reducer,
-    user: User.reducer
+    user: User.reducer,
+    // NOTE: The plugins reducer is UNPLANNED EXTENSIBILITY, do not modify unless you know what you are doing!
+    plugins: (state) => state || {}
 });
 
 //


### PR DESCRIPTION
Currently the combineReducers function in `neos-ui-redux-store` 
will reset the structure of the global state after each action.

With this change extensions to the ui can store
their own values in `plugins.myExtension.myValue`
without it getting lost after any action.

**What I did**

Add a separate `plugins` reducer that just returns itself without
checking or changing anything.

The naming can be changed of course and it will need documentation.

**How to verify it**

Add another reducer in your extensions manifest which writes a value that does not exist yet inside the `plugins` namespace.
Trigger any action in the Neos backend and check if the value is still there.