### PR TITLE
BUGFIX: Prevent browserlist error on build

### DIFF
--- a/packages/build-essentials/.browserslistrc
+++ b/packages/build-essentials/.browserslistrc
@@ -1,0 +1,2 @@
+# Browsers that we support
+last 2 versions

--- a/packages/build-essentials/src/postcss.config.js
+++ b/packages/build-essentials/src/postcss.config.js
@@ -3,9 +3,7 @@ const styleVars = styles.generateCssVarsObject(styles.config);
 
 module.exports = {
     plugins: [
-        require('autoprefixer')({
-            browsers: ['last 2 versions']
-        }),
+        require('autoprefixer'),
         require('postcss-css-variables')({
             variables: Object.assign(styleVars)
         }),


### PR DESCRIPTION
Use own configuration file for browserlist to prevent error message.

Fixes: #2539