### PR TITLE
BUGFIX: Resolve linting issue

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
@@ -100,8 +100,7 @@ export default class SelectNodeType extends PureComponent {
     };
 
     UNSAFE_componentWillReceiveProps(nextProps) {
-        if (this.props.allowedSiblingNodeTypes !== nextProps.allowedSiblingNodeTypes ||
-            this.props.allowedChildNodeTypes !== nextProps.allowedChildNodeTypes) {
+        if (allowedSiblingsOrChildrenChanged(this.props, nextProps)) {
             this.setState({
                 insertMode: calculateInitialMode(
                     nextProps.allowedSiblingNodeTypes,


### PR DESCRIPTION
The function allowedSiblingsOrChildrenChanged was not in use anymore and it seems that an upmerge has failed.

This is related to the PR for neos 4.x
Take a look at https://github.com/neos/neos-ui/pull/2678