### PR TITLE
BUGFIX: Manually adjust versions

### DIFF
--- a/packages/neos-ui-extensibility/package.json
+++ b/packages/neos-ui-extensibility/package.json
@@ -22,8 +22,8 @@
     "typescript": "3.2.2"
   },
   "dependencies": {
-    "@neos-project/build-essentials": "5.1.1",
-    "@neos-project/positional-array-sorter": "5.1.1",
+    "@neos-project/build-essentials": "5.2.1",
+    "@neos-project/positional-array-sorter": "5.2.1",
     "babel-core": "^6.26.3",
     "babel-eslint": "^7.1.1",
     "babel-loader": "^7.1.2",


### PR DESCRIPTION
The versions of build-essentials and positional-array-sorter are wrong and does not fit the version of the current release. That leads to the problem that in the upcoming release version will be not replaced. The new release only replaces the current version number with the new released version. So the two packages will never get updated.

This is a result of a wrong up merge so that we had not the latest version.

Fixes: #2742