### PR TITLE
BUGFIX: Make loading bar visible

### DIFF
--- a/packages/build-essentials/src/styles/styleConstants.js
+++ b/packages/build-essentials/src/styles/styleConstants.js
@@ -18,8 +18,8 @@ const config = {
     },
     zIndex: {
         secondaryToolbar: ['linkIconButtonFlyout'],
-        flashMessageContainer: '5',
-        loadingIndicatorContainer: '2',
+        flashMessageContainer: '6',
+        loadingIndicatorContainer: '5',
         secondaryInspector: ['context', 'iframe', 'close'],
         secondaryInspectorElevated: ['context', 'dropdownContents'],
         dialog: ['context'],


### PR DESCRIPTION
The loading bar was hidden underneath the primary toolbar.

fixes: #2567