### PR TITLE
BUGFIX: Moves neos backend container

### DIFF
--- a/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -83,7 +83,7 @@ prototype(Neos.Neos:Page) {
     neosBackendContainer.@if.oldBackend = ${false}
 
     newNeosBackendWrappingElement = '<div id="neos-new-backend-container"></div>'
-    newNeosBackendWrappingElement.@position = 'after neosBackendContainer'
+    newNeosBackendWrappingElement.@position = 'before closingBodyTag'
     newNeosBackendWrappingElement.@if.inBackend = ${documentNode.context.inBackend}
 
     //


### PR DESCRIPTION
The neosBackendContainer has been removed with the old emberjs content module. Because this container could not be found the container has been added to the beginning of the body tag.

Now we adjust the position to the end of the body section.

Thanks to @bwaidelich and @suffle for this hint 💙 

Fixes: #2828