### PR TITLE
BUGFIX: Never fall back to UTC when picking date

### DIFF
--- a/packages/react-ui-components/src/DateInput/dateInput.tsx
+++ b/packages/react-ui-components/src/DateInput/dateInput.tsx
@@ -216,7 +216,7 @@ export class DateInput extends PureComponent<DateInputProps, DateInputState> {
                         open={true}
                         defaultValue={value}
                         dateFormat={!timeOnly}
-                        utc={dateOnly}
+                        utc={false}
                         locale={locale}
                         timeFormat={!dateOnly}
                         onChange={this.handleChange}


### PR DESCRIPTION
Since our default date format for ``DateTime`` properties is ``Y-m-d H:i:s.u``
and we also persist the time we must not fall back to ``UTC`` per default.

Example:
If the persisted time is ``00:00:00.000000`` and convert to UTC
this will result in yesterday's date at ``22:00:00.000000`` (depending on DST).

This issue can be hard to reproduce, since by default time
for a selected day could be ``02:00:00.000000`` (depending on timezone
and UTC). So even if the conversion to UTC happens in the frontend
date picker the problem would not occur.

fixes #2467 
