### PR TITLE
BUGFIX: Adding assets in asset lists not working

### DIFF
--- a/packages/neos-ui-editors/src/Editors/AssetEditor/index.js
+++ b/packages/neos-ui-editors/src/Editors/AssetEditor/index.js
@@ -140,9 +140,8 @@ export default class AssetEditor extends PureComponent {
     }
 
     handleMediaSelected = assetIdentifier => {
-        const {value} = this.props;
         if (this.props.options.multiple) {
-            const values = value ? value.slice() : [];
+            const values = this.getValues();
             values.push(assetIdentifier);
             this.handleValuesChange(values);
         } else {


### PR DESCRIPTION
**What I did**
Fixed the bug that did not allow to add additional assets to asset lists, once created.

**How I did it**
Use getValues() instead of directly accessing this.props.value, as then the mapping of asset identifiers is missing.

**How to verify it**
Add a node with an asset list (array of assets) and add some files. Apply your changes and reload the page. Then select the node again and add more assets – it now works. Before, a JavaScript error was thrown and the Media Browser loaded the asset detail view.
