### PR TITLE
BUGFIX: prune all sites before importing test site

### DIFF
--- a/Tests/IntegrationTests/e2e.sh
+++ b/Tests/IntegrationTests/e2e.sh
@@ -21,7 +21,7 @@ for fixture in Packages/Application/Neos.Neos.Ui/Tests/IntegrationTests/Fixtures
     #./flow flow:cache:flushone Neos_Neos_Fusion
     #./flow flow:cache:flushone Neos_Fusion_Content
     ./flow flow:cache:flush
-    ./flow site:prune
+    ./flow site:prune '*'
     ./flow site:import --package-key=Neos.TestSite
     ./flow resource:publish
 


### PR DESCRIPTION
The end to end test fail on master because the prune command can not be executed without
a defined site node.


