### PR TITLE
FEATURE: Parse backend errors instead of showing raw code

### DIFF
--- a/packages/neos-ui/src/index.js
+++ b/packages/neos-ui/src/index.js
@@ -165,7 +165,7 @@ function * application() {
             }
         }
         // Check if the message is a JSON string
-        else if (message.indexOf('{') >= 0) {
+        else if (message.trim()[0] === '{') {
             try {
                 const jsonMessage = JSON.parse(message);
                 if (jsonMessage.error && jsonMessage.error.message) {

--- a/packages/neos-ui/src/index.js
+++ b/packages/neos-ui/src/index.js
@@ -163,9 +163,8 @@ function * application() {
             } else {
                 message = 'Unknown error from unexpected HTML response. Check the logs for details.';
             }
-        }
-        // Check if the message is a JSON string
-        else if (message.trim()[0] === '{') {
+        } else if (message.trim()[0] === '{') {
+            // Check if the message is a JSON string
             try {
                 const jsonMessage = JSON.parse(message);
                 if (jsonMessage.error && jsonMessage.error.message) {


### PR DESCRIPTION
**What I did**

Show human readable output instead of code in the error flash messages.

**How I did it**

Check what kind of text we have in a backend flash message error and parse it.

**How to verify it**

Go to the Forms example in the Demo site and then:

Force JSON error: Rename the form nodetype datasource in yaml to something else.

Force 500 HTML error: break PHP code in form datasource. F.e. by adding `$foo = $forms * $formDefinitions;`

JSON error before:

<img width="591" alt="Bildschirmfoto 2019-11-27 um 12 04 02" src="https://user-images.githubusercontent.com/596967/69718996-e1e0a900-110f-11ea-81a1-43dca2f4dd55.png">

JSON error after:

<img width="780" alt="Bildschirmfoto 2019-11-27 um 12 03 34" src="https://user-images.githubusercontent.com/596967/69718997-e1e0a900-110f-11ea-8338-99604c144028.png">

HTML error before:

<img width="941" alt="Bildschirmfoto 2019-11-27 um 12 02 20" src="https://user-images.githubusercontent.com/596967/69718998-e1e0a900-110f-11ea-801f-cd4325e0e617.png">

HTML error after:

<img width="635" alt="Bildschirmfoto 2019-11-27 um 12 01 39" src="https://user-images.githubusercontent.com/596967/69718999-e1e0a900-110f-11ea-9030-4d074b27203d.png">

