### PR TITLE
BUGFIX: Do not force update within render method

### DIFF
--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -91,7 +91,7 @@ export default class Inspector extends PureComponent {
             );
 
             const processedViewConfiguration = this.preprocessViewConfiguration(
-                {node: nodeForContext}, [], {...originalViewConfiguration}, {...originalViewConfiguration}
+                {node: nodeForContext}, [], originalViewConfiguration, originalViewConfiguration
             );
 
             this.state.viewConfiguration = processedViewConfiguration || {...originalViewConfiguration};
@@ -128,7 +128,6 @@ export default class Inspector extends PureComponent {
     //
     preprocessViewConfiguration = (context = {}, path = [], viewConfiguration, originalViewConfiguration) => {
         const currentLevel = path.length === 0 ? viewConfiguration : $get(path, viewConfiguration);
-
         Object.keys(currentLevel).forEach(propertyName => {
             const propertyValue = currentLevel[propertyName];
             const newPath = path.slice();

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -120,12 +120,14 @@ export default class Inspector extends PureComponent {
     // Update viewConfiguration, while keeping originalViewConfiguration to read original property values from it
     //
     preprocessViewConfiguration = (context = {}, path = []) => {
-        const currentLevel = path.length === 0 ? this.state.viewConfiguration : $get(path, this.state.viewConfiguration);
+        const viewConfiguration = {...this.state.viewConfiguration};
+        const originalViewConfiguration = {...this.state.originalViewConfiguration};
+        const currentLevel = path.length === 0 ? viewConfiguration : $get(path, viewConfiguration);
         Object.keys(currentLevel).forEach(propertyName => {
             const propertyValue = currentLevel[propertyName];
             const newPath = path.slice();
             newPath.push(propertyName);
-            const originalPropertyValue = $get(newPath, this.state.originalViewConfiguration);
+            const originalPropertyValue = $get(newPath, originalViewConfiguration);
 
             if (propertyValue !== null && typeof propertyValue === 'object') {
                 this.preprocessViewConfiguration(context, newPath);
@@ -133,11 +135,11 @@ export default class Inspector extends PureComponent {
                 const {node} = context; // eslint-disable-line
                 const evaluatedValue = eval(originalPropertyValue.replace('ClientEval:', '')); // eslint-disable-line
                 if (evaluatedValue !== propertyValue) {
-                    this.setState(prevState => ({
-                        viewConfiguration: produce(prevState.viewConfiguration, draft => {
+                    this.setState({
+                        viewConfiguration: produce(viewConfiguration, draft => {
                             setIn(draft, newPath, evaluatedValue);
                         })
-                    }));
+                    });
                 }
             }
         });

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -101,7 +101,7 @@ export default class Inspector extends PureComponent {
         }
     }
 
-    componentDidMount() {
+    componentWillMount() {
         this.preprocessViewConfigurationDebounced();
     }
 

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -88,12 +88,10 @@ export default class Inspector extends PureComponent {
 
     componentWillReceiveProps(newProps) {
         if (newProps.focusedNode !== this.props.focusedNode) {
-            this.setState(prevState => ({
+            this.setState({
                 viewConfiguration: newProps.nodeTypesRegistry.getInspectorViewConfigurationFor($get('nodeType', newProps.focusedNode)),
-                originalViewConfiguration: {...prevState.viewConfiguration}
-            },
-            () => this.preprocessViewConfigurationDebounced()
-            ));
+                originalViewConfiguration: newProps.nodeTypesRegistry.getInspectorViewConfigurationFor($get('nodeType', newProps.focusedNode))
+            });
         }
         if (!newProps.shouldShowSecondaryInspector) {
             this.setState({

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -93,6 +93,10 @@ export default class Inspector extends PureComponent {
         }
     }
 
+    componentDidUpdate() {
+        this.preprocessViewConfigurationDebounced();
+    }
+
     componentWillUnmount() {
         // Abort any debounced calls
         this.preprocessViewConfigurationDebounced.cancel();
@@ -241,7 +245,6 @@ export default class Inspector extends PureComponent {
             return this.renderFallback();
         }
 
-        this.preprocessViewConfigurationDebounced();
         const {viewConfiguration} = this;
 
         if (!$get('tabs', viewConfiguration)) {

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -101,6 +101,10 @@ export default class Inspector extends PureComponent {
         }
     }
 
+    componentDidMount() {
+        this.preprocessViewConfigurationDebounced();
+    }
+
     componentDidUpdate() {
         this.preprocessViewConfigurationDebounced();
     }

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -139,9 +139,7 @@ export default class Inspector extends PureComponent {
             } else if (typeof originalPropertyValue === 'string' && originalPropertyValue.indexOf('ClientEval:') === 0) {
                 const {node} = context; // eslint-disable-line
                 try {
-                    const evaluatedValue = eval(
-                        originalPropertyValue.replace('ClientEval:', '')
-                    ); // eslint-disable-line
+                    const evaluatedValue = eval(originalPropertyValue.replace('ClientEval:', '')); // eslint-disable-line
                     if (evaluatedValue !== propertyValue) {
                         this.configurationIsProcessed = true;
                         viewConfiguration = produce(
@@ -152,7 +150,7 @@ export default class Inspector extends PureComponent {
                         );
                     }
                 } catch (e) {
-                    console.warn('An error occurred while trying to evaluate "' + originalPropertyValue + '"\n' , e);
+                    console.warn('An error occurred while trying to evaluate "' + originalPropertyValue + '"\n', e);
                 }
             }
         });

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -138,12 +138,21 @@ export default class Inspector extends PureComponent {
                 viewConfiguration = this.preprocessViewConfiguration(context, newPath, viewConfiguration, originalViewConfiguration);
             } else if (typeof originalPropertyValue === 'string' && originalPropertyValue.indexOf('ClientEval:') === 0) {
                 const {node} = context; // eslint-disable-line
-                const evaluatedValue = eval(originalPropertyValue.replace('ClientEval:', '')); // eslint-disable-line
-                if (evaluatedValue !== propertyValue) {
-                    this.configurationIsProcessed = true;
-                    viewConfiguration = produce(viewConfiguration, draft => {
-                        setIn(draft, newPath, evaluatedValue);
-                    });
+                try {
+                    const evaluatedValue = eval(
+                        originalPropertyValue.replace('ClientEval:', '')
+                    ); // eslint-disable-line
+                    if (evaluatedValue !== propertyValue) {
+                        this.configurationIsProcessed = true;
+                        viewConfiguration = produce(
+                            viewConfiguration,
+                            draft => {
+                                setIn(draft, newPath, evaluatedValue);
+                            }
+                        );
+                    }
+                } catch (e) {
+                    console.warn('An error occurred while trying to evaluate "' + originalPropertyValue + '"\n' , e);
                 }
             }
         });

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -94,8 +94,8 @@ export default class Inspector extends PureComponent {
                 {node: nodeForContext}, [], originalViewConfiguration, originalViewConfiguration
             );
 
-            this.state.viewConfiguration = processedViewConfiguration || {...originalViewConfiguration};
-            this.state.originalViewConfiguration = {...originalViewConfiguration};
+            this.state.viewConfiguration = processedViewConfiguration || originalViewConfiguration;
+            this.state.originalViewConfiguration = originalViewConfiguration;
         }
     }
 
@@ -161,8 +161,8 @@ export default class Inspector extends PureComponent {
         const processedViewConfiguration = this.preprocessViewConfiguration(
             {node: nodeForContext},
             [],
-            {...this.state.viewConfiguration},
-            {...this.state.originalViewConfiguration}
+            this.state.viewConfiguration,
+            this.state.originalViewConfiguration
         );
 
         if (this.configurationIsProcessed === true) {

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -78,6 +78,8 @@ export default class Inspector extends PureComponent {
         originalViewConfiguration: null
     };
 
+    configurationIsProcessed = false;
+
     constructor(props) {
         super(props);
 
@@ -139,6 +141,7 @@ export default class Inspector extends PureComponent {
                 const {node} = context; // eslint-disable-line
                 const evaluatedValue = eval(originalPropertyValue.replace('ClientEval:', '')); // eslint-disable-line
                 if (evaluatedValue !== propertyValue) {
+                    this.configurationIsProcessed = true;
                     viewConfiguration = produce(viewConfiguration, draft => {
                         setIn(draft, newPath, evaluatedValue);
                     });
@@ -155,6 +158,7 @@ export default class Inspector extends PureComponent {
             this.props.transientValues
         );
 
+        this.configurationIsProcessed = false;
         const processedViewConfiguration = this.preprocessViewConfiguration(
             {node: nodeForContext},
             [],
@@ -162,7 +166,7 @@ export default class Inspector extends PureComponent {
             {...this.state.originalViewConfiguration}
         );
 
-        if (JSON.stringify(processedViewConfiguration) !== JSON.stringify(this.state.viewConfiguration)) {
+        if (this.configurationIsProcessed === true) {
             this.setState({
                 viewConfiguration: processedViewConfiguration
             });

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -91,7 +91,9 @@ export default class Inspector extends PureComponent {
             this.setState(prevState => ({
                 viewConfiguration: newProps.nodeTypesRegistry.getInspectorViewConfigurationFor($get('nodeType', newProps.focusedNode)),
                 originalViewConfiguration: {...prevState.viewConfiguration}
-            }));
+            },
+            () => this.preprocessViewConfigurationDebounced()
+            ));
         }
         if (!newProps.shouldShowSecondaryInspector) {
             this.setState({


### PR DESCRIPTION
There was a call within the render method that contained `this.forceUpdate()`, which led to a warning in the console only visible for dev builds.

Moving the call to the `componentDidUpdate` lifecycle function resolves the issue while keeping the same functionality (`ClientEval` annotations are still evaluated).