### PR TITLE
!!! BUGFIX: Speed up move actions to prevent timeouts

### DIFF
--- a/Classes/Domain/Model/Changes/AbstractCopy.php
+++ b/Classes/Domain/Model/Changes/AbstractCopy.php
@@ -14,6 +14,7 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Service as ContentRepository;
 use Neos\Flow\Annotations as Flow;
+use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
 
 abstract class AbstractCopy extends AbstractStructuralChange
 {
@@ -22,6 +23,21 @@ abstract class AbstractCopy extends AbstractStructuralChange
      * @var ContentRepository\NodeServiceInterface
      */
     protected $contentRepositoryNodeService;
+
+    /**
+     * Perform finish tasks - needs to be called from inheriting class on `apply`
+     *
+     * @param NodeInterface $node
+     * @return void
+     */
+    protected function finish(NodeInterface $node): void
+    {
+        $updateNodeInfo = new UpdateNodeInfo();
+        $updateNodeInfo->setNode($node);
+        $updateNodeInfo->recursive();
+        $this->feedbackCollection->add($updateNodeInfo);
+        parent::finish($node);
+    }
 
     /**
      * Generate a unique node name for the copied node

--- a/Classes/Domain/Model/Changes/AbstractCreate.php
+++ b/Classes/Domain/Model/Changes/AbstractCreate.php
@@ -16,6 +16,7 @@ use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Domain\Service\NodeServiceInterface;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\Flow\Annotations as Flow;
+use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
 use Neos\Neos\Ui\Exception\InvalidNodeCreationHandlerException;
 use Neos\Neos\Ui\NodeCreationHandler\NodeCreationHandlerInterface;
 
@@ -53,6 +54,21 @@ abstract class AbstractCreate extends AbstractStructuralChange
      * @var NodeServiceInterface
      */
     protected $nodeService;
+
+    /**
+     * Perform finish tasks - needs to be called from inheriting class on `apply`
+     *
+     * @param NodeInterface $node
+     * @return void
+     */
+    protected function finish(NodeInterface $node): void
+    {
+        $updateNodeInfo = new UpdateNodeInfo();
+        $updateNodeInfo->setNode($node);
+        $updateNodeInfo->recursive();
+        $this->feedbackCollection->add($updateNodeInfo);
+        parent::finish($node);
+    }
 
     /**
      * Set the node type

--- a/Classes/Domain/Model/Changes/AbstractMove.php
+++ b/Classes/Domain/Model/Changes/AbstractMove.php
@@ -16,6 +16,7 @@ use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Service as ContentRepository;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\RemoveNode;
 use Neos\Flow\Annotations as Flow;
+use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodePath;
 
 abstract class AbstractMove extends AbstractStructuralChange
 {
@@ -33,10 +34,12 @@ abstract class AbstractMove extends AbstractStructuralChange
      */
     protected function finish(NodeInterface $node)
     {
-        $removeNode = new RemoveNode();
-        $removeNode->setNode($node);
-
-        $this->feedbackCollection->add($removeNode);
+        if ($node->getContextPath() !== $this->getSubject()->getContextPath()) {
+            $updateNodePath = new UpdateNodePath();
+            $updateNodePath->setOldContextPath($node->getContextPath());
+            $updateNodePath->setNewContextPath($this->getSubject()->getContextPath());
+            $this->feedbackCollection->add($updateNodePath);
+        }
 
         // $this->getSubject() is the moved node at the NEW location!
         parent::finish($this->getSubject());

--- a/Classes/Domain/Model/Changes/AbstractStructuralChange.php
+++ b/Classes/Domain/Model/Changes/AbstractStructuralChange.php
@@ -18,7 +18,6 @@ use Neos\Neos\Ui\Domain\Model\AbstractChange;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\ReloadDocument;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\RenderContentOutOfBand;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
-use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodePath;
 use Neos\Neos\Ui\Domain\Model\RenderedNodeDomAddress;
 
 /**

--- a/Classes/Domain/Model/Changes/AbstractStructuralChange.php
+++ b/Classes/Domain/Model/Changes/AbstractStructuralChange.php
@@ -18,6 +18,7 @@ use Neos\Neos\Ui\Domain\Model\AbstractChange;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\ReloadDocument;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\RenderContentOutOfBand;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
+use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodePath;
 use Neos\Neos\Ui\Domain\Model\RenderedNodeDomAddress;
 
 /**
@@ -131,14 +132,8 @@ abstract class AbstractStructuralChange extends AbstractChange
     {
         $this->persistenceManager->persistAll();
 
-        $updateNodeInfo = new UpdateNodeInfo();
-        $updateNodeInfo->setNode($node);
-        $updateNodeInfo->recursive();
-
         $updateParentNodeInfo = new UpdateNodeInfo();
         $updateParentNodeInfo->setNode($node->getParent());
-
-        $this->feedbackCollection->add($updateNodeInfo);
         $this->feedbackCollection->add($updateParentNodeInfo);
 
         $this->updateWorkspaceInfo();

--- a/Classes/Domain/Model/Feedback/Operations/UpdateNodePath.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateNodePath.php
@@ -1,0 +1,121 @@
+<?php
+namespace Neos\Neos\Ui\Domain\Model\Feedback\Operations;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Mvc\Controller\ControllerContext;
+use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
+use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
+
+class UpdateNodePath extends AbstractFeedback
+{
+
+    /**
+     * @var string
+     */
+    protected $oldContextPath;
+
+    /**
+     * @var string
+     */
+    protected $newContextPath;
+
+    /**
+     * Set the original context path before a node was moved
+     *
+     * @param string $contextPath
+     * @return void
+     */
+    public function setOldContextPath(string $contextPath): void
+    {
+        $this->oldContextPath = $contextPath;
+    }
+
+    /**
+     * Set the new context path after a node was moved
+     *
+     * @param string $contextPath
+     * @return void
+     */
+    public function setNewContextPath(string $contextPath): void
+    {
+        $this->newContextPath = $contextPath;
+    }
+
+    /**
+     * Get the original context path of the moved node
+     *
+     * @return string
+     */
+    public function getOldContextPath(): string
+    {
+        return $this->oldContextPath;
+    }
+
+    /**
+     * Get the new context path of the moved node
+     *
+     * @return string
+     */
+    public function getNewContextPath(): string
+    {
+        return $this->newContextPath;
+    }
+
+    /**
+     * Get the type identifier
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return 'Neos.Neos.Ui:UpdateNodePath';
+    }
+
+    /**
+     * Get the description
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return sprintf('Updated path for node context path "%s" is available.', $this->getOldContextPath());
+    }
+
+    /**
+     * Checks whether this feedback is similar to another
+     *
+     * @param FeedbackInterface $feedback
+     * @return boolean
+     */
+    public function isSimilarTo(FeedbackInterface $feedback)
+    {
+        if (!$feedback instanceof self) {
+            return false;
+        }
+
+        return $this->getOldContextPath() === $feedback->getOldContextPath();
+    }
+
+    /**
+     * Serialize the payload for this feedback
+     *
+     * @param ControllerContext $controllerContext
+     * @return mixed
+     */
+    public function serializePayload(ControllerContext $controllerContext)
+    {
+        return [
+            'oldContextPath' => $this->getOldContextPath(),
+            'newContextPath' => $this->getNewContextPath(),
+        ];
+    }
+}

--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
@@ -446,6 +446,8 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
             // This action will only be called by the old CR therefore we can expect the '@' sign
             const [oldPath] = oldContextPath.split('@');
             const [newPath] = newContextPath.split('@');
+            const encodedOldPath = encodeURIComponent(oldPath);
+            const encodedNewPath = encodeURIComponent(newPath);
 
             // Update the context path for stored descendant of the moved node including the node itself
             Object.keys(draft.byContextPath).forEach(contextPath => {
@@ -462,6 +464,11 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
 
                 const updatedContextPath = contextPath.replace(oldPath, newPath);
                 node.contextPath = updatedContextPath;
+
+                // Update also the preview uri for document nodes stored in the node data
+                if (node.uri) {
+                    node.uri = node.uri.replace(encodedOldPath, encodedNewPath);
+                }
 
                 node.children.forEach(child => {
                     child.contextPath = child.contextPath.replace(oldPath, newPath);

--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
@@ -78,6 +78,7 @@ export enum actionTypes {
     COMMIT_PASTE = '@neos/neos-ui/CR/Nodes/COMMIT_PASTE',
     HIDE = '@neos/neos-ui/CR/Nodes/HIDE',
     SHOW = '@neos/neos-ui/CR/Nodes/SHOW',
+    UPDATE_PATH = '@neos/neos-ui/CR/Nodes/UPDATE_PATH',
     UPDATE_URI = '@neos/neos-ui/CR/Nodes/UPDATE_URI',
     SET_INLINE_VALIDATION_ERRORS = '@neos/neos-ui/CR/Nodes/SET_INLINE_VALIDATION_ERRORS'
 }
@@ -278,6 +279,15 @@ const show = (contextPath: NodeContextPath) => createAction(actionTypes.SHOW, co
  */
 const updateUri = (oldUriFragment: string, newUriFragment: string) => createAction(actionTypes.UPDATE_URI, {oldUriFragment, newUriFragment});
 
+/**
+ * Update context path of all affected nodes after a node has been moved
+ * Must update the node itself and all of its descendants
+ *
+ * @param {String} oldContextPath
+ * @param {String} newContextPath
+ */
+const updatePath = (oldContextPath: string, newContextPath: string) => createAction(actionTypes.UPDATE_PATH, {oldContextPath, newContextPath});
+
 //
 // Export the actions
 //
@@ -302,6 +312,7 @@ export const actions = {
     commitPaste,
     hide,
     show,
+    updatePath,
     updateUri,
     setInlineValidationErrors
 };
@@ -428,6 +439,36 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
         }
         case actionTypes.REMOVE: {
             delete draft.byContextPath[action.payload];
+            break;
+        }
+        case actionTypes.UPDATE_PATH: {
+            const {oldContextPath, newContextPath} = action.payload;
+            // This action will only be called by the old CR therefore we can expect the '@' sign
+            const [oldPath] = oldContextPath.split('@');
+            const [newPath] = newContextPath.split('@');
+
+            // Update the context path for stored descendant of the moved node including the node itself
+            Object.keys(draft.byContextPath).forEach(contextPath => {
+                // Skip nodes that don't match the old path exactly or a descendant path
+                if (!contextPath.startsWith(oldPath + '/')
+                    && contextPath.split('@')[0] !== oldPath) {
+                    return;
+                }
+
+                const node = draft.byContextPath[contextPath];
+                if (!node) {
+                    return;
+                }
+
+                const updatedContextPath = contextPath.replace(oldPath, newPath);
+                node.contextPath = updatedContextPath;
+
+                node.children.forEach(child => {
+                    child.contextPath = child.contextPath.replace(oldPath, newPath);
+                });
+
+                delete Object.assign(draft.byContextPath, {[updatedContextPath]: node })[contextPath];
+            });
             break;
         }
         case actionTypes.SET_DOCUMENT_NODE: {

--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -297,6 +297,20 @@ manifest('main', {}, globalRegistry => {
             store.dispatch(actions.UI.ContentCanvas.setSrc($get(['cr', 'nodes', 'byContextPath', newContextPath, 'uri'], newState)));
             store.dispatch(actions.CR.Nodes.setDocumentNode(newContextPath));
         }
+
+        // Remove the node from the old position in the dom
+        if ($get('cr.nodes.documentNode', state) !== oldContextPath) {
+            findAllOccurrencesOfNodeInGuestFrame(oldContextPath).forEach(el => {
+                const closestContentCollection = el.closest('.neos-contentcollection');
+                el.remove();
+
+                createEmptyContentCollectionPlaceholderIfMissing(closestContentCollection);
+
+                dispatchCustomEvent('Neos.NodeRemoved', 'Node was removed.', {
+                    element: el
+                });
+            });
+        }
     });
 
     //

--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -250,6 +250,13 @@ manifest('main', {}, globalRegistry => {
     });
 
     //
+    // When the server has updated node path, apply it to the store
+    //
+    serverFeedbackHandlers.set('Neos.Neos.Ui:UpdateNodePath/Main', (feedbackPayload, {store}) => {
+        store.dispatch(actions.CR.Nodes.updatePath(feedbackPayload.oldContextPath, feedbackPayload.newContextPath));
+    });
+
+    //
     // When the server has removed a node, remove it as well from the store amd the dom
     //
     serverFeedbackHandlers.set('Neos.Neos.Ui:RemoveNode/Main', ({contextPath, parentContextPath}, {store}) => {


### PR DESCRIPTION
**What I did**

WIth this change instead of returning the information for the moved node and all its
descendants only the changes to the new and old parent and the information
about the old and new context path are submitted.

The already stored nodes are then updated with this information instead of being replaced
completely with the new information from the server.

This improves the response time by ~50% and memory consumption by 25% - 80%.
Large move operations still need a lot of memory and some time to compute
the updated workspace information. This issue will be fixed in a future PR.

This change also has the side effect, that after a move action the moved node can be focused again, 
as the information is now available where it went.
Before the old was removed and a redirect to the parent happened.

**Possible breaking change**

As the `Neos.Neos.Ui:RemoveNode/Main` feedback from the server was replaced with a `Neos.Neos.Ui:UpdateNodePath/Main` this change can be breaking for plugins that listened to it.
They will now have to listen to both.

**How I did it**

Replace the old `remove` + `update` feedbacks with a single `UpdatePath` feedback.
The Feedback contains the old and new path and the UI can update the known nodes with this information.

**How to verify it**

Move some nodes with child nodes.
The node tree should still be consistent after the operation.

Example with 4500 changed nodes (including the fix in https://github.com/neos/neos-development-collection/pull/3015):

<img width="1499" alt="Performance difference for 4500 changed nodes" src="https://user-images.githubusercontent.com/596967/89905647-b8f33c00-dbea-11ea-8767-523c68fc7756.png">

