### PR TITLE
BUGFIX: Reduce z-index from toolbar by 1

### DIFF
--- a/packages/build-essentials/src/styles/styleConstants.js
+++ b/packages/build-essentials/src/styles/styleConstants.js
@@ -36,7 +36,7 @@ const config = {
         sideBar: ['dropTargetBefore', 'dropTargetAfter'],
         wrapperDropdown: ['context'],
         unappliedChangesOverlay: ['context'],
-        nodeToolBar: '2147483647'
+        nodeToolBar: '2147483646'
     },
     fontSize: {
         base: '14px',


### PR DESCRIPTION
As `2147483647` is the absolute maximum for `z-index`, it is not possible to have content over the toolbar. But in some special cases, it can be very useful to show some HTML over a toolbar (`<dialog>`, e. g. )


