### PR TITLE
TASK: Rollback the FEATURE: Skip 'new element' dialog if there is only one

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
@@ -172,23 +172,11 @@ export default class SelectNodeType extends PureComponent {
 
     handleNodeTypeFilterChange = filterSearchTerm => this.setState({filterSearchTerm});
 
-    skipNodeTypeDialogIfPossible() {
-        const {insertMode} = this.state;
-        if (insertMode === 'into' &&
-            this.getAllowedNodeTypesByCurrentInsertMode().length === 1 &&
-            this.getAllowedNodeTypesByCurrentInsertMode()[0].nodeTypes.length === 1) {
-            this.handleApply(this.getAllowedNodeTypesByCurrentInsertMode()[0].nodeTypes[0].name);
-            return true;
-        }
-
-        return false;
-    }
-
     render() {
         const {insertMode, filterSearchTerm} = this.state;
         const {isOpen, allowedSiblingNodeTypes, allowedChildNodeTypes} = this.props;
 
-        if (!isOpen || this.skipNodeTypeDialogIfPossible()) {
+        if (!isOpen) {
             return null;
         }
 


### PR DESCRIPTION
The recently introduced Feature https://github.com/neos/neos-ui/pull/2223/files led to irritations on editors side. Let's remove this and someday replace it with other optimizations like: https://github.com/neos/guild-ux/issues/10