### PR TITLE
BUGFIX: Allow compiling ui plugins again

### DIFF
--- a/packages/build-essentials/src/webpack.config.js
+++ b/packages/build-essentials/src/webpack.config.js
@@ -42,7 +42,9 @@ const webpackConfig = {
             {
                 test: /\.js$/,
                 include: transpileNodeModuleRegex,
-                loader: 'babel-loader'
+                use: [{
+                    loader: 'babel-loader'
+                }]
             },
             {
                 test: /\.tsx?$/,


### PR DESCRIPTION
The webpack config in neos-extensibility expects the key „use“ to exist.

This was a regression in a634cf1d and therefore affects 2.4 & 2.5 & 3.4 & 3.5