### PR TITLE
BUGFIX: fix creating and moving nodes with tree preset activated

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -178,13 +178,14 @@ class BackendController extends ActionController
 
     /**
      * @param NodeInterface $node
+     * @param string $presetBaseNodeType
      * @throws StopActionException
      */
-    public function redirectToAction(NodeInterface $node)
+    public function redirectToAction(NodeInterface $node, string $presetBaseNodeType = null)
     {
         $this->response->getHeaders()->setCacheControlDirective('no-cache');
         $this->response->getHeaders()->setCacheControlDirective('no-store');
-        $this->redirect('show', 'Frontend\Node', 'Neos.Neos', ['node' => $node]);
+        $this->redirect('show', 'Frontend\Node', 'Neos.Neos', ['node' => $node, 'presetBaseNodeType' => $presetBaseNodeType]);
     }
 
     /**

--- a/Classes/Domain/Model/Changes/AbstractCreate.php
+++ b/Classes/Domain/Model/Changes/AbstractCreate.php
@@ -65,6 +65,7 @@ abstract class AbstractCreate extends AbstractStructuralChange
     {
         $updateNodeInfo = new UpdateNodeInfo();
         $updateNodeInfo->setNode($node);
+        $updateNodeInfo->setBaseNodeType($this->baseNodeType);
         $updateNodeInfo->recursive();
         $this->feedbackCollection->add($updateNodeInfo);
         parent::finish($node);

--- a/Classes/Domain/Model/Changes/AbstractStructuralChange.php
+++ b/Classes/Domain/Model/Changes/AbstractStructuralChange.php
@@ -51,6 +51,33 @@ abstract class AbstractStructuralChange extends AbstractChange
     protected $cachedSiblingNode = null;
 
     /**
+     * Used when creating nodes within non-default tree preset
+     *
+     * @var string|null
+     */
+    protected $baseNodeType = null;
+
+    /**
+     * Set the baseNodeType
+     *
+     * @param string $baseNodeType
+     */
+    public function setBaseNodeType($baseNodeType)
+    {
+        $this->baseNodeType = $baseNodeType;
+    }
+
+    /**
+     * Get the baseNodeType
+     *
+     * @return string|null
+     */
+    public function getBaseNodeType()
+    {
+        return $this->baseNodeType;
+    }
+
+    /**
      * Get the insertion mode (before|after|into) that is represented by this change
      *
      * @return string
@@ -133,6 +160,7 @@ abstract class AbstractStructuralChange extends AbstractChange
 
         $updateParentNodeInfo = new UpdateNodeInfo();
         $updateParentNodeInfo->setNode($node->getParent());
+        $updateParentNodeInfo->setBaseNodeType($this->baseNodeType);
         $this->feedbackCollection->add($updateParentNodeInfo);
 
         $this->updateWorkspaceInfo();

--- a/Classes/Domain/Model/Changes/MoveAfter.php
+++ b/Classes/Domain/Model/Changes/MoveAfter.php
@@ -52,6 +52,7 @@ class MoveAfter extends AbstractMove
 
             $updateParentNodeInfo = new UpdateNodeInfo();
             $updateParentNodeInfo->setNode($parent);
+            $updateParentNodeInfo->setBaseNodeType($this->baseNodeType);
 
             $this->feedbackCollection->add($updateParentNodeInfo);
 

--- a/Classes/Domain/Model/Changes/MoveBefore.php
+++ b/Classes/Domain/Model/Changes/MoveBefore.php
@@ -53,6 +53,7 @@ class MoveBefore extends AbstractMove
 
             $updateParentNodeInfo = new UpdateNodeInfo();
             $updateParentNodeInfo->setNode($parent);
+            $updateParentNodeInfo->setBaseNodeType($this->baseNodeType);
 
             $this->feedbackCollection->add($updateParentNodeInfo);
 

--- a/Classes/Domain/Model/Changes/MoveInto.php
+++ b/Classes/Domain/Model/Changes/MoveInto.php
@@ -91,6 +91,7 @@ class MoveInto extends AbstractMove
 
             $updateParentNodeInfo = new UpdateNodeInfo();
             $updateParentNodeInfo->setNode($parent);
+            $updateParentNodeInfo->setBaseNodeType($this->baseNodeType);
 
             $this->feedbackCollection->add($updateParentNodeInfo);
 

--- a/Classes/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
@@ -33,6 +33,28 @@ class UpdateNodeInfo extends AbstractFeedback
 
     protected $isRecursive = false;
 
+    protected $baseNodeType = null;
+
+    /**
+     * Set the baseNodeType
+     *
+     * @param string $baseNodeType
+     */
+    public function setBaseNodeType($baseNodeType)
+    {
+        $this->baseNodeType = $baseNodeType;
+    }
+
+    /**
+     * Get the baseNodeType
+     *
+     * @return string|null
+     */
+    public function getBaseNodeType()
+    {
+        return $this->baseNodeType;
+    }
+
     /**
      * Set the node
      *
@@ -122,7 +144,7 @@ class UpdateNodeInfo extends AbstractFeedback
     public function serializeNodeRecursively(NodeInterface $node, ControllerContext $controllerContext)
     {
         $result = [
-            $node->getContextPath() => $this->nodeInfoHelper->renderNodeWithPropertiesAndChildrenInformation($node, $controllerContext)
+            $node->getContextPath() => $this->nodeInfoHelper->renderNodeWithPropertiesAndChildrenInformation($node, $controllerContext, $this->baseNodeType)
         ];
 
         if ($this->isRecursive === true) {

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -69,7 +69,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
      * @Flow\InjectConfiguration(path="userInterface.navigateComponent.nodeTree.presets.default.baseNodeType", package="Neos.Neos")
      * @var string
      */
