### PR TITLE
BUGFIX: fix empty CKE5 StyleSelect when no headings are allowed

### DIFF
--- a/packages/neos-ui-ckeditor5-bindings/src/manifest.richtextToolbar.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/manifest.richtextToolbar.js
@@ -157,7 +157,7 @@ export default ckEditorRegistry => {
         }],
         label: 'Paragraph',
         isVisible: $get('formatting.p'),
-        isActive: formattingUnderCursor => $get('heading', formattingUnderCursor) === false
+        isActive: formattingUnderCursor => !$get('heading', formattingUnderCursor)
     });
 
     // H1


### PR DESCRIPTION
Fixes: #2480 

Steps to reproduce:

You'd see an empty selectbox when no heading is allowed, e.g.:

```
"Neos.TestNodeTypes:Content.Text":
  superTypes:
    "Neos.Neos:Content": true
  ui:
    label: Text
    icon: icon-file-text
    position: 200
    inlineEditable: true
  properties:
    text:
      type: string
      ui:
        inlineEditable: true
        inline:
          editorOptions:
            formatting:
              h1: false
              h2: false
              h3: false
              h4: false
              h5: false
              p: true

```
