### PR TITLE
BUGFIX: Allow additional options to inline link editor

### DIFF
--- a/packages/neos-ui-editors/src/Library/LinkInput.js
+++ b/packages/neos-ui-editors/src/Library/LinkInput.js
@@ -81,16 +81,17 @@ export default class LinkInput extends PureComponent {
     };
 
     getDataLoaderOptions() {
-        const contextForNodeLinking = $get('options.startingPoint', this.props) ?
-            Object.assign({}, this.props.contextForNodeLinking, {
-                contextNode: this.props.options.startingPoint
-            }) :
+        const options = {...this.props.options, ...this.props.linkingOptions};
+
+        const contextForNodeLinking = $get('startingPoint', options) ?
+            {...this.props.contextForNodeLinking, contextNode: options.startingPoint} :
             this.props.contextForNodeLinking;
+
         return {
-            nodeTypes: $get('options.nodeTypes', this.props) || ['Neos.Neos:Document'],
-            asset: $get('options.assets', this.props),
-            node: $get('options.nodes', this.props),
-            startingPoint: $get('options.startingPoint', this.props),
+            nodeTypes: $get('nodeTypes', options) || ['Neos.Neos:Document'],
+            asset: $get('assets', options),
+            node: $get('nodes', options),
+            startingPoint: $get('startingPoint', options),
             contextForNodeLinking
         };
     }


### PR DESCRIPTION
Make it possible to pass options to the inline link editor through configuration, so the inline link editor is fully configurable like the link editor within the inspector.

resolves: #2710