### PR TITLE
BUGFIX: Fix NodeType filter regression

### DIFF
--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -17,7 +17,7 @@ import {hasNestedNodes} from '@neos-project/neos-ui/src/Containers/LeftSideBar/N
 import animate from 'amator';
 import hashSum from 'hash-sum';
 import moment from 'moment';
-import {urlAppendParams} from '@neos-project/neos-ui-backend-connector/src/Endpoints/Helpers';
+import {urlWithParams} from '@neos-project/utils-helpers/src/urlWithParams';
 
 const getContextPath = $get('contextPath');
 
@@ -370,7 +370,7 @@ export default class Node extends PureComponent {
         }
 
         // Append presetBaseNodeType param to src
-        const srcWithBaseNodeType = this.props.filterNodeType ? urlAppendParams(
+        const srcWithBaseNodeType = this.props.filterNodeType ? urlWithParams(
             $get('uri', node),
             {presetBaseNodeType: this.props.filterNodeType}
         ) : $get('uri', node);

--- a/packages/utils-helpers/src/urlWithParams.spec.js
+++ b/packages/utils-helpers/src/urlWithParams.spec.js
@@ -74,3 +74,14 @@ test(`should convert params to strings`, () => {
     expect(urlWithParams(url, params)).toEqual('http://www.domain.com?string=123&number=123&array%5B0%5D=1&array%5B1%5D=2&array%5B2%5D=3&true=true&false=false');
 });
 
+test(`should append params to existing query`, () => {
+    const url = 'http://www.domain.com?some=existing&query=string';
+    const params = {
+        string: '123',
+        number: 123,
+        array: [1, 2, 3],
+        true: true,
+        false: false
+    };
+    expect(urlWithParams(url, params)).toEqual('http://www.domain.com?some=existing&query=string&string=123&number=123&array%5B0%5D=1&array%5B1%5D=2&array%5B2%5D=3&true=true&false=false');
+});

--- a/packages/utils-helpers/src/urlWithParams.ts
+++ b/packages/utils-helpers/src/urlWithParams.ts
@@ -3,7 +3,11 @@
 //
 export function urlWithParams(urlString: string, params: any = {}): string {
     const queryString = encodeAsQueryString(params);
-    return urlString + (queryString === '' ? '' : '?' + queryString);
+    if (queryString === '') {
+        return urlString;
+    }
+    const url = new URL(urlString);
+    return urlString + (url.search === '' ? '?' : '&') + queryString;
 }
 
 export const encodeAsQueryString = (obj: any, prefix: string = ''): string => {


### PR DESCRIPTION
Fixes a regression introduced with upmerging #2794 since
the new helper `urlWithParams` wasn't added.

Note:

Instead of adding the helper to the endpoint helpers, this
extends the already existing `urlWithParams` helper such that
it keeps existing query params.

Fixes: #2805