### PR TITLE
BUGFIX: Use correct color constant for search input

### DIFF
--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/NodeTreeSearchInput/style.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/NodeTreeSearchInput/style.css
@@ -6,7 +6,7 @@
 
         &:focus {
             background: var(--colors-ContrastDark);
-            color: var(--contrastBrightest);
+            color: var(--colors-ContrastBrightest);
         }
     }
 }


### PR DESCRIPTION
Color constant was used wrong and sadly no that did not popped up earlier.
Thanks to @johannessteu for reporting that.

Fixes: #2504 