### PR TITLE
FEATURE: Add new e2e test for nodetype help with markdown

### DIFF
--- a/Tests/IntegrationTests/Fixtures/1Dimension/createNewNodes.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/createNewNodes.e2e.js
@@ -13,6 +13,32 @@ fixture`Create new nodes`
     .afterEach(() => checkPropTypes())
     .requestHooks(changeRequestLogger);
 
+test('Check the nodetype help in create dialog', async t => {
+    subSection('Open create dialog node');
+    await Page.waitForIframeLoading(t);
+    await t
+        .switchToIframe(contentIframeSelector)
+        .click(Selector('.neos-contentcollection'))
+        .click(Selector('#neos-InlineToolbar-AddNode'))
+        .switchToMainWindow()
+        .click(Selector('button#into'));
+
+    subSection('Open context help and check for Markdown rendering');
+    await t
+        .click(ReactSelector('NodeTypeItem').withProps({ nodeType: { label: 'Headline_Test' }}).find('button svg[data-icon="question-circle"]'))
+        .expect(ReactSelector('ReactMarkdown').find('strong').withText('test').exists).ok('Bold test from Markdown has been rendered');
+});
+
+test('Check that nodetype withou help has no help button', async t => {
+    await t
+        .switchToIframe(contentIframeSelector)
+        .click(Selector('.neos-contentcollection'))
+        .click(Selector('#neos-InlineToolbar-AddNode'))
+        .switchToMainWindow()
+        .click(Selector('button#into'))
+        .expect(ReactSelector('NodeTypeItem').withProps({ nodeType: { label: 'Text_Test' }}).find('button').count).eql(1);
+});
+
 test('Create an Image node from ContentTree', async t => {
 
     await t.switchToIframe(contentIframeSelector);
@@ -72,9 +98,7 @@ test('Can create content node from inside InlineUI', async t => {
         .click(Selector('#neos-InlineToolbar-AddNode'))
         .switchToMainWindow()
         .click(Selector('button#into'))
-        // TODO: this selector will only work with English translation.
-        // Change to `withProps` when implemented: https://github.com/DevExpress/testcafe-react-selectors/issues/14
-        .click(ReactSelector('NodeTypeItem').find('button>span>span').withText('Headline_Test'));
+        .click(ReactSelector('NodeTypeItem').withProps({ nodeType: { label: 'Headline_Test' }}));
 
     subSection('Type something inside of it');
     await Page.waitForIframeLoading(t);

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Content.Headline.yaml
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Content.Headline.yaml
@@ -6,6 +6,8 @@
     icon: icon-header
     position: 200
     inlineEditable: true
+    help:
+      message: 'Markdown **test**.'
   properties:
     title:
       type: string


### PR DESCRIPTION
It is possible to configure a context help for each nodetype. And you can use markdown for this help message.
As we sometime upgrade the Markdown library we should also have a test for that.

Resolves: #2825