### PR TITLE
BUGFIX: Fix content operations after empty outOfBandRendering

### DIFF
--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
@@ -164,7 +164,7 @@ export default class NodeToolbar extends PureComponent {
         });
 
         return (
-            <div className={classNames} style={toolbarPosition}>
+            <div className={classNames} data-ignore_click_outside="true" style={toolbarPosition}>
                 <div className={style.toolBar__btnGroup}>
                     <AddNode {...props}/>
                     <HideSelectedNode {...props}/>

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
@@ -163,6 +163,10 @@ export default class NodeToolbar extends PureComponent {
             [style['toolBar--isSticky']]: isSticky
         });
 
+        // The data attribute data-ignore_click_outside is used to disable the enhanceWithClickOutside
+        // handling. For the special case that the outOfBandRender returns an empty rendered content
+        // we need to disable the enhanceWithClickOutside handling to prevent hick ups in the event
+        // registration after guest frame reload.
         return (
             <div className={classNames} data-ignore_click_outside="true" style={toolbarPosition}>
                 <div className={style.toolBar__btnGroup}>

--- a/packages/react-ui-components/src/Frame/frame.tsx
+++ b/packages/react-ui-components/src/Frame/frame.tsx
@@ -53,9 +53,8 @@ export default class Frame extends PureComponent<FrameProps> {
 
     private readonly addClickListener = () => {
         if (this.ref && this.ref.contentDocument && this.ref.contentWindow) {
-            this.ref.contentDocument.addEventListener('click', (e) => {
-                this.relayClickEventToHostDocument(e);
-            });
+            this.ref.contentDocument.removeEventListener('click', this.relayClickEventToHostDocument);
+            this.ref.contentDocument.addEventListener('click', this.relayClickEventToHostDocument);
             this.ref.contentWindow.addEventListener('unload', () => {
                 this.handleUnload();
             });

--- a/packages/react-ui-components/src/enhanceWithClickOutside/index.tsx
+++ b/packages/react-ui-components/src/enhanceWithClickOutside/index.tsx
@@ -5,6 +5,15 @@ interface InnerComponent extends React.Component {
     readonly handleClickOutside?: (e: MouseEvent | TouchEvent) => void;
 }
 
+const isTargetExcludedForClickOutside : (el: any) => boolean = el => {
+    if (!el) {
+        // top level: the targt is not excluded
+        return false;
+    }
+
+    return (el.dataset && el.dataset.ignore_click_outside) ? true : isTargetExcludedForClickOutside(el.parentNode);
+};
+
 const enhanceWithClickOutside = <P extends {}>(Component: React.ComponentClass<P>): React.ComponentClass<P> => {
     class EnhancedComponent extends React.Component<P> {
         private wrappedInstanceRef = React.createRef<InnerComponent>();
@@ -23,8 +32,20 @@ const enhanceWithClickOutside = <P extends {}>(Component: React.ComponentClass<P
                 (e.target instanceof HTMLElement || e.target instanceof HTMLDocument)
             ) {
                 const domNode = ReactDOM.findDOMNode(this.wrappedInstanceRef.current);
+
+                // if the iframeTarget is set, we ignore the event's target, as there might
+                // be rubbish in there.
+                const target = e.iframeTarget || e.target;
+
+                // Ignore target if it has the data attribute data-ignore_click_outside
+                // with value true. We skip the click outside handling. For further information
+                // take look at https://github.com/neos/neos-ui/issues/2489
+                if (isTargetExcludedForClickOutside(target)) {
+                    return;
+                }
+
                 if (
-                    (!domNode || (!domNode.contains(e.iframeTarget) && !domNode.contains(e.target))) &&
+                    (!domNode || !domNode.contains(target)) &&
                     this.wrappedInstanceRef &&
                     this.wrappedInstanceRef.current &&
                     typeof this.wrappedInstanceRef.current.handleClickOutside === 'function'

--- a/packages/react-ui-components/src/enhanceWithClickOutside/index.tsx
+++ b/packages/react-ui-components/src/enhanceWithClickOutside/index.tsx
@@ -37,9 +37,34 @@ const enhanceWithClickOutside = <P extends {}>(Component: React.ComponentClass<P
                 // be rubbish in there.
                 const target = e.iframeTarget || e.target;
 
-                // Ignore target if it has the data attribute data-ignore_click_outside
-                // with value true. We skip the click outside handling. For further information
-                // take look at https://github.com/neos/neos-ui/issues/2489
+                /**
+                 * Ignore target if it has the data attribute data-ignore_click_outside
+                 * with value true. We skip the click outside handling. For further information
+                 *
+                 * What happend:
+                 *
+                 * When you create a new node that has an empty renderedContent in RenderContentOutOfBand
+                 * response, the UI throw an error and reloads the GuestFrame.
+                 * This behavior is intended but lead to the error that it was not possible to use the NodeToolBar
+                 * after that reload on each node without reloading the whole window or changing the preview mode.
+                 *
+                 * Problem:
+                 *
+                 * We found out that we have an issue with the reload of the guestframe when it is triggered from
+                 * inside the guest frame. The events are all fired, but not in the right order.
+                 * So we want to handle the "click outside handling" when you click on the "add Node" Button to close
+                 * dropdowns like the publishing. But now we have the issue that the that the saga for the
+                 * nodeCreationWorkflow is fired to early and we close the dialog we just opened with
+                 * the "click outside handling" of the "add node" button.
+                 * We did not find a proper way to change the event order, yet. At the moment we add a
+                 * data-attribute to detect that we triggered the "click outside handling" from the NodeToolBar inside the
+                 * GuestFrame and skip the event.
+                 *
+                 * So it can happen that you have a opened publish drop down and it does not close when you open the
+                 * node creation dialog. But when you select the node type in the dialog the drop down will close.
+                 * And in general the drop down is opened before you click the "add node" button. Because you need
+                 * to click on the node to get the NodeToolBar and then the dialog will close.
+                 */
                 if (isTargetExcludedForClickOutside(target)) {
                     return;
                 }


### PR DESCRIPTION
After creating a new node with an empty renderedContent
payload from RenderContentOutOfBand lead to an issue with
the NodeToolBar.

So it was not possible to create, delete, copy or cut a node.
This patch prevent the clickOutside handling for the NodeToolBar. So we don`t close the dialog by accident.

Fixes: #2489
