### PR TITLE
[BUGFIX] really ;) correctly merge nodedata after updates and update tree

### DIFF
--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
@@ -444,7 +444,7 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
                 if (!newNode) {
                     throw new Error('This error should never be thrown, it\'s a way to fool TypeScript');
                 }
-                const mergedNode = defaultsDeep(newNode, draft.byContextPath[contextPath], {});
+                const mergedNode = defaultsDeep({}, newNode, draft.byContextPath[contextPath]);
                 // Force overwrite of children
                 if (newNode.children !== undefined) {
                     mergedNode.children = newNode.children;
@@ -550,7 +550,7 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
             draft.focused.fusionPath = null;
             draft.focused.contextPaths = [];
             if (nodes) {
-                draft.byContextPath = merge ? defaultsDeep(nodes, draft.byContextPath, {}) : nodes;
+                draft.byContextPath = merge ? defaultsDeep({}, nodes, draft.byContextPath) : nodes;
             }
             break;
         }


### PR DESCRIPTION
This fixes a regression introduced by #2578, and not fully fixed by #2743.

## the change in MERGE:

originally (see https://github.com/neos/neos-ui/pull/2578/files#diff-a1ae46b74f22675b47bfe28db766094fL393)
the code looked like:

    mergedNode = mergeDeepRight(draft.byContextPath[contextPath], newNode);

NOT modifying any parameters; and parameters further to the right override
    parameters on the left.

With https://github.com/neos/neos-ui/pull/2743/files, this was changed to:

mergedNode = defaultsDeep(newNode, draft.byContextPath[contextPath], {});

- defaultsDeep MODIFIES the first parameter AND returns it. (see https://lodash.com/docs#defaultsDeep).
    Parameters are merged from right to left, so parameters further on the left override parameters further
    to the right. EXCEPT the leftmost parameter, where everything is applied to.
- the above line MODIFIES newNode; which leads to #2768 happening.

what we want is "take everything from draft.byContextPath, then override with everything from newNode,
AND APPLY TO AN EMPTY OBJECT".

Thus, we want:

    const mergedNode = defaultsDeep({}, newNode, draft.byContextPath[contextPath]);

## the change in SET_STATE (analogous)

the old line was:

    draft.byContextPath = merge ? mergeDeepRight(draft.byContextPath, nodes) : nodes;

the new line is:

    draft.byContextPath = merge ? defaultsDeep(nodes, draft.byContextPath, {}) : nodes;

but it should be:

    draft.byContextPath = merge ? defaultsDeep({}, nodes, draft.byContextPath) : nodes;

Resolves: #2768
Related: #2743
Related: #2578
