### PR TITLE
Makes the select box content fly out

### DIFF
--- a/packages/react-ui-components/src/Dialog/style.css
+++ b/packages/react-ui-components/src/Dialog/style.css
@@ -62,7 +62,7 @@
 }
 .dialog__body {
     max-height: calc(65vh);
-    overflow-y: auto;
+    overflow-y: visible;
 }
 .dialog__actions {
     composes: reset from './../reset.css';

--- a/packages/react-ui-components/src/SelectBox/style.css
+++ b/packages/react-ui-components/src/SelectBox/style.css
@@ -35,6 +35,7 @@
     z-index: var(--zIndex-SelectBoxContents);
     padding: 2px !important;
     margin-top: -2px;
+    max-height: calc(30vh);
 }
 
 .selectBox__item {


### PR DESCRIPTION
This PR continues the change from https://github.com/neos/neos-ui/pull/2221

After discussing the issue with some UI people we now define a viewport driven height for the drop down. The content can now also fly out.

If you configure a create dialog with a select box. The select box options are cutted and you need to find out that you are able to scroll down.

example:
```
'Neos.Neos:Document':
  ui:
    group: 'general'
    creationDialog:
      elements:
        title:
          type: string
          ui:
            label: i18n
            editor: 'Neos.Neos/Inspector/Editors/TextFieldEditor'
          validation:
            'Neos.Neos/Validation/NotEmptyValidator': []
        country:
          type: string
          ui:
            label: 'Country'
            editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
            editorOptions:
              values:
                italy:
                  label: 'Italy'
                  group: 'Southern Europe'
                austria:
                  label: 'Austria'
                  group: 'Central Europe'
                germany:
                  label: 'Germany'
                  group: 'Central Europe'
                poland:
                  label: 'Poland'
                  group: 'Central Europe'
                netherlands:
                  label: 'Netherlands'
                  group: 'Central Europe'
                denmark:
                  label: 'Denmark'
                  group: 'Central Europe'
                sweden:
                  label: 'Sweden'
                  group: 'Central Europe'
                norway:
                  label: 'Norway'
                  group: 'Central Europe'
                switzerland:
                  label: 'Swiss'
                  group: 'Central Europe'
                finnland:
                  label: 'Finnland'
                  group: 'Central Europe'
          validation:
            'Neos.Neos/Validation/NotEmptyValidator': []
```

Fixes: #1214 