### PR TITLE
BUGFIX: logo.svg was missing in esm build

### DIFF
--- a/packages/react-ui-components/package.json
+++ b/packages/react-ui-components/package.json
@@ -6,7 +6,7 @@
   "main": "./src/index",
   "scripts": {
     "build": "exit 0",
-    "build-standalone-esm": "rm -Rf .postcssrc lib-esm && tsc --build tsconfig.esm.json && tsc --build tsconfig.esmtypes.json && rsync --prune-empty-dirs  -r --include='*/' --include='*.css' --exclude='*' src/ lib-esm -v && node scripts/generate-standalone-postcssrc.js",
+    "build-standalone-esm": "rm -Rf .postcssrc lib-esm && tsc --build tsconfig.esm.json && tsc --build tsconfig.esmtypes.json && rsync --prune-empty-dirs  -r --include='*/' --include='*.css' --include='*.svg' --exclude='*' src/ lib-esm -v && node scripts/generate-standalone-postcssrc.js",
     "build:watch": "exit 0",
     "test": "yarn jest -w 2 --coverage",
     "test:watch": "yarn jest --watch",


### PR DESCRIPTION
This caused an error when trying to build the library
