### PR TITLE
TASK: Remove deprecated isDisabled Button prop

### DIFF
--- a/packages/react-ui-components/src/Button/button.tsx
+++ b/packages/react-ui-components/src/Button/button.tsx
@@ -46,11 +46,6 @@ export interface ButtonProps extends HTMLButtonElementAttributesExceptStyle {
     readonly disabled?: boolean;
 
     /**
-     * DEPRECATED, will be removed in the future
-     */
-    readonly isDisabled?: boolean;
-
-    /**
      * This prop controls the visual active state of the `Button`.
      */
     readonly isActive?: boolean;
@@ -117,10 +112,7 @@ class Button extends React.PureComponent<ButtonProps> {
     public static readonly defaultProps = defaultProps;
 
     private getDisabled(): boolean {
-        if (this.props.isDisabled !== undefined) {
-            console.error('`isDisabled` prop on Button component is DEPRECATED, use `disabled instead`'); // tslint:disable-line no-console
-        }
-        return Boolean(this.props.disabled || this.props.isDisabled);
+        return Boolean(this.props.disabled);
     }
 
     public render(): JSX.Element {


### PR DESCRIPTION
**What I did**

Removed the property isDisabled from the button component.
The prop has beed deprecated two years ago.

Relates: #2798
