### PR TITLE
BUGFIX: change ckeditor column insertion commands

### DIFF
--- a/Resources/Private/Translations/af/Main.xlf
+++ b/Resources/Private/Translations/af/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="af" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="af" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="af" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/ar/Main.xlf
+++ b/Resources/Private/Translations/ar/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="ar" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="ar" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="ar" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/ca/Main.xlf
+++ b/Resources/Private/Translations/ca/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="ca" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="ca" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="ca" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/cs/Main.xlf
+++ b/Resources/Private/Translations/cs/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="cs" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="cs" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="cs" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/da/Main.xlf
+++ b/Resources/Private/Translations/da/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="da" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="da" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="da" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve" approved="yes">
 				<source>Header column</source>
 			<target xml:lang="de">Kopfspalte</target><alt-trans><target xml:lang="de">Kopfzeile Spalte</target></alt-trans><alt-trans><target xml:lang="de">Kopfzeile</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve" approved="yes">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve" approved="yes">
 				<source>Insert column before</source>
 			<target xml:lang="de">Spalte links einfügen</target><alt-trans><target xml:lang="de">füge als erst eine Spalte ein</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve" approved="yes">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve" approved="yes">
 				<source>Insert column after</source>
 			<target xml:lang="de">Spalte rechts einfügen</target><alt-trans><target xml:lang="de">füge Spalte danach ein</target></alt-trans></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve" approved="yes">

--- a/Resources/Private/Translations/el/Main.xlf
+++ b/Resources/Private/Translations/el/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="el" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="el" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="el" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -143,10 +143,10 @@
 			<trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+			<trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+			<trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			</trans-unit>
 			<trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/es/Main.xlf
+++ b/Resources/Private/Translations/es/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="es-ES" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="es-ES" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="es-ES" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/fi/Main.xlf
+++ b/Resources/Private/Translations/fi/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="fi" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="fi" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="fi" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/fr/Main.xlf
+++ b/Resources/Private/Translations/fr/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="fr" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="fr" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="fr" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/he/Main.xlf
+++ b/Resources/Private/Translations/he/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="he" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="he" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="he" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/hu/Main.xlf
+++ b/Resources/Private/Translations/hu/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="hu" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="hu" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="hu" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/id/Main.xlf
+++ b/Resources/Private/Translations/id/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="id" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="id" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="id" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/it/Main.xlf
+++ b/Resources/Private/Translations/it/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="it" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="it" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="it" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/ja/Main.xlf
+++ b/Resources/Private/Translations/ja/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="ja" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="ja" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="ja" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/kk/Main.xlf
+++ b/Resources/Private/Translations/kk/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="kk" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="kk" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="kk" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/km/Main.xlf
+++ b/Resources/Private/Translations/km/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="km" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="km" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="km" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/ko/Main.xlf
+++ b/Resources/Private/Translations/ko/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="ko" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="ko" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="ko" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/lv/Main.xlf
+++ b/Resources/Private/Translations/lv/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="lv" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="lv" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="lv" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/mr/Main.xlf
+++ b/Resources/Private/Translations/mr/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="mr" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="mr" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="mr" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/nl/Main.xlf
+++ b/Resources/Private/Translations/nl/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="nl" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="nl" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="nl" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/no/Main.xlf
+++ b/Resources/Private/Translations/no/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="no" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="no" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="no" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/pl/Main.xlf
+++ b/Resources/Private/Translations/pl/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="pl" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="pl" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="pl" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/ps/Main.xlf
+++ b/Resources/Private/Translations/ps/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="ps" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="ps" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="ps" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/pt/Main.xlf
+++ b/Resources/Private/Translations/pt/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="pt-BR" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="pt-BR" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="pt-BR" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/pt_PT/Main.xlf
+++ b/Resources/Private/Translations/pt_PT/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="pt-PT" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="pt-PT" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="pt-PT" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/ro/Main.xlf
+++ b/Resources/Private/Translations/ro/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="ro" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="ro" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="ro" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/ru/Main.xlf
+++ b/Resources/Private/Translations/ru/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="ru" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="ru" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="ru" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/sr/Main.xlf
+++ b/Resources/Private/Translations/sr/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="sr" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="sr" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="sr" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/sv/Main.xlf
+++ b/Resources/Private/Translations/sv/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="sv-SE" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="sv-SE" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="sv-SE" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/tl/Main.xlf
+++ b/Resources/Private/Translations/tl/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="tl" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="tl" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="tl" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/tr/Main.xlf
+++ b/Resources/Private/Translations/tr/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="tr" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="tr" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="tr" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/uk/Main.xlf
+++ b/Resources/Private/Translations/uk/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="uk" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="uk" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="uk" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/vi/Main.xlf
+++ b/Resources/Private/Translations/vi/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="vi" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="vi" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="vi" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/zh/Main.xlf
+++ b/Resources/Private/Translations/zh/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="zh-CN" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="zh-CN" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="zh-CN" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/Resources/Private/Translations/zh_TW/Main.xlf
+++ b/Resources/Private/Translations/zh_TW/Main.xlf
@@ -143,10 +143,10 @@
       <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
 				<source>Header column</source>
 			<target xml:lang="zh-TW" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnBefore" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
 				<source>Insert column before</source>
 			<target xml:lang="zh-TW" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnAfter" xml:space="preserve">
+      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
 				<source>Insert column after</source>
 			<target xml:lang="zh-TW" state="needs-translation">Insert column after</target></trans-unit>
       <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">

--- a/packages/neos-ui-ckeditor5-bindings/src/manifest.richtextToolbar.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/manifest.richtextToolbar.js
@@ -388,11 +388,11 @@ export default ckEditorRegistry => {
                 type: 'checkBox'
             },
             {
-                commandName: 'insertTableColumnBefore',
+                commandName: 'insertTableColumnLeft',
                 label: 'Neos.Neos.Ui:Main:ckeditor__toolbar__insertTableColumnBefore'
             },
             {
-                commandName: 'insertTableColumnAfter',
+                commandName: 'insertTableColumnRight',
                 label: 'Neos.Neos.Ui:Main:ckeditor__toolbar__insertTableColumnAfter'
             },
             {

--- a/packages/neos-ui-ckeditor5-bindings/src/manifest.richtextToolbar.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/manifest.richtextToolbar.js
@@ -389,11 +389,11 @@ export default ckEditorRegistry => {
             },
             {
                 commandName: 'insertTableColumnLeft',
-                label: 'Neos.Neos.Ui:Main:ckeditor__toolbar__insertTableColumnBefore'
+                label: 'Neos.Neos.Ui:Main:ckeditor__toolbar__insertTableColumnLeft'
             },
             {
                 commandName: 'insertTableColumnRight',
-                label: 'Neos.Neos.Ui:Main:ckeditor__toolbar__insertTableColumnAfter'
+                label: 'Neos.Neos.Ui:Main:ckeditor__toolbar__insertTableColumnRight'
             },
             {
                 commandName: 'removeTableColumn',


### PR DESCRIPTION
The CK Editor table plugin renamed the commands to insert table columns (see referenced issue).

Resolves #2532.

**What I did**
Rename the CK Editor commands and match the translation labels accordingly.

**How to verify it**
Create a node with an inline-editable table (e.g. create in a text node of the demo package) and insert a column. Instead of an error message on the console, a column will be inserted.