### PR TITLE
BUGFIX: fix refreshing of page tree with expanded nodes

### DIFF
--- a/Classes/FlowQueryOperations/NeosUiDefaultNodesOperation.php
+++ b/Classes/FlowQueryOperations/NeosUiDefaultNodesOperation.php
@@ -74,7 +74,7 @@ class NeosUiDefaultNodesOperation extends AbstractOperation
         /** @var TraversableNodeInterface $siteNode */
         /** @var TraversableNodeInterface $documentNode */
         list($siteNode, $documentNode) = $flowQuery->getContext();
-        /** @var TraversableNodeInterface $toggledNodes */
+        /** @var string[] $toggledNodes */
         list($baseNodeType, $loadingDepth, $toggledNodes, $clipboardNodesContextPaths) = $arguments;
 
         // Collect all parents of documentNode up to siteNode
@@ -100,7 +100,7 @@ class NeosUiDefaultNodesOperation extends AbstractOperation
             if (
                 $level < $loadingDepth || // load all nodes within loadingDepth
                 $loadingDepth === 0 || // unlimited loadingDepth
-                in_array((string)$baseNode->getNodeAggregateIdentifier(), $toggledNodes) || // load toggled nodes
+                in_array($baseNode->getContextPath(), $toggledNodes) || // load toggled nodes
                 in_array((string)$baseNode->getNodeAggregateIdentifier(), $parents) // load children of all parents of documentNode
             ) {
                 foreach ($baseNode->findChildNodes($this->nodeTypeConstraintFactory->parseFilterString($baseNodeType)) as $childNode) {


### PR DESCRIPTION
$toggledNodes from the client side is an array of strings, each being a currently expanded NodeContextPath.

Thus, we cannot compare it based on the NodeAggregateIdentifier; because that's not what it is from the client side.

**How to verify it**

- In the Document tree, expand a few nodes which are not automatically loaded (i.e. below the default loadingDepth)
- then, press the "refresh" icon.
- EXPECTED: the full tree is refreshed
- ACTUAL: the tree is collapsed again.

Note: This is only broken since https://github.com/neos/neos-ui/pull/2178 - and only master is affected.