### PR TITLE
TASK: Add a core migration for legacy RTE formatting options

### DIFF
--- a/Migrations/Code/Version20180907103800.php
+++ b/Migrations/Code/Version20180907103800.php
@@ -10,7 +10,6 @@ namespace Neos\Flow\Core\Migrations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-use Neos\Flow\Configuration\ConfigurationManager;
 
 /**
  * Migrate RTE formatting configuration to new format

--- a/Migrations/Code/Version20180907103800.php
+++ b/Migrations/Code/Version20180907103800.php
@@ -81,11 +81,11 @@ class Version20180907103800 extends AbstractMigration
             $editorOptions['placeholder'] = $aloha['placeholder'];
         }
         if (isset($editorOptions['formatting']['b'])) {
-            $editorOptions['formatting']['strong'] = true;
+            $editorOptions['formatting']['strong'] = $editorOptions['formatting']['b'];
             unset($editorOptions['formatting']['b']);
         }
         if (isset($editorOptions['formatting']['i'])) {
-            $editorOptions['formatting']['em'] = true;
+            $editorOptions['formatting']['em'] = $editorOptions['formatting']['i'];
             unset($editorOptions['formatting']['i']);
         }
         if ($editorOptions['formatting'] === []) {

--- a/Migrations/Code/Version20190319094900.php
+++ b/Migrations/Code/Version20190319094900.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Core\Migrations;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Migrate additional RTE formatting configuration to new format
+ */
+class Version20190319094900 extends AbstractMigration
+{
+    /**
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return 'Neos.Neos.Ui-20190319094900';
+    }
+
+    /**
+     * @return void
+     */
+    public function up()
+    {
+        $this->processConfiguration(
+            'NodeTypes',
+            function (&$configuration) {
+                foreach ($configuration as &$nodeType) {
+                    if (!isset($nodeType['properties'])) {
+                        return;
+                    }
+
+                    foreach ($nodeType['properties'] as &$propertyConfiguration) {
+                        if (isset($propertyConfiguration['ui']['inline'])) {
+                            $this->transformLegacyFormatting($propertyConfiguration['ui']['inline']['editorOptions']);
+                        }
+                    }
+                }
+            },
+            true
+        );
+    }
+
+    /**
+     * Takes legacy aloha formatting and return editorOptions
+     *
+     * @param array $editorOptions
+     */
+    protected function transformLegacyFormatting(array &$editorOptions)
+    {
+
+        if (isset($editorOptions['formatting']['u'])) {
+            $editorOptions['formatting']['underline'] = true;
+            unset($editorOptions['formatting']['u']);
+        }
+        if (isset($editorOptions['formatting']['del'])) {
+            $editorOptions['formatting']['strikethrough'] = true;
+            unset($editorOptions['formatting']['del']);
+        }
+    }
+}

--- a/Migrations/Code/Version20190319094900.php
+++ b/Migrations/Code/Version20190319094900.php
@@ -59,11 +59,11 @@ class Version20190319094900 extends AbstractMigration
     {
 
         if (isset($editorOptions['formatting']['u'])) {
-            $editorOptions['formatting']['underline'] = true;
+            $editorOptions['formatting']['underline'] = $editorOptions['formatting']['u'];
             unset($editorOptions['formatting']['u']);
         }
         if (isset($editorOptions['formatting']['del'])) {
-            $editorOptions['formatting']['strikethrough'] = true;
+            $editorOptions['formatting']['strikethrough'] = $editorOptions['formatting']['del'];
             unset($editorOptions['formatting']['del']);
         }
     }


### PR DESCRIPTION
Migrates `u => underline` and `del => strikethrough` 