### PR TITLE
FEATURE: Prevent page reload when editing fixed childnodes

### DIFF
--- a/Classes/Domain/Model/Changes/Property.php
+++ b/Classes/Domain/Model/Changes/Property.php
@@ -239,7 +239,9 @@ class Property extends AbstractChange
                     // which would allows us to reload its children. Then we request a reload on the child that is
                     // a parent of our modified node.
                     $closestCollectionChildNode = $node;
-                    while (!($closestCollectionChildNode->getParent()->getNodeType()->isOfType('Neos.Neos:ContentCollection') || $closestCollectionChildNode->getParent()->getNodeType()->isOfType('Neos.Neos:Document'))) {
+                    while ($closestCollectionChildNode->getParent()
+                        && !($closestCollectionChildNode->getParent()->getNodeType()->isOfType('Neos.Neos:ContentCollection')
+                            || $closestCollectionChildNode->getParent()->getNodeType()->isOfType('Neos.Neos:Document'))) {
                         $closestCollectionChildNode = $closestCollectionChildNode->getParent();
                     }
                     if ($closestCollectionChildNode && $closestCollectionChildNode->getParent() && $closestCollectionChildNode->getParent()->getNodeType()->isOfType('Neos.Neos:ContentCollection')) {

--- a/Classes/Domain/Model/Changes/Property.php
+++ b/Classes/Domain/Model/Changes/Property.php
@@ -245,12 +245,12 @@ class Property extends AbstractChange
                         $closestCollectionChildNode = $closestCollectionChildNode->getParent();
                     }
                     if ($closestCollectionChildNode && $closestCollectionChildNode->getParent() && $closestCollectionChildNode->getParent()->getNodeType()->isOfType('Neos.Neos:ContentCollection')) {
-                        $fusionContextNodeType = $closestCollectionChildNode->getNodeType();
+                        $fusionContextNodeTypeTag = '<' . $closestCollectionChildNode->getNodeType() . '>';
 
-                        // Traverse to the fusion path that matches the closest node we can reload
+                        // Traverse to the fusion path that matches the tag of the closest node we can reload
                         $closestCollectionChildNodeFusionPath = explode('/', $this->getNodeDomAddress()->getFusionPath());
                         for ($i = count($closestCollectionChildNodeFusionPath) - 1; $i >= 0; $i--) {
-                            if (strpos($closestCollectionChildNodeFusionPath[$i], $fusionContextNodeType->getName()) === false) {
+                            if (strpos($closestCollectionChildNodeFusionPath[$i], $fusionContextNodeTypeTag) === false) {
                                 array_pop($closestCollectionChildNodeFusionPath);
                             } else {
                                 break;


### PR DESCRIPTION
**What I did**

Instead of telling the UI to force a reload on the whole document when a node is changed that is not child of a `ContentCollection` now the server looks for a node that can be safely reloaded in the list of parents of the node.

**How I did it**

Traverse the parents and fusion path of the node until we find a good spot to reload.

**How to verify it**

Add a node like the following to the demo site and edit the TextWithImage node.
Without this change the document reloads. With the change only the `FixedChildren` node.

```
'My.Site:Content.FixedChildren':
  superTypes:
    'Neos.Neos:Content': true
  ui:
    label: 'Node with fixed children'
    icon: columns
  childNodes:
    text:
      type: 'Neos.Demo:Content.Text'
    textWithImage:
      type: 'Neos.Demo:Content.TextWithImage'
```

```
prototype(My.Site:Content.FixedChildren) < prototype(Neos.Neos:ContentComponent) {

    text = ${q(node).children('text').get(0)}
    textWithImage = ${q(node).children('textWithImage').get(0)}

    renderer = afx`
        <div>
            <header>
                Der Header:
                <Neos.Demo:Content.Text @context.node={props.text} />
            </header>
            <section>
                Ein Bild mit Text:
                <Neos.Demo:Content.TextWithImage @context.node={props.textWithImage} />
            </section>
        </div>
    `
}
```