### PR TITLE
BUGFIX: Remove duplicate closing tag

### DIFF
--- a/Resources/Private/Translations/da/Main.xlf
+++ b/Resources/Private/Translations/da/Main.xlf
@@ -207,7 +207,7 @@
 			<target xml:lang="da">Skjul/vis inspektør</target></trans-unit>
     <trans-unit id="UI.RightSideBar.tabs.validationErrorTooltip" xml:space="preserve">
         <source>{tabName} - amount of properties with validation issues: {amountOfErrors}</source>
-        <target xml:lang="da">{tabName} - Antal egenskaber med valideringsproblemer: {amountOfErrors}</target></trans-unit>
+        <target xml:lang="da">{tabName} - Antal egenskaber med valideringsproblemer: {amountOfErrors}</target>
     </trans-unit>
 		<group id="UI.RightSideBar.tabs.validationErrorTooltip" restype="x-gettext-plurals">
 			<trans-unit id="UI.RightSideBar.tabs.validationErrorTooltip[0]" xml:space="preserve">


### PR DESCRIPTION
Simple fix, which makes the danish language XML valid again (just removing double closing tag).

Solves #2646 