### PR TITLE
TASK: Adjust circleci environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,25 +12,25 @@ aliases:
       - yarn-cache-v1-{{ checksum "yarn.lock" }}
 
   - &store_app_cache
-    key: full-app-cache-v2-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}-{{ checksum "Tests/IntegrationTests/TestDistribution/Configuration/Settings.yaml" }}
+    key: full-app-cache-v3-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}-{{ checksum "Tests/IntegrationTests/TestDistribution/Configuration/Settings.yaml" }}
     paths:
       - /home/circleci/app
 
   - &restore_app_cache
     keys:
-      - full-app-cache-v2-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}-{{ checksum "Tests/IntegrationTests/TestDistribution/Configuration/Settings.yaml" }}
-      - full-app-cache-v2-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}-
-      - full-app-cache-v2-
+      - full-app-cache-v3-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}-{{ checksum "Tests/IntegrationTests/TestDistribution/Configuration/Settings.yaml" }}
+      - full-app-cache-v3-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}-
+      - full-app-cache-v3-
 
   - &save_composer_cache
-    key: composer-cache-v1-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}
+    key: composer-cache-v3-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}
     paths:
       - /composer/cache-dir
 
   - &restore_composer_cache
     keys:
-      - composer-cache-v1-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}
-      - composer-cache-v1-
+      - composer-cache-v3-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}
+      - composer-cache-v3-
 
   - &attach_workspace
     at: *workspace_root
@@ -79,7 +79,7 @@ jobs:
     environment:
       COMPOSER_CACHE_DIR: /composer/cache-dir
     docker:
-      - image: quay.io/yeebase/ci-build:7.2
+      - image: quay.io/yeebase/ci-build:7.3
     steps:
       - attach_workspace: *attach_workspace
       - restore_cache: *restore_composer_cache
@@ -95,7 +95,7 @@ jobs:
     environment:
       FLOW_CONTEXT: Production
     docker:
-      - image: quay.io/yeebase/ci-build:7.2
+      - image: quay.io/yeebase/ci-build:7.3
       - image: circleci/mariadb:10.2
         environment:
           MYSQL_DATABASE: neos

--- a/Tests/IntegrationTests/TestDistribution/composer.json
+++ b/Tests/IntegrationTests/TestDistribution/composer.json
@@ -6,7 +6,7 @@
         "bin-dir": "bin"
     },
     "require": {
-        "neos/neos": "dev-master",
+      "neos/neos": "dev-master",
         "neos/flow": "dev-master",
         "neos/eel": "dev-master",
         "neos/fluid-adaptor": "dev-master",


### PR DESCRIPTION
Since we support mariadb 10.4 with 5.1 we should also use that. This commit also switch to php 7.3 for the end to end tests.
