### PR TITLE
BUGFIX: DataSource SelectBoxEditor must re-load data if options change

### DIFF
--- a/packages/neos-ui-editors/src/Editors/SelectBox/DataSourceBasedSelectBoxEditor.js
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/DataSourceBasedSelectBoxEditor.js
@@ -8,7 +8,7 @@ import {selectors} from '@neos-project/neos-ui-redux-store';
 import {neos} from '@neos-project/neos-ui-decorators';
 import {shouldDisplaySearchBox, searchOptions, processSelectBoxOptions} from './SelectBoxHelpers';
 
-const getDataLoaderOptionsForProps = (props) => ({
+const getDataLoaderOptionsForProps = props => ({
     contextNodePath: props.focusedNodePath,
     dataSourceIdentifier: props.options.dataSourceIdentifier,
     dataSourceUri: props.options.dataSourceUri,

--- a/packages/neos-ui-editors/src/Editors/SelectBox/DataSourceBasedSelectBoxEditor.js
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/DataSourceBasedSelectBoxEditor.js
@@ -8,6 +8,14 @@ import {selectors} from '@neos-project/neos-ui-redux-store';
 import {neos} from '@neos-project/neos-ui-decorators';
 import {shouldDisplaySearchBox, searchOptions, processSelectBoxOptions} from './SelectBoxHelpers';
 
+const getDataLoaderOptionsForProps = (props) => ({
+    contextNodePath: props.focusedNodePath,
+    dataSourceIdentifier: props.options.dataSourceIdentifier,
+    dataSourceUri: props.options.dataSourceUri,
+    dataSourceAdditionalData: props.options.dataSourceAdditionalData,
+    dataSourceDisableCaching: Boolean(props.options.dataSourceDisableCaching)
+});
+
 @neos(globalRegistry => ({
     i18nRegistry: globalRegistry.get('i18n'),
     dataSourcesDataLoader: globalRegistry.get('dataLoaders').get('DataSources')
@@ -67,19 +75,20 @@ export default class DataSourceBasedSelectBoxEditor extends PureComponent {
         selectBoxOptions: {}
     };
 
-    getDataLoaderOptions() {
-        return {
-            contextNodePath: this.props.focusedNodePath,
-            dataSourceIdentifier: this.props.options.dataSourceIdentifier,
-            dataSourceUri: this.props.options.dataSourceUri,
-            dataSourceAdditionalData: this.props.options.dataSourceAdditionalData,
-            dataSourceDisableCaching: Boolean(this.props.options.dataSourceDisableCaching)
-        };
+    componentDidMount() {
+        this.loadSelectBoxOptions();
     }
 
-    componentDidMount() {
+    componentDidUpdate(prevProps) {
+        // if our data loader options have changed (e.g. due to use of ClientEval), we want to re-initialize the data source.
+        if (JSON.stringify(getDataLoaderOptionsForProps(this.props)) !== JSON.stringify(getDataLoaderOptionsForProps(prevProps))) {
+            this.loadSelectBoxOptions();
+        }
+    }
+
+    loadSelectBoxOptions() {
         this.setState({isLoading: true});
-        this.props.dataSourcesDataLoader.resolveValue(this.getDataLoaderOptions(), this.props.value)
+        this.props.dataSourcesDataLoader.resolveValue(getDataLoaderOptionsForProps(this.props), this.props.value)
             .then(selectBoxOptions => {
                 this.setState({
                     isLoading: false,


### PR DESCRIPTION
This is needed when using e.g. ClientEval, to dynamically evaluate DataSource options.