### PR TITLE
FEATURE: Allow adding and overriding fusion code for Neos UI backend in all packages

### DIFF
--- a/Classes/View/BackendFusionView.php
+++ b/Classes/View/BackendFusionView.php
@@ -18,6 +18,6 @@ class BackendFusionView extends FusionView
     public function __construct(array $options = [])
     {
         parent::__construct($options);
-        $this->setFusionPathPattern('resource://@package/Private/Fusion/Backend/');
+        $this->setFusionPathPattern('resource://@package/Private/Fusion/Backend');
     }
 }

--- a/Classes/View/BackendFusionView.php
+++ b/Classes/View/BackendFusionView.php
@@ -18,6 +18,6 @@ class BackendFusionView extends FusionView
     public function __construct(array $options = [])
     {
         parent::__construct($options);
-        $this->setFusionPathPattern('resource://Neos.Neos.Ui/Private/Fusion/Backend');
+        $this->setFusionPathPattern('resource://@package/Private/Fusion/Backend/');
     }
 }


### PR DESCRIPTION
The `@package` placeholder gets replaced by the package name, so you are able to add your own Fusion code for Neos UI backend in your own packages in path `/Private/Fusion/Backend/`.

