### PR TITLE
BUGFIX: update build-essentials to 5.2.1

### DIFF
--- a/packages/neos-ui-extensibility/package.json
+++ b/packages/neos-ui-extensibility/package.json
@@ -22,8 +22,8 @@
     "typescript": "3.2.2"
   },
   "dependencies": {
-    "@neos-project/build-essentials": "5.1.1",
-    "@neos-project/positional-array-sorter": "5.1.1",
+    "@neos-project/build-essentials": "5.2.1",
+    "@neos-project/positional-array-sorter": "5.2.1",
     "babel-core": "^6.26.3",
     "babel-eslint": "^7.1.1",
     "babel-loader": "^7.1.2",


### PR DESCRIPTION
Update @neos-project/build-essentials and @neos-project/positional-array-sorter to fix build problem with css-loader because the used css-loader version expects a different configuration syntax than in version 5.1.1 of @neos-project/build-essentials.

I upgrade an existing ui plugin and tried to use the newest version of the neos-ui-extensibility package. When i tried to build the plugin, the build failed with an error.
![Bildschirmfoto 2020-07-03 um 13 21 40](https://user-images.githubusercontent.com/23524251/86464699-5c217d80-bd30-11ea-9ccd-e3c2f441adab.png)

After examining the version I saw, that the dev dependencies were incorrect.