### PR TITLE
BUGFIX: Make the baseNodeType optional in updateNodeInfo

### DIFF
--- a/Classes/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
@@ -38,9 +38,9 @@ class UpdateNodeInfo extends AbstractFeedback
     /**
      * Set the baseNodeType
      *
-     * @param string $baseNodeType
+     * @param string|null $baseNodeType
      */
-    public function setBaseNodeType(string $baseNodeType): void
+    public function setBaseNodeType(?string $baseNodeType): void
     {
         $this->baseNodeType = $baseNodeType;
     }


### PR DESCRIPTION
Fixes: #2813