### PR TITLE
TASK: Updates whatwg-fetch to version 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "url-loader": "^1.0.1",
     "uuid": "^3.2.1",
     "webpack-cli": "^3.2.3",
-    "whatwg-fetch": "^2.0.0"
+    "whatwg-fetch": "^3.0.0"
   },
   "workspaces": [
     "packages/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13433,9 +13433,14 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.23"
 
-whatwg-fetch@>=0.10.0, whatwg-fetch@^2.0.0:
+whatwg-fetch@>=0.10.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
+
+whatwg-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 whatwg-mimetype@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
We actually use it as wrapper to be able to use fetch also in IE 11 and other older browsers.

Resolves: #2417