### PR TITLE
TASK: Hotfix to replace node[__identity] in preview uri

### DIFF
--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -413,7 +413,10 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
         }
 
         // Create an absolute URI without resolving shortcuts
-        return $this->linkingService->createNodeUri($controllerContext, $node, null, null, true, [], '', false, [], false);
+        $uri = urldecode($this->linkingService->createNodeUri($controllerContext, $node, null, null, true));
+        // @todo remove this hack when the uri is again without the [__identity] part.
+        $uri = str_replace('node[__identity]=', 'node=', $uri);
+        return $uri;
     }
 
     /**


### PR DESCRIPTION
This is just a temporary fix. We should remove this when the routing handling is fixed.

**What I did**
The backend was currently broken because the preview uri contained `[__identity]` .. this is a kind of a dirty quickfix and needs to be removed afterwards.

**How I did it**
relaced node[__identity] with node in the created preview URI

**How to verify it**
Just open the backend ;)

Relates: https://github.com/neos/neos-development-collection/pull/3183