### PR TITLE
FEATURE: validate inline properties

### DIFF
--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Content.Headline.yaml
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Content.Headline.yaml
@@ -22,3 +22,8 @@
               h4: true
               h5: true
               a: true
+      validation:
+        'Neos.Neos/Validation/NotEmptyValidator': []
+        'Neos.Neos/Validation/StringLengthValidator':
+          minimum: 1
+          maximum: 255

--- a/packages/neos-ui-ckeditor-bindings/src/createCkEditor.js
+++ b/packages/neos-ui-ckeditor-bindings/src/createCkEditor.js
@@ -2,7 +2,7 @@ import {$get} from 'plow-js';
 
 import {getGuestFrameWindow} from '@neos-project/neos-ui-guest-frame/src/dom';
 
-export default ({propertyDomNode, propertyName, contextPath, editorOptions, globalRegistry, userPreferences, persistChange}) => {
+export default ({propertyDomNode, propertyName, editorOptions, globalRegistry, userPreferences, onChange}) => {
     const formattingRulesRegistry = globalRegistry.get('ckEditor').get('formattingRules');
     const pluginsRegistry = globalRegistry.get('ckEditor').get('plugins');
     const i18nRegistry = globalRegistry.get('i18n');
@@ -39,15 +39,5 @@ export default ({propertyDomNode, propertyName, contextPath, editorOptions, glob
             placeholder ? {neosPlaceholder: placeholder} : {}
         ));
 
-    getGuestFrameWindow().NeosCKEditorApi.createEditor(propertyDomNode, ckEditorConfiguration, propertyName, contents => {
-        persistChange({
-            type: 'Neos.Neos.Ui:Property',
-            subject: contextPath,
-            payload: {
-                propertyName,
-                value: contents,
-                isInline: true
-            }
-        });
-    });
+    getGuestFrameWindow().NeosCKEditorApi.createEditor(propertyDomNode, ckEditorConfiguration, propertyName, onChange);
 };

--- a/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
@@ -48,7 +48,7 @@ export const bootstrap = _editorConfig => {
 };
 
 export const createEditor = options => {
-    const {propertyDomNode, propertyName, contextPath, editorOptions, globalRegistry, userPreferences, persistChange} = options;
+    const {propertyDomNode, propertyName, editorOptions, globalRegistry, userPreferences, onChange} = options;
     const ckEditorConfig = editorConfig.configRegistry.getCkeditorConfig({
         editorOptions,
         userPreferences,
@@ -70,15 +70,7 @@ export const createEditor = options => {
             editor.neos = options;
 
             editor.model.document.on('change', () => handleUserInteractionCallback());
-            editor.model.document.on('change:data', debounce(() => persistChange({
-                type: 'Neos.Neos.Ui:Property',
-                subject: contextPath,
-                payload: {
-                    propertyName,
-                    value: cleanupContentBeforeCommit(editor.getData()),
-                    isInline: true
-                }
-            }), 500, {maxWait: 5000}));
+            editor.model.document.on('change:data', debounce(() => onChange(cleanupContentBeforeCommit(editor.getData())), 500, {maxWait: 5000}));
         }).catch(e => console.error(e));
 };
 

--- a/packages/neos-ui-guest-frame/src/InlineUI/InlineValidationErrors/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/InlineValidationErrors/index.js
@@ -70,7 +70,7 @@ export default class InlineValidationTooltips extends PureComponent {
 
         return <Fragment>{Object.keys(inlineValidationErrors).map(contextAndPropertyName => {
             const validationErrorsForProperty = inlineValidationErrors[contextAndPropertyName];
-            const [contextPath, propertyName] = contextAndPropertyName.split('~');
+            const [contextPath, propertyName] = contextAndPropertyName.split(' ');
             const domNodes = findAllOccurrencesOfNodePropertyInGuestFrame(contextPath, propertyName);
             return domNodes.map((domNode, index) => {
                 this.invalidInlinePropertiesDomNodes.push(domNode);

--- a/packages/neos-ui-guest-frame/src/InlineUI/InlineValidationErrors/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/InlineValidationErrors/index.js
@@ -1,0 +1,97 @@
+import React, {PureComponent, Fragment} from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+import {$transform} from 'plow-js';
+import {selectors} from '@neos-project/neos-ui-redux-store';
+import {neos} from '@neos-project/neos-ui-decorators';
+import {Tooltip} from '@neos-project/react-ui-components';
+import throttle from 'lodash.throttle';
+import style from './style.css';
+
+import {findAllOccurrencesOfNodePropertyInGuestFrame, getAbsolutePositionOfElementInGuestFrame, getGuestFrameWindow, getGuestFrameBody} from '@neos-project/neos-ui-guest-frame/src/dom';
+
+@neos(globalRegistry => ({
+    nodeTypesRegistry: globalRegistry.get('@neos-project/neos-ui-contentrepository')
+}))
+@connect($transform({
+    inlineValidationErrors: selectors.CR.Nodes.inlineValidationErrorsSelector
+}))
+export default class InlineValidationTooltips extends PureComponent {
+    static propTypes = {
+        inlineValidationErrors: PropTypes.object
+    };
+
+    iframeWindow = getGuestFrameWindow();
+
+    tooltipRefs = new WeakMap();
+
+    invalidInlinePropertiesDomNodes = [];
+
+    updateTooltipsPosition = () => {
+        this.invalidInlinePropertiesDomNodes.forEach(domNode => {
+            const position = getAbsolutePositionOfElementInGuestFrame(domNode);
+            const tooltipNode = this.tooltipRefs.get(domNode) && this.tooltipRefs.get(domNode).current;
+            if (tooltipNode && tooltipNode.children.length === 2) {
+                const [border, tooltip] = tooltipNode.children;
+
+                border.style.top = position.top + 'px';
+                border.style.left = position.left + 'px';
+                border.style.width = position.width + 'px';
+                border.style.height = position.height + 'px';
+
+                tooltip.style.top = position.top + position.height + 'px';
+                tooltip.style.left = position.left + 'px';
+            }
+        });
+    }
+
+    updateTooltipsPositionDebounced = throttle(this.updateTooltipsPosition, 5);
+
+    mutationObserver = new MutationObserver(this.updateTooltipsPositionDebounced);
+
+    componentDidMount() {
+        this.iframeWindow.addEventListener('resize', this.updateTooltipsPositionDebounced);
+
+        this.mutationObserver.observe(getGuestFrameBody(), {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            characterData: true
+        });
+    }
+
+    componentWillUnmount() {
+        this.iframeWindow.removeEventListener('resize', this.updateTooltipsPositionDebounced);
+        this.mutationObserver.disconnect();
+    }
+
+    render() {
+        const {inlineValidationErrors} = this.props;
+
+        return <Fragment>{Object.keys(inlineValidationErrors).map(contextAndPropertyName => {
+            const validationErrorsForProperty = inlineValidationErrors[contextAndPropertyName];
+            const [contextPath, propertyName] = contextAndPropertyName.split('~');
+            const domNodes = findAllOccurrencesOfNodePropertyInGuestFrame(contextPath, propertyName);
+            return domNodes.map((domNode, index) => {
+                this.invalidInlinePropertiesDomNodes.push(domNode);
+                const position = getAbsolutePositionOfElementInGuestFrame(domNode);
+                const ref = React.createRef();
+                this.tooltipRefs.set(domNode, ref);
+                return <div key={index} ref={ref}>
+                    <div className={style.border} style={{
+                        top: position.top,
+                        left: position.left,
+                        width: position.width,
+                        height: position.height
+                    }}/>
+                    <div className={style.tooltip} style={{
+                        top: position.top + position.height,
+                        left: position.left
+                    }}>
+                        <Tooltip renderInline asError><ul>{validationErrorsForProperty.map((error, index) => <li key={index}>{error}</li>)}</ul></Tooltip>
+                    </div>
+                </div>;
+            });
+        })}</Fragment>;
+    }
+}

--- a/packages/neos-ui-guest-frame/src/InlineUI/InlineValidationErrors/style.css
+++ b/packages/neos-ui-guest-frame/src/InlineUI/InlineValidationErrors/style.css
@@ -1,0 +1,9 @@
+.border {
+    border: 2px solid var(--colors-Error);
+    position: absolute;
+    pointer-events: none;
+}
+
+.tooltip {
+    position: absolute;
+}

--- a/packages/neos-ui-guest-frame/src/InlineUI/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/index.js
@@ -8,6 +8,7 @@ import {neos} from '@neos-project/neos-ui-decorators';
 import NodeToolbar from './NodeToolbar/index';
 
 import style from './style.css';
+import InlineValidationErrors from './InlineValidationErrors/index';
 
 @neos(globalRegistry => ({
     nodeTypesRegistry: globalRegistry.get('@neos-project/neos-ui-contentrepository')
@@ -39,10 +40,6 @@ export default class InlineUI extends PureComponent {
         const focusedNodeContextPath = focused.contextPath;
         const {nodeTypesRegistry, focusedNode, shouldScrollIntoView, requestScrollIntoView, destructiveOperationsAreDisabled, clipboardMode, clipboardNodeContextPath} = this.props;
         const isDocument = nodeTypesRegistry.hasRole($get('nodeType', focusedNode), 'document');
-        // Don't render toolbar for the document nodes
-        if (isDocument) {
-            return null;
-        }
         const isCut = focusedNodeContextPath === clipboardNodeContextPath && clipboardMode === 'Move';
         const isCopied = focusedNodeContextPath === clipboardNodeContextPath && clipboardMode === 'Copy';
         const canBeDeleted = $get('policy.canRemove', this.props.focusedNode) || false;
@@ -51,7 +48,7 @@ export default class InlineUI extends PureComponent {
 
         return (
             <div className={style.inlineUi} data-__neos__inline-ui="TRUE">
-                <NodeToolbar
+                {!isDocument && <NodeToolbar
                     shouldScrollIntoView={shouldScrollIntoView}
                     requestScrollIntoView={requestScrollIntoView}
                     destructiveOperationsAreDisabled={destructiveOperationsAreDisabled}
@@ -61,7 +58,8 @@ export default class InlineUI extends PureComponent {
                     canBeEdited={canBeEdited}
                     visibilityCanBeToggled={visibilityCanBeToggled}
                     {...focused}
-                    />
+                    />}
+                <InlineValidationErrors />
             </div>
         );
     }

--- a/packages/neos-ui-guest-frame/src/dom.js
+++ b/packages/neos-ui-guest-frame/src/dom.js
@@ -52,6 +52,11 @@ export const findAllPropertiesInGuestFrame = () =>
     findAllInGuestFrame('[data-__neos-property]');
 
 //
+// Find all DOM nodes that represent a particular node property in the guest frame
+//
+export const findAllOccurrencesOfNodePropertyInGuestFrame = (contextPath, propertyName) => findAllInGuestFrame(`[data-__neos-editable-node-contextpath="${contextPath}"][data-__neos-property="${propertyName}"]`);
+
+//
 // Find all DOM nodes that represent CR node properties in the guest frame
 //
 export const findRelativePropertiesInGuestFrame = contentDomNode =>
@@ -208,7 +213,9 @@ export const getAbsolutePositionOfElementInGuestFrame = element => {
             top: relativeElementDimensions.top - relativeDocumentDimensions.top,
             left: relativeElementDimensions.left - relativeDocumentDimensions.left,
             bottom: relativeDocumentDimensions.bottom - relativeElementDimensions.bottom,
-            right: relativeDocumentDimensions.right - relativeElementDimensions.right
+            right: relativeDocumentDimensions.right - relativeElementDimensions.right,
+            width: relativeElementDimensions.width,
+            height: relativeElementDimensions.height
         };
     }
 

--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.spec.js
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.spec.js
@@ -17,6 +17,7 @@ test(`should export actionTypes`, () => {
     expect(typeof (actionTypes.HIDE)).toBe('string');
     expect(typeof (actionTypes.SHOW)).toBe('string');
     expect(typeof (actionTypes.UPDATE_URI)).toBe('string');
+    expect(typeof (actionTypes.SET_INLINE_VALIDATION_ERRORS)).toBe('string');
 });
 
 test(`should export action creators`, () => {
@@ -34,6 +35,7 @@ test(`should export action creators`, () => {
     expect(typeof (actions.hide)).toBe('function');
     expect(typeof (actions.show)).toBe('function');
     expect(typeof (actions.updateUri)).toBe('function');
+    expect(typeof (actions.setInlineValidationErrors)).toBe('function');
 });
 
 test(`should export a reducer`, () => {
@@ -51,7 +53,8 @@ test(`The reducer should create a valid initial state`, () => {
         siteNode: 'siteNode',
         documentNode: 'documentNode',
         clipboard: null,
-        clipboardMode: null
+        clipboardMode: null,
+        inlineValidationErrors: {}
     };
     const expectedState = {
         byContextPath: {},
@@ -63,7 +66,8 @@ test(`The reducer should create a valid initial state`, () => {
         },
         toBeRemoved: null,
         clipboard: null,
-        clipboardMode: null
+        clipboardMode: null,
+        inlineValidationErrors: {}
     };
     const nextState = reducer(undefined, {
         type: system.INIT,
@@ -195,5 +199,22 @@ test(`The "updateUri" action should update uris.`, () => {
                 uri: 'https://domain/someUri2/someUri@user-admin;language=en_US'
             }
         }
+    });
+});
+
+test(`The "setInlineValidationErrors" action should set validation errors.`, () => {
+    const state = {
+        inlineValidationErrors: {}
+    };
+    const nextState = reducer(state, actions.setInlineValidationErrors('abc@user-admin;language=en_US', 'title', ['Some error']));
+    expect(nextState).toEqual({
+        inlineValidationErrors: {
+            'abc@user-admin;language=en_US title': ['Some error']
+        }
+    });
+
+    const nextState2 = reducer(nextState, actions.setInlineValidationErrors('abc@user-admin;language=en_US', 'title', null));
+    expect(nextState2).toEqual({
+        inlineValidationErrors: {}
     });
 });

--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
@@ -8,6 +8,14 @@ import {parentNodeContextPath, getNodeOrThrow} from './helpers';
 
 import {FusionPath, NodeContextPath, InsertPosition, NodeMap, ClipboardMode, NodeTypeName} from '@neos-project/neos-ts-interfaces';
 
+interface InlineValidationErrors {
+    [itemProp: string]: any;
+}
+
+interface ErrorsMap {
+    [itemProp: string]: any;
+}
+
 //
 // Export the subreducer state shape interface
 //
@@ -22,6 +30,7 @@ export interface State extends Readonly<{
     toBeRemoved: NodeContextPath | null;
     clipboard: NodeContextPath | null;
     clipboardMode: ClipboardMode | null;
+    inlineValidationErrors: InlineValidationErrors
 }> {}
 
 export const defaultState: State = {
@@ -34,7 +43,8 @@ export const defaultState: State = {
     },
     toBeRemoved: null,
     clipboard: null,
-    clipboardMode: null
+    clipboardMode: null,
+    inlineValidationErrors: {}
 };
 
 // An object describing a node property change
@@ -68,7 +78,8 @@ export enum actionTypes {
     COMMIT_PASTE = '@neos/neos-ui/CR/Nodes/COMMIT_PASTE',
     HIDE = '@neos/neos-ui/CR/Nodes/HIDE',
     SHOW = '@neos/neos-ui/CR/Nodes/SHOW',
-    UPDATE_URI = '@neos/neos-ui/CR/Nodes/UPDATE_URI'
+    UPDATE_URI = '@neos/neos-ui/CR/Nodes/UPDATE_URI',
+    SET_INLINE_VALIDATION_ERRORS = '@neos/neos-ui/CR/Nodes/SET_INLINE_VALIDATION_ERRORS'
 }
 
 export type Action = ActionType<typeof actions>;
@@ -151,6 +162,11 @@ const remove = (contextPath: NodeContextPath) => createAction(actionTypes.REMOVE
  * Set the document node and optionally site node
  */
 const setDocumentNode = (documentNode: NodeContextPath, siteNode?: NodeContextPath) => createAction(actionTypes.SET_DOCUMENT_NODE, {documentNode, siteNode});
+
+/**
+ * Set inline validation errors for property
+ */
+const setInlineValidationErrors = (node: NodeContextPath, propertyName: string, errors: ErrorsMap | null) => createAction(actionTypes.SET_INLINE_VALIDATION_ERRORS, {node, propertyName, errors});
 
 /**
  * Set CR state on page load or after dimensions or workspaces switch
@@ -286,7 +302,8 @@ export const actions = {
     commitPaste,
     hide,
     show,
-    updateUri
+    updateUri,
+    setInlineValidationErrors
 };
 
 //
@@ -487,6 +504,15 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
                     node.uri = newNodeUri;
                 }
             });
+            break;
+        }
+        case actionTypes.SET_INLINE_VALIDATION_ERRORS: {
+            const {node, propertyName, errors} = action.payload;
+            if (errors) {
+                draft.inlineValidationErrors[`${node}~${propertyName}`] = errors;
+            } else {
+                delete draft.inlineValidationErrors[`${node}~${propertyName}`];
+            }
             break;
         }
     }

--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
@@ -509,9 +509,9 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
         case actionTypes.SET_INLINE_VALIDATION_ERRORS: {
             const {node, propertyName, errors} = action.payload;
             if (errors) {
-                draft.inlineValidationErrors[`${node}~${propertyName}`] = errors;
+                draft.inlineValidationErrors[`${node} ${propertyName}`] = errors;
             } else {
-                delete draft.inlineValidationErrors[`${node}~${propertyName}`];
+                delete draft.inlineValidationErrors[`${node} ${propertyName}`];
             }
             break;
         }

--- a/packages/neos-ui-redux-store/src/CR/Nodes/selectors.ts
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/selectors.ts
@@ -4,6 +4,7 @@ import {GlobalState} from '@neos-project/neos-ui-redux-store/src/System';
 import {parentNodeContextPath} from './helpers';
 import {NodeContextPath, NodeMap, Node, NodeTypeName, ClipboardMode, NodeTypesRegistry} from '@neos-project/neos-ts-interfaces';
 
+export const inlineValidationErrorsSelector = (state: GlobalState) => $get(['cr', 'nodes', 'inlineValidationErrors'], state);
 export const nodesByContextPathSelector = (state: GlobalState) => $get(['cr', 'nodes', 'byContextPath'], state);
 export const siteNodeContextPathSelector = (state: GlobalState) => $get(['cr', 'nodes', 'siteNode'], state);
 export const documentNodeContextPathSelector = (state: GlobalState) => $get(['cr', 'nodes', 'documentNode'], state);

--- a/packages/neos-ui-validators/src/index.ts
+++ b/packages/neos-ui-validators/src/index.ts
@@ -1,14 +1,6 @@
 import {$get} from 'plow-js';
 import {ValidatorRegistry, PropertyConfiguration, ValidatorConfiguration} from '@neos-project/neos-ts-interfaces';
-/**
- * Takes object of values and their configuration, and returns either null
- * or object filled with validation erros per element.
- *
- * @param object values. Elements' values
- * @param object elementConfigurations. Elements' configuration
- * @param object validatorRegistry. Validator registry
- * @return object or null
- */
+
 interface ValuesMap {
     [itemProp: string]: any;
 }
@@ -18,8 +10,12 @@ interface ErrorsMap {
 interface ElementConfiguarionsMap {
     [itemProp: string]: PropertyConfiguration | undefined;
 }
-// TODO: typing could be greatly improved. E.g. we could gather all possible options interfaces and make a discriminated union out of them
-const validate = (values: ValuesMap, elementConfigurations: ElementConfiguarionsMap, validatorRegistry: ValidatorRegistry) => {
+
+/**
+ * Takes a single value and its configuration, and returns either null
+ * or an array of validation errors.
+ */
+export const validateElement = (elementValue: any, elementConfiguration: PropertyConfiguration | undefined, validatorRegistry: ValidatorRegistry) => {
     const checkValidator = (elementValue: any, validatorName: string, validatorConfiguration: ValidatorConfiguration | undefined) => {
         const validator = validatorRegistry.get(validatorName);
         if (validator) {
@@ -29,24 +25,34 @@ const validate = (values: ValuesMap, elementConfigurations: ElementConfiguarions
         return null;
     };
 
-    const validateElement = (elementValue: any, elementConfiguration: PropertyConfiguration | undefined) => {
-        if (elementConfiguration && elementConfiguration.validation) {
-            const validators = elementConfiguration.validation;
-            const validationResults = Object.keys(validators).map(validatorName => {
-                const validatorConfiguration = validators[validatorName];
-                return checkValidator(elementValue, validatorName, validatorConfiguration);
-            });
-            return validationResults.filter(result => result);
-        }
-        return null;
-    };
+    if (elementConfiguration && elementConfiguration.validation) {
+        const validators = elementConfiguration.validation;
+        const validationResults = Object.keys(validators).map(validatorName => {
+            const validatorConfiguration = validators[validatorName];
+            return checkValidator(elementValue, validatorName, validatorConfiguration);
+        }).filter(result => result);
+        return validationResults.length === 0 ? null : validationResults;
+    }
+    return null;
+};
 
+/**
+ * Takes object of values and their configuration, and returns either null
+ * or object filled with validation erros per element.
+ *
+ * @param object values. Elements' values
+ * @param object elementConfigurations. Elements' configuration
+ * @param object validatorRegistry. Validator registry
+ * @return object or null
+ */
+// TODO: typing could be greatly improved. E.g. we could gather all possible options interfaces and make a discriminated union out of them
+const validate = (values: ValuesMap, elementConfigurations: ElementConfiguarionsMap, validatorRegistry: ValidatorRegistry) => {
     const errors: ErrorsMap = {};
     let hasErrors = false;
     Object.keys(elementConfigurations).forEach(elementName => {
         const elementValue = $get([elementName], values);
         const elementConfiguration = elementConfigurations[elementName];
-        const elementErrors = validateElement(elementValue, elementConfiguration);
+        const elementErrors = validateElement(elementValue, elementConfiguration, validatorRegistry);
         if (elementErrors && elementErrors.length > 0) {
             hasErrors = true;
             errors[elementName] = elementErrors;

--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -77,7 +77,8 @@ manifest('main', {}, globalRegistry => {
             - nodeType: The nodeType of the associated node
             - editorOptions: The configuration for this inline editor
             - globalRegistry: The global registry
-            - persistChange: Will dispatch the respective action in from '@neos-project/neos-ui-redux-store' package (actions.Changes.persistChanges)
+            - onChange: Will first validate the property value and then persist the change if valid
+            - persistChange: Low level, use "onChange" in instead. Will dispatch the respective action in from '@neos-project/neos-ui-redux-store' package (actions.Changes.persistChanges)
     `));
 
     //


### PR DESCRIPTION
Takes existing property validators configuration (`properties.propertyName.validation`) and applies it inline.
If property value is not valid, it will not be persisted until it becomes valid again.

TODO:
- [x] fix the tests
- [x] E2E tests
- [x] update the docs

![valid](https://user-images.githubusercontent.com/837032/62453738-9d558a00-b77b-11e9-9fed-890af7ba8d2b.gif)
