### PR TITLE
TASK: Pull in ^5.0 only

### DIFF
--- a/Tests/IntegrationTests/TestDistribution/DistributionPackages/Neos.TestNodeTypes/composer.json
+++ b/Tests/IntegrationTests/TestDistribution/DistributionPackages/Neos.TestNodeTypes/composer.json
@@ -3,8 +3,8 @@
     "description": "Some dummy nodetypes",
     "type": "neos-package",
     "require": {
-        "neos/neos": "*",
-        "neos/neos-ui": "*"
+        "neos/neos-ui": "*",
+        "neos/fusion-afx": "*"
     },
     "extra": {
         "neos": {

--- a/Tests/IntegrationTests/TestDistribution/DistributionPackages/Neos.TestSite/composer.json
+++ b/Tests/IntegrationTests/TestDistribution/DistributionPackages/Neos.TestSite/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "neos/neos": "*",
         "neos/neos-ui": "*",
-        "neos/neos-ui-compiled": "*"
+        "neos/fusion-afx": "*"
     },
     "extra": {
         "neos": {

--- a/Tests/IntegrationTests/TestDistribution/DistributionPackages/Neos.TestSite/composer.json
+++ b/Tests/IntegrationTests/TestDistribution/DistributionPackages/Neos.TestSite/composer.json
@@ -3,7 +3,6 @@
     "description": "A dummy site package that will be replaced by fixtures during tests",
     "type": "neos-site",
     "require": {
-        "neos/neos": "*",
         "neos/neos-ui": "*",
         "neos/fusion-afx": "*"
     },

--- a/Tests/IntegrationTests/TestDistribution/composer.json
+++ b/Tests/IntegrationTests/TestDistribution/composer.json
@@ -6,21 +6,7 @@
         "bin-dir": "bin"
     },
     "require": {
-        "neos/neos": "dev-master",
-        "neos/flow": "dev-master",
-        "neos/eel": "dev-master",
-        "neos/fluid-adaptor": "dev-master",
-        "neos/neos-ui": "dev-master",
-        "neos/neos-ui-compiled": "dev-master",
-        "neos/fusion-afx": "dev-master",
-        "neos/media": "dev-master",
-        "neos/content-repository": "dev-master",
-        "neos/fusion": "dev-master",
-        "neos/media-browser": "dev-master",
-        "neos/http-factories": "dev-master",
-        "neos/form": "dev-master",
-        "neos/neos-setup": "dev-master",
-        "neos/setup": "dev-master",
+        "neos/neos-ui": "^5.0",
         "neos/test-site": "@dev",
         "neos/test-nodetypes": "@dev"
     },

--- a/Tests/IntegrationTests/TestDistribution/composer.json
+++ b/Tests/IntegrationTests/TestDistribution/composer.json
@@ -7,7 +7,6 @@
     },
     "require": {
         "neos/neos-ui": "^5.0.0",
-        "neos/fusion-afx": "*",
         "neos/test-site": "@dev",
         "neos/test-nodetypes": "@dev"
     },

--- a/Tests/IntegrationTests/TestDistribution/composer.json
+++ b/Tests/IntegrationTests/TestDistribution/composer.json
@@ -7,6 +7,7 @@
     },
     "require": {
         "neos/neos-ui": "^5.0.0",
+        "neos/fusion-afx": "*",
         "neos/test-site": "@dev",
         "neos/test-nodetypes": "@dev"
     },

--- a/Tests/IntegrationTests/TestDistribution/composer.json
+++ b/Tests/IntegrationTests/TestDistribution/composer.json
@@ -6,7 +6,7 @@
         "bin-dir": "bin"
     },
     "require": {
-        "neos/neos-ui": "^5.0",
+        "neos/neos-ui": "^5.0.0",
         "neos/test-site": "@dev",
         "neos/test-nodetypes": "@dev"
     },


### PR DESCRIPTION
This pulls in only `neos/neos-ui` as `^5.0`. That in turn pulls in
`neos/neos` as `^5.0`, which in turn requires it's own dependencies.
That _should_ suffice. If it needs to be more pinned down, we could
add `"neos/neos": "~5.0.0"` as well, to limit it to 5.0.x.
