### PR TITLE
TASK: Upgrade typesafe-actions to version 5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "regenerator": "^0.8.46",
     "reselect": "^3.0.1",
     "terser-webpack-plugin": "^2.3.1",
-    "typesafe-actions": "^4.4.2",
+    "typesafe-actions": "^5.1.0",
     "url-loader": "^3.0.0",
     "uuid": "^3.2.1",
     "webpack-cli": "^3.3.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15483,10 +15483,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typesafe-actions@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/typesafe-actions/-/typesafe-actions-4.4.2.tgz#8f817c479d12130b5ebb442032968b2a18929e1a"
-  integrity sha512-QW61P4cOX8dCNmrfpcUMjvU/MF/sFTC8/PlG9215W1gKDzZUBjRGdyYSO6ZcEUNsn491S2VpryJOHSIVSDqJrg==
+typesafe-actions@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/typesafe-actions/-/typesafe-actions-5.1.0.tgz#9afe8b1e6a323af1fd59e6a57b11b7dd6623d2f1"
+  integrity sha512-bna6Yi1pRznoo6Bz1cE6btB/Yy8Xywytyfrzu/wc+NFW3ZF0I+2iCGImhBsoYYCOWuICtRO4yHcnDlzgo1AdNg==
 
 typescript-compare@^0.0.2:
   version "0.0.2"


### PR DESCRIPTION
Normally this upgrade has breaking changes but we don't use this functions.
It is by the way a bit confusion that we ```import {action as createAction, ActionType} from 'typesafe-actions';``` because createAction is also part of the general API of `typesafe-actions`.

It is not a problem, more a naming thing because when you want to use the createAction you need to rename the import.