### PR TITLE
BUGFIX: Change element type of wrapper

### DIFF
--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -317,7 +317,8 @@ manifest('main', {}, globalRegistry => {
         // because many frameworkds (e.g. CKE, React) use the following checks
         // `obj instanceof obj.ownerDocument.defaultView.Node`
         // which would fail if this node was created in Host
-        const tempNodeInGuest = getGuestFrameDocument().createElement('div');
+        const wrapTagName = parentElement.tagName ? parentElement.tagName : 'div';
+        const tempNodeInGuest = getGuestFrameDocument().createElement(wrapTagName);
         tempNodeInGuest.innerHTML = renderedContent;
         const contentElement = tempNodeInGuest
             .querySelector(`[data-__neos-node-contextpath="${contextPath}"]`);


### PR DESCRIPTION
The ui uses since ck editor 5 a wrapping element to
detect the element that should be created in the canvas.

This element was always a div and that does not work for
tables for instance.

Fixes: #2365
