### PR TITLE
BUGFIX: added missing <meta> charset attribute

### DIFF
--- a/Resources/Private/Templates/Backend/Index.html
+++ b/Resources/Private/Templates/Backend/Index.html
@@ -2,6 +2,7 @@
 {namespace neos=Neos\Neos\ViewHelpers}
 <html>
     <head>
+        <meta charset="utf-8" />
         <title>Neos CMS</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
         <script>_NEOS_UI_configuration = {configuration -> f:format.raw()};</script>


### PR DESCRIPTION
I added the missing <meta> charset attribute. This fix some encoding issues if the server is not set to UTF-8. 

You can already find `<meta charset="utf-8" />` on every Page that get printed by Neos but not in the Neos Content Backend.

Before:
![image](https://user-images.githubusercontent.com/35105681/77753195-54fc1c80-7029-11ea-8563-e8286b240117.png)
After:
![image](https://user-images.githubusercontent.com/35105681/77753386-ad331e80-7029-11ea-8125-1a2cf9f76227.png)

I use 4.0 as base branch because it is the lowest maintained branch but the bug exist since version 1.
