### PR TITLE
BUGFIX: Prevent preview button to link to the personal user workspace

### DIFF
--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -39,6 +39,7 @@ use Neos\Neos\Ui\Domain\Model\Feedback\Operations\Redirect;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\ReloadDocument;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\RemoveNode;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
+use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodePreviewUrl;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateWorkspaceInfo;
 use Neos\Neos\Ui\Domain\Model\FeedbackCollection;
 use Neos\Neos\Ui\Service\NodeClipboard;
@@ -222,6 +223,12 @@ class BackendServiceController extends ActionController
             foreach ($nodeContextPaths as $contextPath) {
                 $node = $this->nodeService->getNodeFromContextPath($contextPath, null, null, true);
                 $this->publishingService->publishNode($node, $targetWorkspace);
+
+                if ($node->getNodeType()->isAggregate()) {
+                    $updateNodePreviewUrl = new UpdateNodePreviewUrl();
+                    $updateNodePreviewUrl->setNode($node);
+                    $this->feedbackCollection->add($updateNodePreviewUrl);
+                }
             }
 
             $count = count($nodeContextPaths);

--- a/Classes/Domain/Model/Feedback/Operations/UpdateNodePreviewUrl.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateNodePreviewUrl.php
@@ -89,12 +89,15 @@ class UpdateNodePreviewUrl extends AbstractFeedback
     {
         if ($this->node === null) {
             $newPreviewUrl = '';
+            $contextPath = '';
         } else {
             $nodeInfoHelper = new NodeInfoHelper();
             $newPreviewUrl = $nodeInfoHelper->createRedirectToNode($controllerContext, $this->node);
+            $contextPath = $this->node->getContextPath();
         }
         return [
             'newPreviewUrl' => $newPreviewUrl,
+            'contextPath' => $contextPath,
         ];
     }
 }

--- a/Classes/Domain/Model/Feedback/Operations/UpdateNodePreviewUrl.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateNodePreviewUrl.php
@@ -1,0 +1,100 @@
+<?php
+namespace Neos\Neos\Ui\Domain\Model\Feedback\Operations;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Flow\Mvc\Controller\ControllerContext;
+use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
+use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
+use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
+
+class UpdateNodePreviewUrl extends AbstractFeedback
+{
+    /**
+     * @var NodeInterface
+     */
+    protected $node;
+
+    /**
+     * Set the node
+     *
+     * @param NodeInterface $node
+     * @return void
+     */
+    public function setNode(NodeInterface $node)
+    {
+        $this->node = $node;
+    }
+
+    /**
+     * Get the node
+     *
+     * @return NodeInterface
+     */
+    public function getNode()
+    {
+        return $this->node;
+    }
+
+    /**
+     * Get the type identifier
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return 'Neos.Neos.Ui:UpdateNodePreviewUrl';
+    }
+
+    /**
+     * Get the description
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return sprintf('The "preview URL" of node "%s" has been changed potentially.', $this->getNode()->getLabel());
+    }
+
+    /**
+     * Checks whether this feedback is similar to another
+     *
+     * @param FeedbackInterface $feedback
+     * @return boolean
+     */
+    public function isSimilarTo(FeedbackInterface $feedback)
+    {
+        if (!$feedback instanceof UpdateNodePreviewUrl) {
+            return false;
+        }
+        return $this->getNode()->getContextPath() === $feedback->getNode()->getContextPath();
+    }
+
+    /**
+     * Serialize the payload for this feedback
+     *
+     * @param ControllerContext $controllerContext
+     * @return array
+     */
+    public function serializePayload(ControllerContext $controllerContext)
+    {
+        if ($this->node === null) {
+            $newPreviewUrl = '';
+        } else {
+            $nodeInfoHelper = new NodeInfoHelper();
+            $newPreviewUrl = $nodeInfoHelper->createRedirectToNode($controllerContext, $this->node);
+        }
+        return [
+            'newPreviewUrl' => $newPreviewUrl,
+        ];
+    }
+}

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -111,12 +111,11 @@ Neos:
         metaData:
           documentNode: '${q(documentNode).property("_contextPath")}'
           siteNode: '${q(site).property(''_contextPath'')}'
