### PR TITLE
TASK: Remove global cache identifier as old Ui is not longer supported

### DIFF
--- a/Resources/Private/Fusion/Prototypes/GlobalCacheIdentifiers.fusion
+++ b/Resources/Private/Fusion/Prototypes/GlobalCacheIdentifiers.fusion
@@ -1,3 +1,0 @@
-prototype(Neos.Fusion:GlobalCacheIdentifiers) {
-    uiVersion = 'new'
-}


### PR DESCRIPTION
As the old UI is not usable anymore the special global cache identifier
can be removed.