### PR TITLE
BUGFIX: Check for validators w/o configuration

### DIFF
--- a/Classes/Domain/Model/Changes/Property.php
+++ b/Classes/Domain/Model/Changes/Property.php
@@ -182,6 +182,9 @@ class Property extends AbstractChange
 
         if (isset($nodeTypeProperties[$propertyName]['validation'])) {
             foreach ($nodeTypeProperties[$propertyName]['validation'] as $validatorName => $validatorConfiguration) {
+                if (!\is_array($validatorConfiguration)) {
+                    $validatorConfiguration = [];
+                }
                 if ($this->nodePropertyValidationService->validate($this->value, $validatorName, $validatorConfiguration) === false) {
                     return false;
                 }


### PR DESCRIPTION
It can happen that validators does not have additional configuration
like a maximum or minimum.

The exception is kind of eval that you get for the label validator. So we should check this here and prevent the hard exception.

Fixes: #2452