### PR TITLE
BUGFIX: fix reload when filtering or searching

### DIFF
--- a/packages/neos-ui-redux-store/src/UI/PageTree/index.ts
+++ b/packages/neos-ui-redux-store/src/UI/PageTree/index.ts
@@ -13,6 +13,8 @@ export interface State extends Readonly<{
     intermediate: NodeContextPath[];
     loading: NodeContextPath[];
     errors: NodeContextPath[];
+    query: string;
+    filterNodeType: string;
 }> {}
 
 export const defaultState: State = {
@@ -21,7 +23,9 @@ export const defaultState: State = {
     hidden: [],
     intermediate: [],
     loading: [],
-    errors: []
+    errors: [],
+    query: '',
+    filterNodeType: ''
 };
 
 //
@@ -116,6 +120,12 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
             draft.hidden = action.payload.hiddenContextPaths;
             draft.toggled = action.payload.toggledContextPaths;
             draft.intermediate = action.payload.intermediateContextPaths;
+            break;
+        }
+        case actionTypes.COMMENCE_SEARCH: {
+            // Store search arguments, to be used during tree reload
+            draft.query = action.payload.query;
+            draft.filterNodeType = action.payload.filterNodeType;
             break;
         }
     }

--- a/packages/neos-ui-sagas/src/CR/NodeOperations/reloadState.js
+++ b/packages/neos-ui-sagas/src/CR/NodeOperations/reloadState.js
@@ -7,7 +7,16 @@ import {actions, actionTypes} from '@neos-project/neos-ui-redux-store';
 export default function * watchReloadState({configuration}) {
     yield takeLatest(actionTypes.CR.Nodes.RELOAD_STATE, function * reloadState(action) {
         const {q} = backend.get();
+
         const currentSiteNodeContextPath = yield select($get('cr.nodes.siteNode'));
+        const query = yield select($get('ui.pageTree.query'));
+        const filterNodeType = yield select($get('ui.pageTree.filterNodeType'));
+        // If either search of filtering presets are set, we should re-commence the search instead of default nodes reload
+        if (query || filterNodeType) {
+            yield put(actions.UI.PageTree.commenceSearch(currentSiteNodeContextPath, {query, filterNodeType}));
+            return;
+        }
+
         const clipboardNodeContextPath = yield select($get('cr.nodes.clipboard'));
         const toggledNodes = yield select($get('ui.pageTree.toggled'));
         const siteNodeContextPath = $get('payload.siteNodeContextPath', action) || currentSiteNodeContextPath;


### PR DESCRIPTION
Fixes: https://github.com/neos/neos-ui/issues/2093

**What I did**

Currently if you reload the document tree nodes during searching or filtering by preset, it leads to very odd results. This PR fixes it.

**How I did it**

I store the current query and filter preset inside redux state and do `commenceSearch` instead of reloading the default nodes when the refresh button is clicked.

**How to verify it**

Put this into Settings.yaml:

```yaml
Neos:
  Neos:
    userInterface:
      navigateComponent:
        nodeTree:
          presets:
            'default':
              baseNodeType: 'Neos.Neos:Document,!Neos.Demo:Chapter'
            'legalPages':
              ui:
                label: 'Test Preset'
              baseNodeType: 'Neos.Demo:Chapter'
```

Toggle the preset and hit reload. Also try searching for something and hit reload.