### PR TITLE
BUGFIX: Do not show login page in guest frame

### DIFF
--- a/packages/neos-ui-backend-connector/src/FetchWithErrorHandling/index.ts
+++ b/packages/neos-ui-backend-connector/src/FetchWithErrorHandling/index.ts
@@ -95,7 +95,10 @@ class FetchWithErrorHandling {
                 if (response.ok) {
                     // CASE: all good; no errors!
                     resolve(response);
-                } else if (response.status === 401) {
+                } else if (
+                    response.status === 401 ||
+                    response.headers.get('X-Authentication-Required')
+                ) {
                     // CASE: Unauthorized!
                     // - all following requests have to fail; thus we enqueue them.
                     // - we enqueue our current request; so that it is re-run after successful re-login.

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -43,13 +43,14 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
     const inlineEditorRegistry = globalRegistry.get('inlineEditors');
     const guestFrameWindow = getGuestFrameWindow();
     const documentInformation = Object.assign({}, guestFrameWindow['@Neos.Neos.Ui:DocumentInformation']);
+    const authenticationTimeout = yield select(selectors.System.authenticationTimeout);
 
     // The user may have navigated by clicking an inline link - that's why we need to update the contentCanvas URL to be in sync with the shown content.
-    // We need to set the src to the actual src of the iframe, and not retrive it from documentInformation, as it may differ, e.g. contain additional arguments.
+    // We need to set the src to the actual src of the iframe, and not retrieve it from documentInformation, as it may differ, e.g. contain additional arguments.
     yield put(actions.UI.ContentCanvas.setSrc(guestFrameWindow.document.location.href));
 
-    // If we have no document information, guest frame intialziation ends here
-    if (Object.entries(documentInformation).length === 0) {
+    // If we have no document information, guest frame initialziation ends here
+    if (Object.entries(documentInformation).length === 0 || authenticationTimeout === true) {
         return;
     }
 


### PR DESCRIPTION
We should now show (the ugly flashing) login page when an authentication error occurs, since we already handle the login within our login popup overlay.

Keeping the current page open and retrying after successful login is the more logical approach.

resolves: https://github.com/neos/neos-ui/issues/2644


