### PR TITLE
BUGFIX: With some configurations the creation dialog was readonly

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
@@ -65,9 +65,12 @@ export default class NodeCreationDialog extends PureComponent {
             }, {});
 
             return {
-                ...currentState,
-                isDirty: true,
-                values
+                values: {
+                    ...defaultValues,
+                    ...currentState.values
+                },
+                validationErrors: currentState.validationErrors,
+                isDirty: true
             };
         }
         return null;

--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
@@ -56,9 +56,11 @@ export default class NodeCreationDialog extends PureComponent {
 
     static getDerivedStateFromProps(props, currentState) {
         const {configuration} = props;
-        if (configuration && !isEqual(Object.keys(currentState.values), Object.keys(configuration.elements))) {
-            const values = Object.keys(configuration.elements).reduce((carry, elementName) => {
-                if (configuration.elements[elementName].defaultValue !== undefined) {
+        if (configuration && !isEqual(Object.keys(currentState.values).sort(), Object.keys(configuration.elements).sort())) {
+            const defaultValues = Object.keys(configuration.elements).reduce((carry, elementName) => {
+                if (configuration.elements[elementName].defaultValue === undefined) {
+                    carry[elementName] = null;
+                } else {
                     carry[elementName] = configuration.elements[elementName].defaultValue;
                 }
                 return carry;


### PR DESCRIPTION
This was a regression in 61d01af9

Also includes an optimisation to prevent repeated reassignment of the same state.