### PR TITLE
EditNodePrivilege not always respected in UI (Inspector loads; Drag&Drop in Tree works)

### DIFF
--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -307,7 +307,7 @@ export default class Node extends PureComponent {
                     onToggle={this.handleNodeToggle}
                     onClick={this.handleNodeClick}
                     dragAndDropContext={this.getDragAndDropContext()}
-                    dragForbidden={$get('isAutoCreated', node)}
+                    dragForbidden={$get('isAutoCreated', node) || !$get(['policy', 'canEdit'], node)}
                     title={labelTitle}
                     />
                 {this.isCollapsed() ? null : (

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -267,6 +267,11 @@ export default class Inspector extends PureComponent {
             i18nRegistry
         } = this.props;
 
+        if (!$get(['policy', 'canEdit'], focusedNode)) {
+            // We cannot edit the current node, so we disable the inspector.
+            return (<div></div>);
+        }
+
         const augmentedCommit = (propertyId, value, hooks) => {
             commit(propertyId, value, hooks, focusedNode);
         };


### PR DESCRIPTION
### Description

When node editing is forbidden using `EditNodePrivilege`, the user can still edit/modify it in the inspector or change its position in the node tree. As the backend forbids this behavior, he gets an exception on saving.

### Steps to Reproduce

1. as an example, in the Demo page, use the following `Policy.yaml`:

  ```yaml
  privilegeTargets:
    'Neos\ContentRepository\Security\Authorization\Privilege\Node\EditNodePrivilege':
      'Neos.Demo:EditPageNodes':
        matcher: 'nodeIsOfType("Neos.Demo:Document.Chapter")'
      'Neos.Demo:EditTextNodes':
        matcher: 'nodeIsOfType("Neos.Demo:Content.Text")'
  ```

  This policy forbids editing `Document.Chapter` nodes and `Text` nodes for *everybody*.

2. Log into the backend.
3. Select one of the following nodes:
   - In the page tree, select a chapter node
   - On a page, select a `Text` node through the Structure tree


4. The inspector is loaded as usual, with values filled in.
5. You can change values, press *apply* in inspector
6. You are greeted with an error message, as the data cannot be saved.

  <img width="840" alt="Screenshot 2020-01-13 at 09 52 27" src="https://user-images.githubusercontent.com/190777/72242745-759c0500-35ea-11ea-93b9-44ad8806430d.png">

The same happens when dragging disallowed nodes in the Node Tree.

#### Expected behavior

- The Inspector should be empty for non-editable nodes.
- Non-editable nodes should be not drag/droppable

### Affected Versions

UI: (all versions)

Resolves: #2647