-          previewUrl: '${Neos.Ui.NodeInfo.createRedirectToNode(controllerContext, q(documentNode).context({workspaceName: documentNode.context.workspace.baseWorkspace.name}).get(0))}'
+          previewUrl: '${Neos.Ui.NodeInfo.createRedirectToNode(controllerContext, documentNode)}'
           contentDimensions:
             active: '${documentNode.context.dimensions}'
             allowedPresets: '${Neos.Ui.Api.emptyArrayToObject(Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.context.dimensions))}'
           documentNodeSerialization: '${Neos.Ui.NodeInfo.renderNodeWithPropertiesAndChildrenInformation(documentNode, controllerContext)}'
-          url: '${Neos.Ui.NodeInfo.uri(documentNode, controllerContext)}'
       initialState:
         changes:
           pending: {  }

--- a/packages/neos-ui-sagas/src/Publish/index.js
+++ b/packages/neos-ui-sagas/src/Publish/index.js
@@ -20,11 +20,6 @@ export function * watchPublish() {
                 const feedback = yield call(publish, nodeContextPaths, targetWorkspaceName);
                 yield put(actions.UI.Remote.finishPublishing());
                 yield put(actions.ServerFeedback.handleServerFeedback(feedback));
-
-                const documentNode = yield select(selectors.CR.Nodes.documentNodeSelector);
-                const previewUrl = decodeURIComponent($get('uri', documentNode));
-
-                yield put(actions.UI.ContentCanvas.setPreviewUrl(previewUrl));
             } catch (error) {
                 console.error('Failed to publish', error);
             }

--- a/packages/neos-ui-sagas/src/UI/Inspector/index.js
+++ b/packages/neos-ui-sagas/src/UI/Inspector/index.js
@@ -151,11 +151,6 @@ function * flushInspector(inspectorRegistry) {
                 const oldUriFragment = oldUri.split('@')[0];
                 const newUriFragment = oldUriFragment.replace(new RegExp(escapeRegExp(oldValue) + '$'), newValue);
                 yield put(actions.CR.Nodes.updateUri(oldUriFragment, newUriFragment));
-
-                // Update previewUrl
-                const oldPreviewUrl = $get('ui.contentCanvas.previewUrl', state);
-                const newPreviewUrl = oldPreviewUrl.replace(oldUriFragment, newUriFragment);
-                yield put(actions.UI.ContentCanvas.setPreviewUrl(newPreviewUrl));
             }
         }
     }

--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -219,6 +219,13 @@ manifest('main', {}, globalRegistry => {
     });
 
     //
+    // When the server advices to update the nodes preview URL, dispatch the action to do so
+    //
+    serverFeedbackHandlers.set('Neos.Neos.Ui:UpdateNodePreviewUrl/Main', (feedbackPayload, {store}) => {
+        store.dispatch(actions.UI.ContentCanvas.setPreviewUrl(feedbackPayload.newPreviewUrl));
+    });
+
+    //
     // When the server advices to reload the children of a document node, dispatch the action to do so.
     //
     serverFeedbackHandlers.set('Neos.Neos.Ui:NodeCreated/Main', (feedbackPayload, {store}) => {

--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -222,7 +222,11 @@ manifest('main', {}, globalRegistry => {
     // When the server advices to update the nodes preview URL, dispatch the action to do so
     //
     serverFeedbackHandlers.set('Neos.Neos.Ui:UpdateNodePreviewUrl/Main', (feedbackPayload, {store}) => {
-        store.dispatch(actions.UI.ContentCanvas.setPreviewUrl(feedbackPayload.newPreviewUrl));
+        const state = store.getState();
+        const currentDocumentNodePath = $get('cr.nodes.documentNode', state);
+        if (feedbackPayload.contextPath === currentDocumentNodePath) {
+            store.dispatch(actions.UI.ContentCanvas.setPreviewUrl(feedbackPayload.newPreviewUrl));
+        }
     });
 
     //


### PR DESCRIPTION
With this change the `PreviewButton` of the UI never links to a preview
of the node in the personal user workspace.
Instead it:

* Is disabled if the node is hidden/missing in the base workspace
* Points to a `/neos/redirect?<node-in-base-workspace>` URL that redirects to the current node
  in its base workspace

For the "usual editing case" (personal workspace with target == `live`)
that means, that clicking the button will lead to the version in the live
workspace (i.e. `/the/final/url.html`).

For shared workspaces the redirect will point to a preview URL for that
workspace (i.e. `/neos/preview?node=<node-in-shared-workspace>`)

Fixes: neos/neos-development-collection#3019