### PR TITLE
BUGFIX: fix JSON encoding of empty `allowedPresets`

### DIFF
--- a/Classes/Fusion/Helper/ApiHelper.php
+++ b/Classes/Fusion/Helper/ApiHelper.php
@@ -19,11 +19,13 @@ class ApiHelper implements ProtectedContextAwareInterface
      * Converts an empty array to an empty object. Does nothing if array is not empty.
      *
      * Use this helper to prevent associative arrays from being converted to non-associative arrays by json_encode.
+     * This is an internal helper and might change without further notice
+     * FIXME: Probably better to produce objects in the first place "upstream".
      *
      * @param array $array Associative array which may be empty
      * @return array|\stdClass Non-empty associative array or empty object
      */
-    public function keepAssociative(array $array)
+    public function emptyArrayToObject(array $array)
     {
         return $array === [] ? new \stdClass() : $array;
     }

--- a/Classes/Fusion/Helper/ApiHelper.php
+++ b/Classes/Fusion/Helper/ApiHelper.php
@@ -1,0 +1,39 @@
+<?php
+namespace Neos\Neos\Ui\Fusion\Helper;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Eel\ProtectedContextAwareInterface;
+
+class ApiHelper implements ProtectedContextAwareInterface
+{
+    /**
+     * Converts an empty array to an empty object. Does nothing if array is not empty.
+     *
+     * Use this helper to prevent associative arrays from being converted to non-associative arrays by json_encode.
+     *
+     * @param array $array Associative array which may be empty
+     * @return array|\stdClass Non-empty associative array or empty object
+     */
+    public function keepAssociative(array $array)
+    {
+        return $array === [] ? new \stdClass() : $array;
+    }
+
+    /**
+     * @param string $methodName
+     * @return bool
+     */
+    public function allowsCallOfMethod($methodName) : bool
+    {
+        return true;
+    }
+}

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -109,6 +109,7 @@ Neos:
         Math: Neos\Eel\Helper\MathHelper
         Json: Neos\Eel\Helper\JsonHelper
         I18n: Neos\Flow\I18n\EelHelper\TranslationHelper
+        Neos.Ui.Api: Neos\Neos\Ui\Fusion\Helper\ApiHelper
         Neos.Ui.Workspace: Neos\Neos\Ui\Fusion\Helper\WorkspaceHelper
         Neos.Ui.NodeInfo: Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper
         Neos.Ui.ContentDimensions: Neos\Neos\Ui\Fusion\Helper\ContentDimensionsHelper
@@ -121,7 +122,7 @@ Neos:
           previewUrl: '${Neos.Ui.NodeInfo.createRedirectToNode(controllerContext, q(documentNode).context({workspaceName: documentNode.context.workspace.baseWorkspace.name}).get(0))}'
           contentDimensions:
             active: '${documentNode.context.dimensions}'
-            allowedPresets: '${Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.context.dimensions)}'
+            allowedPresets: '${Neos.Ui.Api.keepAssociative(Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.context.dimensions))}'
           documentNodeSerialization: '${Neos.Ui.NodeInfo.renderNodeWithPropertiesAndChildrenInformation(documentNode, controllerContext)}'
           url: '${Neos.Ui.NodeInfo.uri(documentNode, controllerContext)}'
       initialState:
@@ -139,7 +140,7 @@ Neos:
           contentDimensions:
             byName: '${Neos.Ui.ContentDimensions.contentDimensionsByName()}'
             active: '${documentNode.context.dimensions}'
-            allowedPresets: '${Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.context.dimensions)}'
+            allowedPresets: '${Neos.Ui.Api.keepAssociative(Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.context.dimensions))}'
           workspaces:
             personalWorkspace: '${Neos.Ui.Workspace.getPersonalWorkspace()}'
         ui:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -122,7 +122,7 @@ Neos:
           previewUrl: '${Neos.Ui.NodeInfo.createRedirectToNode(controllerContext, q(documentNode).context({workspaceName: documentNode.context.workspace.baseWorkspace.name}).get(0))}'
           contentDimensions:
             active: '${documentNode.context.dimensions}'
-            allowedPresets: '${Neos.Ui.Api.keepAssociative(Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.context.dimensions))}'
+            allowedPresets: '${Neos.Ui.Api.emptyArrayToObject(Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.context.dimensions))}'
           documentNodeSerialization: '${Neos.Ui.NodeInfo.renderNodeWithPropertiesAndChildrenInformation(documentNode, controllerContext)}'
           url: '${Neos.Ui.NodeInfo.uri(documentNode, controllerContext)}'
       initialState:
@@ -140,7 +140,7 @@ Neos:
           contentDimensions:
             byName: '${Neos.Ui.ContentDimensions.contentDimensionsByName()}'
             active: '${documentNode.context.dimensions}'
-            allowedPresets: '${Neos.Ui.Api.keepAssociative(Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.context.dimensions))}'
+            allowedPresets: '${Neos.Ui.Api.emptyArrayToObject(Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.context.dimensions))}'
           workspaces:
             personalWorkspace: '${Neos.Ui.Workspace.getPersonalWorkspace()}'
         ui:


### PR DESCRIPTION
For now only used for `contentDimensions.allowedPresets`.
It is probably needed in other places too.

This fixes a problem when the backend outputs an empty array and the frontend expects it to be an object. This is due to PHP arrays being converted by `json_encode()` to JS objects when they are associative and to arrays when not. Empty arrays are interpreted as non-associative (unless `JSON_FORCE_OBJECT` is used).
In many cases we don't want the whole array/object which gets json_encoded to be forced to an object, so we must catch this edge case sooner.