### PR TITLE
BUGFIX: Internal server errors were not parsed

### DIFF
--- a/packages/neos-ui/src/index.js
+++ b/packages/neos-ui/src/index.js
@@ -173,6 +173,11 @@ function * application() {
                     message = 'Unknown error from unexpected JSON response. Check the logs for details.';
                 }
             } catch (e) {}
+        } else if (message.indexOf('Internal Server Error') >= 0) {
+            const htmlContainer = document.createElement('div');
+            htmlContainer.innerHTML = message;
+            const exception = htmlContainer.querySelector('body');
+            message = exception.textContent;
         }
 
         store.dispatch(actions.UI.FlashMessages.add('fetch error', message, 'error'));


### PR DESCRIPTION
Internal server errors without the Flow stacktrace html
were not properly parsed and rendered.
Therefore the raw html was shown as error message.