### PR TITLE
FEATURE: publish transpiled (ES-Modules) version of react-ui-components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,15 @@ setup: check-requirements install build
 build-subpackages:
 	$(lerna) run build --concurrency 1
 
+# we build the react UI components ready for standalone usage;
+# so that they can be published on NPM properly.
+build-react-ui-components-standalone:
+	cd packages/react-ui-components && yarn run build-standalone-esm
+
+
 build:
 	make build-subpackages
+	make build-react-ui-components-standalone
 	NEOS_BUILD_ROOT=$(shell pwd) $(webpack) --progress --colors
 
 build-watch:

--- a/packages/react-ui-components/.gitignore
+++ b/packages/react-ui-components/.gitignore
@@ -7,3 +7,7 @@ coverage
 .idea
 lcov.info
 .idea
+
+# the following files are just for standalone usage
+lib-esm/
+.postcssrc

--- a/packages/react-ui-components/README.md
+++ b/packages/react-ui-components/README.md
@@ -87,6 +87,12 @@ yarn watch:build
 
 Please folllow these commit guidlines. [commit-analyzer](https://github.com/Inkdpixels/commit-analyzer)
 
+#### Building for standalone usage outside of Neos
+
+we build a `lib-esm/` folder to be consumed by e.g. webpack.
+
+This is done by `yarn run build-standalone-esm`.
+
 
 ## License
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/packages/react-ui-components/package.json
+++ b/packages/react-ui-components/package.json
@@ -2,9 +2,11 @@
   "name": "@neos-project/react-ui-components",
   "version": "4.0.3",
   "description": "The UI components which power the Neos backend application.",
+  "module": "./lib-esm/index",
   "main": "./src/index",
   "scripts": {
     "build": "exit 0",
+    "build-standalone-esm": "rm -Rf .postcssrc lib-esm && tsc --build tsconfig.esm.json && tsc --build tsconfig.esmtypes.json && rsync --prune-empty-dirs  -r --include='*/' --include='*.css' --exclude='*' src/ lib-esm -v && node scripts/generate-standalone-postcssrc.js",
     "build:watch": "exit 0",
     "test": "yarn jest -w 2 --coverage",
     "test:watch": "yarn jest --watch",

--- a/packages/react-ui-components/scripts/generate-standalone-postcssrc.js
+++ b/packages/react-ui-components/scripts/generate-standalone-postcssrc.js
@@ -1,0 +1,25 @@
+const styles = require('../../build-essentials/src/styles/styleConstants');
+const styleVars = styles.generateCssVarsObject(styles.config);
+
+const postcssRc = {
+    "modules": true,
+    "plugins": {
+        "autoprefixer": {},
+        // "postcss-css-variables" will EAT css class names with two dashes...
+        // so we will use "postcss-custom-properties" instead, which works properly.
+        "postcss-custom-properties": {
+            preserve: false,
+            importFrom: [
+                {
+                    customProperties: styleVars
+                }
+            ]
+        },
+        "postcss-import": {},
+        "postcss-nested": {},
+        'postcss-hexrgba': {}
+    }
+};
+
+const fs = require('fs');
+fs.writeFileSync(__dirname + '/../.postcssrc', JSON.stringify(postcssRc, null, 4));

--- a/packages/react-ui-components/src/DateInput/dateInput.tsx
+++ b/packages/react-ui-components/src/DateInput/dateInput.tsx
@@ -11,7 +11,7 @@ import Button from '../Button';
 import Icon from '../Icon';
 
 
-interface DateInputProps {
+export interface DateInputProps {
     /**
      * The Date instance which represents the selected value.
      */

--- a/packages/react-ui-components/src/DropDown/header.tsx
+++ b/packages/react-ui-components/src/DropDown/header.tsx
@@ -4,7 +4,7 @@ import mergeClassNames from 'classnames';
 import {PickDefaultProps} from '../../types';
 import {makeFocusNode} from './../_lib/focusNode';
 import Icon from '../Icon';
-import {IconProps} from '@neos-project/react-ui-components/src/Icon/icon';
+import {IconProps} from '../Icon/icon';
 
 interface ShallowDropDownHeaderTheme {
     readonly 'dropDown__btn': string;

--- a/packages/react-ui-components/src/DropDown/index.ts
+++ b/packages/react-ui-components/src/DropDown/index.ts
@@ -1,11 +1,11 @@
 import {themr} from '@friendsofreactjs/react-css-themr';
 
-import identifiers from '@neos-project/react-ui-components/src/identifiers';
+import identifiers from '../identifiers';
 import ContextDropDownWrapper, {
     StatelessDropDownWrapper,
     ContextDropDownHeader,
     ContextDropDownContents
-} from '@neos-project/react-ui-components/src/DropDown/wrapper';
+} from './wrapper';
 
 import style from './style.css';
 

--- a/packages/react-ui-components/src/DropDown/wrapper.tsx
+++ b/packages/react-ui-components/src/DropDown/wrapper.tsx
@@ -57,7 +57,7 @@ export const defaultProps: PickDefaultProps<DropDownWrapperProps, 'isOpen' | 'st
     style: 'default'
 };
 
-interface DropDownWrapperState {
+export interface DropDownWrapperState {
     readonly isOpen: boolean;
 }
 

--- a/packages/react-ui-components/src/IconButtonDropDown/iconButtonDropDown.tsx
+++ b/packages/react-ui-components/src/IconButtonDropDown/iconButtonDropDown.tsx
@@ -86,7 +86,7 @@ export const defaultProps: DefaultProps = {
     modeIcon: 'long-arrow-right',
 };
 
-interface IconButtonDropDownState {
+export interface IconButtonDropDownState {
     readonly isOpen: boolean;
 }
 

--- a/packages/react-ui-components/tsconfig.esm.json
+++ b/packages/react-ui-components/tsconfig.esm.json
@@ -1,0 +1,17 @@
+{
+  "exclude": [
+    "scripts/",
+    "**/*.spec.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.js",
+    "**/*.story.js"
+  ],
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "lib-esm",
+    "module": "esnext",
+    "target": "es6",
+    "moduleResolution": "node",
+    "allowJs": true
+  }
+}

--- a/packages/react-ui-components/tsconfig.esmtypes.json
+++ b/packages/react-ui-components/tsconfig.esmtypes.json
@@ -1,0 +1,19 @@
+{
+  "exclude": [
+    "scripts/",
+    "**/*.spec.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.js",
+    "**/*.story.js"
+  ],
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "lib-esm",
+    "module": "esnext",
+    "target": "esnext",
+    "moduleResolution": "node",
+    "allowJs": false
+  }
+}


### PR DESCRIPTION
To make react-ui-components usable standalone, we
should publish a transpiled-to-es-modules version
of the code, in the same manner as many other projects
publish their library code.

This way, the react-ui-components are embeddable
e.g. using parcel.js, or via webpack; without setting
up typescript compilation of node_modules (which is
discouraged).
