### PR TITLE
TASK: Rename neos backend container

### DIFF
--- a/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -3,23 +3,10 @@
 // augments the website itself
 //
 prototype(Neos.Neos:Page) {
-
-    //
-    // Disable all html attributes printed for the Neos backend
-    //
-    htmlTag.attributes {
-        version.@if.oldBackend = ${false}
-        xmlns.@if.oldBackend = ${false}
-        xmlns:typo3.@if.oldBackend = ${false}
-        xmlns:xsd.@if.oldBackend = ${false}
-    }
-
     //
     // Disable rendering of the Neos backend
     //
     head {
-        neosBackendHeader.@if.oldBackend = ${false}
-        neosBackendEndpoints.@if.oldBackend = ${false}
 
         javascriptBackendInformation = Neos.Neos.Ui:RenderConfiguration {
             path = 'documentNodeInformation'
@@ -72,24 +59,9 @@ prototype(Neos.Neos:Page) {
         }
     }
 
-    //
-    // Do not print document meta data
-    //
-    neosBackendDocumentNodeData.@if.oldBackend = ${false}
-
-    //
-    // Do not render the Neos backend container
-    //
-    neosBackendContainer.@if.oldBackend = ${false}
-
-    newNeosBackendWrappingElement = '<div id="neos-backend-container"></div>'
-    newNeosBackendWrappingElement.@position = 'before closingBodyTag'
-    newNeosBackendWrappingElement.@if.inBackend = ${documentNode.context.inBackend}
-
-    //
-    // Do not render the Neos backend footer
-    //
-    neosBackendFooter.@if.oldBackend = ${false}
+    neosBackendContainer = '<div id="neos-backend-container"></div>'
+    neosBackendContainer.@position = 'before closingBodyTag'
+    neosBackendContainer.@if.inBackend = ${documentNode.context.inBackend}
 
     neosBackendNotification = Neos.Fusion:Template {
         @position = 'before closingBodyTag'

--- a/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -82,7 +82,7 @@ prototype(Neos.Neos:Page) {
     //
     neosBackendContainer.@if.oldBackend = ${false}
 
-    newNeosBackendWrappingElement = '<div id="neos-new-backend-container"></div>'
+    newNeosBackendWrappingElement = '<div id="neos-backend-container"></div>'
     newNeosBackendWrappingElement.@position = 'before closingBodyTag'
     newNeosBackendWrappingElement.@if.inBackend = ${documentNode.context.inBackend}
 

--- a/Resources/Private/Templates/Error/ErrorMessage.html
+++ b/Resources/Private/Templates/Error/ErrorMessage.html
@@ -7,6 +7,6 @@
     {guestNotificationScript -> f:format.raw()}
 </head>
 <body class="neos">
-    <div id="neos-new-backend-container" class="neos-error-screen">{message -> f:format.raw()}</div>
+    <div id="neos-backend-container" class="neos-error-screen">{message -> f:format.raw()}</div>
 </body>
 </html>

--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -126,7 +126,7 @@ export default class ContentCanvas extends PureComponent {
                         name="neos-content-main"
                         className={style.contentCanvas__contents}
                         style={canvasContentStyle}
-                        mountTarget="#neos-new-backend-container"
+                        mountTarget="#neos-backend-container"
                         contentDidUpdate={this.onFrameChange}
                         onLoad={this.handleFrameAccess}
                         onUnload={this.handelLoadStart}


### PR DESCRIPTION
Rename the container from `neos-new-backend-container` to `neos-backend-container`. The emberjs content module has been removed for 5.0 and now we rename the backend container as we have no old and new one anymore.

This can cause issues when the third party code rely on the neos-new-backend-container id.

Related: #2828
Fixes: #2849