### PR TITLE
BUGFIX: Prevent exception on missing context string

### DIFF
--- a/packages/neos-ui-backend-connector/src/Endpoints/Helpers.ts
+++ b/packages/neos-ui-backend-connector/src/Endpoints/Helpers.ts
@@ -26,6 +26,12 @@ export const searchParams = (params = {}) => {
     return searchParams;
 };
 
+export const getContextString = (uri: string) => {
+    const decodedUri = unescape(uri);
+    const uriParts = decodedUri.split('@');
+    return uriParts ? uriParts[1].split('.')[0] : '';
+};
+
 /**
  * Serializes an object to PHP-compatible URL serialization, with support for nested objects and arrays.
  *

--- a/packages/neos-ui-backend-connector/src/Endpoints/index.ts
+++ b/packages/neos-ui-backend-connector/src/Endpoints/index.ts
@@ -1,4 +1,4 @@
-import {urlWithParams, searchParams, getElementInnerText, getElementAttributeValue} from './Helpers';
+import {urlWithParams, searchParams, getElementInnerText, getElementAttributeValue, getContextString} from './Helpers';
 
 import fetchWithErrorHandling from '../FetchWithErrorHandling/index';
 import {Change, NodeContextPath, WorkspaceName, DimensionCombination, DimensionPresetCombination, DimensionName} from '@neos-project/neos-ts-interfaces';
@@ -478,7 +478,7 @@ export default (routes: Routes) => {
                 }
 
                 // Hackish way to get context string from uri
-                const contextString = nodeFrontendUri.split('@')[1].split('.')[0];
+                const contextString = getContextString(nodeFrontendUri);
                 // TODO: Temporary hack due to missing contextPath in the API response
                 const nodeContextPath = `${nodePath.innerHTML}@${contextString}`;
 


### PR DESCRIPTION
It can happen that the URI is encoded and then the context
string could not be extracted. It seems to be a change from
the preview urls.

(https://github.com/neos/neos-development-collection/pull/2654)
(https://github.com/neos/neos-ui/pull/2604)

This patch now decodes the frontend URI and checks if the
URI contains an @ part.
