### PR TITLE
TASK: rewrite positional array sorter to behave like the php implementation

### DIFF
--- a/packages/positional-array-sorter/src/positionalArraySorter.spec.js
+++ b/packages/positional-array-sorter/src/positionalArraySorter.spec.js
@@ -217,6 +217,23 @@ test('Handles non-word keys', () => {
     ];
     expect(positionalArraySorter(source)).toEqual(result);
 });
+test('Handle invalid position strings', () => {
+    const source = [
+        {position: 10},
+        {position: 'after'},
+        {position: 'end'},
+        {position: 'before'},
+        {position: 'twenty'}
+    ];
+    const result = [
+        {position: 'after'},
+        {position: 'before'},
+        {position: 'twenty'},
+        {position: 10},
+        {position: 'end'}
+    ];
+    expect(positionalArraySorter(source)).toEqual(result);
+});
 test('Access position value by callback', () => {
     const source = [
         {__meta: {position: 'end'}},

--- a/packages/positional-array-sorter/src/positionalArraySorter.spec.js
+++ b/packages/positional-array-sorter/src/positionalArraySorter.spec.js
@@ -2,205 +2,205 @@ import positionalArraySorter from './positionalArraySorter';
 
 test('Position end should put element to end', () => {
     const source = [
-        { key: 'second', position: 'end' },
-        { key: 'first' }
+        {key: 'second', position: 'end'},
+        {key: 'first'}
     ];
     const result = [
-        { key: 'first' },
-        { key: 'second', position: 'end' }
+        {key: 'first'},
+        {key: 'second', position: 'end'}
     ];
     expect(positionalArraySorter(source)).toEqual(result);
 });
 test('Position start should put element to start', () => {
     const source = [
-        { key: 'second' },
-        { key: 'first', position: 'start' }
+        {key: 'second'},
+        {key: 'first', position: 'start'}
     ];
     const result = [
-        { key: 'first', position: 'start' },
-        { key: 'second' }
+        {key: 'first', position: 'start'},
+        {key: 'second'}
     ];
     expect(positionalArraySorter(source)).toEqual(result);
 });
 test('Position start should respect priority', () => {
     const source = [
-        { key: 'second', position: 'start 50' },
-        { key: 'first', position: 'start 52' }
+        {key: 'second', position: 'start 50'},
+        {key: 'first', position: 'start 52'}
     ];
     const result = [
-        { key: 'first', position: 'start 52' },
-        { key: 'second', position: 'start 50' }
+        {key: 'first', position: 'start 52'},
+        {key: 'second', position: 'start 50'}
     ];
     expect(positionalArraySorter(source)).toEqual(result);
 });
 test('Position end should respect priority', () => {
     const source = [
-        { key: 'second', position: 'end 17' },
-        { key: 'first', position: 'end' }
+        {key: 'second', position: 'end 17'},
+        {key: 'first', position: 'end'}
     ];
     const result = [
-        { key: 'first', position: 'end' },
-        { key: 'second', position: 'end 17' }
+        {key: 'first', position: 'end'},
+        {key: 'second', position: 'end 17'}
     ];
     expect(positionalArraySorter(source)).toEqual(result);
 });
 test('Positional numbers are in the middle', () => {
     const source = [
-        { key: 'last', position: 'end' },
-        { key: 'second', position: '17' },
-        { key: 'first', position: '5' },
-        { key: 'third', position: '18' }
+        {key: 'last', position: 'end'},
+        {key: 'second', position: '17'},
+        {key: 'first', position: '5'},
+        {key: 'third', position: '18'}
     ];
     const result = [
-        { key: 'first', position: '5' },
-        { key: 'second', position: '17' },
-        { key: 'third', position: '18' },
-        { key: 'last', position: 'end' }
+        {key: 'first', position: '5'},
+        {key: 'second', position: '17'},
+        {key: 'third', position: '18'},
+        {key: 'last', position: 'end'}
     ];
     expect(positionalArraySorter(source)).toEqual(result);
 });
 test('Position before adds before named element if present', () => {
     const source = [
-        { key: 'second' },
-        { key: 'first', position: 'before second' }
+        {key: 'second'},
+        {key: 'first', position: 'before second'}
     ];
     const result = [
-        { key: 'first', position: 'before second' },
-        { key: 'second' }
+        {key: 'first', position: 'before second'},
+        {key: 'second'}
     ];
     expect(positionalArraySorter(source)).toEqual(result);
 });
 test('Position before adds after start if named element not present', () => {
     const source = [
-        { key: 'third' },
-        { key: 'second', position: 'before third' },
-        { key: 'first', position: 'before unknown' }
+        {key: 'third'},
+        {key: 'second', position: 'before third'},
+        {key: 'first', position: 'before unknown'}
     ];
     const result = [
-        { key: 'first', position: 'before unknown' },
-        { key: 'second', position: 'before third' },
-        { key: 'third' }
+        {key: 'first', position: 'before unknown'},
+        {key: 'second', position: 'before third'},
+        {key: 'third'}
     ];
     expect(positionalArraySorter(source)).toEqual(result);
 });
 test('Position before uses priority when referencing the same element; The higher the priority the closer before the element gets added.', () => {
     const source = [
-        { key: 'third' },
-        { key: 'second', position: 'before third' },
-        { key: 'first', position: 'before third 12' }
+        {key: 'third'},
+        {key: 'second', position: 'before third'},
+        {key: 'first', position: 'before third 12'}
     ];
     const result = [
-        { key: 'second', position: 'before third' },
-        { key: 'first', position: 'before third 12' },
-        { key: 'third' }
+        {key: 'second', position: 'before third'},
+        {key: 'first', position: 'before third 12'},
+        {key: 'third'}
     ];
     expect(positionalArraySorter(source)).toEqual(result);
 });
 test('Position before works recursively', () => {
     const source = [
-        { key: 'third' },
-        { key: 'second', position: 'before third' },
-        { key: 'first', position: 'before second' }
+        {key: 'third'},
+        {key: 'second', position: 'before third'},
+        {key: 'first', position: 'before second'}
     ];
     const result = [
-        { key: 'first', position: 'before second' },
-        { key: 'second', position: 'before third' },
-        { key: 'third' }
+        {key: 'first', position: 'before second'},
+        {key: 'second', position: 'before third'},
+        {key: 'third'}
     ];
     expect(positionalArraySorter(source)).toEqual(result);
 });
 test('Position after adds after named element if present', () => {
     const source = [
-        { key: 'second', position: 'after first' },
-        { key: 'first' }
+        {key: 'second', position: 'after first'},
+        {key: 'first'}
     ];
     const result = [
-        { key: 'first' },
-        { key: 'second', position: 'after first' }
+        {key: 'first'},
+        {key: 'second', position: 'after first'}
     ];
     expect(positionalArraySorter(source)).toEqual(result);
 });
 test('Position after adds before end if named element not present', () => {
     const source = [
-        { key: 'second', position: 'after unknown' },
-        { key: 'third', position: 'end' },
-        { key: 'first' }
+        {key: 'second', position: 'after unknown'},
+        {key: 'third', position: 'end'},
+        {key: 'first'}
     ];
     const result = [
-        { key: 'first' },
-        { key: 'second', position: 'after unknown' },
-        { key: 'third', position: 'end' }
+        {key: 'first'},
+        {key: 'second', position: 'after unknown'},
+        {key: 'third', position: 'end'}
     ];
     expect(positionalArraySorter(source)).toEqual(result);
 });
 test('Position after uses priority when referencing the same element; The higher the priority the closer after the element gets added.', () => {
     const source = [
-        { key: 'third', position: 'after first' },
-        { key: 'second', position: 'after first 12' },
-        { key: 'first' }
+        {key: 'third', position: 'after first'},
+        {key: 'second', position: 'after first 12'},
+        {key: 'first'}
     ];
     const result = [
-        { key: 'first' },
-        { key: 'second', position: 'after first 12' },
-        { key: 'third', position: 'after first' }
+        {key: 'first'},
+        {key: 'second', position: 'after first 12'},
+        {key: 'third', position: 'after first'}
     ];
     expect(positionalArraySorter(source)).toEqual(result);
 });
 test('Position after works recursively', () => {
     const source = [
-        { key: 'third', position: 'after second' },
-        { key: 'second', position: 'after first' },
-        { key: 'first' }
+        {key: 'third', position: 'after second'},
+        {key: 'second', position: 'after first'},
+        {key: 'first'}
     ];
     const result = [
-        { key: 'first' },
-        { key: 'second', position: 'after first' },
-        { key: 'third', position: 'after second' }
+        {key: 'first'},
+        {key: 'second', position: 'after first'},
+        {key: 'third', position: 'after second'}
     ];
     expect(positionalArraySorter(source)).toEqual(result);
 });
 test('Array keys may contain special characters', () => {
     const source = [
-        { key: 'thi:rd', position: 'end' },
-        { key: 'sec.ond', position: 'before thi:rd' },
-        { key: 'fir-st', position: 'before sec.ond' }
+        {key: 'thi:rd', position: 'end'},
+        {key: 'sec.ond', position: 'before thi:rd'},
+        {key: 'fir-st', position: 'before sec.ond'}
     ];
     const result = [
-        { key: 'fir-st', position: 'before sec.ond' },
-        { key: 'sec.ond', position: 'before thi:rd' },
-        { key: 'thi:rd', position: 'end' }
+        {key: 'fir-st', position: 'before sec.ond'},
+        {key: 'sec.ond', position: 'before thi:rd'},
+        {key: 'thi:rd', position: 'end'}
     ];
     expect(positionalArraySorter(source)).toEqual(result);
 });
 test('numerical string-positions work like numbers', () => {
     const source = [
         {},
-        { position: '100' },
-        { position: 10 },
-        { position: '1' },
-        { position: 1000 }
+        {position: '100'},
+        {position: 10},
+        {position: '1'},
+        {position: 1000}
     ];
     const result = [
         {},
-        { position: '1' },
-        { position: 10 },
-        { position: '100' },
-        { position: 1000 }
+        {position: '1'},
+        {position: 10},
+        {position: '100'},
+        {position: 1000}
     ];
     expect(positionalArraySorter(source)).toEqual(result);
 });
 test('Should gracefully handle circular references', () => {
     const source = [
-        { position: 'before abc2', key: 'abc1' },
-        { position: 'before abc3', key: 'abc2' },
-        { position: 'before abc1', key: 'abc3' },
-        { position: 'end', key: 'plain-key' }
+        {position: 'before abc2', key: 'abc1'},
+        {position: 'before abc3', key: 'abc2'},
+        {position: 'before abc1', key: 'abc3'},
+        {position: 'end', key: 'plain-key'}
     ];
     const result = [
-        { position: 'before abc3', key: 'abc2' },
-        { position: 'before abc1', key: 'abc3' },
-        { position: 'before abc2', key: 'abc1' },
-        { position: 'end', key: 'plain-key' }
+        {position: 'before abc3', key: 'abc2'},
+        {position: 'before abc1', key: 'abc3'},
+        {position: 'before abc2', key: 'abc1'},
+        {position: 'end', key: 'plain-key'}
     ];
     expect(positionalArraySorter(source)).toEqual(result);
 });
@@ -219,14 +219,14 @@ test('Handles non-word keys', () => {
 });
 test('Access position value by callback', () => {
     const source = [
-        {__meta: { position: 'end' }},
-        {__meta: { position: 'start' }},
+        {__meta: {position: 'end'}},
+        {__meta: {position: 'start'}},
         {}
     ];
     const result = [
-        {__meta: { position: 'start' }},
+        {__meta: {position: 'start'}},
         {},
-        {__meta: { position: 'end' }}
+        {__meta: {position: 'end'}}
     ];
-    expect(positionalArraySorter(source, (e) => e.__meta ? e.__meta.position : undefined)).toEqual(result);
+    expect(positionalArraySorter(source, e => e.__meta ? e.__meta.position : undefined)).toEqual(result);
 });

--- a/packages/positional-array-sorter/src/positionalArraySorter.spec.js
+++ b/packages/positional-array-sorter/src/positionalArraySorter.spec.js
@@ -1,114 +1,210 @@
 import positionalArraySorter from './positionalArraySorter';
 
-test(`Middle`, () => {
+test('Position end should put element to end', () => {
+    const source = [
+        { key: 'second', position: 'end' },
+        { key: 'first' }
+    ];
+    const result = [
+        { key: 'first' },
+        { key: 'second', position: 'end' }
+    ];
+    expect(positionalArraySorter(source)).toEqual(result);
+});
+test('Position start should put element to start', () => {
+    const source = [
+        { key: 'second' },
+        { key: 'first', position: 'start' }
+    ];
+    const result = [
+        { key: 'first', position: 'start' },
+        { key: 'second' }
+    ];
+    expect(positionalArraySorter(source)).toEqual(result);
+});
+test('Position start should respect priority', () => {
+    const source = [
+        { key: 'second', position: 'start 50' },
+        { key: 'first', position: 'start 52' }
+    ];
+    const result = [
+        { key: 'first', position: 'start 52' },
+        { key: 'second', position: 'start 50' }
+    ];
+    expect(positionalArraySorter(source)).toEqual(result);
+});
+test('Position end should respect priority', () => {
+    const source = [
+        { key: 'second', position: 'end 17' },
+        { key: 'first', position: 'end' }
+    ];
+    const result = [
+        { key: 'first', position: 'end' },
+        { key: 'second', position: 'end 17' }
+    ];
+    expect(positionalArraySorter(source)).toEqual(result);
+});
+test('Positional numbers are in the middle', () => {
+    const source = [
+        { key: 'last', position: 'end' },
+        { key: 'second', position: '17' },
+        { key: 'first', position: '5' },
+        { key: 'third', position: '18' }
+    ];
+    const result = [
+        { key: 'first', position: '5' },
+        { key: 'second', position: '17' },
+        { key: 'third', position: '18' },
+        { key: 'last', position: 'end' }
+    ];
+    expect(positionalArraySorter(source)).toEqual(result);
+});
+test('Position before adds before named element if present', () => {
+    const source = [
+        { key: 'second' },
+        { key: 'first', position: 'before second' }
+    ];
+    const result = [
+        { key: 'first', position: 'before second' },
+        { key: 'second' }
+    ];
+    expect(positionalArraySorter(source)).toEqual(result);
+});
+test('Position before adds after start if named element not present', () => {
+    const source = [
+        { key: 'third' },
+        { key: 'second', position: 'before third' },
+        { key: 'first', position: 'before unknown' }
+    ];
+    const result = [
+        { key: 'first', position: 'before unknown' },
+        { key: 'second', position: 'before third' },
+        { key: 'third' }
+    ];
+    expect(positionalArraySorter(source)).toEqual(result);
+});
+test('Position before uses priority when referencing the same element; The higher the priority the closer before the element gets added.', () => {
+    const source = [
+        { key: 'third' },
+        { key: 'second', position: 'before third' },
+        { key: 'first', position: 'before third 12' }
+    ];
+    const result = [
+        { key: 'second', position: 'before third' },
+        { key: 'first', position: 'before third 12' },
+        { key: 'third' }
+    ];
+    expect(positionalArraySorter(source)).toEqual(result);
+});
+test('Position before works recursively', () => {
+    const source = [
+        { key: 'third' },
+        { key: 'second', position: 'before third' },
+        { key: 'first', position: 'before second' }
+    ];
+    const result = [
+        { key: 'first', position: 'before second' },
+        { key: 'second', position: 'before third' },
+        { key: 'third' }
+    ];
+    expect(positionalArraySorter(source)).toEqual(result);
+});
+test('Position after adds after named element if present', () => {
+    const source = [
+        { key: 'second', position: 'after first' },
+        { key: 'first' }
+    ];
+    const result = [
+        { key: 'first' },
+        { key: 'second', position: 'after first' }
+    ];
+    expect(positionalArraySorter(source)).toEqual(result);
+});
+test('Position after adds before end if named element not present', () => {
+    const source = [
+        { key: 'second', position: 'after unknown' },
+        { key: 'third', position: 'end' },
+        { key: 'first' }
+    ];
+    const result = [
+        { key: 'first' },
+        { key: 'second', position: 'after unknown' },
+        { key: 'third', position: 'end' }
+    ];
+    expect(positionalArraySorter(source)).toEqual(result);
+});
+test('Position after uses priority when referencing the same element; The higher the priority the closer after the element gets added.', () => {
+    const source = [
+        { key: 'third', position: 'after first' },
+        { key: 'second', position: 'after first 12' },
+        { key: 'first' }
+    ];
+    const result = [
+        { key: 'first' },
+        { key: 'second', position: 'after first 12' },
+        { key: 'third', position: 'after first' }
+    ];
+    expect(positionalArraySorter(source)).toEqual(result);
+});
+test('Position after works recursively', () => {
+    const source = [
+        { key: 'third', position: 'after second' },
+        { key: 'second', position: 'after first' },
+        { key: 'first' }
+    ];
+    const result = [
+        { key: 'first' },
+        { key: 'second', position: 'after first' },
+        { key: 'third', position: 'after second' }
+    ];
+    expect(positionalArraySorter(source)).toEqual(result);
+});
+test('Array keys may contain special characters', () => {
+    const source = [
+        { key: 'thi:rd', position: 'end' },
+        { key: 'sec.ond', position: 'before thi:rd' },
+        { key: 'fir-st', position: 'before sec.ond' }
+    ];
+    const result = [
+        { key: 'fir-st', position: 'before sec.ond' },
+        { key: 'sec.ond', position: 'before thi:rd' },
+        { key: 'thi:rd', position: 'end' }
+    ];
+    expect(positionalArraySorter(source)).toEqual(result);
+});
+test('numerical string-positions work like numbers', () => {
     const source = [
         {},
-        {position: '100'},
-        {position: 10},
-        {position: '1'},
-        {position: 1000}
+        { position: '100' },
+        { position: 10 },
+        { position: '1' },
+        { position: 1000 }
     ];
     const result = [
-        {position: '1'},
-        {position: 10},
-        {position: '100'},
-        {position: 1000},
-        {}
+        {},
+        { position: '1' },
+        { position: 10 },
+        { position: '100' },
+        { position: 1000 }
     ];
     expect(positionalArraySorter(source)).toEqual(result);
 });
-test(`Start`, () => {
+test('Should gracefully handle circular references', () => {
     const source = [
-        {position: 'start 100'},
-        {position: 'start 10'},
-        {position: 'start 1'},
-        {position: 'start 1000'}
+        { position: 'before abc2', key: 'abc1' },
+        { position: 'before abc3', key: 'abc2' },
+        { position: 'before abc1', key: 'abc3' },
+        { position: 'end', key: 'plain-key' }
     ];
     const result = [
-        {position: 'start 1'},
-        {position: 'start 10'},
-        {position: 'start 100'},
-        {position: 'start 1000'}
+        { position: 'before abc3', key: 'abc2' },
+        { position: 'before abc1', key: 'abc3' },
+        { position: 'before abc2', key: 'abc1' },
+        { position: 'end', key: 'plain-key' }
     ];
     expect(positionalArraySorter(source)).toEqual(result);
 });
-test(`End`, () => {
-    const source = [
-        {position: 'end 100'},
-        {position: 'end 10'},
-        {position: 'end 1'},
-        {position: 'end 1000'}
-    ];
-    const result = [
-        {position: 'end 1'},
-        {position: 'end 10'},
-        {position: 'end 100'},
-        {position: 'end 1000'}
-    ];
-    expect(positionalArraySorter(source)).toEqual(result);
-});
-test(`Before`, () => {
-    const source = [
-        {key: 'abc'},
-        {position: 'before abc'},
-        {position: 'before abc', key: 1},
-        {position: 'before 1'}
-    ];
-    const result = [
-        {position: 'before abc'},
-        {position: 'before 1'},
-        {position: 'before abc', key: 1},
-        {key: 'abc'}
-    ];
-    expect(positionalArraySorter(source)).toEqual(result);
-});
-test(`After`, () => {
-    const source = [
-        {position: 'after abc'},
-        {position: 'after abc', key: 1},
-        {position: 'after 1'},
-        {key: 'abc'}
-    ];
-    const result = [
-        {key: 'abc'},
-        {position: 'after abc', key: 1},
-        {position: 'after 1'},
-        {position: 'after abc'}
-    ];
-    expect(positionalArraySorter(source)).toEqual(result);
-});
-
-test(`Circulare reference go to the end (before)`, () => {
-    const source = [
-        {position: 'before abc2', key: 'abc1'},
-        {position: 'before abc3', key: 'abc2'},
-        {position: 'before abc1', key: 'abc3'},
-        {position: 'end', key: 'plain-key'}
-    ];
-    const result = [
-        {position: 'end', key: 'plain-key'},
-        {position: 'before abc2', key: 'abc1'},
-        {position: 'before abc3', key: 'abc2'},
-        {position: 'before abc1', key: 'abc3'}
-    ];
-    expect(positionalArraySorter(source)).toEqual(result);
-});
-test(`Circulare reference go to the end (after)`, () => {
-    const source = [
-        {position: 'after abc2', key: 'abc1'},
-        {position: 'after abc3', key: 'abc2'},
-        {position: 'after abc1', key: 'abc3'},
-        {position: 'end', key: 'plain-key'}
-    ];
-    const result = [
-        {position: 'end', key: 'plain-key'},
-        {position: 'after abc2', key: 'abc1'},
-        {position: 'after abc3', key: 'abc2'},
-        {position: 'after abc1', key: 'abc3'}
-    ];
-    expect(positionalArraySorter(source)).toEqual(result);
-});
-test(`Handles non-word keys`, () => {
+test('Handles non-word keys', () => {
     const source = [
         {position: 'after $#@!'},
         {key: '$#@!'},
@@ -121,63 +217,16 @@ test(`Handles non-word keys`, () => {
     ];
     expect(positionalArraySorter(source)).toEqual(result);
 });
-test(`Corrupt keys go after the middle`, () => {
+test('Access position value by callback', () => {
     const source = [
-        {position: {}},
-        {position: 'blah blah'},
-        {position: 'after abc'},
-        {position: 'after'},
-        {position: 'before abc'},
-        {position: 'before'},
-        {position: 'after abc1'},
-        {key: 'some-key'}
+        {__meta: { position: 'end' }},
+        {__meta: { position: 'start' }},
+        {}
     ];
     const result = [
-        {key: 'some-key'},
-        {position: {}},
-        {position: 'blah blah'},
-        {position: 'after abc'},
-        {position: 'after'},
-        {position: 'before abc'},
-        {position: 'before'},
-        {position: 'after abc1'}
-    ];
-    expect(positionalArraySorter(source)).toEqual(result);
-});
-test(`Altogether`, () => {
-    const source = [
+        {__meta: { position: 'start' }},
         {},
-        {position: 'end 10'},
-        {position: 'start', key: 'cba1'},
-        {position: 'after abc3', key: 'abc2'},
-        {position: 'start 10'},
-        {position: 'after abc2', key: 'abc1'},
-        {position: 'end', key: 'abc3'},
-        {position: '0'},
-        {position: 0},
-        {position: 'before cba1', key: 'cba2'},
-        {position: 'after abc1'},
-        {position: '10'},
-        {position: 'before cba2', key: 'cba3'},
-        {position: 10},
-        {position: 'before cba3'}
+        {__meta: { position: 'end' }}
     ];
-    const result = [
-        {position: 'before cba3'},
-        {position: 'before cba2', key: 'cba3'},
-        {position: 'before cba1', key: 'cba2'},
-        {position: 'start', key: 'cba1'},
-        {position: 'start 10'},
-        {position: '0'},
-        {position: 0},
-        {position: '10'},
-        {position: 10},
-        {},
-        {position: 'end', key: 'abc3'},
-        {position: 'after abc3', key: 'abc2'},
-        {position: 'after abc2', key: 'abc1'},
-        {position: 'after abc1'},
-        {position: 'end 10'}
-    ];
-    expect(positionalArraySorter(source)).toEqual(result);
+    expect(positionalArraySorter(source, (e) => e.__meta ? e.__meta.position : undefined)).toEqual(result);
 });

--- a/packages/positional-array-sorter/src/positionalArraySorter.ts
+++ b/packages/positional-array-sorter/src/positionalArraySorter.ts
@@ -1,6 +1,3 @@
-const isOriginal = (value: any) => value && value.indexOf && value.indexOf('_original_') === 0;
-const getOriginal = (value: any) => value && value.substring && Number(value.substring(10));
-
 interface Value {
     [propName: string]: any;
 }
@@ -35,128 +32,155 @@ type Index = number;
 type PositionAccessor = (value: Value) => string | number;
 const positionalArraySorter = <T extends Value[]>(subject: T, position: string | PositionAccessor = 'position', idKey = 'key'): T => {
     const positionAccessor = typeof position === 'string' ? (value: Value) => value[position] : position;
-    // Extract all position keys from the subject.
-    // If the position is not in the value, we encode its original position into a string
-    // to preserve original sort order later
-    const positionsArray = subject.map((value, index) => {
-        const position = positionAccessor(value);
-        return position === undefined ? `_original_${index}` : position;
-    });
-    // Extract valid id keys
-    const validKeys = subject.map(value => idKey in value && value[idKey]).filter(i => i).map(i => String(i));
+    // internally we work with string representations of the index/item-key
+    const indexMapping: {[key: string]: Index} = {};
+    // all "normal" keys with numerical or no "position", grouped by that position
+    const middleKeys: {[position: number]: string[]} = {};
+    // all keys of items with "position" "start*" grouped by weight
+    const startKeys: {[weight: number]: string[]} = {};
+    // all keys of items with "position" "end*" grouped by weight
+    const endKeys: {[weight: number]: string[]} = {};
+    // all keys of items with "position" "before*" grouped by reference key, grouped by weight
+    const beforeKeys: {[key: string]: {[weight: number]: string[]}} = {};
+    // all keys of items with "position" "after*" grouped by reference key, grouped by weight
+    const afterKeys: {[key: string]: {[weight: number]: string[]}} = {};
 
-    const middleKeys: Array<[Index, any]> = [];
-    const startKeys: Array<[Index, number]> = [];
-    const endKeys: Array<[Index, number]> = [];
-    const beforeKeys: Array<[Index, string]> = [];
-    const afterKeys: Array<[Index, string]> = [];
-    const corruptKeys: number[] = [];
-
-    // Split all positions into start, end, before, after and middle keys
-    positionsArray.forEach((value, index) => {
-        if (isNaN(value) === false || isOriginal(value)) {
-            middleKeys.push([index, value]);
-        } else if (typeof value === 'string') {
-            if (value.includes('start')) {
-                const weightMatch = value.match(/start\s+(\d+)/);
-                const weight = (weightMatch && weightMatch[1]) || 0;
-                startKeys.push([index, Number(weight)]);
-            } else if (value.includes('end')) {
-                const weightMatch = value.match(/end\s+(\d+)/);
-                const weight = (weightMatch && weightMatch[1]) || 0;
-                endKeys.push([index, Number(weight)]);
-            } else if (value.includes('before')) {
-                const keyMatch = value.match(/before\s+(\S+)/);
-                const key = keyMatch && keyMatch[1];
-                if (key && validKeys.includes(key)) {
-                    beforeKeys.push([index, key]);
-                } else {
-                    corruptKeys.push(index);
-                    console.warn('The following position value is corrupt: %s', value); // tslint:disable-line no-console
-                }
-            } else if (value.includes('after')) {
-                const keyMatch = value.match(/after\s+(\S+)/);
-                const key = keyMatch && keyMatch[1];
-                if (key && validKeys.includes(key)) {
-                    afterKeys.push([index, key]);
-                } else {
-                    corruptKeys.push(index);
-                    console.warn('The following position value is corrupt: %s', value); // tslint:disable-line no-console
-                }
-            } else {
-                corruptKeys.push(index);
-                console.warn('The following position value is corrupt: %s', value); // tslint:disable-line no-console
+    // group items
+    subject.forEach((item, index) => {
+        const key = item[idKey] ? item[idKey] : String(index);
+        indexMapping[key] = index;
+        const positionValue = positionAccessor(item);
+        const position = String(positionValue ? positionValue : index);
+        let invalid = false;
+        if (position.startsWith('start')) {
+            const weightMatch = position.match(/start\s+(\d+)/);
+            const weight = weightMatch && weightMatch[1] ? Number(weightMatch[1]) : 0;
+            if (!startKeys[weight]) {
+                startKeys[weight] = [];
             }
-        } else {
-            corruptKeys.push(index);
-            console.warn('The following position value is corrupt: %s', value); // tslint:disable-line no-console
+            startKeys[weight].push(key);
+        }
+        else if (position.startsWith('end')) {
+            const weightMatch = position.match(/end\s+(\d+)/);
+            const weight = weightMatch && weightMatch[1] ? Number(weightMatch[1]) : 0;
+            if (!endKeys[weight]) {
+                endKeys[weight] = [];
+            }
+            endKeys[weight].push(key);
+        }
+        else if (position.startsWith('before')) {
+            const match = position.match(/before\s+(\S+)(\s+(\d+))?/);
+            if (!match) {
+                invalid = true;
+            } else {
+                const reference = match[1];
+                const weight = match[3] ? Number(match[3]) : 0;
+                if (!beforeKeys[reference]) {
+                    beforeKeys[reference] = {};
+                }
+                if (!beforeKeys[reference][weight]) {
+                    beforeKeys[reference][weight] = [];
+                }
+                beforeKeys[reference][weight].push(key);
+            }
+        }
+        else if (position.startsWith('after')) {
+            const match = position.match(/after\s+(\S+)(\s+(\d+))?/);
+            if (!match) {
+                invalid = true;
+            } else {
+                const reference = match[1];
+                const weight = match[3] ? Number(match[3]) : 0;
+                if (!afterKeys[reference]) {
+                    afterKeys[reference] = {};
+                }
+                if (!afterKeys[reference][weight]) {
+                    afterKeys[reference][weight] = [];
+                }
+                afterKeys[reference][weight].push(key);
+            }
+        }
+        else {
+            invalid = true;
+        }
+        if (invalid) {
+            let numberPosition = parseFloat(position);
+            if (isNaN(numberPosition) || !isFinite(numberPosition)) {
+                numberPosition = index;
+            }
+            if (!middleKeys[numberPosition]) {
+                middleKeys[numberPosition] = [];
+            }
+            middleKeys[numberPosition].push(key);
         }
     });
 
-    const sortByWeightFunc = (a: [any, number], b: [any, number]) => a[1] - b[1];
-    const sortWithRetainingOriginalPos = (_a: [any, string | number], _b: [any, string | number]) => {
-        const a = _a[1];
-        const b = _b[1];
-        // If both items don't have position, retain original sorting order
-        if (isOriginal(a) && isOriginal(b)) {
-            return getOriginal(a) - getOriginal(b);
-        }
-        // If only item `a` doesn't have position, push it down
-        if (typeof a === 'string' && a.includes && a.includes('_original_')) {
-            return 1;
-        }
-        // If only item `b` doesn't have position, push it down
-        if (typeof b === 'string' && b.includes && b.includes('_original_')) {
-            return -1;
-        }
-        // If both items have position, sort them in a standard way
-        return Number(a) - Number(b);
+    const resultStart: string[] = [];
+    const resultMiddle: string[] = [];
+    const resultEnd: string[] = [];
+    const processedKeys: string[] = [];
+
+    // helper function to retrieve all weights in e.g. beforeKeys[...] in the necessary order
+    const sortedWeights = (dict: {[key: number]: any}, asc: boolean) => {
+        const weights = Object.keys(dict).map(x => Number(x)).sort((a, b) => a - b);
+        return asc ? weights : weights.reverse();
+    };
+    // helper function to add all keys of a grouping to a then ordered result set considering before and after keys
+    const addToResults = (keys: string[], result: string[]) => {
+        keys.forEach(key => {
+            if (processedKeys.indexOf(key) >= 0) {
+                return;
+            }
+            processedKeys.push(key);
+            if (beforeKeys[key]) {
+                const beforeWeights = sortedWeights(beforeKeys[key], true);
+                for (let i of beforeWeights) {
+                    addToResults(beforeKeys[key][i], result);
+                }
+            }
+            result.push(key);
+            if (afterKeys[key]) {
+                const afterWeights = sortedWeights(afterKeys[key], false);
+                for (let i of afterWeights) {
+                    addToResults(afterKeys[key][i], result);
+                }
+            }
+        });
     };
 
-
-    // Merged array of all sorted indexes, except for before and after
-    let sortedIndexes = [
-        ...startKeys.sort(sortByWeightFunc).map(pair => pair[0]),
-        ...middleKeys.sort(sortWithRetainingOriginalPos).map(pair => pair[0]),
-        ...corruptKeys,
-        ...endKeys.sort(sortByWeightFunc).map(pair => pair[0])
-    ];
-
-    // Go through all before and after keys and move them to the right position in sortedIndexes.
-    // We may need multiple iterations for this, as before or after keys may point at one another.
-    while (beforeKeys.length > 0 || afterKeys.length > 0) {
-        let alteredNumber = 0;
-        beforeKeys.forEach((pair, index) => { // eslint-disable-line no-loop-func
-            const targetIndexInSubject = subject.findIndex(item => String(item[idKey]) === pair[1]);
-            const indexInIndexes = sortedIndexes.findIndex(item => item === targetIndexInSubject);
-            if (indexInIndexes !== -1) {
-                sortedIndexes.splice(indexInIndexes, 0, pair[0]);
-                beforeKeys.splice(index, 1);
-                alteredNumber++;
-            }
-        });
-        afterKeys.forEach((pair, index) => { // eslint-disable-line no-loop-func
-            const targetIndexInSubject = subject.findIndex(item => String(item[idKey]) === pair[1]);
-            const indexInIndexes = sortedIndexes.findIndex(item => item === targetIndexInSubject);
-            if (indexInIndexes !== -1) {
-                sortedIndexes.splice(indexInIndexes + 1, 0, pair[0]);
-                afterKeys.splice(index, 1);
-                alteredNumber++;
-            }
-        });
-
-        // If no operations were performed in a loop, it means we got stuck in a circular reference.
-        // Break out of it and just append faulty values at the end.
-        if (alteredNumber === 0) {
-            console.warn('Circular reference detected. Append broken entries at the end.'); // tslint:disable-line no-console
-            sortedIndexes = sortedIndexes.concat(
-                beforeKeys.map(pair => pair[0]),
-                afterKeys.map(pair => pair[0])
-            );
-            break;
+    // add all start* keys weighted in descending order
+    for (let i of sortedWeights(startKeys, false)) {
+        addToResults(startKeys[i], resultStart);
+    }
+    // add all middle keys weighted in ascending order
+    for (let i of sortedWeights(middleKeys, true)) {
+        addToResults(middleKeys[i], resultMiddle);
+    }
+    // add all after* keys weighted in ascending order
+    for (let i of sortedWeights(endKeys, true)) {
+        addToResults(endKeys[i], resultEnd);
+    }
+    // orphaned items
+    for (let key of Object.keys(beforeKeys)) {
+        if (processedKeys.indexOf(key) >= 0) {
+            continue;
+        }
+        // add all "orphaned" before* key in descending order before the middle keys
+        for (let i of sortedWeights(beforeKeys[key], false)) {
+            addToResults(beforeKeys[key][i], resultStart);
         }
     }
+    for (let key of Object.keys(afterKeys)) {
+        if (processedKeys.indexOf(key) >= 0) {
+            continue;
+        }
+        // add all "orphaned" after* key in descending order before the end* keys
+        for (let i of sortedWeights(afterKeys[key], false)) {
+            addToResults(afterKeys[key][i], resultMiddle);
+        }
+    }
+    const sortedKeys = [...resultStart, ...resultMiddle, ...resultEnd];
     // TODO fix type assertion
-    return sortedIndexes.map(index => subject[index]) as T;
+    return sortedKeys.map(key => indexMapping[key]).map(i => subject[i]) as T;
 };
 export default positionalArraySorter;

--- a/packages/positional-array-sorter/src/positionalArraySorter.ts
+++ b/packages/positional-array-sorter/src/positionalArraySorter.ts
@@ -134,14 +134,14 @@ const positionalArraySorter = <T extends Value[]>(subject: T, position: string |
             processedKeys.push(key);
             if (beforeKeys[key]) {
                 const beforeWeights = sortedWeights(beforeKeys[key], true);
-                for (let i of beforeWeights) {
+                for (const i of beforeWeights) {
                     addToResults(beforeKeys[key][i], result);
                 }
             }
             result.push(key);
             if (afterKeys[key]) {
                 const afterWeights = sortedWeights(afterKeys[key], false);
-                for (let i of afterWeights) {
+                for (const i of afterWeights) {
                     addToResults(afterKeys[key][i], result);
                 }
             }
@@ -149,33 +149,33 @@ const positionalArraySorter = <T extends Value[]>(subject: T, position: string |
     };
 
     // add all start* keys weighted in descending order
-    for (let i of sortedWeights(startKeys, false)) {
+    for (const i of sortedWeights(startKeys, false)) {
         addToResults(startKeys[i], resultStart);
     }
     // add all middle keys weighted in ascending order
-    for (let i of sortedWeights(middleKeys, true)) {
+    for (const i of sortedWeights(middleKeys, true)) {
         addToResults(middleKeys[i], resultMiddle);
     }
     // add all after* keys weighted in ascending order
-    for (let i of sortedWeights(endKeys, true)) {
+    for (const i of sortedWeights(endKeys, true)) {
         addToResults(endKeys[i], resultEnd);
     }
     // orphaned items
-    for (let key of Object.keys(beforeKeys)) {
+    for (const key of Object.keys(beforeKeys)) {
         if (processedKeys.indexOf(key) >= 0) {
             continue;
         }
         // add all "orphaned" before* key in descending order before the middle keys
-        for (let i of sortedWeights(beforeKeys[key], false)) {
+        for (const i of sortedWeights(beforeKeys[key], false)) {
             addToResults(beforeKeys[key][i], resultStart);
         }
     }
-    for (let key of Object.keys(afterKeys)) {
+    for (const key of Object.keys(afterKeys)) {
         if (processedKeys.indexOf(key) >= 0) {
             continue;
         }
         // add all "orphaned" after* key in descending order before the end* keys
-        for (let i of sortedWeights(afterKeys[key], false)) {
+        for (const i of sortedWeights(afterKeys[key], false)) {
             addToResults(afterKeys[key][i], resultMiddle);
         }
     }


### PR DESCRIPTION
**What I did**
Adjust the ordering in the positional-array-sorter to behave more like the implementation in neos/utility-arrays (#2379): `before` and `after` positions may now be weighted, `start` and `after` positions will now be sorted appropriately according to descending weight. Positions like `after start` are no longer matched as `start` key.

**How I did it**
Mending the existing implementation did not prove easy as features like weighted `before` or `after` positions were not implemented, so I implemented the function anew.

**How to verify it**
I developed against the test cases (mostly ported from the php version). As a lot of parts in the UI use this functionality, I can't really tell how to best verify this in the actual UI.

