### PR TITLE
BUGFIX: merge children instead of replacing them

### DIFF
--- a/packages/neos-ui-redux-store/src/CR/Nodes/helpers.ts
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/helpers.ts
@@ -54,3 +54,19 @@ export const getNodeOrThrow = (nodeMap: NodeMap, contextPath: NodeContextPath) =
     }
     return node;
 };
+
+// We have to merge children and not just override them, as there still may be children from different node tree preset, and we shouldn't overwrite
+export const mergeChildren = (node?: Node, newNode?: Node) => {
+    const existingNodes: {
+        [key: string]: boolean
+    } = {};
+
+    // First merge children arrays
+    const mergedChildren = [...(node?.children || []), ...(newNode?.children || [])];
+    // Than return unique children
+    return mergedChildren.filter((node) => {
+        const exists = existingNodes[node.contextPath];
+        existingNodes[node.contextPath] = true;
+        return !exists;
+    });
+};

--- a/packages/neos-ui-redux-store/src/CR/Nodes/helpers.ts
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/helpers.ts
@@ -62,7 +62,7 @@ export const mergeChildren = (node?: Node, newNode?: Node) => {
     } = {};
 
     // First merge children arrays
-    const mergedChildren = [...(node?.children || []), ...(newNode?.children || [])];
+    const mergedChildren = [...(node ? node.children : []), ...(newNode ? newNode.children : [])];
     // Than return unique children
     return mergedChildren.filter((node) => {
         const exists = existingNodes[node.contextPath];

--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
@@ -4,7 +4,7 @@ import {action as createAction, ActionType} from 'typesafe-actions';
 import {actionTypes as system, InitAction} from '@neos-project/neos-ui-redux-store/src/System';
 
 import * as selectors from './selectors';
-import {parentNodeContextPath, getNodeOrThrow} from './helpers';
+import {parentNodeContextPath, getNodeOrThrow, mergeChildren} from './helpers';
 
 import {FusionPath, NodeContextPath, InsertPosition, NodeMap, ClipboardMode, NodeTypeName} from '@neos-project/neos-ts-interfaces';
 
@@ -402,9 +402,8 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
                     throw new Error('This error should never be thrown, it\'s a way to fool TypeScript');
                 }
                 const mergedNode = mergeDeepRight(draft.byContextPath[contextPath], newNode);
-                // Force overwrite of children
                 if (newNode.children !== undefined) {
-                    mergedNode.children = newNode.children;
+                    mergedNode.children = mergeChildren(draft.byContextPath[contextPath], newNode);
                 }
                 // Force overwrite of matchesCurrentDimensions
                 if (newNode.matchesCurrentDimensions !== undefined) {


### PR DESCRIPTION
Fixes: https://github.com/neos/neos-ui/issues/1691

**What I did**

When you toggle a custom tree preset and then navigate the tree, the children of the node missing in the default preset would disappear. I fixed it.

**How I did it**

When we are navigating to some page, the node information about this node is being read from the script tags rendered on that page and merged into the redux state. Now it so happens that those inline script tags are rendered according to the default preset, and so the nodes that exist only in the preset get removed from the redux state.

The only way I could think of fixing it is to actually merge children instead of overwriting them. I first merge them, then make sure there are now duplicates left comparing them by context paths.

**How to verify it**

See the issue description basically.