### PR TITLE
BUGFIX: Increase memory limit for node in jenkins build

### DIFF
--- a/Build/Jenkins/update-neos-ui-compiled.sh
+++ b/Build/Jenkins/update-neos-ui-compiled.sh
@@ -27,6 +27,8 @@ if [ -n "$GIT_TAG_MANUAL" ]; then
     GIT_TAG="$GIT_TAG_MANUAL"
 fi
 
+NODE_OPTIONS="--max-old-space-size=4096"
+
 make install
 make build-production
 


### PR DESCRIPTION
This should solve the out of memory errors with 5.2.0 production build https://jenkins.neos.io/job/neos-build-minified/18450/console