### PR TITLE
BUGFIX: Prevent infinite refresh loop

### DIFF
--- a/Classes/Fusion/ExceptionHandler/PageExceptionHandler.php
+++ b/Classes/Fusion/ExceptionHandler/PageExceptionHandler.php
@@ -96,6 +96,10 @@ class PageExceptionHandler extends AbstractRenderingExceptionHandler
         $fluidView->setFormat('html');
         $fluidView->setTemplatePathAndFilename('resource://Neos.Neos.Ui/Private/Templates/Error/ErrorMessage.html');
 
+        $guestNotificationScript = new StandaloneView();
+        $guestNotificationScript->setTemplatePathAndFilename('resource://Neos.Neos.Ui/Private/Templates/Backend/GuestNotificationScript.html');
+        $fluidView->assign('guestNotificationScript', $guestNotificationScript->render());
+
         return $fluidView;
     }
 }

--- a/Resources/Private/Templates/Error/ErrorMessage.html
+++ b/Resources/Private/Templates/Error/ErrorMessage.html
@@ -4,8 +4,9 @@
     <meta charset="utf-8">
     <title>Neos Error</title>
     <link rel="stylesheet" href="{f:uri.resource(path: 'Styles/Error.css', package: 'Neos.Neos')}"/>
+    {guestNotificationScript -> f:format.raw()}
 </head>
 <body class="neos">
-    <div class="neos-error-screen">{message -> f:format.raw()}</div>
+    <div id="neos-new-backend-container" class="neos-error-screen">{message -> f:format.raw()}</div>
 </body>
 </html>

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -44,6 +44,15 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
     const guestFrameWindow = getGuestFrameWindow();
     const documentInformation = Object.assign({}, guestFrameWindow['@Neos.Neos.Ui:DocumentInformation']);
 
+    // The user may have navigated by clicking an inline link - that's why we need to update the contentCanvas URL to be in sync with the shown content.
+    // We need to set the src to the actual src of the iframe, and not retrive it from documentInformation, as it may differ, e.g. contain additional arguments.
+    yield put(actions.UI.ContentCanvas.setSrc(guestFrameWindow.document.location.href));
+
+    // If we have no document information, guest frame intialziation ends here
+    if (Object.entries(documentInformation).length === 0) {
+        return;
+    }
+
     const nodes = Object.assign({}, guestFrameWindow['@Neos.Neos.Ui:Nodes'], {
         [documentInformation.metaData.documentNode]: documentInformation.metaData.documentNodeSerialization
     });


### PR DESCRIPTION
Prevent infinite reloading if the content inside the guest frame is a Neos exception. This does not occur on initial load, but when switching to a page that throws an exception (for example when
navigating in the node tree).

fixes: #2358