### PR TITLE
TASK: Change icon to actual "grip lines" icon

### DIFF
--- a/packages/react-ui-components/src/MultiSelectBox_ListPreviewSortable_DraggableListPreviewElement/multiSelectBox_ListPreviewSortable_DraggableListPreviewElement.js
+++ b/packages/react-ui-components/src/MultiSelectBox_ListPreviewSortable_DraggableListPreviewElement/multiSelectBox_ListPreviewSortable_DraggableListPreviewElement.js
@@ -124,7 +124,7 @@ export default class MultiSelectBox_ListPreviewSortable_DraggableListPreviewElem
                 <div className={finalClassNames}>
                     {isDraggable && (
                         <IconButton
-                            icon={'ellipsis-v'}
+                            icon={'grip-lines-vertical'}
                             className={theme.selectedOption__moveButton}
                             hoverStyle={'clean'}
                             />


### PR DESCRIPTION
Thanks to @maya-shines update of FontAwesome, we can now use the proper "grip lines" icon for the dragging bars, see screenshots:

Before:
![Bildschirmfoto 2019-05-15 um 16 04 52](https://user-images.githubusercontent.com/3976405/57782167-fc32d680-772b-11e9-899c-250b2c6445d0.png)

After:
![Bildschirmfoto 2019-05-15 um 16 08 29](https://user-images.githubusercontent.com/3976405/57782172-fe953080-772b-11e9-9684-8380a9bff3cc.png)
