### PR TITLE
Restrict style for td's in guest frame to CKE content

### DIFF
--- a/packages/neos-ui-guest-frame/src/style.css
+++ b/packages/neos-ui-guest-frame/src/style.css
@@ -42,7 +42,7 @@
     background-image: linear-gradient(to bottom, rgba(50, 50, 50, .1), rgba(50, 50, 50, .2), rgba(50, 50, 50, .1));
 }
 
-.ck-content .table table td {
+:global(.ck-content .table table td) {
     padding: 5px;
     border: 1px solid gray;
 }

--- a/packages/neos-ui-guest-frame/src/style.css
+++ b/packages/neos-ui-guest-frame/src/style.css
@@ -42,7 +42,7 @@
     background-image: linear-gradient(to bottom, rgba(50, 50, 50, .1), rgba(50, 50, 50, .2), rgba(50, 50, 50, .1));
 }
 
-:global(td) {
+.ck-content .table table td {
     padding: 5px;
     border: 1px solid gray;
 }


### PR DESCRIPTION
The global `td` style is not resticted to any subject within the guest frame. Moreover it affects the styles of users.