### PR TITLE
BUGFIX: Backend tables center text

### DIFF
--- a/packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/TableStyles.vanilla-css
+++ b/packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/TableStyles.vanilla-css
@@ -157,7 +157,6 @@
 .ck-content .table table td,.ck-content .table table th{
     min-width:2em;
     padding:.4em;
-    text-align:center;
     border-color:#d9d9d9
 }
 .ck-content .table table th{


### PR DESCRIPTION
**What I did**
Fix bug where text in table cells created using the inline editor is centered in backend. 
This potentially results in different text alignment in front- and backend.
Fixes: #2260

**How I did it**
Removed `text-align: center` in backend css.

**How to verify it**
* Create a text node in the backend
* Add a table using the inline editor
* write some text in a cell
* the text should be left aligned in the front- and backend (if no site specific stylesheet overwrites the alignment).