### PR TITLE
BUGFIX: Correctly merge nodedata after updates and update tree

### DIFF
--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
@@ -433,7 +433,7 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
                 if (!newNode) {
                     throw new Error('This error should never be thrown, it\'s a way to fool TypeScript');
                 }
-                const mergedNode = defaultsDeep({}, draft.byContextPath[contextPath], newNode);
+                const mergedNode = defaultsDeep(newNode, draft.byContextPath[contextPath], {});
                 // Force overwrite of children
                 if (newNode.children !== undefined) {
                     mergedNode.children = newNode.children;
@@ -502,7 +502,7 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
             draft.focused.fusionPath = null;
             draft.focused.contextPaths = [];
             if (nodes) {
-                draft.byContextPath = merge ? defaultsDeep({}, draft.byContextPath, nodes) : nodes;
+                draft.byContextPath = merge ? defaultsDeep(nodes, draft.byContextPath, {}) : nodes;
             }
             break;
         }


### PR DESCRIPTION
In #2578 the merge function was replaced
but the new one needs a different parameter
order as it merged from left to right instead
of right to left.

Resolves: #2665