### PR TITLE
BUGFIX: Allow dropdown contents to break out of overflow-restricted areas

### DIFF
--- a/Tests/IntegrationTests/Fixtures/1Dimension/SitePackage/Resources/Private/Content/Sites.xml
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/SitePackage/Resources/Private/Content/Sites.xml
@@ -632,6 +632,48 @@
       </node>
      </node>
     </node>
+    <node identifier="f25d1518-60c2-4842-b2b0-bbd449697e77" nodeName="node-xel5da127kla5">
+     <variant sortingIndex="600" workspace="live" nodeType="Neos.TestNodeTypes:Document.Page" version="3" removed="" hidden="" hiddenInIndex="">
+      <dimensions>
+       <language>en_US</language>
+      </dimensions>
+      <accessRoles __type="array"/>
+      <creationDateTime __type="object" __classname="DateTime">2019-03-21T17:56:22+00:00</creationDateTime>
+      <lastModificationDateTime __type="object" __classname="DateTime">2019-03-21T17:57:31+00:00</lastModificationDateTime>
+      <lastPublicationDateTime __type="object" __classname="DateTime">2019-03-21T17:57:30+00:00</lastPublicationDateTime>
+      <properties>
+       <uriPathSegment __type="string">select-boxes</uriPathSegment>
+       <title __type="string">Select Boxes</title>
+      </properties>
+     </variant>
+     <node identifier="1fd64db3-c35f-4604-ad25-de0ef6d2bb32" nodeName="main">
+      <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+       <dimensions>
+        <language>en_US</language>
+       </dimensions>
+       <accessRoles __type="array"/>
+       <creationDateTime __type="object" __classname="DateTime">2019-03-21T17:56:22+00:00</creationDateTime>
+       <lastModificationDateTime __type="object" __classname="DateTime">2019-03-21T17:57:31+00:00</lastModificationDateTime>
+       <lastPublicationDateTime __type="object" __classname="DateTime">2019-03-21T17:57:30+00:00</lastPublicationDateTime>
+       <properties/>
+      </variant>
+     </node>
+     <node identifier="3938292e-bf62-472a-a701-baf6e9ff395f" nodeName="node-hg78tr7bvmmn4r">
+      <variant sortingIndex="200" workspace="live" nodeType="Neos.TestNodeTypes:Document.SelectBoxTestPage.OpensAboveInInspector" version="2" removed="" hidden="" hiddenInIndex="">
+       <dimensions>
+        <language>en_US</language>
+       </dimensions>
+       <accessRoles __type="array"/>
+       <creationDateTime __type="object" __classname="DateTime">2019-03-21T17:56:50+00:00</creationDateTime>
+       <lastModificationDateTime __type="object" __classname="DateTime">2019-03-21T17:57:31+00:00</lastModificationDateTime>
+       <lastPublicationDateTime __type="object" __classname="DateTime">2019-03-21T17:57:30+00:00</lastPublicationDateTime>
+       <properties>
+        <uriPathSegment __type="string">select-box-opens-above-in-inspector</uriPathSegment>
+        <title __type="string">SelectBox opens above in Inspector</title>
+       </properties>
+      </variant>
+     </node>
+    </node>
    </node>
   </nodes>
  </site>

