### PR TITLE
Revert "Makes the select box content fly out"

### DIFF
--- a/packages/react-ui-components/src/Dialog/style.css
+++ b/packages/react-ui-components/src/Dialog/style.css
@@ -62,7 +62,7 @@
 }
 .dialog__body {
     max-height: calc(65vh);
-    overflow-y: visible;
+    overflow-y: auto;
 }
 .dialog__actions {
     composes: reset from './../reset.css';

--- a/packages/react-ui-components/src/SelectBox/style.css
+++ b/packages/react-ui-components/src/SelectBox/style.css
@@ -34,7 +34,6 @@
     z-index: var(--zIndex-SelectBoxContents);
     padding: 2px !important;
     margin-top: -2px;
-    max-height: calc(30vh);
 }
 
 .selectBox__item {


### PR DESCRIPTION
This reverts commit d52b7ffc93f020f7f01343d2110e657ad7238409.
In the Pull Request https://github.com/neos/neos-ui/pull/2398 we changed the handling of the select box. So that the content of the select box could fly out of the create dialog. This also leads the issue #2429

Because this is a critical issue, we revert the PR and search for another solution later on.

Fixes: #2429