### PR TITLE
BUGFIX: Reduce the number of NodeTypes to run policy check against #2784

### DIFF
--- a/Classes/Service/NodePolicyService.php
+++ b/Classes/Service/NodePolicyService.php
@@ -119,7 +119,7 @@ class NodePolicyService
         $nodeNodeType = $node->getNodeType();
 
         $superTypes = [];
-        $generateSuperTypes = function(array $nodeTypes, &$superTypes) use (&$generateSuperTypes) {
+        $generateSuperTypes = function (array $nodeTypes, &$superTypes) use (&$generateSuperTypes) {
             foreach ($nodeTypes as $nodeType) {
                 $superTypes[$nodeType->getName()] = $nodeType;
                 $generateSuperTypes($nodeType->getDeclaredSuperTypes(), $superTypes);
@@ -131,7 +131,7 @@ class NodePolicyService
         try {
             $parentNode = $node->findParentNode();
             $parentNodeType = $parentNode->getNodeType();
-        }catch(NodeException $exception){
+        } catch (NodeException $exception) {
             // no parentNode found
         }
 
@@ -150,16 +150,15 @@ class NodePolicyService
                 if ($parentNodeType && $parentNodeType->allowsGrandchildNodeType($nodeName, $nodeType)) {
                     return true;
                 }
-            }
-            else if ($nodeNodeType->allowsChildNodeType($nodeType)) {
+            } elseif ($nodeNodeType->allowsChildNodeType($nodeType)) {
                 return true;
             }
             // check if the nodeType is a supertype
-            else if (isset($superTypes[$nodeType->getName()])) {
+            elseif (isset($superTypes[$nodeType->getName()])) {
                 return true;
             }
             // check if the nodeType is the same as that of the current $node's nodeType
-            else if ($nodeType->getName() == $nodeNodeType->getName()) {
+            elseif ($nodeType->getName() == $nodeNodeType->getName()) {
                 return true;
             }
 

--- a/Classes/Service/NodePolicyService.php
+++ b/Classes/Service/NodePolicyService.php
@@ -136,17 +136,17 @@ class NodePolicyService
         }
 
         // check if the node is auto-created
-        $isAutCreated   = false;
+        $isAutoCreated   = false;
         if ($parentNodeType && array_key_exists((string)$node->getNodeName(), $parentNodeType->getAutoCreatedChildNodes())) {
-            $isAutCreated = true;
+            $isAutoCreated = true;
         }
 
         // filter the set of configured nodeTypes
         $nodeName = (string)$node->getNodeName();
 
-        $constraintAndSuperTypeFilter = function ($nodeType) use ($nodeName, $nodeNodeType, $superTypes, $isAutCreated, $parentNodeType) {
+        $constraintAndSuperTypeFilter = function ($nodeType) use ($nodeName, $nodeNodeType, $superTypes, $isAutoCreated, $parentNodeType) {
             // check if the nodeType is mentioned in the constraints
-            if ($isAutCreated) {
+            if ($isAutoCreated) {
                 if ($parentNodeType && $parentNodeType->allowsGrandchildNodeType($nodeName, $nodeType)) {
                     return true;
                 }
@@ -166,7 +166,7 @@ class NodePolicyService
             return false;
         };
 
-        $nodeTypes = array_filter($this->nodeTypeManager->getNodeTypes(), $constraintAndSuperTypeFilter);
+        $filteredNodeTypes = array_filter($this->nodeTypeManager->getNodeTypes(), $constraintAndSuperTypeFilter);
 
         // filter the remaining nodeTypes via policy check
         $filter = function ($nodeType) use ($node) {
@@ -176,7 +176,7 @@ class NodePolicyService
             );
         };
 
-        $disallowedNodeTypeObjects = array_filter($nodeTypes, $filter);
+        $disallowedNodeTypeObjects = array_filter($filteredNodeTypes, $filter);
 
         $mapper = function ($nodeType) {
             return $nodeType->getName();

--- a/Classes/Service/NodePolicyService.php
+++ b/Classes/Service/NodePolicyService.php
@@ -12,6 +12,7 @@ namespace Neos\Neos\Ui\Service;
  */
 
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+use Neos\ContentRepository\Exception\NodeException;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\CreateNodePrivilege;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\CreateNodePrivilegeSubject;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\EditNodePrivilege;
@@ -114,6 +115,61 @@ class NodePolicyService
             return $disallowedNodeTypes;
         }
 
+        // determine the set of configured node supertypes
+        $nodeNodeType = $node->getNodeType();
+
+        $superTypes = [];
+        $generateSuperTypes = function(array $nodeTypes, &$superTypes) use (&$generateSuperTypes) {
+            foreach ($nodeTypes as $nodeType) {
+                $superTypes[$nodeType->getName()] = $nodeType;
+                $generateSuperTypes($nodeType->getDeclaredSuperTypes(), $superTypes);
+            }
+        };
+        $generateSuperTypes($nodeNodeType->getDeclaredSuperTypes(), $superTypes);
+
+        $parentNodeType = null;
+        try {
+            $parentNode = $node->findParentNode();
+            $parentNodeType = $parentNode->getNodeType();
+        }catch(NodeException $exception){
+            // no parentNode found
+        }
+
+        // check if the node is auto-created
+        $isAutCreated   = false;
+        if ($parentNodeType && array_key_exists((string)$node->getNodeName(), $parentNodeType->getAutoCreatedChildNodes())) {
+            $isAutCreated = true;
+        }
+
+        // filter the set of configured nodeTypes
+        $nodeName = (string)$node->getNodeName();
+
+        $constraintAndSuperTypeFilter = function ($nodeType) use ($nodeName, $nodeNodeType, $superTypes, $isAutCreated, $parentNodeType) {
+            // check if the nodeType is mentioned in the constraints
+            if ($isAutCreated) {
+                if ($parentNodeType && $parentNodeType->allowsGrandchildNodeType($nodeName, $nodeType)) {
+                    return true;
+                }
+            }
+            else if ($nodeNodeType->allowsChildNodeType($nodeType)) {
+                return true;
+            }
+            // check if the nodeType is a supertype
+            else if (isset($superTypes[$nodeType->getName()])) {
+                return true;
+            }
+            // check if the nodeType is the same as that of the current $node's nodeType
+            else if ($nodeType->getName() == $nodeNodeType->getName()) {
+                return true;
+            }
+
+            // ignore other nodeType
+            return false;
+        };
+
+        $nodeTypes = array_filter($this->nodeTypeManager->getNodeTypes(), $constraintAndSuperTypeFilter);
+
+        // filter the remaining nodeTypes via policy check
         $filter = function ($nodeType) use ($node) {
             return !$this->privilegeManager->isGranted(
                 CreateNodePrivilege::class,
@@ -121,7 +177,7 @@ class NodePolicyService
             );
         };
 
-        $disallowedNodeTypeObjects = array_filter($this->nodeTypeManager->getNodeTypes(), $filter);
+        $disallowedNodeTypeObjects = array_filter($nodeTypes, $filter);
 
         $mapper = function ($nodeType) {
             return $nodeType->getName();


### PR DESCRIPTION
fixes #2784

**What I did**

In `getDisallowedNodeTypes(NodeInterface $node)` the list of configured NodeTypes is filtered using the NodeType constraints of the given `$node`. Abstract NodeTypes are still included which might be relevant for the policy check.

**How I did it**

Before running the policy check, `array_filter` is called used on all NodeTypes (`$this->nodeTypeManager->getNodeTypes()`). The filter method then checks the constraints depending if `$node` is auto-created or if the NodeType to filter is a superType or the NodeType of the node itself.

**How to verify it**

One need to compare the runtime of of the /get-additional-node-metadata endpoint in the Neos Backend UI on a project with configured CreateNodePrivilege policy.

This is a screenshot for a Neos 4.3 project without the code changes: 
![image](https://user-images.githubusercontent.com/19683930/93858061-dcb2a300-fcbb-11ea-9bae-cf746dc297e0.png)

And this one has the code changes in place:
![image](https://user-images.githubusercontent.com/19683930/93858152-ffdd5280-fcbb-11ea-82a4-46ac6a08a0e4.png)

