### PR TITLE
FEATURE: Save searchbar state in persitedState

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -146,6 +146,8 @@ Neos:
             isHidden: false
             contentTree:
               isHidden: true
+            searchBar:
+              searchToggled: true
           rightSideBar:
             isHidden: false
           addNodeModal:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -63,6 +63,7 @@ Neos:
           'UI.FullScreen.toggle': 't f'
           'UI.LeftSideBar.toggle': 't l'
           'UI.LeftSideBar.toggleContentTree': 't c'
+          'UI.LeftSideBar.toggleSearchBar': 't s'
 
           'UI.AddNodeModal.close': 'c m'
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -147,7 +147,7 @@ Neos:
             contentTree:
               isHidden: true
             searchBar:
-              searchToggled: true
+              searchToggled: false
           rightSideBar:
             isHidden: false
           addNodeModal:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -148,7 +148,7 @@ Neos:
             contentTree:
               isHidden: true
             searchBar:
-              searchToggled: false
+              isVisible: false
           rightSideBar:
             isHidden: false
           addNodeModal:

--- a/Tests/IntegrationTests/Fixtures/1Dimension/treeSearch.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/treeSearch.e2e.js
@@ -84,3 +84,14 @@ test('Pagetree search field state is stored', async t => {
         .expect(nodeTreeSearchInput.exists)
         .ok();
 });
+
+test('Pagetree search field toggles on hotkey', async t => {
+    subSection('Search is initially hidden and we open it with "t s"');
+    const nodeTreeSearchInput = ReactSelector('NodeTreeSearchInput');
+
+    await t
+        .pressKey('t')
+        .pressKey('s')
+        .expect(nodeTreeSearchInput.exists)
+        .ok();
+});

