### PR TITLE
TASK: Remove close button for relogin dialog

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/KeyboardShortcutModal/index.js
+++ b/packages/neos-ui/src/Containers/Modals/KeyboardShortcutModal/index.js
@@ -7,6 +7,7 @@ import {neos} from '@neos-project/neos-ui-decorators';
 import {actions} from '@neos-project/neos-ui-redux-store';
 import Dialog from '@neos-project/react-ui-components/src/Dialog/';
 import I18n from '@neos-project/neos-ui-i18n';
+import Button from '@neos-project/react-ui-components/src/Button/';
 
 import style from './style.css';
 
@@ -33,11 +34,26 @@ class KeyboardShortcutModal extends PureComponent {
         </div>
     )
 
+    renderCloseAction() {
+        return (
+            <Button
+                id="neos-KeyboardShortcutModal-Close"
+                key="close"
+                style="lighter"
+                hoverStyle="brand"
+                onClick={() => this.props.close()}
+                >
+                <I18n id="Neos.Neos:Main:close" fallback="Close"/>
+            </Button>
+        );
+    }
+
     render() {
         const {close, isOpen, hotkeyRegistry} = this.props;
 
         return (
             <Dialog
+                actions={[this.renderCloseAction()]}
                 title={<I18n fallback="Keyboard Shortcuts" />}
                 isOpen={isOpen}
                 onRequestClose={() => close()}

--- a/packages/neos-ui/src/Containers/Modals/ReloginDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/ReloginDialog/index.js
@@ -15,8 +15,6 @@ import Tooltip from '@neos-project/react-ui-components/src/Tooltip/';
 import I18n from '@neos-project/neos-ui-i18n';
 import style from './style.css';
 
-const emptyFn = () => {};
-
 @neos(globalRegistry => ({
     i18nRegistry: globalRegistry.get('i18n')
 }))
@@ -84,6 +82,7 @@ export default class ReloginDialog extends PureComponent {
                 <div className={style.modalContents}>
                     <TextInput
                         className={style.inputField}
+                        containerClassName={style.inputFieldWrapper}
                         value={this.state.username}
                         name="__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][username]"
                         placeholder={i18nRegistry.translate('Neos.Neos:Main:username', 'Username')}
@@ -94,6 +93,7 @@ export default class ReloginDialog extends PureComponent {
                     <TextInput
                         type="password"
                         className={style.inputField}
+                        containerClassName={style.inputFieldWrapper}
                         value={this.state.password}
                         name="__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][password]"
                         placeholder={i18nRegistry.translate('Neos.Neos:Main:password', 'Password')}

--- a/packages/neos-ui/src/Containers/Modals/ReloginDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/ReloginDialog/index.js
@@ -74,7 +74,6 @@ export default class ReloginDialog extends PureComponent {
         return (
             <Dialog
                 title={<I18n id="Neos.Neos:Main:login.expired" fallback="Your login has expired. Please log in again."/>}
-                onRequestClose=""
                 style="narrow"
                 isOpen
                 id="neos-ReloginDialog"

--- a/packages/neos-ui/src/Containers/Modals/ReloginDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/ReloginDialog/index.js
@@ -76,7 +76,7 @@ export default class ReloginDialog extends PureComponent {
         return (
             <Dialog
                 title={<I18n id="Neos.Neos:Main:login.expired" fallback="Your login has expired. Please log in again."/>}
-                onRequestClose={emptyFn}
+                onRequestClose=""
                 style="narrow"
                 isOpen
                 id="neos-ReloginDialog"

--- a/packages/neos-ui/src/Containers/Modals/ReloginDialog/style.css
+++ b/packages/neos-ui/src/Containers/Modals/ReloginDialog/style.css
@@ -1,7 +1,7 @@
 .modalContents {
     padding: var(--spacing-Full);
 }
-.inputField {
+.inputFieldWrapper {
     margin-bottom: 15px;
 }
 .loginButton {

--- a/packages/neos-ui/src/Containers/Modals/ReloginDialog/style.css
+++ b/packages/neos-ui/src/Containers/Modals/ReloginDialog/style.css
@@ -2,7 +2,7 @@
     padding: var(--spacing-Full);
 }
 .inputFieldWrapper {
-    margin-bottom: 15px;
+    margin-bottom: var(--spacing-Half);
 }
 .loginButton {
     width: 100%;

--- a/packages/react-ui-components/src/Dialog/__snapshots__/dialog.spec.tsx.snap
+++ b/packages/react-ui-components/src/Dialog/__snapshots__/dialog.spec.tsx.snap
@@ -8,16 +8,6 @@ exports[`<Dialog/> Content should render correctly. 1`] = `
   <div
     className="contentsClassName"
   >
-    <ThemedIconButton
-      className="closeBtnClassName"
-      composeTheme="deeply"
-      hoverStyle="clean"
-      icon="times"
-      mapThemrProps={[Function]}
-      onClick={[Function]}
-      size="regular"
-      style="clean"
-    />
     <div
       className="titleClassName"
     >

--- a/packages/react-ui-components/src/Dialog/dialog.spec.tsx
+++ b/packages/react-ui-components/src/Dialog/dialog.spec.tsx
@@ -3,7 +3,6 @@ import toJson from 'enzyme-to-json';
 import React from 'react';
 import {Portal} from 'react-portal';
 
-import IconButton from '../IconButton';
 import DialogWithEscape, {DialogProps, DialogWithoutEscape} from './dialog';
 
 describe('<Dialog/>', () => {
@@ -57,16 +56,6 @@ describe('<Dialog/>', () => {
         const section = portal.find('section');
 
         expect(section.prop('className')).toContain('narrowClassName');
-    });
-
-    it('should call the "onRequestClose" prop when clicking on the "IconButtonComponent" component.', () => {
-        const onRequestClose = jest.fn();
-        const wrapper = shallow(<DialogWithoutEscape {...props} onRequestClose={onRequestClose}/>);
-        const btn = wrapper.find(IconButton);
-
-        btn.simulate('click');
-
-        expect(onRequestClose.mock.calls.length).toBe(1);
     });
 
     it('should render the actions if passed.', () => {

--- a/packages/react-ui-components/src/Dialog/dialog.tsx
+++ b/packages/react-ui-components/src/Dialog/dialog.tsx
@@ -4,8 +4,6 @@ import enhanceWithClickOutside from '../enhanceWithClickOutside/index';
 import CloseOnEscape from 'react-close-on-escape';
 import {Portal} from 'react-portal';
 
-import IconButton from '../IconButton';
-
 type DialogType = 'success' | 'warn' | 'error';
 type DialogStyle = 'wide' | 'narrow';
 
@@ -86,8 +84,7 @@ export class DialogWithoutEscape extends PureComponent<DialogProps> {
             children,
             actions,
             theme,
-            type,
-            onRequestClose
+            type
         } = this.props;
 
         const finalClassNameBody = mergeClassNames(
@@ -103,16 +100,6 @@ export class DialogWithoutEscape extends PureComponent<DialogProps> {
         return (
             <div ref={this.handleReference} className={theme.dialog__contentsPosition} tabIndex={0}>
                 <div className={theme.dialog__contents}>
-                    {onRequestClose && (
-                        <IconButton
-                            icon="times"
-                            className={theme.dialog__closeBtn}
-                            onClick={onRequestClose}
-                            size="regular"
-                            style="clean"
-                            hoverStyle="clean"
-                        />
-                    )}
 
                     <div className={theme.dialog__title}>
                         {title}


### PR DESCRIPTION
Former behavior:
When the backend session expires, the relogin dialog forces the user to login again.
This relogin dialog has an "x"-Button to close it, but the button does nothing.

![image](https://user-images.githubusercontent.com/6552092/57841546-08ba3c00-77cb-11e9-9421-dba145b04e70.png)

New behavior:
The relogin dialog still opens, but now no longer has the useless "x"-Button:

![image](https://user-images.githubusercontent.com/6552092/57841598-2687a100-77cb-11e9-98bb-0fd5b93a85f3.png)

Sidenote: The dialog.tsx already checks, if the "onRequestClose" is set to something. However, "{emptyFn}" seems to evaluate as not empty, thus rendering the button, despite it not having a function. All I did was to replace the empty function with an empty string. 