### PR TITLE
FEATURE: Make default behavior of "Publish"/"Publish all" buttons configurable

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -184,7 +184,8 @@ Neos:
           preferences:
             interfaceLanguage: '${q(user).property(''preferences.interfaceLanguage'')}'
           settings:
-            isAutoPublishingEnabled: false
+            isAutoPublishingEnabled: '${q(user).property("preferences.preferences")["isAutoPublishingEnabled"]}'
+            isPublishingModeAll: '${q(user).property("preferences.preferences")["isPublishingModeAll"]}'
             targetWorkspace: 'live'
       changes:
         types:

--- a/packages/neos-ui-redux-store/src/User/Settings/index.spec.js
+++ b/packages/neos-ui-redux-store/src/User/Settings/index.spec.js
@@ -4,11 +4,13 @@ import {actionTypes as system} from '../../System/index';
 test(`should export actionTypes`, () => {
     expect(actionTypes).not.toBe(undefined);
     expect(typeof (actionTypes.TOGGLE_AUTO_PUBLISHING)).toBe('string');
+    expect(typeof (actionTypes.TOGGLE_PUBLISHING_MODE_ALL)).toBe('string');
 });
 
 test(`should export action creators`, () => {
     expect(actions).not.toBe(undefined);
     expect(typeof (actions.toggleAutoPublishing)).toBe('function');
+    expect(typeof (actions.togglePublishingModeAll)).toBe('function');
 });
 
 test(`should export a reducer`, () => {
@@ -26,7 +28,8 @@ test(`The reducer should return the default state when called with undefined.`, 
 
 test(`The reducer should correctly rehydrate data on INIT.`, () => {
     const initValues = {
-        isAutoPublishingEnabled: true
+        isAutoPublishingEnabled: true,
+        isPublishingModeAll: true
     };
     const nextState = reducer(undefined, {
         type: system.INIT,
@@ -50,4 +53,17 @@ test(`
 
     expect(nextState1.isAutoPublishingEnabled).toBe(true);
     expect(nextState2.isAutoPublishingEnabled).toBe(false);
+});
+
+test(`
+    The "toggle" action should be able to reverse the value of the
+    "isPublishingModeAll" key.`, () => {
+    const state = {
+        isPublishingModeAll: false
+    };
+    const nextState1 = reducer(state, actions.togglePublishingModeAll());
+    const nextState2 = reducer(nextState1, actions.togglePublishingModeAll());
+
+    expect(nextState1.isPublishingModeAll).toBe(true);
+    expect(nextState2.isPublishingModeAll).toBe(false);
 });

--- a/packages/neos-ui-redux-store/src/User/Settings/index.ts
+++ b/packages/neos-ui-redux-store/src/User/Settings/index.ts
@@ -8,17 +8,20 @@ import {State as UserState} from './../index';
 //
 export interface State extends Readonly<{
     isAutoPublishingEnabled: boolean;
+    isPublishingModeAll: boolean;
 }> {}
 
 export const defaultState: State = {
-    isAutoPublishingEnabled: false
+    isAutoPublishingEnabled: false,
+    isPublishingModeAll: false
 };
 
 //
 // Export the action types
 //
 export enum actionTypes {
-    TOGGLE_AUTO_PUBLISHING = '@neos/neos-ui/User/Settings/TOGGLE_AUTO_PUBLISHING'
+    TOGGLE_AUTO_PUBLISHING = '@neos/neos-ui/User/Settings/TOGGLE_AUTO_PUBLISHING',
+    TOGGLE_PUBLISHING_MODE_ALL = '@neos/neos-ui/User/Settings/TOGGLE_PUBLISHING_MODE_ALL'
 }
 
 //
@@ -26,7 +29,7 @@ export enum actionTypes {
 //
 export const actions = {
     /**
-     * Toggles the auto publishing mode for the current logged in user.
+     * Toggles the publishing modes for the current logged in user.
      */
     toggleAutoPublishing: (state: UserState) => createAction(actionTypes.TOGGLE_AUTO_PUBLISHING, state),
     togglePublishingModeAll: (state: UserState) => createAction(actionTypes.TOGGLE_PUBLISHING_MODE_ALL, state)
@@ -44,9 +47,13 @@ export const reducer = (state: State = defaultState, action: Action | InitAction
     switch (action.type) {
         case system.INIT:
             draft.isAutoPublishingEnabled = action.payload.user.settings.isAutoPublishingEnabled;
+            draft.isPublishingModeAll = action.payload.user.settings.isPublishingModeAll;
             break;
         case actionTypes.TOGGLE_AUTO_PUBLISHING:
             draft.isAutoPublishingEnabled = !state.isAutoPublishingEnabled;
+            break;
+        case actionTypes.TOGGLE_PUBLISHING_MODE_ALL:
+            draft.isPublishingModeAll = !state.isPublishingModeAll;
             break;
     }
 });

--- a/packages/neos-ui-redux-store/src/User/Settings/index.ts
+++ b/packages/neos-ui-redux-store/src/User/Settings/index.ts
@@ -1,7 +1,7 @@
 import produce from 'immer';
 import {action as createAction, ActionType} from 'typesafe-actions';
-
 import {actionTypes as system, InitAction} from '../../System';
+import {State as UserState} from './../index';
 
 //
 // Export the subreducer state shape interface
@@ -28,7 +28,8 @@ export const actions = {
     /**
      * Toggles the auto publishing mode for the current logged in user.
      */
-    toggleAutoPublishing: () => createAction(actionTypes.TOGGLE_AUTO_PUBLISHING)
+    toggleAutoPublishing: (state: UserState) => createAction(actionTypes.TOGGLE_AUTO_PUBLISHING, state),
+    togglePublishingModeAll: (state: UserState) => createAction(actionTypes.TOGGLE_PUBLISHING_MODE_ALL, state)
 };
 
 //

--- a/packages/neos-ui-sagas/src/User/AutoPublishingEnabled/index.js
+++ b/packages/neos-ui-sagas/src/User/AutoPublishingEnabled/index.js
@@ -1,0 +1,15 @@
+import {takeLatest} from 'redux-saga/effects';
+
+import {actionTypes} from '@neos-project/neos-ui-redux-store';
+import backend from '@neos-project/neos-ui-backend-connector';
+
+/**
+ * Save currently-chosen AutoPublishingEnabled
+ */
+export function * watchAutoPublishingEnabledChanged() {
+    yield takeLatest(actionTypes.User.Settings.TOGGLE_AUTO_PUBLISHING, function * autoPublishingEnabledChanged(action) {
+        const isAutoPublishingEnabled = action.payload;
+
+        yield backend.get().endpoints.setUserPreferences('isAutoPublishingEnabled', isAutoPublishingEnabled);
+    });
+}

--- a/packages/neos-ui-sagas/src/User/PublishingModeAll/index.js
+++ b/packages/neos-ui-sagas/src/User/PublishingModeAll/index.js
@@ -1,0 +1,15 @@
+import {takeLatest} from 'redux-saga/effects';
+
+import {actionTypes} from '@neos-project/neos-ui-redux-store';
+import backend from '@neos-project/neos-ui-backend-connector';
+
+/**
+ * Save currently-chosen PublishingModeAll
+ */
+export function * watchPublishingModeAllChanged() {
+    yield takeLatest(actionTypes.User.Settings.TOGGLE_PUBLISHING_MODE_ALL, function * publishingModeAllChanged(action) {
+        const isPublishingModeAll = action.payload;
+
+        yield backend.get().endpoints.setUserPreferences('isPublishingModeAll', isPublishingModeAll);
+    });
+}

--- a/packages/neos-ui-sagas/src/index.js
+++ b/packages/neos-ui-sagas/src/index.js
@@ -11,6 +11,8 @@ import * as uiEditPreviewMode from './UI/EditPreviewMode/index';
 import * as uiInspector from './UI/Inspector/index';
 import * as uiPageTree from './UI/PageTree/index';
 import * as uiHotkeys from './UI/Hotkeys/index';
+import * as userAutoPublishingEnabled from './User/AutoPublishingEnabled/index';
+import * as userPublishingModeAll from './User/PublishingModeAll/index';
 
 module.exports = {
     browser,
@@ -25,5 +27,7 @@ module.exports = {
     uiEditPreviewMode,
     uiInspector,
     uiPageTree,
-    uiHotkeys
+    uiHotkeys,
+    userPublishingModeAll,
+    userAutoPublishingEnabled
 };

--- a/packages/neos-ui-sagas/src/manifest.js
+++ b/packages/neos-ui-sagas/src/manifest.js
@@ -14,7 +14,9 @@ import {
     uiEditPreviewMode,
     uiInspector,
     uiPageTree,
-    uiHotkeys
+    uiHotkeys,
+    userPublishingModeAll,
+    userAutoPublishingEnabled
 } from './index';
 
 manifest('main.sagas', {}, globalRegistry => {
@@ -73,4 +75,7 @@ manifest('main.sagas', {}, globalRegistry => {
     sagasRegistry.set('neos-ui/UI/PageTree/watchToggle', {saga: uiPageTree.watchToggle});
 
     sagasRegistry.set('neos-ui/UI/Hotkeys/handleHotkeys', {saga: uiHotkeys.handleHotkeys});
+
+    sagasRegistry.set('neos-ui/User/AutoPublishingEnabled/watchAutoPublishingEnabledChanged', {saga: userAutoPublishingEnabled.watchAutoPublishingEnabledChanged});
+    sagasRegistry.set('neos-ui/User/PublishingModeAll/watchPublishingModeAllChanged', {saga: userPublishingModeAll.watchPublishingModeAllChanged});
 });

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -317,6 +317,10 @@ export default class PublishDropDown extends PureComponent {
             return <I18n id="Neos.Neos:Main:autoPublish" fallback="Auto publish"/>;
         }
 
+        if (canPublish && isPublishingModeAll) {
+            return <I18n id="Neos.Neos:Main:publishAllTo" fallback={'Publish all to ' + baseWorkspaceTitle} params={{0: baseWorkspaceTitle}}/>;
+        }
+
         if (canPublish) {
             return <I18n id="Neos.Neos:Main:publishTo" fallback="Publish to" params={{0: baseWorkspaceTitle}}/>;
         }


### PR DESCRIPTION
Add a user preference ```publishingModeAll``` (true/false) to configure the publishing behavior, see: https://github.com/neos/neos-ui/issues/107

If set to true, the main publish dropdown button will publish all dirty nodes, if set to false, only the current document node.

Also fixes a bug (?): the auto-publishing settings have not been saved into user preferences until now, this is also fixed.

![bildschirmfoto 2018-10-26 um 15 05 22](https://user-images.githubusercontent.com/3976405/47568133-9c601400-d930-11e8-90b1-344501a5f050.png)