--- a/Tests/IntegrationTests/Fixtures/1Dimension/treeSearch.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/treeSearch.e2e.js
@@ -16,12 +16,10 @@ test('PageTree search and filter', async t => {
     const searchmePage = 'Searchme page';
     const searchmeShortcut = 'Searchme shortcut';
 
-    const nodeTreeSearchToggler = ReactSelector('NodeTreeSearchBar IconButton');
     const nodeTreeSearchInput = ReactSelector('NodeTreeSearchInput');
     const nodeTreeFilter = ReactSelector('NodeTreeFilter');
     const shortcutFilter = ReactSelector('NodeTreeFilter').find('li').withText('Shortcut');
     await t
-        .click(nodeTreeSearchToggler)
         .typeText(nodeTreeSearchInput, seachTerm)
         .expect(Page.treeNode.withText(seachTerm).count).eql(2, 'Two "Searchme" nodes should be found, one shortcut and one normal page')
         .expect(Page.treeNode.withText(notSearchedPage).exists).notOk('Other unsearched page should be hidden ');

--- a/Tests/IntegrationTests/Fixtures/1Dimension/treeSearch.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/treeSearch.e2e.js
@@ -16,10 +16,12 @@ test('PageTree search and filter', async t => {
     const searchmePage = 'Searchme page';
     const searchmeShortcut = 'Searchme shortcut';
 
+    const nodeTreeSearchToggler = ReactSelector('NodeTreeSearchBar IconButton');
     const nodeTreeSearchInput = ReactSelector('NodeTreeSearchInput');
     const nodeTreeFilter = ReactSelector('NodeTreeFilter');
     const shortcutFilter = ReactSelector('NodeTreeFilter').find('li').withText('Shortcut');
     await t
+        .click(nodeTreeSearchToggler)
         .typeText(nodeTreeSearchInput, seachTerm)
         .expect(Page.treeNode.withText(seachTerm).count).eql(2, 'Two "Searchme" nodes should be found, one shortcut and one normal page')
         .expect(Page.treeNode.withText(notSearchedPage).exists).notOk('Other unsearched page should be hidden ');

--- a/Tests/IntegrationTests/Fixtures/1Dimension/treeSearch.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/treeSearch.e2e.js
@@ -47,3 +47,40 @@ test('PageTree search and filter', async t => {
         .click(clearFilter)
         .expect(Page.treeNode.withText(notSearchedPage).exists).ok('Other unsearched page should shown again');
 });
+
+test('Pagetree search field can be toggled', async t => {
+    subSection('Search is initially hidden and can be opened');
+    const nodeTreeSearchToggler = ReactSelector('NodeTreeSearchBar IconButton');
+    const nodeTreeSearchInput = ReactSelector('NodeTreeSearchInput');
+
+    await t
+        .click(nodeTreeSearchToggler)
+        .expect(nodeTreeSearchInput.exists)
+        .ok();
+
+    subSection('Close the search input again');
+    await t
+        .click(nodeTreeSearchToggler)
+        .expect(nodeTreeSearchInput.exists)
+        .notOk();
+});
+
+test('Pagetree search field state is stored', async t => {
+    subSection('Search is initially hidden and we open it');
+    const nodeTreeSearchToggler = ReactSelector('NodeTreeSearchBar IconButton');
+    const nodeTreeSearchInput = ReactSelector('NodeTreeSearchInput');
+
+    await t
+        .click(nodeTreeSearchToggler)
+        .expect(nodeTreeSearchInput.exists)
+        .ok();
+
+    subSection('We reload the page');
+    await t.eval(() => location.reload(true));
+    await t.wait(5000);
+
+    subSection('We expect to have a visible search field');
+    await t
+        .expect(nodeTreeSearchInput.exists)
+        .ok();
+});

--- a/packages/neos-ui-redux-store/src/UI/LeftSideBar/index.ts
+++ b/packages/neos-ui-redux-store/src/UI/LeftSideBar/index.ts
@@ -10,7 +10,7 @@ export interface State extends Readonly<{
         isHidden: boolean;
     },
     searchBar:  {
-        searchToggled: boolean;
+        isVisible: boolean;
     };
 }> {}
 
@@ -20,7 +20,7 @@ export const defaultState: State = {
         isHidden: false
     },
     searchBar: {
-        searchToggled: false
+        isVisible: false
     }
 };
 
@@ -61,7 +61,7 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
         case system.INIT: {
             draft.isHidden = $get(['payload', 'ui', 'leftSideBar', 'isHidden'], action) || false;
             draft.contentTree.isHidden = $get(['payload', 'ui', 'leftSideBar', 'contentTree', 'isHidden'], action) || false;
-            draft.searchBar.searchToggled = $get(['payload', 'ui', 'leftSideBar', 'searchBar', 'searchToggled'], action) || false;
+            draft.searchBar.isVisible = $get(['payload', 'ui', 'leftSideBar', 'searchBar', 'isVisible'], action) || false;
             break;
         }
         case actionTypes.TOGGLE: {
@@ -73,7 +73,7 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
             break;
         }
         case actionTypes.TOGGLE_SEARCH_BAR: {
-            draft.searchBar.searchToggled = !draft.searchBar.searchToggled;
+            draft.searchBar.isVisible = !draft.searchBar.isVisible;
             break;
         }
     }

--- a/packages/neos-ui-redux-store/src/UI/LeftSideBar/index.ts
+++ b/packages/neos-ui-redux-store/src/UI/LeftSideBar/index.ts
@@ -8,6 +8,9 @@ export interface State extends Readonly<{
     isHidden: boolean;
     contentTree: {
         isHidden: boolean;
+    },
+    searchBar:  {
+        isHidden: boolean;
     };
 }> {}
 
@@ -15,6 +18,9 @@ export const defaultState: State = {
     isHidden: false,
     contentTree: {
         isHidden: false
+    },
+    searchBar: {
+        isHidden: true
     }
 };
 
@@ -25,7 +31,8 @@ export const defaultState: State = {
 //
 export enum actionTypes {
     TOGGLE = '@neos/neos-ui/UI/LeftSideBar/TOGGLE',
-    TOGGLE_CONTENT_TREE = '@neos/neos-ui/UI/LeftSideBar/TOGGLE_CONTENT_TREE'
+    TOGGLE_CONTENT_TREE = '@neos/neos-ui/UI/LeftSideBar/TOGGLE_CONTENT_TREE',
+    TOGGLE_SEARCH_BAR = '@neos/neos-ui/UI/LeftSideBar/TOGGLE_SEARCH_BAR'
 }
 
 /**
@@ -33,13 +40,15 @@ export enum actionTypes {
  */
 const toggle = () => createAction(actionTypes.TOGGLE);
 const toggleContentTree = () => createAction(actionTypes.TOGGLE_CONTENT_TREE);
+const toggleSearchBar = () => createAction(actionTypes.TOGGLE_SEARCH_BAR);
 
 //
 // Export the actions
 //
 export const actions = {
     toggle,
-    toggleContentTree
+    toggleContentTree,
+    toggleSearchBar
 };
 
 export type Action = ActionType<typeof actions>;
@@ -52,6 +61,7 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
         case system.INIT: {
             draft.isHidden = $get(['payload', 'ui', 'leftSideBar', 'isHidden'], action) || false;
             draft.contentTree.isHidden = $get(['payload', 'ui', 'leftSideBar', 'contentTree', 'isHidden'], action) || false;
+            draft.searchBar.isHidden = $get(['payload', 'ui', 'leftSideBar', 'searchBar', 'isHidden'], action) || true;
             break;
         }
         case actionTypes.TOGGLE: {
@@ -60,6 +70,10 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
         }
         case actionTypes.TOGGLE_CONTENT_TREE: {
             draft.contentTree.isHidden = !draft.contentTree.isHidden;
+            break;
+        }
+        case actionTypes.TOGGLE_SEARCH_BAR: {
+            draft.searchBar.isHidden = !draft.searchBar.isHidden;
             break;
         }
     }

--- a/packages/neos-ui-redux-store/src/UI/LeftSideBar/index.ts
+++ b/packages/neos-ui-redux-store/src/UI/LeftSideBar/index.ts
@@ -10,7 +10,7 @@ export interface State extends Readonly<{
         isHidden: boolean;
     },
     searchBar:  {
-        isHidden: boolean;
+        searchToggled: boolean;
     };
 }> {}
 
