### PR TITLE
TASK: Adjust CircleCI config to run master tests with php 7.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
     environment:
       COMPOSER_CACHE_DIR: /composer/cache-dir
     docker:
-      - image: quay.io/yeebase/ci-build:7.2
+      - image: cimg/php:7.4.12-node
     steps:
       - attach_workspace: *attach_workspace
       - restore_cache: *restore_composer_cache
@@ -96,7 +96,7 @@ jobs:
     environment:
       FLOW_CONTEXT: Production
     docker:
-      - image: quay.io/yeebase/ci-build:7.2
+      - image: cimg/php:7.4.12-node
       - image: circleci/mariadb:10.2
         environment:
           MYSQL_DATABASE: neos

--- a/Tests/IntegrationTests/TestDistribution/DistributionPackages/Neos.TestSite/composer.json
+++ b/Tests/IntegrationTests/TestDistribution/DistributionPackages/Neos.TestSite/composer.json
@@ -3,7 +3,7 @@
     "description": "A dummy site package that will be replaced by fixtures during tests",
     "type": "neos-site",
     "require": {
-        "neos/neos": "~5.3.0 || dev-master",
+        "neos/neos": "dev-master",
         "neos/neos-ui": "*",
         "neos/fusion-afx": "*"
     },

--- a/Tests/IntegrationTests/TestDistribution/composer.json
+++ b/Tests/IntegrationTests/TestDistribution/composer.json
@@ -1,11 +1,12 @@
 
 {
     "name": "neos/test-distribution",
-    "description": "Neos test distribution. Change this number if you need to break CircleCI's cache: 6",
+    "description": "Neos test distribution. Change this number if you need to break CircleCI's cache: 12",
     "config": {
         "vendor-dir": "Packages/Libraries",
         "bin-dir": "bin"
     },
+    "minimum-stability": "dev",
     "require": {
       "neos/neos-ui": "~5.3.0",
       "neos/fusion-afx": "*",


### PR DESCRIPTION
**What I did**
Changed the base image for the circle ci pipeline to a php 7.4 based.
Also use the neos/neos master as we have changes there that are needed for the neos-ui master.

The old test suite installed neos 5.3.