### PR TITLE
FEATURE: Allow override of rootnodes in node trees

### DIFF
--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
@@ -147,6 +147,8 @@ export const PageTree = connect(state => ({
     setActiveContentCanvasContextPath: actions.CR.Nodes.setDocumentNode,
     moveNodes: actions.CR.Nodes.moveMultiple,
     requestScrollIntoView: null
+}, (stateProps, dispatchProps, ownProps) => {
+    return Object.assign({}, stateProps, dispatchProps, ownProps);
 })(NodeTree);
 
 export const ContentTree = connect(state => ({
@@ -159,4 +161,6 @@ export const ContentTree = connect(state => ({
     focus: actions.CR.Nodes.focus,
     moveNodes: actions.CR.Nodes.moveMultiple,
     requestScrollIntoView: actions.UI.ContentCanvas.requestScrollIntoView
+}, (stateProps, dispatchProps, ownProps) => {
+    return Object.assign({}, stateProps, dispatchProps, ownProps);
 })(NodeTree);

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/index.js
@@ -126,4 +126,6 @@ export const PageTreeSearchbar = connect(state => ({
     rootNode: selectors.CR.Nodes.siteNodeSelector(state)
 }), {
     commenceSearch: actions.UI.PageTree.commenceSearch
+}, (stateProps, dispatchProps, ownProps) => {
+    return Object.assign({}, stateProps, dispatchProps, ownProps);
 })(NodeTreeSearchBar);


### PR DESCRIPTION
With this change it’s possible to change the rootNode via a prop of the page and content tree for extensibility.

Example:

```
const PageTree = containerRegistry.get('LeftSideBar/Top/PageTree');

const ModifiedTree = () => (
        <PageTree rootNode={aRootNodeThatIsNotTheSite} />
 );

containerRegistry.set('LeftSideBar/Top/PageTree', ModifiedTree);
```

**What I did**

The `connect` method allows to define the order of how a components props are merged. By allowing outside props to override the state props it's now possible to change props like `rootNode` from the outside.

The current behaviour is unchanged.
