### PR TITLE
TASK: Remove deprecation warning

### DIFF
--- a/packages/neos-ui/src/index.js
+++ b/packages/neos-ui/src/index.js
@@ -21,8 +21,8 @@ import Root from './Containers/Root';
 import apiExposureMap from './apiExposureMap';
 import DelegatingReducer from './DelegatingReducer';
 
-const devToolsArePresent = typeof window === 'object' && typeof window.devToolsExtension !== 'undefined';
-const devToolsStoreEnhancer = () => devToolsArePresent ? window.devToolsExtension() : f => f;
+const devToolsArePresent = typeof window === 'object' && typeof window.__REDUX_DEVTOOLS_EXTENSION__ !== 'undefined';
+const devToolsStoreEnhancer = () => devToolsArePresent ? window.__REDUX_DEVTOOLS_EXTENSION__() : f => f;
 const sagaMiddleWare = createSagaMiddleware();
 
 const delegatingReducer = new DelegatingReducer();


### PR DESCRIPTION
**What I did**
Switched from deprecated `window.devToolsExtension` to its replacer `window.__REDUX_DEVTOOLS_EXTENSION__`

**How to verify it**
1. The deprecation warning is gone.
2. Devtools still works.
3. Still passes all tests.

**Before**
<img width="441" alt="Screen Shot showing a deprecation warning" src="https://user-images.githubusercontent.com/47516968/69004841-d4cbf900-095c-11ea-8676-7d6b0ec099bc.png">

**After**
<img width="441" alt="Screen Shot not showing any deprecation warning" src="https://user-images.githubusercontent.com/47516968/69004851-e9a88c80-095c-11ea-9d06-e6080c818e54.png">
