### PR TITLE
BUGFIX: Don't disable views for read only nodes

### DIFF
--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
@@ -19,10 +19,14 @@ export default class TabPanel extends PureComponent {
         handleInspectorApply: PropTypes.func
     };
 
-    isPropertyEnabled = ({id}) => {
-        const {node} = this.props;
+    isPropertyEnabled = item => {
+        const {focusedNode} = this.props;
 
-        return !$contains(id, 'policy.disallowedProperties', node);
+        if (item.type !== 'editor') {
+            return true;
+        }
+
+        return $get(['policy', 'canEdit'], focusedNode) && !$contains(item.id, 'policy.disallowedProperties', focusedNode);
     };
 
     render() {

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
@@ -20,13 +20,13 @@ export default class TabPanel extends PureComponent {
     };
 
     isPropertyEnabled = item => {
-        const {focusedNode} = this.props;
+        const {node} = this.props;
 
         if (item.type !== 'editor') {
             return true;
         }
 
-        return $get(['policy', 'canEdit'], focusedNode) && !$contains(item.id, 'policy.disallowedProperties', focusedNode);
+        return $get(['policy', 'canEdit'], node) && !$contains(item.id, 'policy.disallowedProperties', node);
     };
 
     render() {

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -216,10 +216,14 @@ export default class Inspector extends PureComponent {
         }
     }
 
-    isPropertyEnabled = ({id}) => {
+    isPropertyEnabled = item => {
         const {focusedNode} = this.props;
 
-        return !$contains(id, 'policy.disallowedProperties', focusedNode);
+        if (item.type !== 'editor') {
+            return true;
+        }
+
+        return $get(['policy', 'canEdit'], focusedNode) && !$contains(item.id, 'policy.disallowedProperties', focusedNode);
     };
 
     /**
@@ -266,11 +270,6 @@ export default class Inspector extends PureComponent {
             shouldShowSecondaryInspector,
             i18nRegistry
         } = this.props;
-
-        if (!$get(['policy', 'canEdit'], focusedNode)) {
-            // We cannot edit the current node, so we disable the inspector.
-            return (<div></div>);
-        }
 
         const augmentedCommit = (propertyId, value, hooks) => {
             commit(propertyId, value, hooks, focusedNode);


### PR DESCRIPTION
This partly reverts #2648 that completely disabled
the inspector for read-only nodes only removing
editor-properties.

Fixes: #2705