### PR TITLE
BUGFIX: Allow a contentcollection to be the insertion anchor

### DIFF
--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Resources/Private/Fusion/Content/Container/Container.fusion
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Resources/Private/Fusion/Content/Container/Container.fusion
@@ -1,8 +1,11 @@
 prototype(Neos.TestNodeTypes:Content.Container) < prototype(Neos.Neos:ContentComponent) {
     renderer = afx`
         <div class="test-container">
-            <div class="test-container__inner-wrap" data-__neos-insertion-anchor>
-                <Neos.Neos:ContentCollectionRenderer/>
+            <div class="test-container__outer-wrap">
+                <Neos.Neos:ContentCollection
+                    attributes.class="test-container__inner-wrap"
+                    attributes.data-__neos-insertion-anchor
+                />
             </div>
         </div>
     `

--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -340,7 +340,7 @@ manifest('main', {}, globalRegistry => {
             let insertionParent = parentElement;
             const insertionAnchors = parentElement.querySelectorAll('[data-__neos-insertion-anchor]');
             for (const anchorElement of insertionAnchors) {
-                if (closestNodeInGuestFrame(anchorElement) === parentElement) {
+                if (closestNodeInGuestFrame(anchorElement).dataset.__neosNodeContextpath === parentElement.dataset.__neosNodeContextpath) {
                     insertionParent = anchorElement;
                     break;
                 }


### PR DESCRIPTION
This is a fix for #2609 
which now allows to add the insertion-anchor attribute to
Neos.Neos:ContentCollection by default and use it at any position in
AFX for rendering and adding nodes instead of adding
the ContentCollectionRenderer and adding the attribute to the
wrap manually.

Previously the contextpath attribute of a content collection
would break this mechanism as it was checking that only the
outest parent has the contextpath.