### PR TITLE
BUGFIX: Focus node in tree after switching dimensions

### DIFF
--- a/packages/neos-ui-sagas/src/CR/ContentDimensions/index.js
+++ b/packages/neos-ui-sagas/src/CR/ContentDimensions/index.js
@@ -35,8 +35,9 @@ export function * watchSelectPreset() {
                 continue;
             }
 
-            const {nodeFrontendUri} = informationAboutNodeInTargetDimension;
+            const {nodeContextPath, nodeFrontendUri} = informationAboutNodeInTargetDimension;
             yield put(actions.UI.ContentCanvas.setSrc(nodeFrontendUri));
+            yield put(actions.UI.PageTree.focus(nodeContextPath));
         }
     });
 }


### PR DESCRIPTION
Previously, the focused node was not updated after switching,
leading to unexpected behaviour when hiding/deleting nodes from the
NodeTreeToolbar.

**What I did**
Focus new target node after switching dimensions from the DimensionSwitcher.

**How to verify it**
1. Select page in tree
2. Switch content dimensions
3. Hide or delete node from the toolbar

Old behaviour:
The node from the source dimension would be hidden/deleted.

New behaviour:
The node in the new dimension is hidden/deleted.
