### PR TITLE
BUGFIX: make Aloha config migration handle multiple nodetypes per file correctly

### DIFF
--- a/Migrations/Code/Version20190319094900.php
+++ b/Migrations/Code/Version20190319094900.php
@@ -36,7 +36,7 @@ class Version20190319094900 extends AbstractMigration
             function (&$configuration) {
                 foreach ($configuration as &$nodeType) {
                     if (!isset($nodeType['properties'])) {
-                        return;
+                        continue;
                     }
 
                     foreach ($nodeType['properties'] as &$propertyConfiguration) {


### PR DESCRIPTION
Thanks @baschny for reporting!