### PR TITLE
BUGFIX: Avoid URLs to be rendered twice in link- and reference editors

### DIFF
--- a/packages/neos-ui-backend-connector/src/Endpoints/index.ts
+++ b/packages/neos-ui-backend-connector/src/Endpoints/index.ts
@@ -437,14 +437,14 @@ export default (routes: Routes) => {
                 if (!nodeType) {
                     throw new Error('.node-type not found in result');
                 }
-                const uri = uriElement.innerText.trim();
                 return {
                     dataType: 'Neos.ContentRepository:Node',
                     loaderUri: 'node://' + nodeIdentifier.innerText,
                     label: nodeLabel.innerText,
                     identifier: nodeIdentifier.innerText,
                     nodeType: nodeType.innerText,
-                    uri
+                    uri: uriElement.getAttribute('href'),
+                    breadcrumb: uriElement.innerText.trim()
                 };
             });
         })

--- a/packages/neos-ui-backend-connector/src/Endpoints/index.ts
+++ b/packages/neos-ui-backend-connector/src/Endpoints/index.ts
@@ -237,11 +237,6 @@ export default (routes: Routes) => {
     }).then(response => fetchWithErrorHandling.parseJson(response))
     .catch(reason => fetchWithErrorHandling.generalErrorHandler(reason));
 
-    const extractFileEndingFromUri = (uri: string) => {
-        const parts = uri.split('.');
-        return parts.length ? '.' + parts[parts.length - 1] : '';
-    };
-
     const assetProxyImport = (identifier: string) => fetchWithErrorHandling.withCsrfToken(csrfToken => ({
         url: `${routes.core.service.assetProxies}/${identifier.substr(0, identifier.indexOf('/'))}/${identifier.substr(identifier.indexOf('/') + 1)}`,
         method: 'POST',
@@ -449,8 +444,7 @@ export default (routes: Routes) => {
                     label: nodeLabel.innerText,
                     identifier: nodeIdentifier.innerText,
                     nodeType: nodeType.innerText,
-                    uri,
-                    uriInLiveWorkspace: uri.split('@')[0] + extractFileEndingFromUri(uri)
+                    uri
                 };
             });
         })

--- a/packages/neos-ui-editors/src/Library/NodeOption.js
+++ b/packages/neos-ui-editors/src/Library/NodeOption.js
@@ -12,7 +12,7 @@ export default class NodeOption extends PureComponent {
     static propTypes = {
         option: PropTypes.shape({
             label: PropTypes.string,
-            uriInLiveWorkspace: PropTypes.string,
+            uri: PropTypes.string,
             nodeType: PropTypes.string,
             loaderUri: PropTypes.string
         }),
@@ -22,14 +22,14 @@ export default class NodeOption extends PureComponent {
 
     render() {
         const {option, nodeTypesRegistry} = this.props;
-        const {label, uriInLiveWorkspace, nodeType} = option;
+        const {label, uri, nodeType} = option;
         const nodeTypeDefinition = nodeTypesRegistry.getNodeType(nodeType);
         const icon = $get('ui.icon', nodeTypeDefinition);
         return (
             <SelectBox_Option_MultiLineWithThumbnail
                 {...this.props}
                 label={label}
-                secondaryLabel={uriInLiveWorkspace}
+                secondaryLabel={uri}
                 icon={icon}
                 />
         );

--- a/packages/neos-ui-editors/src/Library/NodeOption.js
+++ b/packages/neos-ui-editors/src/Library/NodeOption.js
@@ -12,7 +12,7 @@ export default class NodeOption extends PureComponent {
     static propTypes = {
         option: PropTypes.shape({
             label: PropTypes.string,
-            uri: PropTypes.string,
+            breadcrumb: PropTypes.string,
             nodeType: PropTypes.string,
             loaderUri: PropTypes.string
         }),
@@ -22,14 +22,14 @@ export default class NodeOption extends PureComponent {
 
     render() {
         const {option, nodeTypesRegistry} = this.props;
-        const {label, uri, nodeType} = option;
+        const {label, breadcrumb, nodeType} = option;
         const nodeTypeDefinition = nodeTypesRegistry.getNodeType(nodeType);
         const icon = $get('ui.icon', nodeTypeDefinition);
         return (
             <SelectBox_Option_MultiLineWithThumbnail
                 {...this.props}
                 label={label}
-                secondaryLabel={uri}
+                secondaryLabel={breadcrumb}
                 icon={icon}
                 />
         );


### PR DESCRIPTION
This removes some ancient hack that tried to determine the "uriInLiveWorkspace".

Background:

The code extracted the context path that was previously specified via
`@<context>` in the "backend URLs". Due to the dedicated preview routes
that were introduced with Neos 5.1 this no longer worked and led to the
preview URL rendered twice instead..

Related: neos/neos-development-collection#2965