### PR TITLE
BUGFIX: Localize publish actions

### DIFF
--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -15,6 +15,9 @@ use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\I18n\Exception\InvalidLocaleIdentifierException;
+use Neos\Flow\I18n\Locale;
+use Neos\Flow\I18n\Service;
 use Neos\Flow\I18n\Translator;
 use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Mvc\RequestInterface;
@@ -117,6 +120,12 @@ class BackendServiceController extends ActionController
 
     /**
      * @Flow\Inject
+     * @var Service
+     */
+    protected $localizationService;
+
+    /**
+     * @Flow\Inject
      * @var ContentDimensionPresetSourceInterface
      */
     protected $contentDimensionsPresetSource;
@@ -139,6 +148,12 @@ class BackendServiceController extends ActionController
     {
         parent::initializeController($request, $response);
         $this->feedbackCollection->setControllerContext($this->getControllerContext());
+
+        try {
+            $this->localizationService->getConfiguration()->setCurrentLocale(new Locale($this->userService->getInterfaceLanguage()));
+        } catch (InvalidLocaleIdentifierException $e) {
+            // Do nothing, stay in the default locale
+        }
     }
 
     /**

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -15,6 +15,7 @@ use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\I18n\Translator;
 use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Mvc\RequestInterface;
 use Neos\Flow\Mvc\ResponseInterface;
@@ -121,6 +122,12 @@ class BackendServiceController extends ActionController
     protected $contentDimensionsPresetSource;
 
     /**
+     * @Flow\Inject
+     * @var Translator
+     */
+    protected $translator;
+
+    /**
      * Set the controller context on the feedback collection after the controller
      * has been initialized
      *
@@ -164,7 +171,7 @@ class BackendServiceController extends ActionController
             $changes->apply();
 
             $success = new Info();
-            $success->setMessage(sprintf('%d change(s) successfully applied.', $count));
+            $success->setMessage($this->translator->translateById('changesApplied', [$count], $count, null, 'Main', 'Neos.Neos.Ui'));
 
             $this->feedbackCollection->add($success);
             $this->persistenceManager->persistAll();
@@ -195,8 +202,10 @@ class BackendServiceController extends ActionController
                 $this->publishingService->publishNode($node, $targetWorkspace);
             }
 
+            $count = count($nodeContextPaths);
+
             $success = new Success();
-            $success->setMessage(sprintf('Published %d change(s) to %s.', count($nodeContextPaths), $targetWorkspaceName));
+            $success->setMessage($this->translator->translateById('changesPublished', [$count, $targetWorkspace->getTitle()], $count, null, 'Main', 'Neos.Neos.Ui'));
 
             $this->updateWorkspaceInfo($nodeContextPaths[0]);
             $this->feedbackCollection->add($success);
@@ -254,8 +263,10 @@ class BackendServiceController extends ActionController
                 $this->publishingService->discardNode($node);
             }
 
+            $count = count($nodeContextPaths);
+
             $success = new Success();
-            $success->setMessage(sprintf('Discarded %d node(s).', count($nodeContextPaths)));
+            $success->setMessage($this->translator->translateById('changesDiscarded', [$count], $count, null, 'Main', 'Neos.Neos.Ui'));
 
             $this->updateWorkspaceInfo($nodeContextPaths[0]);
             $this->feedbackCollection->add($success);

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -262,6 +262,36 @@
       <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve" approved="yes">
 				<source>Unfocus Node</source>
 			<target xml:lang="de">Fokus vom Node entfernen</target></trans-unit>
+        <group id="changesApplied" restype="x-gettext-plurals">
+            <trans-unit id="changesApplied[0]" xml:space="preserve">
+                <source>{0} change successfully applied.</source>
+                <target>{0} Änderung erfolgreich angewendet.</target>
+            </trans-unit>
+            <trans-unit id="changesApplied[1]" xml:space="preserve">
+                <source>{0} changes successfully applied.</source>
+                <target>{0} Änderungen erfolgreich angewendet.</target>
+            </trans-unit>
+        </group>
+        <group id="changesPublished" restype="x-gettext-plurals">
+            <trans-unit id="changesPublished[0]" xml:space="preserve">
+                <source>Published {0} change to "{1}".</source>
+                <target>{0} Änderung nach "{1}" veröffentlicht.</target>
+            </trans-unit>
+            <trans-unit id="changesPublished[1]" xml:space="preserve">
+                <source>Published {0} changes to "{1}".</source>
+                <target>{0} Änderungen nach "{1}" veröffentlicht.</target>
+            </trans-unit>
+        </group>
+        <group id="changesDiscarded" restype="x-gettext-plurals">
+            <trans-unit id="changesDiscarded[0]" xml:space="preserve">
+                <source>Discarded {0} change.</source>
+                <target>{0} Änderung verworfen.</target>
+            </trans-unit>
+            <trans-unit id="changesDiscarded[1]" xml:space="preserve">
+                <source>Discarded {0} changes.</source>
+                <target>{0} Änderungen verworfen.</target>
+            </trans-unit>
+        </group>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -258,6 +258,30 @@
 			<trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
 				<source>Unfocus Node</source>
 			</trans-unit>
+            <group id="changesApplied" restype="x-gettext-plurals">
+                <trans-unit id="changesApplied[0]" xml:space="preserve">
+                    <source>{0} change successfully applied.</source>
+                </trans-unit>
+                <trans-unit id="changesApplied[1]" xml:space="preserve">
+                    <source>{0} changes successfully applied.</source>
+                </trans-unit>
+            </group>
+            <group id="changesPublished" restype="x-gettext-plurals">
+                <trans-unit id="changesPublished[0]" xml:space="preserve">
+                    <source>Published {0} change to "{1}".</source>
+                </trans-unit>
+                <trans-unit id="changesPublished[1]" xml:space="preserve">
+                    <source>Published {0} changes to "{1}".</source>
+                </trans-unit>
+            </group>
+            <group id="changesDiscarded" restype="x-gettext-plurals">
+                <trans-unit id="changesDiscarded[0]" xml:space="preserve">
+                    <source>Discarded {0} change.</source>
+                </trans-unit>
+                <trans-unit id="changesDiscarded[1]" xml:space="preserve">
+                    <source>Discarded {0} changes.</source>
+                </trans-unit>
+            </group>
 		</body>
 	</file>
 </xliff>


### PR DESCRIPTION
**What I did**

Use translator for UI messages on workspace actions.

And use the workspace title instead of its technical name
which can be misleading when the title of a workspace
is changed, as the name is not changed in this case.

**How I did it**

Use translator and also support plural/singular forms.

**How to verify it**

Publish & discard changes in the UI

![publish-text](https://user-images.githubusercontent.com/596967/75140768-e35e4500-56ef-11ea-8c64-f968aad0a067.png)