### PR TITLE
BUGFIX: Improve usability for certain editors in creation dialog

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
@@ -155,6 +155,16 @@ export default class NodeCreationDialog extends PureComponent {
         );
     }
 
+    editorNeedsAdditionalSpace(elementConfiguration) {
+        const editorPaths = [
+            'Neos.Neos/Inspector/Editors/ReferenceEditor',
+            'Neos.Neos/Inspector/Editors/ReferencesEditor',
+            'Neos.Neos/Inspector/Editors/SelectBoxEditor'
+        ];
+
+        return editorPaths.includes(elementConfiguration.ui.editor);
+    }
+
     render() {
         const {isOpen, configuration} = this.props;
 
@@ -163,6 +173,7 @@ export default class NodeCreationDialog extends PureComponent {
         }
 
         const {validationErrors, isDirty} = this.state;
+        const elements = Object.keys(configuration.elements).filter(elementName => Boolean(configuration.elements[elementName]));
 
         return (
             <Dialog
@@ -175,33 +186,36 @@ export default class NodeCreationDialog extends PureComponent {
                 id="neos-NodeCreationDialog"
                 >
                 <div id="neos-NodeCreationDialog-Body" className={style.body}>
-                    {Object.keys(configuration.elements)
-                        .filter(elementName => Boolean(configuration.elements[elementName]))
-                        .map((elementName, index) => {
-                            //
-                            // Only display errors after user input (isDirty)
-                            //
-                            const validationErrorsForElement = isDirty ? $get(elementName, validationErrors) : [];
-                            const element = configuration.elements[elementName];
-                            const editorOptions = $set('autoFocus', index === 0, $get('ui.editorOptions', element) || {});
-                            const options = Object.assign({}, editorOptions);
-                            return (
-                                <div key={elementName} className={style.editor}>
-                                    <EditorEnvelope
-                                        identifier={elementName}
-                                        label={$get('ui.label', element)}
-                                        editor={$get('ui.editor', element)}
-                                        options={options}
-                                        commit={this.handleDialogEditorValueChange(elementName)}
-                                        validationErrors={validationErrorsForElement}
-                                        value={this.state.values[elementName] || ''}
-                                        onKeyPress={this.handleKeyPress}
-                                        onEnterKey={this.handleApply}
-                                        />
-                                </div>
-                            );
-                        })
-                    }
+                    {elements.map((elementName, index) => {
+                        //
+                        // Only display errors after user input (isDirty)
+                        //
+                        const validationErrorsForElement = isDirty ? $get(elementName, validationErrors) : [];
+                        const element = configuration.elements[elementName];
+                        const editorOptions = $set('autoFocus', index === 0, $get('ui.editorOptions', element) || {});
+                        const options = Object.assign({}, editorOptions);
+                        const classNames = [style.editor];
+
+                        if (index + 1 === elements.length && this.editorNeedsAdditionalSpace(element)) {
+                            classNames.push(style['editor--additional-spacing']);
+                        }
+
+                        return (
+                            <div key={elementName} className={classNames.join(' ')}>
+                                <EditorEnvelope
+                                    identifier={elementName}
+                                    label={$get('ui.label', element)}
+                                    editor={$get('ui.editor', element)}
+                                    options={options}
+                                    commit={this.handleDialogEditorValueChange(elementName)}
+                                    validationErrors={validationErrorsForElement}
+                                    value={this.state.values[elementName] || ''}
+                                    onKeyPress={this.handleKeyPress}
+                                    onEnterKey={this.handleApply}
+                                    />
+                            </div>
+                        );
+                    })}
                 </div>
             </Dialog>
         );

--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/style.css
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/style.css
@@ -4,6 +4,11 @@
 .editor {
     margin-bottom: var(--spacing-Full);
 }
+
+.editor--additional-spacing {
+    margin-bottom: 100px;
+}
+
 .buttonIcon {
     margin-right: var(--spacing-Half);
 }


### PR DESCRIPTION
Certain editors like the reference editor need a certain amount of space to present results. We now add additional space to the bottom of the editor if it is placed at the end of the dialog.

![before](https://user-images.githubusercontent.com/10533739/83042399-ea278b80-a041-11ea-8a4a-02ac834f84a6.png)
![after](https://user-images.githubusercontent.com/10533739/83042402-eac02200-a041-11ea-8871-9c3b68fdc565.png)

