### PR TITLE
FEATURE: Use language plurals in I18n registry 

### DIFF
--- a/packages/neos-ui-i18n/src/registry/I18nRegistry.spec.js
+++ b/packages/neos-ui-i18n/src/registry/I18nRegistry.spec.js
@@ -53,3 +53,128 @@ test(`
 
     expect(actual).toBe('The Translation');
 });
+
+test(`
+    Host > Containers > I18n: Should display singular when no quantity is defined.`, () => {
+    const translations = {
+        'Neos_Neos': { // eslint-disable-line quote-props
+            'Main': { // eslint-disable-line quote-props
+                'someLabel': 'The Translation', // eslint-disable-line quote-props
+                'pluralLabel': {
+                    0: 'Singular Translation', // eslint-disable-line quote-props
+                    1: 'Plural Translation' // eslint-disable-line quote-props
+                }
+            }
+        }
+    };
+
+    const registry = new I18nRegistry();
+    registry.setTranslations(translations);
+    const actual = registry.translate('Neos.Neos:Main:pluralLabel', undefined, undefined, 'Neos.Neos', 'Main');
+
+    expect(actual).toBe('Singular Translation');
+});
+
+test(`
+    Host > Containers > I18n: Should display singular when quantity is zero.`, () => {
+    const translations = {
+        'Neos_Neos': { // eslint-disable-line quote-props
+            'Main': { // eslint-disable-line quote-props
+                'someLabel': 'The Translation', // eslint-disable-line quote-props
+                'pluralLabel': {
+                    0: 'Singular Translation', // eslint-disable-line quote-props
+                    1: 'Plural Translation' // eslint-disable-line quote-props
+                }
+            }
+        }
+    };
+
+    const registry = new I18nRegistry();
+    registry.setTranslations(translations);
+    const actual = registry.translate('Neos.Neos:Main:pluralLabel', undefined, undefined, 'Neos.Neos', 'Main', 0);
+
+    expect(actual).toBe('Singular Translation');
+});
+
+test(`
+    Host > Containers > I18n: Should display singular when quantity is one.`, () => {
+    const translations = {
+        'Neos_Neos': { // eslint-disable-line quote-props
+            'Main': { // eslint-disable-line quote-props
+                'someLabel': 'The Translation', // eslint-disable-line quote-props
+                'pluralLabel': {
+                    0: 'Singular Translation', // eslint-disable-line quote-props
+                    1: 'Plural Translation' // eslint-disable-line quote-props
+                }
+            }
+        }
+    };
+
+    const registry = new I18nRegistry();
+    registry.setTranslations(translations);
+    const actual = registry.translate('Neos.Neos:Main:pluralLabel', undefined, undefined, 'Neos.Neos', 'Main', 1);
+
+    expect(actual).toBe('Singular Translation');
+});
+
+test(`
+    Host > Containers > I18n: Should display plural when quantity is two.`, () => {
+    const translations = {
+        'Neos_Neos': { // eslint-disable-line quote-props
+            'Main': { // eslint-disable-line quote-props
+                'someLabel': 'The Translation', // eslint-disable-line quote-props
+                'pluralLabel': {
+                    0: 'Singular Translation', // eslint-disable-line quote-props
+                    1: 'Plural Translation' // eslint-disable-line quote-props
+                }
+            }
+        }
+    };
+
+    const registry = new I18nRegistry();
+    registry.setTranslations(translations);
+    const actual = registry.translate('Neos.Neos:Main:pluralLabel', undefined, undefined, 'Neos.Neos', 'Main', 2);
+
+    expect(actual).toBe('Plural Translation');
+});
+
+test(`
+    Host > Containers > I18n: Should display regular language label even when no plural exists and a quantity is defined.`, () => {
+    const translations = {
+        'Neos_Neos': { // eslint-disable-line quote-props
+            'Main': { // eslint-disable-line quote-props
+                'someLabel': 'The Translation', // eslint-disable-line quote-props
+                'pluralLabel': {
+                    0: 'Singular Translation', // eslint-disable-line quote-props
+                    1: 'Plural Translation' // eslint-disable-line quote-props
+                }
+            }
+        }
+    };
+
+    const registry = new I18nRegistry();
+    registry.setTranslations(translations);
+    const actual = registry.translate('Neos.Neos:Main:someLabel', undefined, undefined, 'Neos.Neos', 'Main', 2);
+
+    expect(actual).toBe('The Translation');
+});
+
+test(`
+    Host > Containers > I18n: Should display singular when quantity is higher but plural label is not defined`, () => {
+    const translations = {
+        'Neos_Neos': { // eslint-disable-line quote-props
+            'Main': { // eslint-disable-line quote-props
+                'someLabel': 'The Translation', // eslint-disable-line quote-props
+                'pluralLabel': {
+                    0: 'Singular Translation' // eslint-disable-line quote-props
+                }
+            }
+        }
+    };
+
+    const registry = new I18nRegistry();
+    registry.setTranslations(translations);
+    const actual = registry.translate('Neos.Neos:Main:pluralLabel', undefined, undefined, 'Neos.Neos', 'Main', 2);
+
+    expect(actual).toBe('Singular Translation');
+});

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -365,7 +365,9 @@ export default class Inspector extends PureComponent {
                                     tabName: tabLabel,
                                     amountOfErrors: notifications
                                 },
-                                'Neos.Neos.Ui'
+                                'Neos.Neos.Ui',
+                                'Main',
+                                notifications
                             );
                             // @todo remove that when substitutePlaceholders of I18nRegistry returns strings
                             const notificationTooltipLabel = Array.isArray(notificationTooltipLabelPieces) ?


### PR DESCRIPTION
Sometimes you are using language labels with arguments and it can happen that you need a singular and plural of a word depending on the argument. For instance for the amout of errors.

XLIFF supports that and the flow translator as well. But when you want to use that labels in the JS part of the neos-ui you have no possibility to get the plural. You always get the singular if this is the first value in the group.

The following PR extended the `XliffService` to create a response that also respects plurals, so that the UI is able to consume the plural labels as well. https://github.com/neos/neos-development-collection/issues/2786

This change is not breaking as it uses singular labels when no plural exists. Take a look at the unit tests for instance.

**What I did**

Added a quantity parameter to the translate function of the I18n registry. With that quantity parameter you are able to fetch the plural of a label. If the label has no plural available we use the existing singular.

**How to verify it**

For instance try the tabs validation in the inspector.
In the old version the inspector tooltip was always singular and we just replaced the amount of issues.

![Screenshot 2020-11-09 at 12 28 53](https://user-images.githubusercontent.com/1014126/98539262-4f87d580-228c-11eb-8eda-6d6704b48a91.png)

As we are now able to consume the plurals we can render a better matching label :)

![Screenshot 2020-11-09 at 12 25 36](https://user-images.githubusercontent.com/1014126/98539315-68908680-228c-11eb-993c-d9240c65adef.png)


Resolves: #2595
