### PR TITLE
BUGFIX: Translate textareaeditor placeholder

### DIFF
--- a/packages/neos-ui-editors/src/Editors/TextArea/index.js
+++ b/packages/neos-ui-editors/src/Editors/TextArea/index.js
@@ -1,42 +1,48 @@
-import React from 'react';
+import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import TextArea from '@neos-project/react-ui-components/src/TextArea/';
+import {neos} from '@neos-project/neos-ui-decorators';
 
-const defaultOptions = {
-    disabled: false,
-    maxlength: null,
-    readonly: false,
-    placeholder: '',
-    minRows: 2,
-    expandedRows: 6
-};
+@neos(globalRegistry => ({
+    i18nRegistry: globalRegistry.get('i18n')
+}))
+export default class TextAreaEditor extends PureComponent {
+    static propTypes = {
+        id: PropTypes.string,
+        value: PropTypes.string,
+        highlight: PropTypes.bool,
+        commit: PropTypes.func.isRequired,
+        options: PropTypes.object,
+        validationErrors: PropTypes.array,
+        i18nRegistry: PropTypes.object.isRequired
+    };
 
-const TextAreaEditor = props => {
-    const {id, value, commit, options, className} = props;
+    static defaultOptions = {
+        disabled: false,
+        maxlength: null,
+        readonly: false,
+        placeholder: '',
+        minRows: 2,
+        expandedRows: 6
+    };
 
-    const finalOptions = Object.assign({}, defaultOptions, options);
+    render() {
+        const {id, value, commit, options, className, i18nRegistry} = this.props;
 
-    return (<TextArea
-        id={id}
-        value={value}
-        className={className}
-        onChange={commit}
-        disabled={finalOptions.disabled}
-        maxLength={finalOptions.maxlength}
-        readOnly={finalOptions.readonly}
-        placeholder={finalOptions.placeholder}
-        minRows={finalOptions.minRows}
-        expandedRows={finalOptions.expandedRows}
-        />
-    );
-};
-TextAreaEditor.propTypes = {
-    id: PropTypes.string,
-    value: PropTypes.string,
-    highlight: PropTypes.bool,
-    commit: PropTypes.func.isRequired,
-    options: PropTypes.object,
-    validationErrors: PropTypes.array
-};
+        const finalOptions = Object.assign({}, this.constructor.defaultOptions, options);
+        const placeholder = finalOptions.placeholder && i18nRegistry.translate(unescape(finalOptions.placeholder));
 
-export default TextAreaEditor;
+        return (<TextArea
+            id={id}
+            value={value}
+            className={className}
+            onChange={commit}
+            disabled={finalOptions.disabled}
+            maxLength={finalOptions.maxlength}
+            readOnly={finalOptions.readonly}
+            placeholder={placeholder}
+            minRows={finalOptions.minRows}
+            expandedRows={finalOptions.expandedRows}
+            />);
+    }
+}


### PR DESCRIPTION
This also needed some refactoring of the component
to a class to support the injection of the i18nRegistry.

This will also only work when https://github.com/neos/neos-development-collection/pull/2404 is merged.

**How to verify it**

Have https://github.com/neos/neos-development-collection/pull/2404 applied and use i18n in the placeholder for a textareaeditor like for the meta description of the Neos.Seo package.
