### PR TITLE
FEATURE: Allow StringLengthValidator to ignore HTML tags

### DIFF
--- a/packages/neos-ui-validators/src/StringLength/index.spec.js
+++ b/packages/neos-ui-validators/src/StringLength/index.spec.js
@@ -89,3 +89,31 @@ test('should return an error message if maximum < minimum', () => {
 
     expect(stringLengthValidator('123456', validatorOptions)).toBe('The maximum is less than the minimum.');
 });
+
+test('"abc <br />" should return an error message for max: 5 and not ignore the html', () => {
+    const validatorOptions = {
+        maximum: 5,
+        ignoreHtml: false
+    };
+
+    expect(stringLengthValidator('abc <br />', validatorOptions)).not.toBe(null);
+});
+
+test('"abc <br />" should be valid for max: 5 and ignore the html', () => {
+    const validatorOptions = {
+        maximum: 5,
+        ignoreHtml: true
+    };
+
+    expect(stringLengthValidator('abc <br />', validatorOptions)).toBe(null);
+});
+
+test('"abc <br />" should be valid for min:5 and max: 10 and ignore the html', () => {
+    const validatorOptions = {
+        minimum: 5,
+        maximum: 10,
+        ignoreHtml: true
+    };
+
+    expect(stringLengthValidator('abcd <br />', validatorOptions)).toBe(null);
+});

--- a/packages/neos-ui-validators/src/StringLength/index.tsx
+++ b/packages/neos-ui-validators/src/StringLength/index.tsx
@@ -32,8 +32,8 @@ const StringLength = (value: any, validatorOptions: StringLengthOptions) => {
 
     let castedValue = value.toString ? value.toString() : '';
     if (validatorOptions.ignoreHtml) {
-        const document = new DOMParser().parseFromString(castedValue, 'text/html');
-        castedValue = document.body.textContent ? document.body.textContent : castedValue;
+        const doc = new DOMParser().parseFromString(castedValue, 'text/html');
+        castedValue = doc.body.textContent ? document.body.textContent : castedValue;
     }
     const stringLength = castedValue.length;
     if (stringLength < minimum || stringLength > maximum) {

--- a/packages/neos-ui-validators/src/StringLength/index.tsx
+++ b/packages/neos-ui-validators/src/StringLength/index.tsx
@@ -33,7 +33,7 @@ const StringLength = (value: any, validatorOptions: StringLengthOptions) => {
     let castedValue = value.toString ? value.toString() : '';
     if (validatorOptions.ignoreHtml) {
         const doc = new DOMParser().parseFromString(castedValue, 'text/html');
-        castedValue = doc.body.textContent ? document.body.textContent : castedValue;
+        castedValue = doc.body.textContent ? doc.body.textContent : castedValue;
     }
     const stringLength = castedValue.length;
     if (stringLength < minimum || stringLength > maximum) {

--- a/packages/neos-ui-validators/src/StringLength/index.tsx
+++ b/packages/neos-ui-validators/src/StringLength/index.tsx
@@ -32,8 +32,8 @@ const StringLength = (value: any, validatorOptions: StringLengthOptions) => {
 
     let castedValue = value.toString ? value.toString() : '';
     if (validatorOptions.ignoreHtml) {
-        const doc = new DOMParser().parseFromString(castedValue, 'text/html');
-        castedValue = doc.body.textContent ? doc.body.textContent : castedValue;
+        const documentNode = new DOMParser().parseFromString(castedValue, 'text/html');
+        castedValue = documentNode.body.textContent ? documentNode.body.textContent : castedValue;
     }
     const stringLength = castedValue.length;
     if (stringLength < minimum || stringLength > maximum) {


### PR DESCRIPTION
Adds an option `ignoreHtml` to the StringLengthValidator

Usage:

      validation:
        'Neos.Neos/Validation/StringLengthValidator':
          maximum: 10
          ignoreHtml: true

Resolves: #2579