### PR TITLE
BUGFIX: createNew doesn't set title of new node

### DIFF
--- a/Classes/NodeCreationHandler/ContentTitleNodeCreationHandler.php
+++ b/Classes/NodeCreationHandler/ContentTitleNodeCreationHandler.php
@@ -1,0 +1,33 @@
+<?php
+namespace Neos\Neos\Ui\NodeCreationHandler;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+
+class ContentTitleNodeCreationHandler implements NodeCreationHandlerInterface
+{
+    /**
+     * Set the node title for the newly created Content node
+     *
+     * @param NodeInterface $node The newly created node
+     * @param array $data incoming data from the creationDialog
+     * @return void
+     */
+    public function handle(NodeInterface $node, array $data)
+    {
+        if ($node->getNodeType()->isOfType('Neos.Neos:Content')) {
+            if (isset($data['title'])) {
+                $node->setProperty('title', $data['title']);
+            }
+        }
+    }
+}

--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -14,6 +14,12 @@
     nodeCreationHandlers:
       documentTitle:
         nodeCreationHandler: 'Neos\Neos\Ui\NodeCreationHandler\DocumentTitleNodeCreationHandler'
+  
+'Neos.Neos:Content':
+  options:
+    nodeCreationHandlers:
+      documentTitle:
+        nodeCreationHandler: 'Neos\Neos\Ui\NodeCreationHandler\ContentTitleNodeCreationHandler'
 
 'Neos.Neos:ContentCollection':
   ui:

--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -14,7 +14,7 @@
     nodeCreationHandlers:
       documentTitle:
         nodeCreationHandler: 'Neos\Neos\Ui\NodeCreationHandler\DocumentTitleNodeCreationHandler'
-  
+
 'Neos.Neos:Content':
   options:
     nodeCreationHandlers:


### PR DESCRIPTION
The title set in references editor wasn't used for creating the new content node.

Fixes #1764