### PR TITLE
FEATURE: Expose CK widget and highlight plugins

### DIFF
--- a/packages/neos-ui-ckeditor5-bindings/package.json
+++ b/packages/neos-ui-ckeditor5-bindings/package.json
@@ -19,6 +19,8 @@
     "@ckeditor/ckeditor5-list": "^12.0.2",
     "@ckeditor/ckeditor5-paragraph": "^11.0.2",
     "@ckeditor/ckeditor5-table": "^13.0.0",
+    "@ckeditor/ckeditor5-highlight": "^11.0.2",
+    "@ckeditor/ckeditor5-widget": "^11.0.2",
     "@neos-project/neos-ui-backend-connector": "2.6.1",
     "@neos-project/neos-ui-decorators": "2.6.1",
     "@neos-project/neos-ui-extensibility": "2.6.1",

--- a/packages/neos-ui/src/apiExposureMap.js
+++ b/packages/neos-ui/src/apiExposureMap.js
@@ -28,6 +28,9 @@ import * as NeosUiViews from '@neos-project/neos-ui-views';
 // Feel free to export more parts as needed.
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import Command from '@ckeditor/ckeditor5-core/src/command';
+import Widget from '@ckeditor/ckeditor5-widget/src/widget';
+import {toWidget} from '@ckeditor/ckeditor5-widget/src/utils';
+import HighlightEditing from '@ckeditor/ckeditor5-highlight/src/highlightediting';
 
 import ModelDocument from '@ckeditor/ckeditor5-engine/src/model/document';
 import ModelDocumentFragment from '@ckeditor/ckeditor5-engine/src/model/documentfragment';
@@ -68,7 +71,50 @@ import ViewUIElement from '@ckeditor/ckeditor5-engine/src/view/uielement.js';
 import View from '@ckeditor/ckeditor5-engine/src/view/view.js';
 import DownCastWriter from '@ckeditor/ckeditor5-engine/src/view/downcastwriter';
 
