### PR TITLE
TASK: Upgrade react-close-on-escape to version 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "prop-types": "^15.5.10",
     "raf": "^3.4.1",
     "react": "^16.4",
-    "react-close-on-escape": "^2.0.0",
+    "react-close-on-escape": "^3.0.0",
     "react-codemirror2": "^6.0.0",
     "react-collapse": "^2.4.1",
     "react-datetime": "^2.8.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11008,9 +11008,10 @@ react-addons-create-fragment@^15.5.3:
     loose-envify "^1.3.1"
     object-assign "^4.1.0"
 
-react-close-on-escape@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-close-on-escape/-/react-close-on-escape-2.0.0.tgz#d3bf6d18fac516979d76e7732fda39057176f017"
+react-close-on-escape@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-close-on-escape/-/react-close-on-escape-3.0.0.tgz#02ea1f78301cd3e3c24c944cdfde2b37456c870a"
+  integrity sha512-cpOkGa/FPOYbvXw1HmNNCQLTKlXEPkfA0MXBat9ui7bGRnqNNQUGTQg6fadW1F/MYGnsGrHjex77DfkqNYHjUw==
 
 react-codemirror2@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
Updates the library react-close-on-escape to version 3.|
This is used in the dialogs of the UI