### PR TITLE
BUGFIX: Disable preview mode in assetlist dropzone

### DIFF
--- a/packages/neos-ui-editors/src/Library/AssetUpload.js
+++ b/packages/neos-ui-editors/src/Library/AssetUpload.js
@@ -117,6 +117,7 @@ export default class AssetUpload extends PureComponent {
                         activeClassName={style['dropzone--isActive']}
                         rejectClassName={style['dropzone--isRejecting']}
                         disableClick={true}
+                        disablePreview={true}
                         multiple={Boolean(multiple)}
                         >
                         {children}


### PR DESCRIPTION
The asset list throws an error when you change the ordering
of asset nodes. This commit disables the preview mode
and so we don`t have the error anymore.

Fixes: #2491 