-const CkEditor5 = {Plugin, Command, ModelDocument, ModelDocumentFragment, ModelDocumentSelection, ModelElement, ModelNode, ModelNodeList, ModelPosition, ModelRange, ModelSchema, ModelSelection, ModelText, ModelTextProxy, ModelTreeWalker, ModelWriter, ViewAttributeElement, ViewContainerElement, ViewDocument, ViewDocumentFragment, ViewDocumentSelection, ViewDOMConverter, ViewEditableElement, ViewElement, ViewEmptyElement, ViewFiller, ViewMatcher, ViewNode, ViewPlaceholder, ViewPosition, ViewRange, ViewRenderer, ViewSelection, ViewText, ViewTextProxy, ViewTreeWalker, ViewUIElement, View, DownCastWriter};
+const CkEditor5 = {
+    Plugin,
+    Command,
+    Widget,
+    toWidget,
+    HighlightEditing,
+    ModelDocument,
+    ModelDocumentFragment,
+    ModelDocumentSelection,
+    ModelElement,
+    ModelNode,
+    ModelNodeList,
+    ModelPosition,
+    ModelRange,
+    ModelSchema,
+    ModelSelection,
+    ModelText,
+    ModelTextProxy,
+    ModelTreeWalker,
+    ModelWriter,
+    ViewAttributeElement,
+    ViewContainerElement,
+    ViewDocument,
+    ViewDocumentFragment,
+    ViewDocumentSelection,
+    ViewDOMConverter,
+    ViewEditableElement,
+    ViewElement,
+    ViewEmptyElement,
+    ViewFiller,
+    ViewMatcher,
+    ViewNode,
+    ViewPlaceholder,
+    ViewPosition,
+    ViewRange,
+    ViewRenderer,
+    ViewSelection,
+    ViewText,
+    ViewTextProxy,
+    ViewTreeWalker,
+    ViewUIElement,
+    View,
+    DownCastWriter
+};
 
 export default {
     '@vendor': () => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -296,6 +296,14 @@
     "@ckeditor/ckeditor5-ui" "^13.0.0"
     "@ckeditor/ckeditor5-utils" "^12.1.1"
 
+"@ckeditor/ckeditor5-highlight@^11.0.2":
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-11.0.2.tgz#fcf4b55c5d042da30340129a5130b06ef0de29fd"
+  integrity sha512-RXsgg+ckMiyE7tDfTNRLBUlUYrpFjcynvuhlkW59UThD7Rz1lGrX4IEez72Ezyw+4NMbinivluFoJKAelrsAEQ==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "^12.1.1"
+    "@ckeditor/ckeditor5-ui" "^13.0.0"
+
 "@ckeditor/ckeditor5-link@^11.0.2":
   version "11.0.2"
   resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-link/-/ckeditor5-link-11.0.2.tgz#d4afc6cde5e8ad542c3e7d5e820437a5e8fb2a74"
@@ -2742,7 +2750,6 @@ body@^5.1.0:
 boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
-  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
 bower-config@^1.4.0:
   version "1.4.1"
@@ -2901,12 +2908,12 @@ browserslist@^3.2.6:
     electron-to-chromium "^1.3.47"
 
 browserslist@^4.0.0:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.6.2.tgz#574c665950915c2ac73a4594b8537a9eba26203f"
-  integrity sha512-2neU/V0giQy9h3XMPwLhEY3+Ao0uHSwHvU8Q1Ea6AgLVL1sXbX3dzPrJ8NWe5Hi4PoTkCYXOtVR9rfRLI0J/8Q==
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.6.3.tgz#0530cbc6ab0c1f3fc8c819c72377ba55cf647f05"
+  integrity sha512-CNBqTCq22RKM8wKJNowcqihHJ4SkI8CGeK7KOR9tPboXUuS5Zk5lQgzzTbs4oxD8x+6HUshZUa2OyNI9lR93bQ==
   dependencies:
-    caniuse-lite "^1.0.30000974"
-    electron-to-chromium "^1.3.150"
+    caniuse-lite "^1.0.30000975"
+    electron-to-chromium "^1.3.164"
     node-releases "^1.1.23"
 
 browserslist@^4.1.0:
@@ -3117,10 +3124,10 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   version "1.0.30000885"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000885.tgz#cdc98dd168ed59678650071f7f6a70910e275bc8"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000974:
-  version "1.0.30000974"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz#b7afe14ee004e97ce6dc73e3f878290a12928ad8"
-  integrity sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000975:
+  version "1.0.30000979"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000979.tgz#92f16d00186a6cf20d6c5711bb6e042a3d667029"
+  integrity sha512-gcu45yfq3B7Y+WB05fOMfr0EiSlq+1u+m6rPHyJli/Wy3PVQNGaU7VA4bZE5qw+AU2UVOBR/N5g1bzADUqdvFw==
 
 caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000884:
   version "1.0.30000885"
@@ -4476,6 +4483,7 @@ defaults@^1.0.3:
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
   dependencies:
     object-keys "^1.0.12"
 
@@ -4782,10 +4790,10 @@ electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30, electron-to-chromium@
   version "1.3.64"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.64.tgz#39f5a93bf84ab7e10cfbb7522ccfc3f1feb756cf"
 
-electron-to-chromium@^1.3.150:
-  version "1.3.160"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.160.tgz#0153f6c479869ba7f19b009296a56d954b284c11"
-  integrity sha512-kmpBwawcCbEaGOePtjJF56p7YIWM/XBtP5cdR68mh48zjpZYgR9ulqDhXkSFcTH2G4gynKysDZ+tVAgefzrasw==
+electron-to-chromium@^1.3.164:
+  version "1.3.180"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.180.tgz#8e8c6be930d137e88cf2946ad2ec6521d24ba70e"
+  integrity sha512-jwI82/63GeH7f08IR+4v/tbGM4DMAApMZO0SXLcC0np4lcqWjQBl0MIHkfXEqesLc55+NhVVX8g7eFlamEWoNQ==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -9106,9 +9114,9 @@ node-releases@^1.0.0-alpha.11:
     semver "^5.3.0"
 
 node-releases@^1.1.23:
-  version "1.1.23"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.23.tgz#de7409f72de044a2fa59c097f436ba89c39997f0"
-  integrity sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==
+  version "1.1.24"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.24.tgz#2fb494562705c01bfb81a7af9f8584c4d56311b4"
+  integrity sha512-wym2jptfuKowMmkZsfCSTsn8qAVo8zm+UiQA6l5dNqUcpfChZSnS/vbbpOeXczf+VdPhutxh+99lWHhdd6xKzg==
   dependencies:
     semver "^5.3.0"
 


### PR DESCRIPTION
This allows using them in custom packages without getting
errors and warning for duplicate plugins & modules.

The widget plugin allows creating inline widgets for
placeholders, icons etc…

The highlight plugins allows marking text with custom
classes and styles.

The class list is reformatted to see future diffs better
and get a faster overview of available classes.

These additional classes have to be imported like this:

`import {toWidget, Widget, HighlightEditing} from 'ckeditor5-exports';`