### PR TITLE
TASK: Trim node-frontend-uri

### DIFF
--- a/packages/neos-ui-backend-connector/src/Endpoints/index.ts
+++ b/packages/neos-ui-backend-connector/src/Endpoints/index.ts
@@ -360,7 +360,7 @@ export default (routes: Routes) => {
                 if (!nodeType) {
                     throw new Error('.node-type not found in result');
                 }
-                const uri = uriElement.innerText;
+                const uri = uriElement.innerText.trim();
                 return {
                     dataType: 'Neos.ContentRepository:Node',
                     loaderUri: 'node://' + nodeIdentifier.innerText,


### PR DESCRIPTION
The node-frontend-uri is fetched from a html response and contains tabs and newlines, which at least on macos leads to visual issues if it's directly used as title attribute.