### PR TITLE
FEATURE: make LinkInput options extendable

### DIFF
--- a/packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/LinkButton.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/LinkButton.js
@@ -90,7 +90,7 @@ export default class LinkButton extends PureComponent {
                 {this.isOpen() ? (
                     <div className={style.linkButton__flyout}>
                         <LinkInput
-                            options={$get('linking', inlineEditorOptions)}
+                            linkingOptions={$get('linking', inlineEditorOptions)}
                             linkValue={this.getLinkValue()}
                             linkTitleValue={this.getLinkTitleValue()}
                             linkRelNofollowValue={this.getLinkRelValue()}

--- a/packages/neos-ui-editors/src/Library/LinkInput.js
+++ b/packages/neos-ui-editors/src/Library/LinkInput.js
@@ -4,7 +4,7 @@ import pick from 'lodash.pick';
 import {connect} from 'react-redux';
 import {$get, $transform} from 'plow-js';
 
-import {IconButton, SelectBox, Icon, CheckBox, TextInput} from '@neos-project/react-ui-components';
+import {IconButton, SelectBox, Icon} from '@neos-project/react-ui-components';
 import LinkOption from '@neos-project/neos-ui-editors/src/Library/LinkOption';
 import {neos} from '@neos-project/neos-ui-decorators';
 
@@ -31,7 +31,8 @@ const looksLikeExternalLink = link => {
 
 @neos(globalRegistry => ({
     linkLookupDataLoader: globalRegistry.get('dataLoaders').get('LinkLookup'),
-    i18nRegistry: globalRegistry.get('i18n')
+    i18nRegistry: globalRegistry.get('i18n'),
+    containerRegistry: globalRegistry.get('containers')
 }))
 @connect($transform({
     contextForNodeLinking: selectors.UI.NodeLinking.contextForNodeLinking
@@ -39,6 +40,7 @@ const looksLikeExternalLink = link => {
 export default class LinkInput extends PureComponent {
     static propTypes = {
         i18nRegistry: PropTypes.object,
+        containerRegistry: PropTypes.object,
         options: PropTypes.shape({
             nodeTypes: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
             placeholder: PropTypes.string,
@@ -306,58 +308,8 @@ export default class LinkInput extends PureComponent {
     renderOptionsPanel() {
         return (
             <div className={style.linkInput__optionsPanel}>
-                {$get('anchor', this.props.options) && (
-                    <div className={style.linkInput__optionsPanelItem}>
-                        <label className={style.linkInput__optionsPanelLabel} htmlFor="__neos__linkEditor--anchor">
-                            {this.props.i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__anchor', 'Link to anchor')}
-                        </label>
-                        <div>
-                            <TextInput
-                                id="__neos__linkEditor--anchor"
-                                value={this.getAnchorValue()}
-                                placeholder={this.props.i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__anchorPlaceholder', 'Enter anchor name')}
-                                onChange={value => {
-                                    this.props.onLinkChange(value ? `${this.getBaseValue()}#${value}` : this.getBaseValue());
-                                }}
-                            />
-                        </div>
-                    </div>)}
-                {$get('title', this.props.options) && (
-                    <div className={style.linkInput__optionsPanelItem}>
-                        <label className={style.linkInput__optionsPanelLabel} htmlFor="__neos__linkEditor--title">
-                            {this.props.i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__title', 'Title')}
-                        </label>
-                        <div>
-                            <TextInput
-                                id="__neos__linkEditor--title"
-                                value={this.props.linkTitleValue || ''}
-                                placeholder={this.props.i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__titlePlaceholder', 'Enter link title')}
-                                onChange={value => {
-                                    this.props.onLinkTitleChange(value);
-                                }}
-                            />
-                        </div>
-                    </div>)}
-                <div className={style.linkInput__optionsPanelDouble}>
-                    {$get('targetBlank', this.props.options) && (
-                        <div className={style.linkInput__optionsPanelItem}>
-                            <label>
-                                <CheckBox
-                                    onChange={this.props.onLinkTargetChange}
-                                    isChecked={this.props.linkTargetBlankValue || false}
-                                /> {this.props.i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__targetBlank', 'Open in new window')}
-                            </label>
-                        </div>)}
-                    {$get('relNofollow', this.props.options) && (
-                        <div className={style.linkInput__optionsPanelItem}>
-                            <label>
-                                <CheckBox
-                                    onChange={this.props.onLinkRelChange}
-                                    isChecked={this.props.linkRelNofollowValue || false}
-                                /> {this.props.i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__noFollow', 'No follow')}
-                            </label>
-                        </div>)}
-                </div>
+                {this.props.containerRegistry.getChildren('LinkInput/OptionsPanel').map((Item, key) => <Item key={key} {...this.props} />)}
+
             </div>
         );
     }

--- a/packages/neos-ui-editors/src/Library/LinkInput.js
+++ b/packages/neos-ui-editors/src/Library/LinkInput.js
@@ -1,6 +1,5 @@
 import React, {PureComponent, Fragment} from 'react';
 import PropTypes from 'prop-types';
-import pick from 'lodash.pick';
 import {connect} from 'react-redux';
 import {$get, $transform} from 'plow-js';
 
@@ -315,7 +314,7 @@ export default class LinkInput extends PureComponent {
     }
 
     render() {
-        const linkingOptions = pick(this.props.options, ['anchor', 'title', 'targetBlank', 'relNofollow']);
+        const linkingOptions = this.props.options;
 
         const optionsPanelEnabled = Boolean(linkingOptions && Object.values(linkingOptions).filter(i => i).length);
         return (

--- a/packages/neos-ui-editors/src/Library/LinkInput.js
+++ b/packages/neos-ui-editors/src/Library/LinkInput.js
@@ -40,14 +40,11 @@ export default class LinkInput extends PureComponent {
     static propTypes = {
         i18nRegistry: PropTypes.object,
         containerRegistry: PropTypes.object,
+        linkingOptions: PropTypes.object,
         options: PropTypes.shape({
             nodeTypes: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
             placeholder: PropTypes.string,
             disabled: PropTypes.bool,
-            anchor: PropTypes.bool,
-            title: PropTypes.bool,
-            targetBlank: PropTypes.bool,
-            relNofollow: PropTypes.bool,
             assets: PropTypes.bool,
             nodes: PropTypes.bool,
             startingPoint: PropTypes.string
@@ -314,7 +311,7 @@ export default class LinkInput extends PureComponent {
     }
 
     render() {
-        const linkingOptions = this.props.options;
+        const {linkingOptions} = this.props;
 
         const optionsPanelEnabled = Boolean(linkingOptions && Object.values(linkingOptions).filter(i => i).length);
         return (

--- a/packages/neos-ui-editors/src/Library/LinkInput.js
+++ b/packages/neos-ui-editors/src/Library/LinkInput.js
@@ -311,7 +311,7 @@ export default class LinkInput extends PureComponent {
     }
 
     render() {
-        const {linkingOptions} = this.props;
+        const {linkingOptions, linkValue} = this.props;
 
         const optionsPanelEnabled = Boolean(linkingOptions && Object.values(linkingOptions).filter(i => i).length);
         return (
@@ -320,6 +320,7 @@ export default class LinkInput extends PureComponent {
                     {this.state.isEditMode && !$get('options.disabled', this.props) ? this.renderEditMode() : this.renderViewMode()}
                     {optionsPanelEnabled && (
                         <IconButton
+                            disabled={!linkValue}
                             onClick={this.handleToggleOptionsPanel}
                             style={this.state.optionsPanelIsOpen ? 'brand' : 'transparent'}
                             className={style.linkInput__innerButton}

--- a/packages/neos-ui-editors/src/Library/LinkInputOptions.js
+++ b/packages/neos-ui-editors/src/Library/LinkInputOptions.js
@@ -1,0 +1,83 @@
+import React, {Fragment} from 'react';
+import {$get} from 'plow-js';
+
+import {TextInput, CheckBox} from '@neos-project/react-ui-components';
+
+import style from './LinkInput.css';
+
+const LinkInputOptions = ({
+    i18nRegistry,
+    onLinkChange,
+    options,
+    linkValue,
+    linkTitleValue,
+    onLinkTitleChange,
+    onLinkTargetChange,
+    linkTargetBlankValue,
+    onLinkRelChange,
+    linkRelNofollowValue
+}) => {
+    const anchorValue = typeof linkValue === 'string' ? linkValue.split('#')[1] : '';
+    const baseValue = typeof linkValue === 'string' ? linkValue.split('#')[0] : '';
+    return $get('anchor', options) && (
+        <Fragment>
+            {$get('anchor', options) && (
+                <div className={style.linkInput__optionsPanelItem}>
+                    <label className={style.linkInput__optionsPanelLabel} htmlFor="__neos__linkEditor--anchor">
+                        {i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__anchor', 'Link to anchor')}
+                    </label>
+                    <div>
+                        <TextInput
+                            id="__neos__linkEditor--anchor"
+                            value={anchorValue}
+                            placeholder={i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__anchorPlaceholder', 'Enter anchor name')}
+                            onChange={value => {
+                                onLinkChange(value ? `${baseValue}#${value}` : baseValue);
+                            }}
+                        />
+                    </div>
+                </div>
+            )}
+            {$get('title', options) && (
+                <div className={style.linkInput__optionsPanelItem}>
+                    <label className={style.linkInput__optionsPanelLabel} htmlFor="__neos__linkEditor--title">
+                        {i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__title', 'Title')}
+                    </label>
+                    <div>
+                        <TextInput
+                            id="__neos__linkEditor--title"
+                            value={linkTitleValue || ''}
+                            placeholder={i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__titlePlaceholder', 'Enter link title')}
+                            onChange={value => {
+                                onLinkTitleChange(value);
+                            }}
+                        />
+                    </div>
+                </div>
+            )}
+
+            <div className={style.linkInput__optionsPanelDouble}>
+                {$get('targetBlank', options) && (
+                    <div className={style.linkInput__optionsPanelItem}>
+                        <label>
+                            <CheckBox
+                                onChange={onLinkTargetChange}
+                                isChecked={linkTargetBlankValue || false}
+                            /> {i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__targetBlank', 'Open in new window')}
+                        </label>
+                    </div>)}
+                {$get('relNofollow', options) && (
+                    <div className={style.linkInput__optionsPanelItem}>
+                        <label>
+                            <CheckBox
+                                onChange={onLinkRelChange}
+                                isChecked={linkRelNofollowValue || false}
+                            /> {i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__noFollow', 'No follow')}
+                        </label>
+                    </div>)}
+            </div>
+        </Fragment>
+    );
+};
+
+export default LinkInputOptions;

--- a/packages/neos-ui-editors/src/Library/LinkInputOptions.js
+++ b/packages/neos-ui-editors/src/Library/LinkInputOptions.js
@@ -19,7 +19,7 @@ const LinkInputOptions = ({
 }) => {
     const anchorValue = typeof linkValue === 'string' ? linkValue.split('#')[1] : '';
     const baseValue = typeof linkValue === 'string' ? linkValue.split('#')[0] : '';
-    return $get('anchor', options) && (
+    return (
         <Fragment>
             {$get('anchor', options) && (
                 <div className={style.linkInput__optionsPanelItem}>

--- a/packages/neos-ui-editors/src/manifest.js
+++ b/packages/neos-ui-editors/src/manifest.js
@@ -3,12 +3,15 @@ import * as Editors from './index';
 import manifest from '@neos-project/neos-ui-extensibility';
 import backend from '@neos-project/neos-ui-backend-connector';
 
+import LinkInputOptions from './Library/LinkInputOptions';
+
 export default Editors.EditorEnvelope;
 
 manifest('inspectorEditors', {}, globalRegistry => {
     const editorsRegistry = globalRegistry.get('inspector').get('editors');
     const secondaryEditorsRegistry = globalRegistry.get('inspector').get('secondaryEditors');
     const saveHooksRegistry = globalRegistry.get('inspector').get('saveHooks');
+    const containerRegistry = globalRegistry.get('containers');
     const {createImageVariant} = backend.get().endpoints;
 
     //
@@ -97,6 +100,12 @@ manifest('inspectorEditors', {}, globalRegistry => {
     secondaryEditorsRegistry.set('Neos.Neos/Inspector/Secondary/Editors/MediaSelectionScreen', {
         component: Editors.MediaSelectionScreen
     });
+
+    //
+    // LinkInput options panel containers.
+    // Feel free to add additional custom options here
+    //
+    containerRegistry.set('LinkInput/OptionsPanel/DefaultLinkInputOptions', LinkInputOptions);
 
     //
     // This hook will create an image variant right before changes to an image


### PR DESCRIPTION
This PR makes LinkInput options extendable by putting them into a registry.

This is useful when you'd want to add some custom options there, e.g.:
![image](https://user-images.githubusercontent.com/837032/61557601-55d9b900-aa6d-11e9-9016-3dd65117193a.png)

Usage example: https://github.com/di-unternehmer/DIU.Neos.Linkeditor.Extension/blob/master/Resources/Private/LinkEditor/src/manifest.js#L24