### PR TITLE
BUGFIX: Avoid use of undefined constant

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -170,7 +170,10 @@ class BackendController extends ActionController
      */
     protected function initializeRedirectToAction()
     {
-        $this->arguments->getArgument('node')->getPropertyMappingConfiguration()->setTypeConverterOption(NodeConverter::class, NodeConverter::INVISIBLE_CONTENT_SHOWN, true);
+        // use this constant only if available (became available with patch level releases in Neos 4.0 and up)
+        if (defined(NodeConverter::class . '::INVISIBLE_CONTENT_SHOWN')) {
+            $this->arguments->getArgument('node')->getPropertyMappingConfiguration()->setTypeConverterOption(NodeConverter::class, NodeConverter::INVISIBLE_CONTENT_SHOWN, true);
+        }
     }
 
     /**


### PR DESCRIPTION
This fixes an error with the UI on earlier Neos versions that lack a
constant introduced to fix #2500.

See #2557