-    protected $baseNodeType;
+    protected $defaultBaseNodeType;
 
     /**
      * @Flow\InjectConfiguration(path="userInterface.navigateComponent.nodeTree.loadingDepth", package="Neos.Neos")
@@ -129,9 +129,12 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
 
         if ($controllerContext !== null) {
             $nodeInfo = array_merge($nodeInfo, $this->getUriInformation($node, $controllerContext));
+            if ($controllerContext->getRequest()->hasArgument('presetBaseNodeType')) {
+                $presetBaseNodeType = $controllerContext->getRequest()->getArgument('presetBaseNodeType');
+            }
         }
 
-        $baseNodeType = $nodeTypeFilterOverride ? $nodeTypeFilterOverride : $this->baseNodeType;
+        $baseNodeType = $nodeTypeFilterOverride ? $nodeTypeFilterOverride : (isset($presetBaseNodeType) ? $presetBaseNodeType : $this->defaultBaseNodeType);
         $nodeTypeFilter = $this->buildNodeTypeFilterString($this->nodeTypeStringsToList($baseNodeType), $this->nodeTypeStringsToList($this->ignoredNodeTypeRole));
 
         $nodeInfo['children'] = $this->renderChildrenInformation($node, $nodeTypeFilter);
@@ -161,9 +164,12 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
 
         if ($controllerContext !== null) {
             $nodeInfo = array_merge($nodeInfo, $this->getUriInformation($node, $controllerContext));
+            if ($controllerContext->getRequest()->hasArgument('presetBaseNodeType')) {
+                $presetBaseNodeType = $controllerContext->getRequest()->getArgument('presetBaseNodeType');
+            }
         }
 
-        $baseNodeType = $nodeTypeFilterOverride ? $nodeTypeFilterOverride : $this->baseNodeType;
+        $baseNodeType = $nodeTypeFilterOverride ? $nodeTypeFilterOverride : (isset($presetBaseNodeType) ? $presetBaseNodeType : $this->defaultBaseNodeType);
         $nodeInfo['children'] = $this->renderChildrenInformation($node, $baseNodeType);
 
         $this->userLocaleService->switchToUILocale(true);

--- a/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -109,3 +109,7 @@ prototype(Neos.Neos:Page) {
 
     @exceptionHandler = 'Neos\\Neos\\Ui\\Fusion\\ExceptionHandler\\PageExceptionHandler'
 }
+
+prototype(Neos.Fusion:GlobalCacheIdentifiers) {
+    presetBaseNodeType = ${request.arguments.presetBaseNodeType}
+}

--- a/packages/neos-ui-backend-connector/src/Endpoints/Helpers.ts
+++ b/packages/neos-ui-backend-connector/src/Endpoints/Helpers.ts
@@ -60,7 +60,7 @@ export const urlAppendParams = (urlString: string, params: {[key: string]: strin
     });
     url.search = searchParams.toString();
     return url.toString();
-}
+};
 
 /**
  *

--- a/packages/neos-ui-backend-connector/src/Endpoints/Helpers.ts
+++ b/packages/neos-ui-backend-connector/src/Endpoints/Helpers.ts
@@ -46,6 +46,23 @@ export const urlWithParams = (urlString: string, params = {}) => {
 };
 
 /**
+ * Append params to url without overriding existing params
+ *
+ * @param urlString
+ * @param params
+ * @return string
+ */
+export const urlAppendParams = (urlString: string, params: {[key: string]: string} = {}) => {
+    const url = new URL(urlString);
+    const searchParams = new URLSearchParams(url.search);
+    Object.keys(params).forEach(paramKey => {
+        searchParams.set(paramKey, params[paramKey]);
+    });
+    url.search = searchParams.toString();
+    return url.toString();
+}
+
+/**
  *
  * @param rootElement
  * @param selector

--- a/packages/neos-ui-redux-store/src/CR/Nodes/helpers.ts
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/helpers.ts
@@ -54,19 +54,3 @@ export const getNodeOrThrow = (nodeMap: NodeMap, contextPath: NodeContextPath) =
     }
     return node;
 };
-
-// We have to merge children and not just override them, as there still may be children from different node tree preset, and we shouldn't overwrite
-export const mergeChildren = (node?: Node, newNode?: Node) => {
-    const existingNodes: {
-        [key: string]: boolean
-    } = {};
-
-    // First merge children arrays
-    const mergedChildren = [...(node ? node.children : []), ...(newNode ? newNode.children : [])];
-    // Than return unique children
-    return mergedChildren.filter((node) => {
-        const exists = existingNodes[node.contextPath];
-        existingNodes[node.contextPath] = true;
-        return !exists;
-    });
-};

--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
@@ -4,7 +4,7 @@ import {action as createAction, ActionType} from 'typesafe-actions';
 import {actionTypes as system, InitAction} from '@neos-project/neos-ui-redux-store/src/System';
 
 import * as selectors from './selectors';
-import {parentNodeContextPath, getNodeOrThrow, mergeChildren} from './helpers';
+import {parentNodeContextPath, getNodeOrThrow} from './helpers';
 
 import {FusionPath, NodeContextPath, InsertPosition, NodeMap, ClipboardMode, NodeTypeName} from '@neos-project/neos-ts-interfaces';
 
@@ -402,8 +402,9 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
                     throw new Error('This error should never be thrown, it\'s a way to fool TypeScript');
                 }
                 const mergedNode = mergeDeepRight(draft.byContextPath[contextPath], newNode);
+                // Force overwrite of children
                 if (newNode.children !== undefined) {
-                    mergedNode.children = mergeChildren(draft.byContextPath[contextPath], newNode);
+                    mergedNode.children = newNode.children;
                 }
                 // Force overwrite of matchesCurrentDimensions
                 if (newNode.matchesCurrentDimensions !== undefined) {

--- a/packages/neos-ui-sagas/src/CR/NodeOperations/addNode.js
+++ b/packages/neos-ui-sagas/src/CR/NodeOperations/addNode.js
@@ -1,4 +1,4 @@
-import {takeLatest, take, put, race, call} from 'redux-saga/effects';
+import {takeLatest, take, put, race, call, select} from 'redux-saga/effects';
 import {$get} from 'plow-js';
 
 import {actions, actionTypes} from '@neos-project/neos-ui-redux-store';
@@ -91,13 +91,15 @@ function * nodeCreationWorkflow(context, step = STEP_SELECT_NODETYPE, workflowDa
             if (nodeTypesRegistry.hasRole(nodeType, 'document')) {
                 yield put(actions.UI.ContentCanvas.startLoading());
             }
+            const baseNodeType = yield select($get('ui.pageTree.filterNodeType'));
             return yield put(actions.Changes.persistChanges([{
                 type: calculateChangeTypeFromMode(mode, 'Create'),
                 subject: referenceNodeContextPath,
                 payload: {
                     ...calculateDomAddressesFromMode(mode, referenceNodeContextPath, referenceNodeFusionPath),
                     nodeType,
-                    data
+                    data,
+                    baseNodeType
                 }
             }]));
         }

--- a/packages/neos-ui-sagas/src/CR/NodeOperations/moveDroppedNode.js
+++ b/packages/neos-ui-sagas/src/CR/NodeOperations/moveDroppedNode.js
@@ -1,4 +1,5 @@
-import {takeEvery, put} from 'redux-saga/effects';
+import {takeEvery, put, select} from 'redux-saga/effects';
+import {$get} from 'plow-js';
 
 import {actions, actionTypes} from '@neos-project/neos-ui-redux-store';
 
@@ -8,13 +9,18 @@ export default function * moveDroppedNode() {
     yield takeEvery(actionTypes.CR.Nodes.MOVE, function * handleNodeMove({payload}) {
         const {nodeToBeMoved: subject, targetNode: reference, position} = payload;
 
+        const baseNodeType = yield select($get('ui.pageTree.filterNodeType'));
+
         yield put(actions.Changes.persistChanges([{
             type: calculateChangeTypeFromMode(position, 'Move'),
             subject,
-            payload: calculateDomAddressesFromMode(
-                position,
-                reference
-            )
+            payload: {
+                ...calculateDomAddressesFromMode(
+                    position,
+                    reference
+                ),
+                baseNodeType
+            }
         }]));
     });
 }

--- a/packages/neos-ui-sagas/src/CR/NodeOperations/pasteNode.js
+++ b/packages/neos-ui-sagas/src/CR/NodeOperations/pasteNode.js
@@ -29,11 +29,16 @@ export default function * pasteNode({globalRegistry}) {
         );
 
         if (mode) {
+            const baseNodeType = yield select($get('ui.pageTree.filterNodeType'));
+
             yield put(actions.CR.Nodes.commitPaste(clipboardMode));
             yield put(actions.Changes.persistChanges([{
                 type: calculateChangeTypeFromMode(mode, clipboardMode),
                 subject,
-                payload: calculateDomAddressesFromMode(mode, reference, fusionPath)
+                payload: {
+                    ...calculateDomAddressesFromMode(mode, reference, fusionPath),
+                    baseNodeType
+                }
             }]));
         }
     });

--- a/packages/neos-ui-sagas/src/UI/PageTree/index.js
+++ b/packages/neos-ui-sagas/src/UI/PageTree/index.js
@@ -197,7 +197,7 @@ export function * watchSearch({configuration}) {
                         if (isCollapsed) {
                             toggledContextPaths.push(contextPath);
                         }
-    
+
                         if (!node.matched) {
                             intermediateContextPaths.push(contextPath);
                         }

--- a/packages/neos-ui-sagas/src/UI/PageTree/index.js
+++ b/packages/neos-ui-sagas/src/UI/PageTree/index.js
@@ -192,13 +192,15 @@ export function * watchSearch({configuration}) {
                 if (node.intermediate) {
                     // We reset all toggled state before search, so we can assume "isToggled == false" here
                     const isToggled = false;
-                    const isCollapsed = isNodeCollapsed(node, isToggled, siteNode, loadingDepth);
-                    if (isCollapsed) {
-                        toggledContextPaths.push(contextPath);
-                    }
-
-                    if (!node.matched) {
-                        intermediateContextPaths.push(contextPath);
+                    if (node && siteNode) {
+                        const isCollapsed = isNodeCollapsed(node, isToggled, siteNode, loadingDepth);
+                        if (isCollapsed) {
+                            toggledContextPaths.push(contextPath);
+                        }
+    
+                        if (!node.matched) {
+                            intermediateContextPaths.push(contextPath);
+                        }
                     }
                 }
             });

--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -4,6 +4,7 @@ import {connect} from 'react-redux';
 import mergeClassNames from 'classnames';
 import {$transform, $get} from 'plow-js';
 
+import {urlWithParams} from '@neos-project/neos-ui-backend-connector/src/Endpoints/Helpers';
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {neos} from '@neos-project/neos-ui-decorators';
 
@@ -18,6 +19,7 @@ import style from './style.css';
     isEditModePanelHidden: $get('ui.editModePanel.isHidden'),
     backgroundColor: $get('ui.contentCanvas.backgroundColor'),
     src: $get('ui.contentCanvas.src'),
+    baseNodeType: $get('ui.pageTree.filterNodeType'),
     currentEditPreviewMode: selectors.UI.EditPreviewMode.currentEditPreviewMode
 }), {
     startLoading: actions.UI.ContentCanvas.startLoading,
@@ -42,6 +44,7 @@ export default class ContentCanvas extends PureComponent {
         requestRegainControl: PropTypes.func.isRequired,
         requestLogin: PropTypes.func.isRequired,
         currentEditPreviewMode: PropTypes.string.isRequired,
+        baseNodeType: PropTypes.string,
 
         editPreviewModes: PropTypes.object.isRequired,
         guestFrameRegistry: PropTypes.object.isRequired
@@ -171,6 +174,19 @@ export default class ContentCanvas extends PureComponent {
                     requestLogin();
                     return;
                 }
+
+                // Append presetBaseNodeType param to all internal links
+                const internalLinks = iframe.contentWindow.document.querySelectorAll('a[href*="@user-"]');
+                internalLinks.forEach(link => {
+                    link.addEventListener('click', e => {
+                        if (this.props.baseNodeType) {
+                            link.setAttribute(
+                                'href',
+                                urlWithParams(link.href, {presetBaseNodeType: this.props.baseNodeType})
+                            );
+                        }
+                    })
+                })
 
                 this.setState({
                     isVisible: true,

--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -4,7 +4,7 @@ import {connect} from 'react-redux';
 import mergeClassNames from 'classnames';
 import {$transform, $get} from 'plow-js';
 
-import {urlWithParams} from '@neos-project/neos-ui-backend-connector/src/Endpoints/Helpers';
+import {urlAppendParams} from '@neos-project/neos-ui-backend-connector/src/Endpoints/Helpers';
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {neos} from '@neos-project/neos-ui-decorators';
 
@@ -182,7 +182,7 @@ export default class ContentCanvas extends PureComponent {
                         if (this.props.baseNodeType) {
                             link.setAttribute(
                                 'href',
-                                urlWithParams(link.href, {presetBaseNodeType: this.props.baseNodeType})
+                                urlAppendParams(link.href, {presetBaseNodeType: this.props.baseNodeType})
                             );
                         }
                     })

--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -178,15 +178,15 @@ export default class ContentCanvas extends PureComponent {
                 // Append presetBaseNodeType param to all internal links
                 const internalLinks = iframe.contentWindow.document.querySelectorAll('a[href*="@user-"]');
                 internalLinks.forEach(link => {
-                    link.addEventListener('click', e => {
+                    link.addEventListener('click', () => {
                         if (this.props.baseNodeType) {
                             link.setAttribute(
                                 'href',
                                 urlAppendParams(link.href, {presetBaseNodeType: this.props.baseNodeType})
                             );
                         }
-                    })
-                })
+                    });
+                });
 
                 this.setState({
                     isVisible: true,

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -15,7 +15,7 @@ import {neos} from '@neos-project/neos-ui-decorators';
 import animate from 'amator';
 import hashSum from 'hash-sum';
 import moment from 'moment';
-import {urlWithParams} from '@neos-project/neos-ui-backend-connector/src/Endpoints/Helpers';
+import {urlAppendParams} from '@neos-project/neos-ui-backend-connector/src/Endpoints/Helpers';
 
 const getContextPath = $get('contextPath');
 
@@ -352,7 +352,7 @@ export default class Node extends PureComponent {
         }
 
         // Append presetBaseNodeType param to src
-        const srcWithBaseNodeType = this.props.filterNodeType ? urlWithParams(
+        const srcWithBaseNodeType = this.props.filterNodeType ? urlAppendParams(
             $get('uri', node),
             {presetBaseNodeType: this.props.filterNodeType}
         ) : $get('uri', node);

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -8,7 +8,7 @@ import Tree from '@neos-project/react-ui-components/src/Tree/';
 import Icon from '@neos-project/react-ui-components/src/Icon/';
 import {stripTags, decodeHtml} from '@neos-project/utils-helpers';
 
-import {selectors} from '@neos-project/neos-ui-redux-store';
+import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {isNodeCollapsed} from '@neos-project/neos-ui-redux-store/src/CR/Nodes/helpers';
 import {neos} from '@neos-project/neos-ui-decorators';
 
@@ -341,10 +341,14 @@ export default class Node extends PureComponent {
     }
 
     handleNodeClick = e => {
-        const {node, onNodeFocus, onNodeClick} = this.props;
+        const {node, onNodeFocus, onNodeClick, isFocused, reload} = this.props;
         const openInNewWindow = e.metaKey || e.shiftKey || e.ctrlKey;
         onNodeFocus($get('contextPath', node), openInNewWindow);
-        onNodeClick($get('uri', node), $get('contextPath', node), openInNewWindow);
+
+        // Trigger reload if clicking on the current document node
+        if (isFocused && reload) {
+            reload();
+        }
     }
 }
 
@@ -377,6 +381,7 @@ export const PageTreeNode = withNodeTypeRegistryAndI18nRegistry(connect(
             loadingNodeContextPaths: selectors.UI.PageTree.getLoading(state),
             errorNodeContextPaths: selectors.UI.PageTree.getErrors(state),
             isNodeDirty: isDocumentNodeDirtySelector(state, $get('contextPath', node)),
+            filterNodeType: $get('ui.pageTree.filterNodeType', state),
             canBeInsertedAlongside: canBeMovedAlongsideSelector(state, {
                 subject: getContextPath(currentlyDraggedNode),
                 reference: getContextPath(node)
@@ -386,6 +391,9 @@ export const PageTreeNode = withNodeTypeRegistryAndI18nRegistry(connect(
                 reference: getContextPath(node)
             })
         });
+    },
+    {
+        reload: actions.UI.ContentCanvas.reload,
     }
 )(Node));
 

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -15,6 +15,7 @@ import {neos} from '@neos-project/neos-ui-decorators';
 import animate from 'amator';
 import hashSum from 'hash-sum';
 import moment from 'moment';
+import {urlWithParams} from '@neos-project/neos-ui-backend-connector/src/Endpoints/Helpers';
 
 const getContextPath = $get('contextPath');
 
@@ -349,6 +350,14 @@ export default class Node extends PureComponent {
         if (isFocused && reload) {
             reload();
         }
+
+        // Append presetBaseNodeType param to src
+        const srcWithBaseNodeType = urlWithParams(
+            $get('uri', node),
+            {presetBaseNodeType: this.props.filterNodeType}
+        );
+
+        onNodeClick(srcWithBaseNodeType, $get('contextPath', node), openInNewWindow);
     }
 }
 

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -352,10 +352,10 @@ export default class Node extends PureComponent {
         }
 
         // Append presetBaseNodeType param to src
-        const srcWithBaseNodeType = urlWithParams(
+        const srcWithBaseNodeType = this.props.filterNodeType ? urlWithParams(
             $get('uri', node),
             {presetBaseNodeType: this.props.filterNodeType}
-        );
+        ) : $get('uri', node);
 
         onNodeClick(srcWithBaseNodeType, $get('contextPath', node), openInNewWindow);
     }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -402,7 +402,7 @@ export const PageTreeNode = withNodeTypeRegistryAndI18nRegistry(connect(
         });
     },
     {
-        reload: actions.UI.ContentCanvas.reload,
+        reload: actions.UI.ContentCanvas.reload
     }
 )(Node));
 

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
@@ -19,8 +19,6 @@ export default class NodeTree extends PureComponent {
         rootNode: PropTypes.object,
         allowOpeningNodesInNewWindow: PropTypes.bool,
         nodeTypeRole: PropTypes.string,
-        contentCanvasSrc: PropTypes.string,
-        reload: PropTypes.func,
         toggle: PropTypes.func,
         focus: PropTypes.func,
         requestScrollIntoView: PropTypes.func,
@@ -50,7 +48,7 @@ export default class NodeTree extends PureComponent {
     }
 
     handleClick = (src, contextPath, openInNewWindow) => {
-        const {setActiveContentCanvasSrc, setActiveContentCanvasContextPath, requestScrollIntoView, allowOpeningNodesInNewWindow, reload, contentCanvasSrc} = this.props;
+        const {setActiveContentCanvasSrc, setActiveContentCanvasContextPath, requestScrollIntoView, allowOpeningNodesInNewWindow} = this.props;
         if (openInNewWindow && allowOpeningNodesInNewWindow) {
             window.open(window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '') + window.location.pathname + '?node=' + contextPath);
             return;
@@ -65,10 +63,6 @@ export default class NodeTree extends PureComponent {
         }
         if (setActiveContentCanvasContextPath) {
             setActiveContentCanvasContextPath(contextPath);
-        }
-        // Trigger reload if clicking on the current document node
-        if (reload && contentCanvasSrc === src) {
-            reload();
         }
     }
 
@@ -124,12 +118,10 @@ export default class NodeTree extends PureComponent {
 export const PageTree = connect(state => ({
     rootNode: selectors.CR.Nodes.siteNodeSelector(state),
     ChildRenderer: PageTreeNode,
-    allowOpeningNodesInNewWindow: true,
-    contentCanvasSrc: $get('ui.contentCanvas.src', state)
+    allowOpeningNodesInNewWindow: true
 }), {
     toggle: actions.UI.PageTree.toggle,
     focus: actions.UI.PageTree.focus,
-    reload: actions.UI.ContentCanvas.reload,
     setActiveContentCanvasSrc: actions.UI.ContentCanvas.setSrc,
     setActiveContentCanvasContextPath: actions.CR.Nodes.setDocumentNode,
     moveNode: actions.CR.Nodes.move,


### PR DESCRIPTION
Fixes: https://github.com/neos/neos-ui/issues/1691

TODO:

- [ ] write E2E tests for this

**What I did**

Creating or moving nodes when tree preset was activated used to cause them to disappear from the tree.
That happened because the node information rendered with NodeInfo helper used to always use the default preset, and not the one that is currently active.

**How I did it**

I'm passing the currently active tree preset along with create and copy/move change requests, and then use it server-side to render the correct child nodes with UpdateNodeInfo feedback.

**How to verify it**

1. Set up some tree presets, e.g.:

```yaml
Neos:
  Neos:
    userInterface:
      navigateComponent:
        nodeTree:
          presets:
            'default':
              baseNodeType: 'Neos.Neos:Document,!Neos.Demo:Document.Chapter'
            'legalPages':
              ui:
                label: 'Test Preset'
              baseNodeType: 'Neos.Demo:Document.Chapter'
```

2. Toggle the preset. Try to create a node. Observe that it appears in the tree.
3. Move a node via DnD.
4. Move a node via toolbar buttons.
5. Copy a node via toolbar buttons.
6. Make sure nothing else breaks