### PR TITLE
BUGFIX: Remove existing element when moving node on same level

### DIFF
--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -397,6 +397,15 @@ manifest('main', {}, globalRegistry => {
         }
 
         const fusionPath = contentElement.dataset.__neosFusionPath;
+        const existingElement = findNodeInGuestFrame(
+            contextPath,
+            fusionPath
+        );
+
+        // Remove duplicate node in case of move action on the same level
+        if (existingElement) {
+            existingElement.remove();
+        }
 
         switch (mode) {
             case 'before':


### PR DESCRIPTION
When moving a node inside a content collection column for instance the node was rendered twice until the user reloads the page. As the move event work in general and we have just the issue that the out of band rendering renders the node two times. We (@Sebobo and me) decided to just remove the existing node and solve the glitch this way.

Fixes: #2773

**What I did**
Remove duplicate node on out of band rendering.

**How to verify it**
Move a node inside a content collection column. So if you have two nodes in one column, just move the second before the first element for instance.

Thanks to @patricekaufmann for reporting the issue and @Sebobo for fixing the issue in a pair programming session 💙 

