### PR TITLE
TASK: remove <hr> divider between the trees

### DIFF
--- a/packages/neos-ui/src/Containers/LeftSideBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/index.js
@@ -87,8 +87,6 @@ export default class LeftSideBar extends PureComponent {
                     {!isHidden && LeftSideBarTop.map((Item, key) => <Item key={key} isExpanded={!isHiddenContentTree}/>)}
                 </div>
 
-                <hr className={style.hr}/>
-
                 <div className={bottomClassNames}>
                     <ContentTreeToolbar/>
                     {!isHidden && !isHiddenContentTree && LeftSideBarBottom.map((Item, key) => <Item key={key}/>)}

--- a/packages/neos-ui/src/Containers/LeftSideBar/style.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/style.css
@@ -63,9 +63,3 @@
     font-weight: bold;
     background: var(--colors-ContrastDarkest);
 }
-
-.hr {
-    height: var(--spacing-Half);
-    background: var(--colors-ContrastDarkest);
-    border: none;
-}


### PR DESCRIPTION
This divider is no longer needed and adds a weird margin

Before:
![image](https://user-images.githubusercontent.com/837032/56118344-bd660100-5f72-11e9-9830-7f134ddfdc1e.png)

After:
![image](https://user-images.githubusercontent.com/837032/56120063-04a1c100-5f76-11e9-84cc-e02fe38088d5.png)
