### PR TITLE
FEATURE: Allow inserting nodes into any position inside an element

### DIFF
--- a/Tests/IntegrationTests/Fixtures/1Dimension/createNewNodeInContainer.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/createNewNodeInContainer.e2e.js
@@ -1,0 +1,35 @@
+import {Selector} from 'testcafe';
+import {ReactSelector} from 'testcafe-react-selectors';
+import {beforeEach, subSection, checkPropTypes} from './../../utils.js';
+import {Page} from './../../pageModel';
+
+/* global fixture:true */
+
+fixture`Create new nodes`
+    .beforeEach(beforeEach)
+    .afterEach(() => checkPropTypes());
+
+test('Create a text node in a new container element at the correct position', async t => {
+    await t.switchToMainWindow();
+
+    subSection('Create content collection node');
+    await t
+        .click(Selector('#neos-ContentTree-ToggleContentTree'))
+        .click(Page.treeNode.withText('Content Collection (main)'))
+        .click(Selector('#neos-ContentTree-AddNode'))
+        .click(ReactSelector('NodeTypeItem').find('button>span>span').withText('Container'));
+    await Page.waitForIframeLoading(t);
+
+    subSection('Create text node in container');
+    await t
+        .click(Page.treeNode.withText('Container'))
+        .click(Selector('#neos-ContentTree-AddNode'))
+        .click(Selector('#into'))
+        .click(ReactSelector('NodeTypeItem').find('button>span>span').withText('Text'));
+    await Page.waitForIframeLoading(t);
+
+    await t.switchToIframe('[name="neos-content-main"]');
+
+    const textIsInWrap = Selector('.test-container .test-text').parent().hasClass('test-container__inner-wrap');
+    await t.expect(textIsInWrap).ok();
+});

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Content.Container.yaml
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Content.Container.yaml
@@ -1,0 +1,8 @@
+'Neos.TestNodeTypes:Content.Container':
+  superTypes:
+    'Neos.Neos:Content': true
+    'Neos.Neos:ContentCollection': true
+  ui:
+    label: Container
+    icon: icon-folder
+

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Resources/Private/Fusion/Content/Container/Container.fusion
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Resources/Private/Fusion/Content/Container/Container.fusion
@@ -1,0 +1,9 @@
+prototype(Neos.TestNodeTypes:Content.Container) < prototype(Neos.Neos:ContentComponent) {
+    renderer = afx`
+        <div class="test-container">
+            <div class="test-container__inner-wrap" data-__neos-insertion-anchor>
+                <Neos.Neos:ContentCollectionRenderer/>
+            </div>
+        </div>
+    `
+}

--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -11,6 +11,7 @@ import {SynchronousRegistry, SynchronousMetaRegistry} from '@neos-project/neos-u
 import {
     getGuestFrameDocument,
     findNodeInGuestFrame,
+    closestNodeInGuestFrame,
     findAllOccurrencesOfNodeInGuestFrame,
     createEmptyContentCollectionPlaceholderIfMissing,
     findAllChildNodes,
@@ -346,7 +347,16 @@ manifest('main', {}, globalRegistry => {
 
             case 'into':
             default:
-                parentElement.appendChild(contentElement);
+                // Check if an insertion anchor is defined and use this one for appending the childnode
+                let insertionParent = parentElement;
+                let insertionAnchors = parentElement.querySelectorAll('[data-__neos-insertion-anchor]');
+                for (let anchorElement of insertionAnchors) {
+                    if (closestNodeInGuestFrame(anchorElement) === parentElement) {
+                        insertionParent = anchorElement;
+                        break;
+                    }
+                }
+                insertionParent.appendChild(contentElement);
                 break;
         }
 

--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -335,6 +335,19 @@ manifest('main', {}, globalRegistry => {
         }
 
         const fusionPath = contentElement.dataset.__neosFusionPath;
+        // Check if an insertion anchor is defined and use this one for appending the childnode
+        const findInsertionParentByAnchor = () => {
+            let insertionParent = parentElement;
+            const insertionAnchors = parentElement.querySelectorAll('[data-__neos-insertion-anchor]');
+            for (const anchorElement of insertionAnchors) {
+                if (closestNodeInGuestFrame(anchorElement) === parentElement) {
+                    insertionParent = anchorElement;
+                    break;
+                }
+            }
+            return insertionParent;
+        };
+        const insertionParent = findInsertionParentByAnchor();
 
         switch (mode) {
             case 'before':
@@ -347,15 +360,6 @@ manifest('main', {}, globalRegistry => {
 
             case 'into':
             default:
-                // Check if an insertion anchor is defined and use this one for appending the childnode
-                let insertionParent = parentElement;
-                let insertionAnchors = parentElement.querySelectorAll('[data-__neos-insertion-anchor]');
-                for (let anchorElement of insertionAnchors) {
-                    if (closestNodeInGuestFrame(anchorElement) === parentElement) {
-                        insertionParent = anchorElement;
-                        break;
-                    }
-                }
                 insertionParent.appendChild(contentElement);
                 break;
         }


### PR DESCRIPTION
Before this change a new node was always inserted as direct child.
With this change there can be any number of dom nodes and one
can be defnied as anchor for insertion.
When multiple anchors exist, the first one will be used.

The primary use case is for me was to have a ContentCollection that is also a content element itself. Usually the content collection has its own wrapper and all the children are in there.
But when it's also a content with some custom markup it can have any structure and therefore we cannot just assume inserting the new node into the content nodes main tag is the right position.

**What I did**

Allow defining a subnode in the template of a content collection to be the parent of new nodes.

**How I did it**

A tag can have a new attribute which marks it as an anchor.
When a new node is inserted a check is made whether there is an anchortag inside the new nodes parent and if yes then this tag will be used to append the new child.

**How to verify it**

See included e2e test