@@ -20,7 +20,7 @@ export const defaultState: State = {
         isHidden: false
     },
     searchBar: {
-        isHidden: true
+        searchToggled: false
     }
 };
 
@@ -61,7 +61,7 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
         case system.INIT: {
             draft.isHidden = $get(['payload', 'ui', 'leftSideBar', 'isHidden'], action) || false;
             draft.contentTree.isHidden = $get(['payload', 'ui', 'leftSideBar', 'contentTree', 'isHidden'], action) || false;
-            draft.searchBar.isHidden = $get(['payload', 'ui', 'leftSideBar', 'searchBar', 'isHidden'], action) || true;
+            draft.searchBar.searchToggled = $get(['payload', 'ui', 'leftSideBar', 'searchBar', 'searchToggled'], action) || false;
             break;
         }
         case actionTypes.TOGGLE: {
@@ -73,7 +73,7 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
             break;
         }
         case actionTypes.TOGGLE_SEARCH_BAR: {
-            draft.searchBar.isHidden = !draft.searchBar.isHidden;
+            draft.searchBar.searchToggled = !draft.searchBar.searchToggled;
             break;
         }
     }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/index.js
@@ -20,7 +20,7 @@ const searchDelay = 300;
 }))
 
 @connect($transform({
-    searchToggled: $get('ui.leftSideBar.searchBar.searchToggled')
+    isSearchBarVisible: $get('ui.leftSideBar.searchBar.isVisible')
 }), {
     toggleSearchBar: actions.UI.LeftSideBar.toggleSearchBar
 })
@@ -30,7 +30,7 @@ class NodeTreeSearchBar extends PureComponent {
         i18nRegistry: PropTypes.object.isRequired,
         rootNode: PropTypes.object,
         commenceSearch: PropTypes.func.isRequired,
-        searchToggled: PropTypes.bool.isRequired,
+        isSearchBarVisible: PropTypes.bool.isRequired,
         toggleSearchBar: PropTypes.func.isRequired
     }
 
