### PR TITLE
BUGFIX: Allow ts imports in plugins

### DIFF
--- a/packages/neos-ui-extensibility/scripts/helpers/webpack.config.js
+++ b/packages/neos-ui-extensibility/scripts/helpers/webpack.config.js
@@ -45,6 +45,7 @@ module.exports = function (neosPackageJson) {
             ]
         },
         resolve: { // override config!
+            extensions: ['.ts', '.tsx', '.js'],
             alias: {
                 'react': '@neos-project/neos-ui-extensibility/src/shims/vendor/react/index',
                 'react-dom': '@neos-project/neos-ui-extensibility/src/shims/vendor/react-dom/index',


### PR DESCRIPTION
Because of the way the webpack configs are merged the extensions list defined in build-essentials was overriden and later replaced by the webpack default which only contains normal js extensions.