### PR TITLE
FEATURE: Increase hitarea to toggle groups in sidebar and inspector

### DIFF
--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/ToggleContentTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/ToggleContentTree/index.js
@@ -27,11 +27,10 @@ export default class ToggleContentTree extends PureComponent {
         const {id, isPanelOpen, i18nRegistry} = this.props;
 
         return (
-            <div className={style.toggle}>
+            <div className={style.toggle} onClick={this.handleClick}>
                 <IconButton
                     id={id}
                     className={style.toggleBtn}
-                    onClick={this.handleClick}
                     icon={isPanelOpen ? 'chevron-circle-down' : 'chevron-circle-up'}
                     hoverStyle="clean"
                     aria-label={i18nRegistry.translate('Neos.Neos:Main:toggleContentTree', 'Toggle content tree')}

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/ToggleContentTree/style.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/ToggleContentTree/style.css
@@ -1,3 +1,6 @@
+.toggle {
+    cursor: pointer;
+}
 .toggleBtn {
     background: var(--colors-ContrastDarkest);
     width: 46px;

--- a/packages/neos-ui/src/Containers/LeftSideBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/index.js
@@ -67,7 +67,6 @@ export default class LeftSideBar extends PureComponent {
                 icon={toggleIcon}
                 className={style.leftSideBar__toggleBtn}
                 hoverStyle="clean"
-                onClick={this.handleToggle}
                 title={i18nRegistry.translate('Neos.Neos:Main:navigate')}
                 />
         );
@@ -78,7 +77,7 @@ export default class LeftSideBar extends PureComponent {
                 className={classNames}
                 aria-hidden={isHidden ? 'true' : 'false'}
                 >
-                <div className={style.leftSideBar__header}>
+                <div className={style.leftSideBar__header} onClick={this.handleToggle}>
                     {toggle}
                     {i18nRegistry.translate('Neos.Neos:Main:documentTree', 'Document Tree')}
                 </div>

--- a/packages/neos-ui/src/Containers/LeftSideBar/style.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/style.css
@@ -69,6 +69,7 @@
     }
 }
 .leftSideBar__header {
+    cursor: pointer;
     height: 41px;
     padding-left: 55px;
     line-height: 40px;

--- a/packages/react-ui-components/src/ToggablePanel/__snapshots__/toggablePanel.spec.js.snap
+++ b/packages/react-ui-components/src/ToggablePanel/__snapshots__/toggablePanel.spec.js.snap
@@ -26,6 +26,7 @@ exports[`<Contents/> should render correctly. 1`] = `
 exports[`<Header/> should render correctly. 1`] = `
 <div
   aria-expanded={false}
+  onClick={[MockFunction]}
 >
   <Component
     className="panelHeadlineClassName"
@@ -37,7 +38,6 @@ exports[`<Header/> should render correctly. 1`] = `
     className="panelToggleBtnClassName"
     hoverStyle="clean"
     icon="closed-icon-prop"
-    onClick={[MockFunction]}
   />
 </div>
 `;

--- a/packages/react-ui-components/src/ToggablePanel/style.css
+++ b/packages/react-ui-components/src/ToggablePanel/style.css
@@ -5,6 +5,7 @@
 
 .panel__headline {
     composes: reset from './../reset.css';
+    cursor: pointer;
     height: var(--spacing-GoldenUnit);
     margin: 0;
     padding: 0 var(--spacing-Full);

--- a/packages/react-ui-components/src/ToggablePanel/toggablePanel.js
+++ b/packages/react-ui-components/src/ToggablePanel/toggablePanel.js
@@ -219,7 +219,7 @@ export class Header extends PureComponent {
         });
 
         return (
-            <div aria-expanded={isPanelOpen} {...rest}>
+            <div aria-expanded={isPanelOpen} onClick={onPanelToggle} {...rest}>
                 <HeadlineComponent
                     className={finalClassName}
                     type="h2"
@@ -230,7 +230,6 @@ export class Header extends PureComponent {
                     className={theme.panel__toggleBtn}
                     hoverStyle="clean"
                     icon={isPanelOpen ? openedIcon : closedIcon}
-                    onClick={onPanelToggle}
                     id={toggleButtonId}
                     />
             </div>


### PR DESCRIPTION
**What I did**

Allow toggling groups in the sidebar / inspector by clicking on the whole group header
instead of just the icon.

**How I did it**

Move the onClick handler to the wrap instead of the button and adjust the pointer via CSS.

**How to verify it**

Click the "Content tree", "Document tree" or any inspector group header.

resolves #2601
