### PR TITLE
BUGFIX: ensure scrolling in guest frame is limited to document dimensions

### DIFF
--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
@@ -137,20 +137,19 @@ export default class NodeToolbar extends PureComponent {
             return null;
         }
 
-        const {top, right} = getAbsolutePositionOfElementInGuestFrame(nodeElement);
+        const {top, width, rightAsMeasuredFromRightDocumentBorder} = getAbsolutePositionOfElementInGuestFrame(nodeElement);
 
         // TODO: hardcoded dimensions
         const TOOLBAR_WIDTH = 200;
         const TOOLBAR_HEIGHT = 50;
 
-        const rect = nodeElement.getBoundingClientRect();
         const toolbarPosition = {
             top: top - TOOLBAR_HEIGHT
         };
-        if (rect.right < TOOLBAR_WIDTH) {
+        if (width < TOOLBAR_WIDTH) {
             toolbarPosition.left = 0;
         } else {
-            toolbarPosition.right = right;
+            toolbarPosition.right = rightAsMeasuredFromRightDocumentBorder + 'px';
         }
 
         const {isSticky} = this.state;

--- a/packages/neos-ui-guest-frame/src/dom.js
+++ b/packages/neos-ui-guest-frame/src/dom.js
@@ -201,19 +201,21 @@ export const getGuestFrameScrollOffsetY = () => {
     return iframeWindow.scrollY || iframeWindow.pageYOffset || iframeDocument.body.scrollTop;
 };
 
-//
-// Get the absolute position of an element in the guest frame, clamped to
-// width and height of the guest frame (i.e. so that it is fully visible).
-//
-export const getAbsolutePositionOfElementInGuestFrame = element => {
-    if (element && element.getBoundingClientRect) {
-        const relativeDocumentDimensions = getGuestFrameDocument().documentElement.getBoundingClientRect();
-        const relativeElementDimensions = element.getBoundingClientRect();
-
-        return clampElementToDocumentDimensions(relativeElementDimensions, relativeDocumentDimensions);
+/**
+ * returns the clamped N, and the amount how much N has been clamped.
+ */
+const clampNumber = (n, min, max) => {
+    if (max < min) {
+        max = min;
     }
 
-    return {top: 0, left: 0, width: 0, height: 0};
+    if (n < min) {
+        return [min, min - n];
+    }
+    if (n > max) {
+        return [max, n - max];
+    }
+    return [n, 0];
 };
 
 // We export this function only for testing.
@@ -226,11 +228,11 @@ export const clampElementToDocumentDimensions = (elementDimensions, documentDime
 
     // Reduce width optionally by the "withShrinkAmount" (if "left" is partially outside the document);
     // then the width can be maximally as big as "remaining" width of the document (when subtracting the left value)
-    const [width,] = clampNumber(elementDimensions.width - widthShrinkAmount, 0, documentWidth - left);
+    const [width] = clampNumber(elementDimensions.width - widthShrinkAmount, 0, documentWidth - left);
 
     // Height works the same as width.
     const [top, heightShrinkAmount] = clampNumber(elementDimensions.top - documentDimensions.top, 0, documentHeight);
-    const [height,] = clampNumber(elementDimensions.height - heightShrinkAmount, 0, documentHeight - top);
+    const [height] = clampNumber(elementDimensions.height - heightShrinkAmount, 0, documentHeight - top);
 
     return {
         top,
@@ -250,24 +252,22 @@ export const clampElementToDocumentDimensions = (elementDimensions, documentDime
         rightAsMeasuredFromRightDocumentBorder: documentWidth - (left + width)
 
     };
-}
+};
 
-/**
- * returns the clamped N, and the amount how much N has been clamped.
- */
-const clampNumber = (n, min, max) => {
-    if (max < min) {
-        max = min;
+//
+// Get the absolute position of an element in the guest frame, clamped to
+// width and height of the guest frame (i.e. so that it is fully visible).
+//
+export const getAbsolutePositionOfElementInGuestFrame = element => {
+    if (element && element.getBoundingClientRect) {
+        const relativeDocumentDimensions = getGuestFrameDocument().documentElement.getBoundingClientRect();
+        const relativeElementDimensions = element.getBoundingClientRect();
+
+        return clampElementToDocumentDimensions(relativeElementDimensions, relativeDocumentDimensions);
     }
 
-    if (n < min) {
-        return [min, min - n];
-    }
-    if (n > max) {
-        return [max, n - max]
-    }
-    return [n, 0];
-}
+    return {top: 0, left: 0, width: 0, height: 0};
+};
 
 //
 // Checks whether the given element is visible to the user

--- a/packages/neos-ui-guest-frame/src/dom.js
+++ b/packages/neos-ui-guest-frame/src/dom.js
@@ -202,25 +202,72 @@ export const getGuestFrameScrollOffsetY = () => {
 };
 
 //
-// Get the absolute position of an element in the guest frame
+// Get the absolute position of an element in the guest frame, clamped to
+// width and height of the guest frame (i.e. so that it is fully visible).
 //
 export const getAbsolutePositionOfElementInGuestFrame = element => {
     if (element && element.getBoundingClientRect) {
         const relativeDocumentDimensions = getGuestFrameDocument().documentElement.getBoundingClientRect();
         const relativeElementDimensions = element.getBoundingClientRect();
 
-        return {
-            top: relativeElementDimensions.top - relativeDocumentDimensions.top,
-            left: relativeElementDimensions.left - relativeDocumentDimensions.left,
-            bottom: relativeDocumentDimensions.bottom - relativeElementDimensions.bottom,
-            right: relativeDocumentDimensions.right - relativeElementDimensions.right,
-            width: relativeElementDimensions.width,
-            height: relativeElementDimensions.height
-        };
+        return clampElementToDocumentDimensions(relativeElementDimensions, relativeDocumentDimensions);
     }
 
-    return {top: 0, left: 0, bottom: 0, right: 0};
+    return {top: 0, left: 0, width: 0, height: 0};
 };
+
+// We export this function only for testing.
+export const clampElementToDocumentDimensions = (elementDimensions, documentDimensions) => {
+    const documentWidth = documentDimensions.width;
+    const documentHeight = documentDimensions.height;
+
+    // If the "left" coordinate is outside the document, clamp it to the document width.
+    const [left, widthShrinkAmount] = clampNumber(elementDimensions.left - documentDimensions.left, 0, documentWidth);
+
+    // Reduce width optionally by the "withShrinkAmount" (if "left" is partially outside the document);
+    // then the width can be maximally as big as "remaining" width of the document (when subtracting the left value)
+    const [width,] = clampNumber(elementDimensions.width - widthShrinkAmount, 0, documentWidth - left);
+
+    // Height works the same as width.
+    const [top, heightShrinkAmount] = clampNumber(elementDimensions.top - documentDimensions.top, 0, documentHeight);
+    const [height,] = clampNumber(elementDimensions.height - heightShrinkAmount, 0, documentHeight - top);
+
+    return {
+        top,
+        left,
+        width,
+        height,
+        // The "right" and Bottom" values are calculated; and are at most documentWidth or documentHeight.
+        right: left + width,
+        bottom: top + height,
+
+        // the coordinates above are all measured from top-left corner of the document;
+        // that means you cannot use it inside a "right" css property for instance (which
+        // is measured from the right border instead).
+        //
+        // Because we need exactly this, we add an additional measurement; to be used
+        // in CSS "right" alignments.
+        rightAsMeasuredFromRightDocumentBorder: documentWidth - (left + width)
+
+    };
+}
+
+/**
+ * returns the clamped N, and the amount how much N has been clamped.
+ */
+const clampNumber = (n, min, max) => {
+    if (max < min) {
+        max = min;
+    }
+
+    if (n < min) {
+        return [min, min - n];
+    }
+    if (n > max) {
+        return [max, n - max]
+    }
+    return [n, 0];
+}
 
 //
 // Checks whether the given element is visible to the user

--- a/packages/neos-ui-guest-frame/src/dom.spec.js
+++ b/packages/neos-ui-guest-frame/src/dom.spec.js
@@ -1,0 +1,290 @@
+import { clampElementToDocumentDimensions } from './dom';
+
+const documentDimensions = {
+    top: 0,
+    height: 5,
+    bottom: 5,
+
+    left: 0,
+    width: 5,
+    right: 5
+}
+
+test(`no clamping because element is fully in document `, () => {
+    /**
+     *  ┌────────┐
+     *  │ ┌───┐  │
+     *  │ │   │  │
+     *  │ │   │  │
+     *  │ └───┘  │
+     *  └────────┘
+     */
+    const elementDimensions = {
+        top: 1,
+        height: 3,
+        bottom: 4,
+
+        left: 1,
+        width: 2,
+        right: 3
+    };
+
+
+    const actual = clampElementToDocumentDimensions(elementDimensions, documentDimensions);
+    expect(actual).toEqual({
+        ...elementDimensions,
+        rightAsMeasuredFromRightDocumentBorder: 2
+    });
+});
+
+describe('X Axis overflows', () => {
+    test(`clamping because element is moved partially outside viewport to right; should shrink dimensions of element`, () => {
+        /**
+         *  ┌────────┐
+         *  │      ┌─┼─┐
+         *  │      │ │ │
+         *  │      │ │ │
+         *  │      └─┼─┘
+         *  └────────┘
+         */
+
+        const elementDimensions = {
+            top: 1,
+            height: 3,
+            bottom: 4,
+
+            left: 4,
+            width: 2,
+            right: 6
+        };
+
+        const actual = clampElementToDocumentDimensions(elementDimensions, documentDimensions);
+        expect(actual).toEqual({
+            ...elementDimensions,
+            width: 1,
+            right: 5,
+            rightAsMeasuredFromRightDocumentBorder: 0
+        });
+    });
+
+    test(`clamping because element is moved fully outside viewport to right; should shrink dimensions of element to 0 px`, () => {
+        /**
+         * ┌────────┐
+         * │        │┌───┐
+         * │        ││   │
+         * │        ││   │
+         * │        │└───┘
+         * └────────┘
+         */
+
+        const elementDimensions = {
+            top: 1,
+            height: 3,
+            bottom: 4,
+
+            left: 6,
+            width: 2,
+            right: 8
+        };
+
+        const actual = clampElementToDocumentDimensions(elementDimensions, documentDimensions);
+        expect(actual).toEqual({
+            ...elementDimensions,
+            left: 5,
+            width: 0,
+            right: 5,
+            rightAsMeasuredFromRightDocumentBorder: 0
+        });
+    });
+
+    test(`clamping because element is moved partially outside viewport to left; should shrink dimensions`, () => {
+        /**
+         *   ┌────────┐
+         * ┌─┼─┐      │
+         * │ │ │      │
+         * │ │ │      │
+         * └─┼─┘      │
+         *   └────────┘
+         */
+
+        const elementDimensions = {
+            top: 1,
+            height: 3,
+            bottom: 4,
+
+            left: -1,
+            width: 2,
+            right: 1
+        };
+
+        const actual = clampElementToDocumentDimensions(elementDimensions, documentDimensions);
+        expect(actual).toEqual({
+            ...elementDimensions,
+            left: 0,
+            width: 1,
+            rightAsMeasuredFromRightDocumentBorder: 4
+        });
+    });
+
+    test(`clamping because element is moved fully outside viewport to left; should shrink dimensions of element to 0 px`, () => {
+        /**
+         *      ┌────────┐
+         * ┌───┐│        │
+         * │   ││        │
+         * │   ││        │
+         * └───┘│        │
+         *      └────────┘
+         */
+        const elementDimensions = {
+            top: 1,
+            height: 3,
+            bottom: 4,
+
+            left: -3,
+            width: 2,
+            right: -1
+        };
+
+        const actual = clampElementToDocumentDimensions(elementDimensions, documentDimensions);
+        expect(actual).toEqual({
+            ...elementDimensions,
+            left: 0,
+            width: 0,
+            right: 0,
+            rightAsMeasuredFromRightDocumentBorder: 5
+        });
+    });
+});
+
+describe('Y Axis overflows', () => {
+    test(`clamping because element is moved partially outside viewport to bottom; should shrink dimensions of element`, () => {
+        /**
+         * ┌────────┐
+         * │        │
+         * │        │
+         * │ ┌───┐  │
+         * │ │   │  │
+         * └─┼───┼──┘
+         *   └───┘
+         */
+
+        const elementDimensions = {
+            top: 4,
+            height: 2,
+            bottom: 6,
+
+            left: 1,
+            width: 2,
+            right: 3
+        };
+
+        const actual = clampElementToDocumentDimensions(elementDimensions, documentDimensions);
+        expect(actual).toEqual({
+            ...elementDimensions,
+            rightAsMeasuredFromRightDocumentBorder: 2,
+
+            height: 1,
+            bottom: 5
+        });
+    });
+
+    test(`clamping because element is moved fully outside viewport to bottom; should shrink dimensions of element to 0 px`, () => {
+        /**
+         * ┌────────┐
+         * │        │
+         * │        │
+         * │        │
+         * │        │
+         * └────────┘
+         *   ┌───┐
+         *   │   │
+         *   │   │
+         *   └───┘
+         */
+
+        const elementDimensions = {
+            top: 6,
+            height: 2,
+            bottom: 8,
+
+            left: 1,
+            width: 2,
+            right: 3
+        };
+
+        const actual = clampElementToDocumentDimensions(elementDimensions, documentDimensions);
+        expect(actual).toEqual({
+            ...elementDimensions,
+            rightAsMeasuredFromRightDocumentBorder: 2,
+
+            top: 5,
+            height: 0,
+            bottom: 5
+        });
+    });
+
+    test(`clamping because element is moved partially outside viewport to top; should shrink dimensions of element`, () => {
+        /**
+         *   ┌───┐
+         * ┌─┼───┼──┐
+         * │ │   │  │
+         * │ └───┘  │
+         * │        │
+         * │        │
+         * └────────┘
+         */
+
+        const elementDimensions = {
+            top: -1,
+            height: 2,
+            bottom: 1,
+
+            left: 1,
+            width: 2,
+            right: 3
+        };
+
+        const actual = clampElementToDocumentDimensions(elementDimensions, documentDimensions);
+        expect(actual).toEqual({
+            ...elementDimensions,
+            rightAsMeasuredFromRightDocumentBorder: 2,
+
+            top: 0,
+            height: 1
+        });
+    });
+
+    test(`clamping because element is moved fully outside viewport to top; should shrink dimensions of element to 0 px`, () => {
+        /**
+         *   ┌───┐
+         *   │   │
+         *   │   │
+         *   └───┘
+         * ┌────────┐
+         * │        │
+         * │        │
+         * │        │
+         * │        │
+         * └────────┘
+         */
+        const elementDimensions = {
+            top: -3,
+            height: 2,
+            bottom: -1,
+
+            left: 1,
+            width: 2,
+            right: 3
+        };
+
+        const actual = clampElementToDocumentDimensions(elementDimensions, documentDimensions);
+        expect(actual).toEqual({
+            ...elementDimensions,
+            rightAsMeasuredFromRightDocumentBorder: 2,
+
+            top: 0,
+            height: 0,
+            bottom: 0
+        });
+    });
+});

--- a/packages/neos-ui-guest-frame/src/dom.spec.js
+++ b/packages/neos-ui-guest-frame/src/dom.spec.js
@@ -1,4 +1,4 @@
-import { clampElementToDocumentDimensions } from './dom';
+import {clampElementToDocumentDimensions} from './dom';
 
 const documentDimensions = {
     top: 0,
@@ -8,7 +8,7 @@ const documentDimensions = {
     left: 0,
     width: 5,
     right: 5
-}
+};
 
 test(`no clamping because element is fully in document `, () => {
     /**
@@ -28,7 +28,6 @@ test(`no clamping because element is fully in document `, () => {
         width: 2,
         right: 3
     };
-
 
     const actual = clampElementToDocumentDimensions(elementDimensions, documentDimensions);
     expect(actual).toEqual({


### PR DESCRIPTION
Without this change, scrolling could happen outside the viewport boundaries,
if e.g. the to-be-scrolled-to-element is placed outside the main document
boundaries (as it happens in a slider component, for example).

This change:

- fixes the bug by clamping the return value of
  `getAbsolutePositionOfElementInGuestFrame` to the document dimensions
- adds lots of test cases for the specifics of clamping
- cleans up a minor detail in InlineUi/NodeToolbar

Resolves: #2040