### PR TITLE
TASK: Append showInvisible only if needed

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -184,7 +184,11 @@ class BackendController extends ActionController
     {
         $this->response->getHeaders()->setCacheControlDirective('no-cache');
         $this->response->getHeaders()->setCacheControlDirective('no-store');
-        $this->redirect('show', 'Frontend\Node', 'Neos.Neos', ['node' => $node, 'showInvisible' => true]);
+        if ($node->isHidden()) {
+            $this->redirect('show', 'Frontend\Node', 'Neos.Neos', ['node' => $node, 'showInvisible' => true]);
+        } else {
+            $this->redirect('show', 'Frontend\Node', 'Neos.Neos', ['node' => $node]);
+        }
     }
 
     /**

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -184,7 +184,7 @@ class BackendController extends ActionController
     {
         $this->response->getHeaders()->setCacheControlDirective('no-cache');
         $this->response->getHeaders()->setCacheControlDirective('no-store');
-        if ($node->isHidden()) {
+        if ($node->isHidden() && $node->getContext()->getWorkspace()->isPublicWorkspace()) {
             $this->redirect('show', 'Frontend\Node', 'Neos.Neos', ['node' => $node, 'showInvisible' => true]);
         } else {
             $this->redirect('show', 'Frontend\Node', 'Neos.Neos', ['node' => $node]);


### PR DESCRIPTION
This appends the `showInvisible` query parameter only of the node to be
previewed is actually hidden.

See #2500 