### PR TITLE
BUGFIX: Prevent exception with missing presetBaseNodeType

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Neos\Ui\Controller;
 
 /*
@@ -189,13 +190,14 @@ class BackendController extends ActionController
      * @param string $presetBaseNodeType
      * @throws StopActionException
      */
-    public function redirectToAction(NodeInterface $node, string $presetBaseNodeType = null)
+    public function redirectToAction(NodeInterface $node, string $presetBaseNodeType = '')
     {
         $this->response->setComponentParameter(SetHeaderComponent::class, 'Cache-Control', [
             'no-cache',
             'no-store'
         ]);
-        $this->redirectToUri($this->linkingService->createNodeUri($this->controllerContext, $node, null, null, false, ['presetBaseNodeType' => $presetBaseNodeType]));
+        $arguments = !empty($presetBaseNodeType) ? ['presetBaseNodeType' => $presetBaseNodeType] : [];
+        $this->redirectToUri($this->linkingService->createNodeUri($this->controllerContext, $node, null, null, false, $arguments));
     }
 
     /**


### PR DESCRIPTION
Make the argument presetBaseNodeType optional. In higher branches that parameter was also missing in the method arguments of redirectToAction.

Thanks to Paavo Limbo for reporting the issue, we appreciate it!

Fixes: #2807