### PR TITLE
TASK: Upgrade react-codemirror2 to version 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "ramda": "^0.25.0",
     "react": "^16.4",
     "react-close-on-escape": "^2.0.0",
-    "react-codemirror2": "^5.0.1",
+    "react-codemirror2": "^6.0.0",
     "react-collapse": "^2.4.1",
     "react-datetime": "^2.8.10",
     "react-dnd": "^7.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10409,9 +10409,10 @@ react-close-on-escape@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/react-close-on-escape/-/react-close-on-escape-2.0.0.tgz#d3bf6d18fac516979d76e7732fda39057176f017"
 
-react-codemirror2@^5.0.1:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/react-codemirror2/-/react-codemirror2-5.1.0.tgz#62de4460178adea40eb52eabf7491669bf3794b8"
+react-codemirror2@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/react-codemirror2/-/react-codemirror2-6.0.0.tgz#180065df57a64026026cde569a9708fdf7656525"
+  integrity sha512-D7y9qZ05FbUh9blqECaJMdDwKluQiO3A9xB+fssd5jKM7YAXucRuEOlX32mJQumUvHUkHRHqXIPBjm6g0FW0Ag==
 
 react-collapse@^2.4.1:
   version "2.4.1"


### PR DESCRIPTION
This package is used in the nodes for HTML. So if you want to test this you just need to create an HTML node in the demo side and click around :)

