### PR TITLE
TASK: Remove use of resolveShortcuts argument

### DIFF
--- a/Classes/Domain/Model/Feedback/Operations/Redirect.php
+++ b/Classes/Domain/Model/Feedback/Operations/Redirect.php
@@ -93,7 +93,7 @@ class Redirect extends AbstractFeedback
     public function serializePayload(ControllerContext $controllerContext)
     {
         $node = $this->getNode();
-        $redirectUri = $this->linkingService->createNodeUri($controllerContext, $node, null, null, true, [], '', false, [], false);
+        $redirectUri = $this->linkingService->createNodeUri($controllerContext, $node, null, null, true, [], '', false, []);
 
         return [
             'redirectUri' => $redirectUri,

--- a/Classes/Domain/Model/Feedback/Operations/Redirect.php
+++ b/Classes/Domain/Model/Feedback/Operations/Redirect.php
@@ -93,7 +93,7 @@ class Redirect extends AbstractFeedback
     public function serializePayload(ControllerContext $controllerContext)
     {
         $node = $this->getNode();
-        $redirectUri = $this->linkingService->createNodeUri($controllerContext, $node, null, null, true, [], '', false, []);
+        $redirectUri = $this->linkingService->createNodeUri($controllerContext, $node, null, null, true);
 
         return [
             'redirectUri' => $redirectUri,

--- a/Classes/Domain/Model/Feedback/Operations/ReloadDocument.php
+++ b/Classes/Domain/Model/Feedback/Operations/ReloadDocument.php
@@ -107,7 +107,7 @@ class ReloadDocument extends AbstractFeedback
         }
         if ($documentNode = $this->nodeService->getClosestDocument($this->node)) {
             return [
-                'uri' => $this->linkingService->createNodeUri($controllerContext, $documentNode, null, null, true, [], '', false, [])
+                'uri' => $this->linkingService->createNodeUri($controllerContext, $documentNode, null, null, true)
             ];
         }
 

--- a/Classes/Domain/Model/Feedback/Operations/ReloadDocument.php
+++ b/Classes/Domain/Model/Feedback/Operations/ReloadDocument.php
@@ -107,7 +107,7 @@ class ReloadDocument extends AbstractFeedback
         }
         if ($documentNode = $this->nodeService->getClosestDocument($this->node)) {
             return [
-                'uri' => $this->linkingService->createNodeUri($controllerContext, $documentNode, null, null, true, [], '', false, [], false)
+                'uri' => $this->linkingService->createNodeUri($controllerContext, $documentNode, null, null, true, [], '', false, [])
             ];
         }
 

--- a/Classes/Domain/Service/NodeTreeBuilder.php
+++ b/Classes/Domain/Service/NodeTreeBuilder.php
@@ -207,9 +207,7 @@ class NodeTreeBuilder
                     /* $addQueryString */
                     false,
                     /* $argumentsToBeExcludedFromQueryString */
-                    [],
-                    /* $resolveShortcuts */
-                    false
+                    []
                 );
             }
         }

--- a/Classes/Domain/Service/NodeTreeBuilder.php
+++ b/Classes/Domain/Service/NodeTreeBuilder.php
@@ -199,15 +199,7 @@ class NodeTreeBuilder
                     /* $format */
                     null,
                     /* $absolute */
-                    true,
-                    /* $arguments */
-                    [],
-                    /* $section */
-                    '',
-                    /* $addQueryString */
-                    false,
-                    /* $argumentsToBeExcludedFromQueryString */
-                    []
+                    true
                 );
             }
         }

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -408,12 +408,12 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
     public function uri(NodeInterface $node = null, ControllerContext $controllerContext)
     {
         if ($node === null) {
-            // This happens when the document node os not published yet
+            // This happens when the document node is not published yet
             return '';
         }
 
-        // Create an absolute URI without resolving shortcuts
-        return $this->linkingService->createNodeUri($controllerContext, $node, null, null, true, [], '', false, [], false);
+        // Create an absolute URI
+        return $this->linkingService->createNodeUri($controllerContext, $node, null, null, true, [], '', false, []);
     }
 
     /**

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -413,7 +413,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
         }
 
         // Create an absolute URI
-        return $this->linkingService->createNodeUri($controllerContext, $node, null, null, true, [], '', false, []);
+        return $this->linkingService->createNodeUri($controllerContext, $node, null, null, true);
     }
 
     /**


### PR DESCRIPTION
The LinkingService.createNodeUri() no longer uses/accepts this
parameter…

See https://github.com/neos/neos-development-collection/pull/3168
