### PR TITLE
BUGFIX: fix dispatching of click events to host in Frame

### DIFF
--- a/packages/react-ui-components/src/Frame/frame.tsx
+++ b/packages/react-ui-components/src/Frame/frame.tsx
@@ -69,7 +69,7 @@ export default class Frame extends PureComponent<FrameProps> {
     }
 
     private readonly relayClickEventToHostDocument = (e: MouseEvent) => {
-        const hostEvent: any = new MouseEvent(e.type, e);
+        const hostEvent: any = new MouseEvent(e.type);
         // Needed for enhanceWithClickOutside
         hostEvent.iframeTarget = e.target;
         window.document.dispatchEvent(hostEvent);


### PR DESCRIPTION
If we passed the original event to the constructor of MouseEvent, then this click event would be dispatched twice. It's enough to just set `iframeTarget`.

The bug that it sometimes caused was that if you click "+" icon from inline the add node dialog would get closed immediately.