@@ -84,13 +84,13 @@ class NodeTreeSearchBar extends PureComponent {
     }
 
     render() {
-        const {i18nRegistry, searchToggled} = this.props;
+        const {i18nRegistry, isSearchBarVisible} = this.props;
         const {searchValue, searchFocused, filterNodeType} = this.state;
         const searchLabel = i18nRegistry.translate('search', 'Search', {}, 'Neos.Neos', 'Main');
 
         const searchToggleClassName = mergeClassNames({
             [style.searchToggleButton]: true,
-            [style['searchToggleButton--active']]: searchToggled
+            [style['searchToggleButton--active']]: isSearchBarVisible
         });
 
         return (
@@ -100,7 +100,7 @@ class NodeTreeSearchBar extends PureComponent {
                     icon="ellipsis-v"
                     onClick={this.handleSearchToggle}
                     />
-                {searchToggled && (
+                {isSearchBarVisible && (
                     <div className={style.searchBar}>
                         <NodeTreeSearchInput
                             label={searchLabel}

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/index.js
@@ -2,7 +2,7 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import debounce from 'lodash.debounce';
-import {$get} from 'plow-js';
+import {$transform, $get} from 'plow-js';
 import mergeClassNames from 'classnames';
 
 import {neos} from '@neos-project/neos-ui-decorators';
@@ -19,15 +19,22 @@ const searchDelay = 300;
     i18nRegistry: globalRegistry.get('i18n')
 }))
 
+@connect($transform({
+    isHiddenSearchBar: $get('ui.leftSideBar.searchBar.isHidden')
+}), {
+    toggleSearchBar: actions.UI.LeftSideBar.toggleSearchBar
+})
+
 class NodeTreeSearchBar extends PureComponent {
     static propTypes = {
         i18nRegistry: PropTypes.object.isRequired,
         rootNode: PropTypes.object,
-        commenceSearch: PropTypes.func.isRequired
+        commenceSearch: PropTypes.func.isRequired,
+        isHiddenSearchBar: PropTypes.bool.isRequired,
+        toggleSearchBar: PropTypes.func.isRequired
     }
 
     state = {
-        searchToggled: false,
         searchFocused: false,
         searchValue: '',
         filterNodeType: null
@@ -72,19 +79,18 @@ class NodeTreeSearchBar extends PureComponent {
     }
 
     handleSearchToggle = () => {
-        this.setState({
-            searchToggled: !this.state.searchToggled
-        });
+        const {toggleSearchBar} = this.props;
+        toggleSearchBar();
     }
 
     render() {
-        const {i18nRegistry} = this.props;
-        const {searchToggled, searchValue, searchFocused, filterNodeType} = this.state;
+        const {i18nRegistry, isHiddenSearchBar} = this.props;
+        const {searchValue, searchFocused, filterNodeType} = this.state;
         const searchLabel = i18nRegistry.translate('search', 'Search', {}, 'Neos.Neos', 'Main');
 
         const searchToggleClassName = mergeClassNames({
             [style.searchToggleButton]: true,
-            [style['searchToggleButton--active']]: searchToggled
+            [style['searchToggleButton--active']]: !isHiddenSearchBar
         });
 
         return (
@@ -94,7 +100,7 @@ class NodeTreeSearchBar extends PureComponent {
                     icon="ellipsis-v"
                     onClick={this.handleSearchToggle}
                     />
-                {searchToggled && (
+                {!isHiddenSearchBar && (
                     <div className={style.searchBar}>
                         <NodeTreeSearchInput
                             label={searchLabel}

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/index.js
@@ -20,7 +20,7 @@ const searchDelay = 300;
 }))
 
 @connect($transform({
-    isHiddenSearchBar: $get('ui.leftSideBar.searchBar.isHidden')
+    searchToggled: $get('ui.leftSideBar.searchBar.searchToggled')
 }), {
     toggleSearchBar: actions.UI.LeftSideBar.toggleSearchBar
 })
@@ -30,7 +30,7 @@ class NodeTreeSearchBar extends PureComponent {
         i18nRegistry: PropTypes.object.isRequired,
         rootNode: PropTypes.object,
         commenceSearch: PropTypes.func.isRequired,
-        isHiddenSearchBar: PropTypes.bool.isRequired,
+        searchToggled: PropTypes.bool.isRequired,
         toggleSearchBar: PropTypes.func.isRequired
     }
 
@@ -84,13 +84,13 @@ class NodeTreeSearchBar extends PureComponent {
     }
 
     render() {
-        const {i18nRegistry, isHiddenSearchBar} = this.props;
+        const {i18nRegistry, searchToggled} = this.props;
         const {searchValue, searchFocused, filterNodeType} = this.state;
         const searchLabel = i18nRegistry.translate('search', 'Search', {}, 'Neos.Neos', 'Main');
 
         const searchToggleClassName = mergeClassNames({
             [style.searchToggleButton]: true,
-            [style['searchToggleButton--active']]: !isHiddenSearchBar
+            [style['searchToggleButton--active']]: searchToggled
         });
 
         return (
@@ -100,7 +100,7 @@ class NodeTreeSearchBar extends PureComponent {
                     icon="ellipsis-v"
                     onClick={this.handleSearchToggle}
                     />
-                {!isHiddenSearchBar && (
+                {searchToggled && (
                     <div className={style.searchBar}>
                         <NodeTreeSearchInput
                             label={searchLabel}

--- a/packages/neos-ui/src/localStorageMiddleware.js
+++ b/packages/neos-ui/src/localStorageMiddleware.js
@@ -40,7 +40,7 @@ const localStorageMiddleware = ({getState}) => {
                                 isHidden: $get('ui.leftSideBar.contentTree.isHidden', state)
                             },
                             searchBar: {
-                                searchToggled: $get('ui.leftSideBar.searchBar.searchToggled', state)
+                                isVisible: $get('ui.leftSideBar.searchBar.isVisible', state)
                             }
                         },
                         rightSideBar: {

--- a/packages/neos-ui/src/localStorageMiddleware.js
+++ b/packages/neos-ui/src/localStorageMiddleware.js
@@ -12,6 +12,7 @@ const localStorageMiddleware = ({getState}) => {
     const persistentActionsPatterns = [
         '@neos/neos-ui/UI/LeftSideBar/TOGGLE',
         '@neos/neos-ui/UI/LeftSideBar/TOGGLE_CONTENT_TREE',
+        '@neos/neos-ui/UI/LeftSideBar/TOGGLE_SEARCH_BAR',
         '@neos/neos-ui/UI/RightSidebar/TOGGLE',
         '@neos/neos-ui/UI/Drawer/TOGGLE_MENU_GROUP'
     ];
@@ -37,6 +38,9 @@ const localStorageMiddleware = ({getState}) => {
                             isHidden: $get('ui.leftSideBar.isHidden', state),
                             contentTree: {
                                 isHidden: $get('ui.leftSideBar.contentTree.isHidden', state)
+                            },
+                            searchBar: {
+                                isHidden: $get('ui.leftSideBar.searchBar.isHidden', state)
                             }
                         },
                         rightSideBar: {

--- a/packages/neos-ui/src/localStorageMiddleware.js
+++ b/packages/neos-ui/src/localStorageMiddleware.js
@@ -40,7 +40,7 @@ const localStorageMiddleware = ({getState}) => {
                                 isHidden: $get('ui.leftSideBar.contentTree.isHidden', state)
                             },
                             searchBar: {
-                                isHidden: $get('ui.leftSideBar.searchBar.isHidden', state)
+                                searchToggled: $get('ui.leftSideBar.searchBar.searchToggled', state)
                             }
                         },
                         rightSideBar: {

--- a/packages/neos-ui/src/manifest.hotkeys.js
+++ b/packages/neos-ui/src/manifest.hotkeys.js
@@ -31,6 +31,11 @@ manifest('main.hotkeys', {}, (globalRegistry, {frontendConfiguration}) => {
             action: actions.UI.LeftSideBar.toggleContentTree
         });
 
+        hotkeyRegistry.set('UI.LeftSideBar.toggleSearchBar', {
+            description: 'Toggle search bar',
+            action: actions.UI.LeftSideBar.toggleSearchBar
+        });
+
         hotkeyRegistry.set('UI.AddNodeModal.close', {
             description: 'Close Add-Node-Modal',
             action: actions.UI.AddNodeModal.close


### PR DESCRIPTION
**What I did**
Replaced the local state of the component with a redux persited state.
So that the state of the searchbar is stored in the local storage like the left sidebar or right sidebar.
So the users don`t need to open it over and over again.

**How to verify it**
Open or close the search bar in the left sidebar and reload. The state should be the same.

![Bildschirmfoto 2019-12-02 um 18 25 01](https://user-images.githubusercontent.com/1014126/69980719-12ba4700-1531-11ea-8352-a428f6fd3ebc.png)

Resolves: #2606