### PR TITLE
BUGFIX: Concat the label parts of the param replacement

### DIFF
--- a/packages/neos-ui-i18n/src/registry/I18nRegistry.js
+++ b/packages/neos-ui-i18n/src/registry/I18nRegistry.js
@@ -56,7 +56,7 @@ const substitutePlaceholders = function (textWithPlaceholders, parameters) {
 
     result.push(textWithPlaceholders.substr(offset));
 
-    return result;
+    return result.join('');
 };
 
 export default class I18nRegistry extends SynchronousRegistry {


### PR DESCRIPTION
The method substitutePlaceholders replaces the markers in language
labels with the given variables. For that all substrings will be saved in an
array and the array will be returned.

This patch concats the array items to a string. Because the translate method returns
strings in general and not arrays.

**What I did**
Just concat the array items to a string so that the return of the translate is consistent.

**How to verify it**

Use a label in JS like that.
```javascript
const label = i18nRegistry.translate(
    'labelId',
    'Default',
    {
        paramA: foo,
        paramB: bar
    },
    'Neos.Neos.Ui'
);
```

Create your label like
```xml
<trans-unit id="labelId" xml:space="preserve">
    <source>{paramA}: Don't be a fool, {paramB}</source>
</trans-unit>
```

Without the params the translate method will just return `{paramA}: Don't be a fool, {paramB}` as string.
But when you submit params you will get an array like that:
```javascript
[
    "",
    "foo",
    ": Don't be a fool, ",
    "bar"
]
```

So this patch will join that and you have your regular label as string with params.