### PR TITLE
TASK: Limit dependencies to neos 5.0

### DIFF
--- a/Tests/IntegrationTests/TestDistribution/DistributionPackages/Neos.TestSite/composer.json
+++ b/Tests/IntegrationTests/TestDistribution/DistributionPackages/Neos.TestSite/composer.json
@@ -3,6 +3,7 @@
     "description": "A dummy site package that will be replaced by fixtures during tests",
     "type": "neos-site",
     "require": {
+        "neos/neos": "~5.0.0 || dev-master",
         "neos/neos-ui": "*",
         "neos/fusion-afx": "*"
     },

--- a/Tests/IntegrationTests/TestDistribution/composer.json
+++ b/Tests/IntegrationTests/TestDistribution/composer.json
@@ -6,7 +6,7 @@
         "bin-dir": "bin"
     },
     "require": {
-        "neos/neos-ui": "^5.0.0",
+        "neos/neos-ui": "~5.0.0",
         "neos/fusion-afx": "*",
         "neos/test-site": "@dev",
         "neos/test-nodetypes": "@dev"


### PR DESCRIPTION
With the current configuration the test distribution always installs the latest 5.x neos and that is not compatible since the preview url change.

So we should limit that to neos 5.0 and adapt that for the upcoming versions.

**What I did**
Changed version constraint from caret version to tilde version.

**How to verify it**
Check end to end tests of the PR.
