### PR TITLE
BUGFIX: Fix missing q helper on latest master in backend

### DIFF
--- a/Classes/Domain/Service/ConfigurationRenderingService.php
+++ b/Classes/Domain/Service/ConfigurationRenderingService.php
@@ -28,10 +28,16 @@ class ConfigurationRenderingService
     protected $eelEvaluator;
 
     /**
+     * @Flow\InjectConfiguration(package="Neos.Fusion", path="defaultContext")
+     * @var array
+     */
+    protected $fusionDefaultEelContext;
+
+    /**
      * @Flow\InjectConfiguration(path="configurationDefaultEelContext")
      * @var array
      */
-    protected $defaultContext;
+    protected $additionalEelDefaultContext;
 
     /**
      * @param array $configuration
@@ -58,7 +64,12 @@ class ConfigurationRenderingService
             if (is_array($value)) {
                 $this->computeConfigurationInternally($value, $context);
             } elseif (is_string($value) && substr($value, 0, 2) === '${' && substr($value, -1) === '}') {
-                $value = Utility::evaluateEelExpression($value, $this->eelEvaluator, $context, $this->defaultContext);
+                $value = Utility::evaluateEelExpression(
+                    $value,
+                    $this->eelEvaluator,
+                    $context,
+                    array_merge($this->fusionDefaultEelContext, $this->additionalEelDefaultContext)
+                );
             }
         }
     }

--- a/Classes/Domain/Service/StyleAndJavascriptInclusionService.php
+++ b/Classes/Domain/Service/StyleAndJavascriptInclusionService.php
@@ -36,10 +36,16 @@ class StyleAndJavascriptInclusionService
     protected $eelEvaluator;
 
     /**
+     * @Flow\InjectConfiguration(package="Neos.Fusion", path="defaultContext")
+     * @var array
+     */
+    protected $fusionDefaultEelContext;
+
+    /**
      * @Flow\InjectConfiguration(path="configurationDefaultEelContext")
      * @var array
      */
-    protected $defaultContext;
+    protected $additionalEelDefaultContext;
 
     /**
      * @Flow\InjectConfiguration(path="resources.javascript")
@@ -75,7 +81,12 @@ class StyleAndJavascriptInclusionService
         foreach ($sortedResources as $element) {
             $resourceExpression = $element['resource'];
             if (substr($resourceExpression, 0, 2) === '${' && substr($resourceExpression, -1) === '}') {
-                $resourceExpression = Utility::evaluateEelExpression($resourceExpression, $this->eelEvaluator, [], $this->defaultContext);
+                $resourceExpression = Utility::evaluateEelExpression(
+                    $resourceExpression,
+                    $this->eelEvaluator,
+                    [],
+                    array_merge($this->fusionDefaultEelContext, $this->additionalEelDefaultContext)
+                );
             }
 
             $hash = null;

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -102,13 +102,6 @@ Neos:
         content: 'Neos.Neos:Content'
         contentCollection: 'Neos.Neos:ContentCollection'
       configurationDefaultEelContext:
-        String: Neos\Eel\Helper\StringHelper
-        Array: Neos\Eel\Helper\ArrayHelper
-        Date: Neos\Eel\Helper\DateHelper
-        Configuration: Neos\Eel\Helper\ConfigurationHelper
-        Math: Neos\Eel\Helper\MathHelper
-        Json: Neos\Eel\Helper\JsonHelper
-        I18n: Neos\Flow\I18n\EelHelper\TranslationHelper
         Neos.Ui.Api: Neos\Neos\Ui\Fusion\Helper\ApiHelper
         Neos.Ui.Workspace: Neos\Neos\Ui\Fusion\Helper\WorkspaceHelper
         Neos.Ui.NodeInfo: Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper


### PR DESCRIPTION
The neos master registers `q` as a static function which is not compatible with later versions of neos where `q` is a magic name. Since some of the services in the ui rely on flowQuery and use a custom defaultConfiguration this causes trouble when running on latest master.

As backwards compatible solution this change includes the eel default context from `Neos.Fusion.defaultContext` and merge those with `Neos.Neos.Ui.configurationDefaultEelContext` before evaluating the expressions.

This also allows to remove the default Eel helpers from the configuration and only register the
additional helpers of the ui itself needs.

This is related to: https://github.com/neos/flow-development-collection/pull/1580