### PR TITLE
TASK: Make testing distribution work with more neos installations

### DIFF
--- a/Tests/IntegrationTests/Fixtures/1Dimension/createNewNodeInContainer.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/createNewNodeInContainer.e2e.js
@@ -17,7 +17,7 @@ test('Create a text node in a new container element at the correct position', as
         .click(Selector('#neos-ContentTree-ToggleContentTree'))
         .click(Page.treeNode.withText('Content Collection (main)'))
         .click(Selector('#neos-ContentTree-AddNode'))
-        .click(ReactSelector('NodeTypeItem').find('button>span>span').withText('Container'));
+        .click(ReactSelector('NodeTypeItem').find('button>span>span').withText('Container_Test'));
     await Page.waitForIframeLoading(t);
 
     subSection('Create text node in container');
@@ -25,7 +25,7 @@ test('Create a text node in a new container element at the correct position', as
         .click(Page.treeNode.withText('Container'))
         .click(Selector('#neos-ContentTree-AddNode'))
         .click(Selector('#into'))
-        .click(ReactSelector('NodeTypeItem').find('button>span>span').withText('Text'));
+        .click(ReactSelector('NodeTypeItem').find('button>span>span').withText('Text_Test'));
     await Page.waitForIframeLoading(t);
 
     await t.switchToIframe('[name="neos-content-main"]');

--- a/Tests/IntegrationTests/Fixtures/1Dimension/createNewNodes.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/createNewNodes.e2e.js
@@ -6,6 +6,7 @@ import {Page} from './../../pageModel';
 /* global fixture:true */
 
 const changeRequestLogger = RequestLogger(request => request.url.endsWith('/neos/ui-services/change') && request.method === 'post' && request.isAjax);
+const contentIframeSelector = Selector('[name="neos-content-main"]', { timeout: 2000 });
 
 fixture`Create new nodes`
     .beforeEach(beforeEach)
@@ -13,8 +14,9 @@ fixture`Create new nodes`
     .requestHooks(changeRequestLogger);
 
 test('Create an Image node from ContentTree', async t => {
-    await t.switchToIframe('[name="neos-content-main"]');
-    const initialImageCount = await Selector('.test-image img[src]').count;
+
+    await t.switchToIframe(contentIframeSelector);
+    const initialImageCount = await Selector('.test-image[src]').count;
     await t.switchToMainWindow();
 
     subSection('Create Image node');
@@ -22,7 +24,7 @@ test('Create an Image node from ContentTree', async t => {
         .click(Selector('#neos-ContentTree-ToggleContentTree'))
         .click(Page.treeNode.withText('Content Collection (main)'))
         .click(Selector('#neos-ContentTree-AddNode'))
-        .click(ReactSelector('NodeTypeItem').find('button>span>span').withText('Image'));
+        .click(ReactSelector('NodeTypeItem').find('button>span>span').withText('Image_Test'));
     await Page.waitForIframeLoading(t);
 
     subSection('Select image from media library');
@@ -34,7 +36,7 @@ test('Create an Image node from ContentTree', async t => {
     await t.switchToMainWindow();
     await t.click(Selector('#neos-Inspector-Apply'));
 
-    await t.switchToIframe('[name="neos-content-main"]');
+    await t.switchToIframe(contentIframeSelector);
     const finalImageCount = await Selector('.test-image[src]').count;
     await t.expect(initialImageCount + 1).eql(finalImageCount, 'Final image count is one more than initial');
 });
@@ -47,15 +49,15 @@ test('Can create a new page', async t => {
         .expect(SelectNodeTypeModal.getReact(({props}) => props.isOpen)).eql(false)
         .click(Selector('#neos-PageTree-AddNode'))
         .expect(SelectNodeTypeModal.getReact(({props}) => props.isOpen)).eql(true)
-        .click(ReactSelector('NodeTypeItem'))
+        .click(ReactSelector('NodeTypeItem').find('button>span>span').withText('Page_Test'))
         .click(Selector('#neos-NodeCreationDialog-Back'))
-        .click(ReactSelector('NodeTypeItem'))
+        .click(ReactSelector('NodeTypeItem').find('button>span>span').withText('Page_Test'))
         .typeText(Selector('#neos-NodeCreationDialog-Body input'), newPageTitle)
         .click(Selector('#neos-NodeCreationDialog-CreateNew'))
         .expect(ReactSelector('NodeCreationDialog').getReact(({props}) => props.isOpen)).eql(false);
     await Page.waitForIframeLoading(t);
     await t
-        .switchToIframe('[name="neos-content-main"]')
+        .switchToIframe(contentIframeSelector)
         .expect(Selector('li').withText(newPageTitle).exists).ok()
         .switchToMainWindow();
 });
@@ -65,19 +67,19 @@ test('Can create content node from inside InlineUI', async t => {
     subSection('Create a headline node');
     await Page.waitForIframeLoading(t);
     await t
-        .switchToIframe('[name="neos-content-main"]')
+        .switchToIframe(contentIframeSelector)
         .click(Selector('.neos-contentcollection'))
         .click(Selector('#neos-InlineToolbar-AddNode'))
         .switchToMainWindow()
         .click(Selector('button#into'))
         // TODO: this selector will only work with English translation.
         // Change to `withProps` when implemented: https://github.com/DevExpress/testcafe-react-selectors/issues/14
-        .click(ReactSelector('NodeTypeItem').find('button>span>span').withText('Headline'));
+        .click(ReactSelector('NodeTypeItem').find('button>span>span').withText('Headline_Test'));
 
     subSection('Type something inside of it');
     await Page.waitForIframeLoading(t);
     await t
-        .switchToIframe('[name="neos-content-main"]')
+        .switchToIframe(contentIframeSelector)
         .typeText(Selector('.test-headline h1'), headlineTitle)
         .expect(Selector('.neos-contentcollection').withText(headlineTitle).exists).ok('Typed headline text exists');
 
@@ -95,7 +97,7 @@ test('Can create content node from inside InlineUI', async t => {
     await t
         .expect(changeRequestLogger.count(() => true)).eql(0, 'No requests were fired with invalid state');
     await t
-        .switchToIframe('[name="neos-content-main"]')
+        .switchToIframe(contentIframeSelector)
         .typeText(Selector('.test-headline h1'), 'Some text')
         .wait(600);
     await t.expect(changeRequestLogger.count(() => true)).eql(1, 'Request fired when field became valid');
@@ -108,7 +110,7 @@ test('Can create content node from inside InlineUI', async t => {
         .click(ReactSelector('EditorToolbar LinkButton'))
         .typeText(ReactSelector('EditorToolbar LinkButton TextInput'), linkTargetPage)
         .click(ReactSelector('EditorToolbar NodeOption'))
-        .switchToIframe('[name="neos-content-main"]')
+        .switchToIframe(contentIframeSelector)
         .expect(Selector('.test-headline h1 a').withAttribute('href').exists).ok('Newly inserted link exists')
         .switchToMainWindow();
 });

--- a/Tests/IntegrationTests/Fixtures/1Dimension/treeMultiselect.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/treeMultiselect.e2e.js
@@ -30,6 +30,7 @@ test('Move multiple nodes via toolbar', async t => {
             const reduxState = props.store.getState();
             return reduxState.cr.nodes.documentNode;
         })).eql('/sites/neos-test-site/node-knm2pltb5454z/node-18qsaeidy6765/node-e8tw6sparbtp3@user-admin;language=en_US', 'Node B\'s context path changed');
+    await t.click(Page.treeNode.withExactText('Home'))
 });
 
 test('Move multiple nodes via DND, CMD-click', async t => {
@@ -46,6 +47,7 @@ test('Move multiple nodes via DND, CMD-click', async t => {
             const reduxState = props.store.getState();
             return reduxState.cr.nodes.documentNode;
         })).eql('/sites/neos-test-site/node-knm2pltb5454z/node-18qsaeidy6765/node-e8tw6sparbtp3@user-admin;language=en_US', 'Node B\'s context path changed');
+    await t.click(Page.treeNode.withExactText('Home'))
 });
 
 test('Move multiple nodes via DND, SHIFT-click', async t => {
@@ -62,4 +64,5 @@ test('Move multiple nodes via DND, SHIFT-click', async t => {
             const reduxState = props.store.getState();
             return reduxState.cr.nodes.documentNode;
         })).eql('/sites/neos-test-site/node-knm2pltb5454z/node-18qsaeidy6765/node-oml0cxaompt29@user-admin;language=en_US', 'Node C\'s context path changed');
+    await t.click(Page.treeNode.withExactText('Home'))
 });

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Content.Container.yaml
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Content.Container.yaml
@@ -3,6 +3,6 @@
     'Neos.Neos:Content': true
     'Neos.Neos:ContentCollection': true
   ui:
-    label: Container
+    label: Container_Test
     icon: icon-folder
 

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Content.Headline.yaml
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Content.Headline.yaml
@@ -2,7 +2,7 @@
   superTypes:
     'Neos.Neos:Content': true
   ui:
-    label: Headline
+    label: Headline_Test
     icon: icon-header
     position: 200
     inlineEditable: true

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Content.Image.yaml
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Content.Image.yaml
@@ -2,7 +2,7 @@
   superTypes:
     'Neos.Neos:Content': true
   ui:
-    label: Image
+    label: Image_Test
     icon: icon-picture
     position: 300
     inspector:

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Content.Text.yaml
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Content.Text.yaml
@@ -2,7 +2,7 @@
   superTypes:
     'Neos.Neos:Content': true
   ui:
-    label: Text
+    label: Text_Test
     icon: icon-file-text
     position: 200
     inlineEditable: true

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Document.Page.yaml
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Document.Page.yaml
@@ -2,7 +2,7 @@
   superTypes:
     'Neos.Neos:Document': true
   ui:
-    label: Page
+    label: Page_Test
     icon: icon-file-o
     position: 100
   childNodes:


### PR DESCRIPTION
It can happen that you have a neos distribution that uses the neos nodetypes and want to execute the neos-ui e2e tests. Then the own node types are not used because they have the same name as the basic neos nodetypes.

**What I did**
Add the _Test to the name of the nodetypes.

**How to verify it**
Run the tests