--- a/Tests/IntegrationTests/Fixtures/1Dimension/createNewNodes.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/createNewNodes.e2e.js
@@ -107,7 +107,7 @@ test('Can create content node from inside InlineUI', async t => {
         .switchToMainWindow()
         .click(ReactSelector('EditorToolbar LinkButton'))
         .typeText(ReactSelector('EditorToolbar LinkButton TextInput'), linkTargetPage)
-        .click(ReactSelector('EditorToolbar NodeOption'))
+        .click(ReactSelector('EditorToolbar ShallowDropDownContents NodeOption'))
         .switchToIframe('[name="neos-content-main"]')
         .expect(Selector('.test-headline h1 a').withAttribute('href').exists).ok('Newly inserted link exists')
         .switchToMainWindow();

--- a/Tests/IntegrationTests/Fixtures/1Dimension/selectBoxes.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/selectBoxes.e2e.js
@@ -1,0 +1,63 @@
+import {Selector} from 'testcafe';
+import {ReactSelector} from 'testcafe-react-selectors';
+import {beforeEach, checkPropTypes, subSection} from './../../utils.js';
+import {Page} from './../../pageModel';
+
+/* global fixture:true */
+
+fixture`Select Boxes`
+    .beforeEach(beforeEach)
+    .afterEach(() => checkPropTypes());
+
+test('SelectBox opens below and breaks out of the creation dialog if there\'s enough space below.', async t => {
+    await t
+        .click(Selector('#neos-PageTree-AddNode'))
+        .click(ReactSelector('NodeTypeItem').withText('SelectBox opens below and breaks out'))
+        .click(ReactSelector('NodeCreationDialog SelectBox'));
+
+    subSection('SelectBox contents open below the SelectBox.');
+    await t
+        .expect(await ReactSelector('NodeCreationDialog SelectBox ShallowDropDownContents').getBoundingClientRectProperty('top'))
+        .gt(await ReactSelector('NodeCreationDialog SelectBox').getBoundingClientRectProperty('top'));
+});
+
+test('SelectBox opens above in creation dialog if there\'s not enough space below.', async t => {
+    await t
+        .click(Selector('#neos-PageTree-AddNode'))
+        .click(ReactSelector('NodeTypeItem').withText('SelectBox opens above'))
+        .click(ReactSelector('NodeCreationDialog SelectBox'));
+
+    subSection('SelectBox contents open above if the SelectBox is just above the screen bottom.');
+    await t
+        .expect(await ReactSelector('NodeCreationDialog SelectBox ShallowDropDownContents').getBoundingClientRectProperty('top'))
+        .lt(await ReactSelector('NodeCreationDialog SelectBox').getBoundingClientRectProperty('top'));
+    await t
+        .expect(await ReactSelector('NodeCreationDialog SelectBox ShallowDropDownContents').getStyleProperty('display'))
+        .eql('block');
+
+    subSection('SelectBox contents disappear when SelectBox is scrolled out of sight.');
+    await t.hover(Selector('#neos-NodeCreationDialog [for="__neos__editor__property---title"]'));
+
+    await t
+        .expect(await ReactSelector('NodeCreationDialog SelectBox ShallowDropDownContents').getStyleProperty('display'))
+        .eql('none');
+});
+
+test('SelectBox opens above in inspector if there\'s not enough space below.', async t => {
+    await t.click(Page.treeNode.withExactText('SelectBox opens above in Inspector'))
+    await Page.waitForIframeLoading(t);
+    await t.click(ReactSelector('Inspector Panel SelectBox'));
+
+    subSection('SelectBox contents open above if the SelectBox is just above the screen bottom.');
+    await t
+        .expect(await ReactSelector('Inspector Panel SelectBox ShallowDropDownContents').getBoundingClientRectProperty('top'))
+        .lt(await ReactSelector('Inspector Panel SelectBox').getBoundingClientRectProperty('top'));
+
+
+    subSection('When the inspector tab panel is scrolled just enough, so that there\'s enough space, SelectBox contents jump below the SelectBox.');
+    await t.hover(Selector('[for="__neos__editor__property---uriPathSegment"]'));
+
+    await t
+        .expect(await ReactSelector('Inspector Panel SelectBox ShallowDropDownContents').getBoundingClientRectProperty('top'))
+        .gt(await ReactSelector('Inspector Panel SelectBox').getBoundingClientRectProperty('top'));
+});

--- a/Tests/IntegrationTests/Fixtures/1Dimension/treeSearch.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/treeSearch.e2e.js
@@ -19,7 +19,7 @@ test('PageTree search and filter', async t => {
     const nodeTreeSearchToggler = ReactSelector('NodeTreeSearchBar IconButton');
     const nodeTreeSearchInput = ReactSelector('NodeTreeSearchInput');
     const nodeTreeFilter = ReactSelector('NodeTreeFilter');
-    const shortcutFilter = ReactSelector('NodeTreeFilter').find('li').withText('Shortcut');
+    const shortcutFilter = ReactSelector('NodeTreeFilter ShallowDropDownContents').find('li').withText('Shortcut');
     await t
         .click(nodeTreeSearchToggler)
         .typeText(nodeTreeSearchInput, seachTerm)

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Document.SelectBoxTestPage.OpensAbove.yaml
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Document.SelectBoxTestPage.OpensAbove.yaml
@@ -1,0 +1,98 @@
+'Neos.TestNodeTypes:Document.SelectBoxTestPage.OpensAbove':
+  superTypes:
+    'Neos.Neos:Document': true
+
+  ui:
+    group: selectBoxes
+    icon: file
+    label: 'SelectBox opens above'
+    inspector:
+      groups:
+        test:
+          label: Test
+    creationDialog:
+      elements:
+        TextField:
+          type: string
+          ui:
+            label: 'TextField #0'
+            editor: 'Neos.Neos/Inspector/Editors/TextFieldEditor'
+        TextField1:
+          type: string
+          ui:
+            label: 'TextField #1'
+            editor: 'Neos.Neos/Inspector/Editors/TextFieldEditor'
+        TextField2:
+          type: string
+          ui:
+            label: 'TextField #2'
+            editor: 'Neos.Neos/Inspector/Editors/TextFieldEditor'
+        TextField3:
+          type: string
+          ui:
+            label: 'TextField #3'
+            editor: 'Neos.Neos/Inspector/Editors/TextFieldEditor'
+        TextField4:
+          type: string
+          ui:
+            label: 'TextField #4'
+            editor: 'Neos.Neos/Inspector/Editors/TextFieldEditor'
+        TextField5:
+          type: string
+          ui:
+            label: 'TextField #5'
+            editor: 'Neos.Neos/Inspector/Editors/TextFieldEditor'
+        TextField6:
+          type: string
+          ui:
+            label: 'TextField #6'
+            editor: 'Neos.Neos/Inspector/Editors/TextFieldEditor'
+        selectBox:
+          type: string
+          ui:
+            label: 'SelectBox'
+            editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
+            editorOptions:
+              values:
+                option:
+                  label: 'Too many options... #0'
+                option1:
+                  label: 'Too many options... #1'
+                option2:
+                  label: 'Too many options... #2'
+                option3:
+                  label: 'Too many options... #3'
+                option4:
+                  label: 'Too many options... #4'
+                option5:
+                  label: 'Too many options... #5'
+                option6:
+                  label: 'Too many options... #6'
+                option7:
+                  label: 'Too many options... #7'
+                option8:
+                  label: 'Too many options... #8'
+                option9:
+                  label: 'Too many options... #9'
+                option10:
+                  label: 'Too many options... #10'
+                option11:
+                  label: 'Too many options... #11'
+                option12:
+                  label: 'Too many options... #12'
+                option13:
+                  label: 'Too many options... #13'
+                option14:
+                  label: 'Too many options... #14'
+                option15:
+                  label: 'Too many options... #15'
+                option16:
+                  label: 'Too many options... #16'
+                option17:
+                  label: 'Too many options... #17'
+                option18:
+                  label: 'Too many options... #18'
+                option19:
+                  label: 'Too many options... #19'
+                option20:
+                  label: 'Too many options... #20'

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Document.SelectBoxTestPage.OpensAboveInInspector.yaml
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Document.SelectBoxTestPage.OpensAboveInInspector.yaml
@@ -1,0 +1,118 @@
+'Neos.TestNodeTypes:Document.SelectBoxTestPage.OpensAboveInInspector':
+  superTypes:
+    'Neos.Neos:Document': true
+
+  ui:
+    group: selectBoxes
+    icon: file
+    label: 'SelectBox opens above in Inspector'
+    inspector:
+      groups:
+        test:
+          label: Test
+  properties:
+    TextField:
+      type: string
+      ui:
+        label: 'TextField #0'
+        inspector:
+          group: test
+    TextField1:
+      type: string
+      ui:
+        label: 'TextField #1'
+        inspector:
+          group: test
+    TextField2:
+      type: string
+      ui:
+        label: 'TextField #2'
+        inspector:
+          group: test
+    TextField3:
+      type: string
+      ui:
+        label: 'TextField #3'
+        inspector:
+          group: test
+    TextField4:
+      type: string
+      ui:
+        label: 'TextField #4'
+        inspector:
+          group: test
+    TextField5:
+      type: string
+      ui:
+        label: 'TextField #5'
+        inspector:
+          group: test
+    TextField6:
+      type: string
+      ui:
+        label: 'TextField #6'
+        inspector:
+          group: test
+    TextField7:
+      type: string
+      ui:
+        label: 'TextField #7'
+        inspector:
+          group: test
+    TextField8:
+      type: string
+      ui:
+        label: 'TextField #8'
+        inspector:
+          group: test
+    selectBox:
+      type: string
+      ui:
+        label: 'SelectBox'
+        inspector:
+          group: test
+          editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
+          editorOptions:
+            values:
+              option:
+                label: 'Too many options... #0'
+              option1:
+                label: 'Too many options... #1'
+              option2:
+                label: 'Too many options... #2'
+              option3:
+                label: 'Too many options... #3'
+              option4:
+                label: 'Too many options... #4'
+              option5:
+                label: 'Too many options... #5'
+              option6:
+                label: 'Too many options... #6'
+              option7:
+                label: 'Too many options... #7'
+              option8:
+                label: 'Too many options... #8'
+              option9:
+                label: 'Too many options... #9'
+              option10:
+                label: 'Too many options... #10'
+              option11:
+                label: 'Too many options... #11'
+              option12:
+                label: 'Too many options... #12'
+              option13:
+                label: 'Too many options... #13'
+              option14:
+                label: 'Too many options... #14'
+              option15:
+                label: 'Too many options... #15'
+              option16:
+                label: 'Too many options... #16'
+              option17:
+                label: 'Too many options... #17'
+              option18:
+                label: 'Too many options... #18'
+              option19:
+                label: 'Too many options... #19'
+              option20:
+                label: 'Too many options... #20'

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Document.SelectBoxTestPage.OpensBelowAndBreaksOut.yaml
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Document.SelectBoxTestPage.OpensBelowAndBreaksOut.yaml
@@ -1,0 +1,63 @@
+'Neos.TestNodeTypes:Document.SelectBoxTestPage.OpensBelowAndBreaksOut':
+  superTypes:
+    'Neos.Neos:Document': true
+
+  ui:
+    group: selectBoxes
+    icon: file
+    label: 'SelectBox opens below and breaks out'
+    inspector:
+      groups:
+        test:
+          label: Test
+    creationDialog:
+      elements:
+        selectBox:
+          type: string
+          ui:
+            label: 'SelectBox'
+            editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
+            editorOptions:
+              values:
+                option:
+                  label: 'Too many options... #0'
+                option1:
+                  label: 'Too many options... #1'
+                option2:
+                  label: 'Too many options... #2'
+                option3:
+                  label: 'Too many options... #3'
+                option4:
+                  label: 'Too many options... #4'
+                option5:
+                  label: 'Too many options... #5'
+                option6:
+                  label: 'Too many options... #6'
+                option7:
+                  label: 'Too many options... #7'
+                option8:
+                  label: 'Too many options... #8'
+                option9:
+                  label: 'Too many options... #9'
+                option10:
+                  label: 'Too many options... #10'
+                option11:
+                  label: 'Too many options... #11'
+                option12:
+                  label: 'Too many options... #12'
+                option13:
+                  label: 'Too many options... #13'
+                option14:
+                  label: 'Too many options... #14'
+                option15:
+                  label: 'Too many options... #15'
+                option16:
+                  label: 'Too many options... #16'
+                option17:
+                  label: 'Too many options... #17'
+                option18:
+                  label: 'Too many options... #18'
+                option19:
+                  label: 'Too many options... #19'
+                option20:
+                  label: 'Too many options... #20'

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/Settings.yaml
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/Settings.yaml
@@ -3,3 +3,9 @@ Neos:
     fusion:
       autoInclude:
         Neos.TestNodeTypes: true
+    nodeTypes:
+      groups:
+        selectBoxes:
+          label: 'SelectBoxes'
+          position: 300
+          collapsed: false

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Resources/Private/Fusion/Document/SelectBoxTestPage/OpensAboveIn.fusion
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Resources/Private/Fusion/Document/SelectBoxTestPage/OpensAboveIn.fusion
@@ -1,0 +1,4 @@
+prototype(Neos.TestNodeTypes:Document.SelectBoxTestPage.OpensAbove) >
+prototype(Neos.TestNodeTypes:Document.SelectBoxTestPage.OpensAbove) < prototype(Neos.Neos:Page) {
+    body = 'NO CONTENT'
+}

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Resources/Private/Fusion/Document/SelectBoxTestPage/OpensAboveInInspector.fusion
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Resources/Private/Fusion/Document/SelectBoxTestPage/OpensAboveInInspector.fusion
@@ -1,0 +1,4 @@
+prototype(Neos.TestNodeTypes:Document.SelectBoxTestPage.OpensAboveInInspector)>
+prototype(Neos.TestNodeTypes:Document.SelectBoxTestPage.OpensAboveInInspector) < prototype(Neos.Neos:Page) {
+    body = 'NO CONTENT'
+}

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Resources/Private/Fusion/Root.fusion
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Resources/Private/Fusion/Root.fusion
@@ -1,2 +1,4 @@
 include: **/*.fusion
-page = Neos.TestNodeTypes:Document.Page
+page = Neos.Fusion:Renderer {
+    type = ${documentNode.nodeType.name}
+}

--- a/Tests/IntegrationTests/pageModel.js
+++ b/Tests/IntegrationTests/pageModel.js
@@ -32,11 +32,13 @@ export class DimensionSwitcher {
 
     static dimensionSwitcherFirstDimensionSelector = ReactSelector('DimensionSwitcher SelectBox');
 
+    static dimensionSwitcherFirstDimensionSelectorWithShallowDropDownContents = ReactSelector('DimensionSwitcher SelectBox ShallowDropDownContents');
+
     static async switchLanguageDimension(name) {
         await t
             .click(this.dimensionSwitcher)
             .click(this.dimensionSwitcherFirstDimensionSelector)
-            .click(this.dimensionSwitcherFirstDimensionSelector.find('li').withText(name));
+            .click(this.dimensionSwitcherFirstDimensionSelectorWithShallowDropDownContents.find('li').withText(name));
     }
 }
 

--- a/packages/build-essentials/src/styles/styleConstants.js
+++ b/packages/build-essentials/src/styles/styleConstants.js
@@ -29,7 +29,7 @@ const config = {
         primaryToolbar: '4',
         checkboxInput: ['context'],
         dropdownContents: ['context'],
-        selectBoxContents: '3',
+        selectBoxContents: '4',
         notInlineEditableOverlay: ['context'],
         calendarFakeInputMirror: ['context'],
         rdtPicker: ['context'],

--- a/packages/react-ui-components/src/DropDown/contents.spec.tsx
+++ b/packages/react-ui-components/src/DropDown/contents.spec.tsx
@@ -6,6 +6,7 @@ import ShallowDropDownContents, {ShallowDropDownContentsProps} from './contents'
 
 describe('<ShallowDropDownContents/>', () => {
     const props: ShallowDropDownContentsProps = {
+        ...ShallowDropDownContents.defaultProps,
         children: 'Foo children',
         isOpen: false,
         closeDropDown: jest.fn(),
@@ -13,7 +14,8 @@ describe('<ShallowDropDownContents/>', () => {
             'dropDown__contents': 'baseDropDownContentsClassName',
             'dropDown__contents--isOpen': 'openDropDownContentsClassName',
             'dropDown__contents--scrollable': 'scrollDropDownContentsClassName'
-        }
+        },
+        wrapperRef: React.createRef(),
     };
 
     it('should not render when having no children.', () => {

--- a/packages/react-ui-components/src/DropDown/contents.tsx
+++ b/packages/react-ui-components/src/DropDown/contents.tsx
@@ -1,5 +1,48 @@
 import React, {PureComponent, ReactNode} from 'react';
+import ReactDOM from 'react-dom';
 import mergeClassNames from 'classnames';
+
+/**
+ * Helper function to find the closest ancestor element that currently
+ * has a scrollbar and could possibly cause the given element not to
+ * be visible on screen.
+ *
+ * @param HTMLElement el
+ * @return HTMLElement
+ */
+function getScrollContainer(el: HTMLElement): HTMLElement {
+    if (el.scrollHeight > el.clientHeight) {
+        const { overflowY } = getComputedStyle(el);
+
+        if (overflowY === 'auto' || overflowY === 'scroll') {
+            return el;
+        }
+    }
+
+    if (el.parentElement) {
+        return getScrollContainer(el.parentElement);
+    } else {
+        return document.body;
+    }
+}
+
+/**
+ * Helper function to determine whether the given element is visible
+ * within its ancestor scroll context.
+ *
+ * @param HTMLElement el
+ * @return boolean
+ */
+function isInScrollView(el: HTMLElement): boolean {
+    const scrollContainer = getScrollContainer(el);
+    const elementBoundingBox = el.getBoundingClientRect();
+    const scrollContainerBoundingBox = scrollContainer.getBoundingClientRect();
+
+    return (
+        elementBoundingBox.top >= scrollContainerBoundingBox.top &&
+        elementBoundingBox.bottom <= scrollContainerBoundingBox.bottom
+    );
+}
 
 interface ShallowDropDownContentsTheme {
     readonly 'dropDown__contents': string;
@@ -35,9 +78,126 @@ export interface ShallowDropDownContentsProps {
      * An optional css theme to be injected.
      */
     readonly theme?: ShallowDropDownContentsTheme;
+
+    /**
+     * A React.RefObject pointing to the dropdown wrapper element
+     */
+    readonly wrapperRef: React.RefObject<HTMLElement>;
+
+    /**
+     * A custom function to calculate the minimum height, in case the
+     * component is marked as scrollable.
+     *
+     * Defaults to: window => .25 * window.innerHeight
+     */
+    readonly getMinHeight: (window: Window, props: ShallowDropDownContentsProps) => number;
+
+    /**
+     * A custom function to calculate the maximum height, in case the
+     * component is marked as scrollable.
+     *
+     * Defaults to: window => .8 * window.innerHeight
+     */
+    readonly getMaxHeight: (window: Window, props: ShallowDropDownContentsProps) => number;
 }
 
-export default class ShallowDropDownContents extends PureComponent<ShallowDropDownContentsProps> {
+export interface ShallowDropDownContentsState {
+    /**
+     * Calculated style properties
+     */
+    style: React.CSSProperties;
+}
+
+export default class ShallowDropDownContents extends PureComponent<ShallowDropDownContentsProps, ShallowDropDownContentsState> {
+    public static defaultProps = {
+        getMinHeight: (window: Window) => .25 * window.innerHeight, // 25vh
+        getMaxHeight: (window: Window) => .8 * window.innerHeight, // 80vh
+    };
+
+    /**
+     * Calculate position and dimensions of ShallowDropDownContents based on
+     * its wrapper element.
+     *
+     * @param ShallowDropDownContentsProps props
+     * @returns React.CSSProperties
+     */
+    public static getCalculatedStyleFromProps(props: ShallowDropDownContentsProps): React.CSSProperties {
+        if (props.scrollable && props.wrapperRef.current) {
+            // We're only going to make this calculation if the component is marked
+            // as scrollable. Otherwise we expect the call-site to be aware of any
+            // screen-related size-restrictions and reserve enough space below
+            // wherever the dropdown is placed.
+
+            if (isInScrollView(props.wrapperRef.current)) {
+                const wrapperBoundingBox = props.wrapperRef.current?.getBoundingClientRect();
+
+                if (wrapperBoundingBox) {
+                    const minHeight = props.getMinHeight(window, props);
+                    const maxHeight = props.getMaxHeight(window, props);
+
+                    if (wrapperBoundingBox.y + wrapperBoundingBox.height + maxHeight <= window.innerHeight) {
+                        // In this case, our dropdown contents component fits comfortably
+                        // below the dropdown header
+                        return {
+                            top: wrapperBoundingBox.y + wrapperBoundingBox.height,
+                            left: wrapperBoundingBox.x,
+                            width: wrapperBoundingBox.width,
+                            maxHeight
+                        };
+                    } else if (wrapperBoundingBox.y + wrapperBoundingBox.height + minHeight <= window.innerHeight) {
+                        // Our dropdown contents component still fits below the
+                        // dropdown header, but we need to shrink it a little
+                        return {
+                            top: wrapperBoundingBox.y + wrapperBoundingBox.height,
+                            left: wrapperBoundingBox.x,
+                            width: wrapperBoundingBox.width,
+                            maxHeight: window.innerHeight - wrapperBoundingBox.height - wrapperBoundingBox.y
+                        };
+                    } else {
+                        // Our dropdown contents component does not fit below the
+                        // dropdown header, so we open it up above. We also keep the height
+                        // at minimum, so that the upper left corner of our contents keeps
+                        // its proximity to the dropdown header.
+                        return {
+                            bottom: window.innerHeight - wrapperBoundingBox.y,
+                            left: wrapperBoundingBox.x,
+                            width: wrapperBoundingBox.width,
+                            maxHeight: minHeight
+                        };
+                    }
+                }
+            } else {
+                // The dropdown wrapper is outside of the users view, so we hide our
+                // dropdown contents component until it comes back.
+                return {
+                    display: 'none'
+                };
+            }
+        }
+
+        return {};
+    }
+
+    public static getDerivedStateFromProps(props: ShallowDropDownContentsProps): ShallowDropDownContentsState {
+        return { style: ShallowDropDownContents.getCalculatedStyleFromProps(props) };
+    }
+
+    public readonly state = ShallowDropDownContents.getDerivedStateFromProps(this.props);
+
+    public readonly recalculateStyle = () => requestAnimationFrame(() => {
+        this.setState({ style: ShallowDropDownContents.getCalculatedStyleFromProps(this.props) });
+    })
+
+    public componentDidMount(): void {
+        document.body.addEventListener('scroll', this.recalculateStyle, { capture: true });
+        window.addEventListener('resize', this.recalculateStyle, { capture: true });
+    }
+
+    public componentWillUnmount(): void {
+        document.body.removeEventListener('scroll', this.recalculateStyle, { capture: true });
+        window.removeEventListener('resize', this.recalculateStyle, { capture: true });
+    }
+
     public render(): JSX.Element | null {
         const {
             className,
@@ -56,16 +216,26 @@ export default class ShallowDropDownContents extends PureComponent<ShallowDropDo
             }
         );
 
-        return isOpen ? (
-            <ul
-                className={finalClassName}
-                aria-hidden={isOpen ? 'false' : 'true'}
-                aria-label="dropdown"
-                role="listbox"
-                onClick={closeDropDown}
-            >
-                {isOpen && children}
-            </ul>
-        ) : null;
+        if (isOpen) {
+            const contents = (
+                <ul
+                    className={finalClassName}
+                    aria-hidden={isOpen ? 'false' : 'true'}
+                    aria-label="dropdown"
+                    role="listbox"
+                    onClick={closeDropDown}
+                    style={this.state.style}
+                    data-ignore_click_outside={true}
+                >
+                    {children}
+                </ul>
+            );
+
+            return scrollable
+                ? ReactDOM.createPortal(contents, document.body)
+                : contents;
+        } else {
+            return null;
+        }
     }
 }

--- a/packages/react-ui-components/src/DropDown/style.css
+++ b/packages/react-ui-components/src/DropDown/style.css
@@ -54,7 +54,8 @@
     box-shadow: 0 5px 5px rgba(0, 0, 0, .2);
 }
 .dropDown__contents--scrollable {
-    max-height: 80vh;
+    position: fixed;
+    top: auto;
     overflow-y: auto;
 }
 .dropDown__contents--isOpen {

--- a/packages/react-ui-components/src/DropDown/wrapper.tsx
+++ b/packages/react-ui-components/src/DropDown/wrapper.tsx
@@ -69,6 +69,7 @@ export interface StatelessDropDownWrapperWithoutClickOutsideBehaviorProps extend
 export interface ChildContext {
     toggleDropDown: (event: MouseEvent) => void;
     closeDropDown: (event: MouseEvent) => void;
+    wrapperRef: React.RefObject<HTMLDivElement>;
 }
 
 class StatelessDropDownWrapperWithoutClickOutsideBehavior extends PureComponent<StatelessDropDownWrapperWithoutClickOutsideBehaviorProps> {
@@ -77,11 +78,15 @@ class StatelessDropDownWrapperWithoutClickOutsideBehavior extends PureComponent<
     public static readonly childContextTypes = {
         toggleDropDown: PropTypes.func.isRequired,
         closeDropDown: PropTypes.func.isRequired,
+        wrapperRef: PropTypes.object.isRequired
     };
+
+    public readonly ref: React.RefObject<HTMLDivElement> = React.createRef();
 
     public readonly getChildContext = (): ChildContext => ({
         toggleDropDown: this.handleToggle,
         closeDropDown: this.handleClose,
+        wrapperRef: this.ref
     })
 
     public readonly handleClickOutside = () => {
@@ -105,7 +110,7 @@ class StatelessDropDownWrapperWithoutClickOutsideBehavior extends PureComponent<
         );
 
         return (
-            <div {...rest} className={finalClassName}>
+            <div ref={this.ref} {...rest} className={finalClassName}>
                 {React.Children.map(
                     children,
                     // @ts-ignore
@@ -168,6 +173,7 @@ export default DropDownWrapper;
 
 export interface ContextDropDownProps extends DropDownWrapperProps {
     isDropdownOpen?: boolean;
+    wrapperRef?: React.RefObject<HTMLElement>;
 }
 
 export class ContextDropDownHeader extends PureComponent<ContextDropDownProps> {
@@ -184,12 +190,13 @@ export class ContextDropDownHeader extends PureComponent<ContextDropDownProps> {
 
 export class ContextDropDownContents extends PureComponent<ContextDropDownProps> {
     public static readonly contextTypes = {
-        closeDropDown: PropTypes.func.isRequired
+        closeDropDown: PropTypes.func.isRequired,
+        wrapperRef: PropTypes.object.isRequired
     };
 
     public render(): JSX.Element {
-        const {isDropdownOpen, ...rest} = this.props;
+        const {isDropdownOpen, wrapperRef, ...rest} = this.props;
 
-        return <ShallowDropDownContents isOpen={isDropdownOpen} {...rest} {...this.context}/>;
+        return <ShallowDropDownContents isOpen={isDropdownOpen} {...rest} {...this.context} wrapperRef={wrapperRef || this.context.wrapperRef}/>;
     }
 }


### PR DESCRIPTION
Hi there!

This PR enhances the DropDown component in two ways:

1. It allows drop down contents to break out of overflow-restricted areas like the content creation dialog.
2. It positions dropdown contents above the dropdown header, if there's not enough space below it.

All of the above are only effective if the DropDown is marked as `scrollable`. Otherwise, it is assumed that the call-site of the DropDown component is aware of any screen-related size-restrictions and reserves enough space below wherever the DropDown is placed.

|**Example:** Creation Dialog, breakout|**Example:** Creation Dialog, positioning|**Example:** Inspector|
|-|-|-|
|![Peek 2020-10-17 16-40](https://user-images.githubusercontent.com/2522299/96348077-6466b400-10a6-11eb-944a-ff2028634806.gif)|![Peek 2020-10-17 16-41](https://user-images.githubusercontent.com/2522299/96348078-6892d180-10a6-11eb-9c51-36772cd17360.gif)|![Peek 2020-10-17 16-46](https://user-images.githubusercontent.com/2522299/96348084-70527600-10a6-11eb-9971-9566b747ce0b.gif)|

## How is this done?

If scrollable, the `ShallowDropDownContents` component gets a fixed positioning and ist rendered directly to the Host frames `document.body` via `React.createPortal`. This way, it is no longer subject to any `overflow: ...`-Restriction within the ancestry of its parent DropDown.

To ensure the correct positioning of `ShallowDropDownContents`, its screen position and dimensions are calculated relative to its closest `DropDownWrapper` component. `DropDownWrapper` provides a DOM reference of itself via the React Context API. Layout recalculation happens on mount, `scroll` on `document.body` and `resize` on `window`. Recalculation is throttled via `requestAnimationFrame`.

Additionally, whenever `DropDownWrapper` is not visible whithin its closest scrollable element, `ShallowDropDownContents` is hidden to avoid interference with other interactive elements.

## Further notes

<s>Unfortunately, I couldn't figure out how to get e2e-Tests to run locally. And since this feature cannot be reliably tested in a `jsdom`-environment alone, I didn't add any tests at all.</s>

<s>If that's a deal-breaker for this PR, any help on the testing part would be greatly appreciated :)</s>

<s>**Edit:** Since e2e-Tests are red in CircleCI and I couldn't reproduce the error that is logged, I'll continue to figure out how to run them locally. Once that's done, I'll probably be able to add some tests for this feature as well.</s>

**Edit:** I figured it out and added some tests :) But I remain open to suggestions as to how this might be tested more thoroughly. As of right now, the tests cover only some rough positioning logic and more could be done, but Testcafe has its limits...

## TODOs

- [x] Figure out how to run e2e-Tests locally
- [x] Fix issue with DimensionSwitcher
- [x] Add e2e-Tests for new DropDown behavior

---

fixes #1214