### PR TITLE
BUGFIX: Focus first form element in node creation dialog

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
@@ -183,7 +183,8 @@ export default class NodeCreationDialog extends PureComponent {
                             //
                             const validationErrorsForElement = isDirty ? $get(elementName, validationErrors) : [];
                             const element = configuration.elements[elementName];
-                            const options = $set('autoFocus', index === 0, $get('ui.editorOptions', element) || {});
+                            const editorOptions = $set('autoFocus', index === 0, $get('ui.editorOptions', element) || {});
+                            const options = Object.assign({}, editorOptions);
                             return (
                                 <div key={elementName} className={style.editor}>
                                     <EditorEnvelope

--- a/packages/react-ui-components/src/Dialog/__snapshots__/dialog.spec.tsx.snap
+++ b/packages/react-ui-components/src/Dialog/__snapshots__/dialog.spec.tsx.snap
@@ -42,6 +42,7 @@ exports[`<Dialog/> Portal should render correctly. 1`] = `
 >
   <Portal>
     <section
+      autoFocus={true}
       className="dialogClassName wideClassName errorClassName"
       role="dialog"
       tabIndex={0}
@@ -53,6 +54,7 @@ exports[`<Dialog/> Portal should render correctly. 1`] = `
             "Foo 2",
           ]
         }
+        autoFocus={true}
         isOpen={true}
         onRequestClose={[Function]}
         style="wide"

--- a/packages/react-ui-components/src/Dialog/dialog.spec.tsx
+++ b/packages/react-ui-components/src/Dialog/dialog.spec.tsx
@@ -10,6 +10,7 @@ describe('<Dialog/>', () => {
         actions: ['Foo 1', 'Foo 2'],
         children: 'Foo children',
         isOpen: true,
+        autoFocus: true,
         onRequestClose: () => null,
         style: 'wide',
         type: 'error',

--- a/packages/react-ui-components/src/Dialog/dialog.tsx
+++ b/packages/react-ui-components/src/Dialog/dialog.tsx
@@ -59,6 +59,11 @@ export interface DialogProps {
     readonly actions: ReadonlyArray<ReactNode>;
 
     /**
+     * This prop controls the focus state of the Dialog.
+     */
+    readonly autoFocus: boolean;
+
+    /**
      * An optional `className` to attach to the wrapper.
      */
     readonly className?: string;
@@ -129,8 +134,8 @@ export class DialogWithoutEscape extends PureComponent<DialogProps> {
 
     public readonly componentDidMount = (): void => {
         document.addEventListener('keydown', (event : KeyboardEvent) => this.handleKeyPress(event));
-
-        if (this.ref) {
+        const {autoFocus} = this.props;
+        if (this.ref && autoFocus) {
             this.ref.focus();
         }
     }

--- a/packages/react-ui-components/src/TextInput/textInput.tsx
+++ b/packages/react-ui-components/src/TextInput/textInput.tsx
@@ -52,11 +52,16 @@ export interface TextInputProps extends Omit<React.InputHTMLAttributes<HTMLInput
 
 class TextInput extends PureComponent<TextInputProps> {
     // tslint:disable-next-line:readonly-keyword
-    private ref?: HTMLInputElement;
+    private ref?: React.RefObject<HTMLInputElement>;
+
+    constructor(props: any) {
+        super(props);
+        this.ref = React.createRef();
+    }
 
     public readonly componentDidMount = (): void => {
-        if (this.ref && this.props.setFocus) {
-            this.ref.focus();
+        if (this.ref && this.ref.current && (this.props.setFocus || this.props.autoFocus)) {
+            this.ref.current.focus();
         }
     }
 
@@ -96,10 +101,6 @@ class TextInput extends PureComponent<TextInputProps> {
             }
         );
 
-        const inputRef = (element: HTMLInputElement) => {
-            this.ref = element;
-        };
-
         return (
             <div className={containerClassName}>
                 <input
@@ -113,7 +114,7 @@ class TextInput extends PureComponent<TextInputProps> {
                     disabled={disabled}
                     onChange={this.handleValueChange}
                     onKeyPress={this.handleKeyPress}
-                    ref={inputRef}
+                    ref={this.ref}
                     />
                 </div>
         );


### PR DESCRIPTION
**What I did**
The NodeCreationDialog always throws errors because the options are passed thru as array instead of an object. So I modified the data type here.

The already set autoFocus property did not work for the first element of the Creation Dialog.
So this patch also fixes the setting of the autofocus for the editor fields.

Another issue was that the dialog always gets the focus by default and therefore the first element was not focused.

**How to verify it**

Create a new page in the backend and the title field will be focused.


Fixes: #2696