### PR TITLE
BUGFIX: Fix single AssetEditor uploads #2642

### DIFF
--- a/packages/neos-ui-editors/src/Editors/AssetEditor/index.js
+++ b/packages/neos-ui-editors/src/Editors/AssetEditor/index.js
@@ -153,9 +153,9 @@ export default class AssetEditor extends PureComponent {
             });
         } else {
             const value = values;
-            const valuePromise = (value.indexOf('/') === -1) ? Promise.resolve(value) : assetProxyImport(value);
+            const valuePromise = (typeof value === 'object' || value instanceof Object || value.indexOf('/') === -1) ? Promise.resolve(value) : assetProxyImport(value);
             valuePromise.then(value => {
-                this.props.commit(value.map(this.getIdentity));
+                this.props.commit(this.getIdentity(value));
                 this.setState({isLoading: false});
             });
         }


### PR DESCRIPTION
The AssetEditor changes to fix functionality for asset proxies sadly contained some code erorrs in the path for single usage editors. This breaks uploads with type errors. The change fixes that by adapting to similar code as is used in the multiple code path.

Fixes: #2642
