### PR TITLE
BUGFIX: Synchronize language labels

### DIFF
--- a/Resources/Private/Translations/af/Main.xlf
+++ b/Resources/Private/Translations/af/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="af">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="af" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="af" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="af" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="af" state="needs-translation">Insert</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="af" state="needs-translation">Insert mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="af" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="af" state="needs-translation">Bold</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="af" state="needs-translation">Italic</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="af" state="needs-translation">Underline</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="af" state="needs-translation">Subscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="af" state="needs-translation">Superscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="af" state="needs-translation">Strikethrough</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="af" state="needs-translation">Link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="af" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="af" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="af" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="af" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="af" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="af" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="af" state="needs-translation">Title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="af" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="af" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="af" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="af" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="af" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="af" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="af" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="af" state="needs-translation">Ordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="af" state="needs-translation">Unordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="af" state="needs-translation">Align left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="af" state="needs-translation">Align right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="af" state="needs-translation">Align center</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="af" state="needs-translation">Align justify</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="af" state="needs-translation">Table</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="af" state="needs-translation">Column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="af" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="af" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="af" state="needs-translation">Remove format</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="af" state="needs-translation">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="af" state="needs-translation">Indent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="af" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="af" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="af" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="af" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="af" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="af" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="af" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="af" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="af" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="af" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="af" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="af" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="af" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="af" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="af" state="needs-translation">Create new</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="af" state="needs-translation">No matches found</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="af" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="af">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="af" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="af" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="af" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="af" state="needs-translation">Insert</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="af" state="needs-translation">Insert mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="af" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="af" state="needs-translation">Bold</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="af" state="needs-translation">Italic</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="af" state="needs-translation">Underline</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="af" state="needs-translation">Subscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="af" state="needs-translation">Superscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="af" state="needs-translation">Strikethrough</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="af" state="needs-translation">Link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="af" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="af" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="af" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="af" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="af" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="af" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="af" state="needs-translation">Title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="af" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="af" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="af" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="af" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="af" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="af" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="af" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="af" state="needs-translation">Ordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="af" state="needs-translation">Unordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="af" state="needs-translation">Align left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="af" state="needs-translation">Align right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="af" state="needs-translation">Align center</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="af" state="needs-translation">Align justify</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="af" state="needs-translation">Table</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="af" state="needs-translation">Column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="af" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="af" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="af" state="needs-translation">Remove format</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="af" state="needs-translation">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="af" state="needs-translation">Indent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="af" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="af" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="af" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="af" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="af" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="af" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="af" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="af" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="af" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="af" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="af" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="af" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="af" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="af" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="af" state="needs-translation">Create new</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="af" state="needs-translation">No matches found</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="af" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="af" state="needs-translation">
+                <target xml:lang="af" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="af" state="needs-translation">Toggle inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="af" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="af" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="af" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="af" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="af" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="af" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="af" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="af" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="af" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="af" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="af" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="af" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="af" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="af" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="af" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="af" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="af" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="af" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="af" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="af" state="needs-translation">Toggle inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="af" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="af" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="af" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="af" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="af" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="af" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="af" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="af" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="af" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="af" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="af" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="af" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="af" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="af" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="af" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="af" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="af" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="af" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="af" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/ar/Main.xlf
+++ b/Resources/Private/Translations/ar/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ar">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="ar" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="ar" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="ar" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="ar" state="needs-translation">Insert</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="ar" state="needs-translation">Insert mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="ar" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="ar" state="needs-translation">Bold</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="ar" state="needs-translation">Italic</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="ar" state="needs-translation">Underline</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="ar" state="needs-translation">Subscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="ar" state="needs-translation">Superscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="ar" state="needs-translation">Strikethrough</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="ar" state="translated">الرابط</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="ar" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="ar" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="ar" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="ar" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="ar" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="ar" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="ar" state="translated">العنوان</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="ar" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="ar" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="ar" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="ar" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="ar" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="ar" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="ar" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="ar" state="needs-translation">Ordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="ar" state="needs-translation">Unordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="ar" state="needs-translation">Align left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="ar" state="needs-translation">Align right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="ar" state="needs-translation">Align center</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="ar" state="needs-translation">Align justify</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="ar" state="needs-translation">Table</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="ar" state="translated">عمود</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="ar" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="ar" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="ar" state="needs-translation">Remove format</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="ar" state="needs-translation">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="ar" state="needs-translation">Indent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="ar" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="ar" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="ar" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="ar" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="ar" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="ar" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="ar" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="ar" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="ar" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="ar" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="ar" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="ar" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="ar" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="ar" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="ar" state="translated">إنشاء جديد</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="ar" state="needs-translation">No matches found</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="ar" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ar">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="ar" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="ar" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="ar" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="ar" state="needs-translation">Insert</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="ar" state="needs-translation">Insert mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="ar" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="ar" state="needs-translation">Bold</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="ar" state="needs-translation">Italic</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="ar" state="needs-translation">Underline</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="ar" state="needs-translation">Subscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="ar" state="needs-translation">Superscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="ar" state="needs-translation">Strikethrough</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="ar" state="translated">الرابط</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="ar" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="ar" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="ar" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="ar" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="ar" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="ar" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="ar" state="translated">العنوان</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="ar" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="ar" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="ar" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="ar" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="ar" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="ar" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="ar" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="ar" state="needs-translation">Ordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="ar" state="needs-translation">Unordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="ar" state="needs-translation">Align left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="ar" state="needs-translation">Align right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="ar" state="needs-translation">Align center</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="ar" state="needs-translation">Align justify</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="ar" state="needs-translation">Table</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="ar" state="translated">عمود</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="ar" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="ar" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="ar" state="needs-translation">Remove format</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="ar" state="needs-translation">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="ar" state="needs-translation">Indent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="ar" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="ar" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="ar" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="ar" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="ar" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="ar" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="ar" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="ar" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="ar" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="ar" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="ar" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="ar" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="ar" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="ar" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="ar" state="translated">إنشاء جديد</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="ar" state="needs-translation">No matches found</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="ar" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="ar" state="needs-translation">
+                <target xml:lang="ar" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="ar" state="needs-translation">Toggle inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="ar" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="ar" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="ar" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="ar" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="ar" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="ar" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="ar" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="ar" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="ar" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="ar" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="ar" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="ar" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="ar" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="ar" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="ar" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="ar" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="ar" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="ar" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="ar" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="ar" state="needs-translation">Toggle inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="ar" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="ar" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="ar" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="ar" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="ar" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="ar" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="ar" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="ar" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="ar" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="ar" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="ar" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="ar" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="ar" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="ar" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="ar" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="ar" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="ar" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="ar" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="ar" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/ca/Main.xlf
+++ b/Resources/Private/Translations/ca/Main.xlf
@@ -1,267 +1,348 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ca">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="ca" state="translated">Còpia {source} a {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="ca" state="translated">Moure {source} a {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="ca" state="translated">Seleccioneu la posició on voleu {source} inserir relatives a {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="ca" state="translated">Inserir</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="ca" state="translated">Inserir mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="ca" state="translated">Escollir una proporció</target><alt-trans><target xml:lang="ca">Escollir una relació d'aspecte</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="ca" state="translated">Negreta</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="ca" state="translated">Cursiva</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="ca" state="translated">Subratllat</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="ca" state="translated">Subíndex</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="ca" state="translated">Superíndex</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="ca" state="translated">Tatxat</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="ca" state="needs-translation">Link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="ca" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="ca" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="ca" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="ca" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="ca" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="ca" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="ca" state="needs-translation">Title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="ca" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="ca" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="ca" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="ca" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="ca" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="ca" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="ca" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="ca" state="translated">Llista ordenada</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="ca" state="translated">Llista sense ordenar</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="ca" state="translated">Alinear a l'esquerra</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="ca" state="translated">Alinear a la dreta</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="ca" state="translated">Centrar</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="ca" state="translated">Justificar</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="ca" state="translated">Taula</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="ca" state="needs-translation">Column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="ca" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="ca" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="ca" state="translated">Eliminar format</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="ca" state="translated">Dessagnat</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="ca" state="translated">Sagnat</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="ca" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="ca" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="ca" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="ca" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="ca" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="ca" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="ca" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="ca" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="ca" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="ca" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="ca" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="ca" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="ca" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="ca" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="ca" state="needs-translation">Create new</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="ca" state="translated">No s’han trobat coincidències</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="ca" state="translated">Si us plau introduïu ###CHARACTERS### més caràcters</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ca">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="ca" state="translated">Còpia {source} a {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="ca" state="translated">Moure {source} a {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="ca" state="translated">Seleccioneu la posició on voleu {source} inserir relatives a {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="ca" state="translated">Inserir</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="ca" state="translated">Inserir mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="ca" state="translated">Escollir una proporció</target>
+                <alt-trans>
+                    <target xml:lang="ca">Escollir una relació d'aspecte</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="ca" state="translated">Negreta</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="ca" state="translated">Cursiva</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="ca" state="translated">Subratllat</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="ca" state="translated">Subíndex</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="ca" state="translated">Superíndex</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="ca" state="translated">Tatxat</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="ca" state="needs-translation">Link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="ca" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="ca" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="ca" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="ca" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="ca" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="ca" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="ca" state="needs-translation">Title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="ca" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="ca" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="ca" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="ca" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="ca" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="ca" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="ca" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="ca" state="translated">Llista ordenada</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="ca" state="translated">Llista sense ordenar</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="ca" state="translated">Alinear a l'esquerra</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="ca" state="translated">Alinear a la dreta</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="ca" state="translated">Centrar</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="ca" state="translated">Justificar</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="ca" state="translated">Taula</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="ca" state="needs-translation">Column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="ca" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="ca" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="ca" state="translated">Eliminar format</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="ca" state="translated">Dessagnat</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="ca" state="translated">Sagnat</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="ca" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="ca" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="ca" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="ca" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="ca" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="ca" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="ca" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="ca" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="ca" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="ca" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="ca" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="ca" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="ca" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="ca" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="ca" state="needs-translation">Create new</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="ca" state="translated">No s’han trobat coincidències</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="ca" state="translated">Si us plau introduïu ###CHARACTERS### més caràcters</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="ca" state="needs-translation">
+                <target xml:lang="ca" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="ca" state="needs-translation">Toggle inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="ca" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="ca" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="ca" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="ca" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="ca" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="ca" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="ca" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="ca" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="ca" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="ca" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="ca" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="ca" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="ca" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="ca" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="ca" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="ca" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="ca" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="ca" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="ca" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="ca" state="needs-translation">Toggle inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="ca" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="ca" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="ca" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="ca" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="ca" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="ca" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="ca" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="ca" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="ca" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="ca" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="ca" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="ca" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="ca" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="ca" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="ca" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="ca" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="ca" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="ca" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="ca" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/cs/Main.xlf
+++ b/Resources/Private/Translations/cs/Main.xlf
@@ -1,267 +1,348 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="cs">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="cs" state="translated">Zkopírovat {source} do {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="cs" state="translated">Přesunout {source} do {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="cs" state="translated">Zvolte pozici vůči {target}, na kterou chcete vložit {source}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="cs" state="translated">Vložit</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="cs" state="translated">Režim vkládání</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="cs" state="translated">Zvolte poměr stran</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="cs" state="translated">Tučné</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="cs" state="translated">Kurzíva</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="cs" state="translated">Podtržení</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="cs" state="translated">Dolní index</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="cs" state="translated">Horní index</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="cs" state="translated">Přeškrtnout</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="cs" state="needs-translation">Link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="cs" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="cs" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="cs" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="cs" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="cs" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="cs" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="cs" state="translated">Titul</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="cs" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="cs" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="cs" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="cs" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="cs" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="cs" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="cs" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="cs" state="translated">Uspořádáný seznam</target><alt-trans><target xml:lang="cs">Řazený seznam</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="cs" state="translated">Neuspořádaný seznam</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="cs" state="translated">Zarovnat vlevo</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="cs" state="translated">Zarovnat vpravo</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="cs" state="translated">Zarovnat na střed</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="cs" state="needs-translation">Align justify</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="cs" state="translated">Tabulka</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="cs" state="needs-translation">Column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="cs" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="cs" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="cs" state="translated">Odstranit formát</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="cs" state="needs-translation">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="cs" state="needs-translation">Indent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="cs" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="cs" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="cs" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="cs" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="cs" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="cs" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="cs" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="cs" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="cs" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="cs" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="cs" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="cs" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="cs" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="cs" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="cs" state="translated">Vytvořit nový</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="cs" state="translated">Nebyla nalezena žádná shoda</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="cs" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="cs">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="cs" state="translated">Zkopírovat {source} do {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="cs" state="translated">Přesunout {source} do {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="cs" state="translated">Zvolte pozici vůči {target}, na kterou chcete vložit {source}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="cs" state="translated">Vložit</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="cs" state="translated">Režim vkládání</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="cs" state="translated">Zvolte poměr stran</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="cs" state="translated">Tučné</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="cs" state="translated">Kurzíva</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="cs" state="translated">Podtržení</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="cs" state="translated">Dolní index</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="cs" state="translated">Horní index</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="cs" state="translated">Přeškrtnout</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="cs" state="needs-translation">Link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="cs" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="cs" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="cs" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="cs" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="cs" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="cs" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="cs" state="translated">Titul</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="cs" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="cs" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="cs" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="cs" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="cs" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="cs" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="cs" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="cs" state="translated">Uspořádáný seznam</target>
+                <alt-trans>
+                    <target xml:lang="cs">Řazený seznam</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="cs" state="translated">Neuspořádaný seznam</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="cs" state="translated">Zarovnat vlevo</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="cs" state="translated">Zarovnat vpravo</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="cs" state="translated">Zarovnat na střed</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="cs" state="needs-translation">Align justify</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="cs" state="translated">Tabulka</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="cs" state="needs-translation">Column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="cs" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="cs" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="cs" state="translated">Odstranit formát</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="cs" state="needs-translation">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="cs" state="needs-translation">Indent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="cs" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="cs" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="cs" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="cs" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="cs" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="cs" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="cs" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="cs" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="cs" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="cs" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="cs" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="cs" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="cs" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="cs" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="cs" state="translated">Vytvořit nový</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="cs" state="translated">Nebyla nalezena žádná shoda</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="cs" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="cs" state="needs-translation">
+                <target xml:lang="cs" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="cs" state="translated">Přepnout inspektor</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="cs" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="cs" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="cs" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="cs" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="cs" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="cs" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="cs" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="cs" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="cs" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="cs" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="cs" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="cs" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="cs" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="cs" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="cs" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="cs" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="cs" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="cs" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="cs" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="cs" state="translated">Přepnout inspektor</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="cs" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="cs" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="cs" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="cs" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="cs" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="cs" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="cs" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="cs" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="cs" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="cs" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="cs" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="cs" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="cs" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="cs" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="cs" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="cs" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="cs" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="cs" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="cs" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/da/Main.xlf
+++ b/Resources/Private/Translations/da/Main.xlf
@@ -1,267 +1,348 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="da">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="da" state="translated">Kopier {source) til {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="da" state="translated">Flyt {source) til {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="da" state="translated">Vælg den position du ønsker {source} indsættes relativt til {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="da" state="translated">Indsæt</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="da" state="translated">Indsætningsmåde</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="da" state="translated">Vælg et billedeformat</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="da" state="translated">Fed</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="da" state="translated">Kursiv</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="da" state="translated">Understreget</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="da" state="translated">Sænket skrift</target><alt-trans><target xml:lang="da">Sænket</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="da" state="translated">Hævet skrift</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="da" state="translated">Gennemstreget</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
-				<source>Link</source>
-			<target xml:lang="da">Link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="da" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="da" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="da" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="da" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="da" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="da" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
-				<source>Title</source>
-			<target xml:lang="da">Titel</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="da" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="da" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="da" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="da" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="da" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="da" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="da" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="da" state="translated">Sorteret liste</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="da" state="translated">Usorteret liste</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="da" state="translated">Juster venstre</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="da" state="translated">Juster højre</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="da" state="translated">Juster centreret</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="da" state="translated">Juster ligefordelt</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="da" state="translated">Tabel</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve" approved="yes">
-				<source>Column</source>
-			<target xml:lang="da">Kolonne</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="da" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="da" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="da" state="translated">Fjern formattering</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="da" state="translated">Udryk</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="da" state="translated">Indryk</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="da" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="da" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="da" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="da" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="da" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="da" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="da" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="da" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="da" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="da" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="da" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="da" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="da" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="da" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve" approved="yes">
-				<source>Create new</source>
-			<target xml:lang="da">Opret ny</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="da" state="translated">Ingen resultater fundet</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="da" state="translated">Venligst indsæt ###CHARACTERS### flere karakterer</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="da">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="da" state="translated">Kopier {source) til {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="da" state="translated">Flyt {source) til {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="da" state="translated">Vælg den position du ønsker {source} indsættes relativt til {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="da" state="translated">Indsæt</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="da" state="translated">Indsætningsmåde</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="da" state="translated">Vælg et billedeformat</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="da" state="translated">Fed</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="da" state="translated">Kursiv</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="da" state="translated">Understreget</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="da" state="translated">Sænket skrift</target>
+                <alt-trans>
+                    <target xml:lang="da">Sænket</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="da" state="translated">Hævet skrift</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="da" state="translated">Gennemstreget</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
+                <source>Link</source>
+                <target xml:lang="da">Link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="da" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="da" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="da" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="da" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="da" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="da" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
+                <source>Title</source>
+                <target xml:lang="da">Titel</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="da" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="da" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="da" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="da" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="da" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="da" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="da" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="da" state="translated">Sorteret liste</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="da" state="translated">Usorteret liste</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="da" state="translated">Juster venstre</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="da" state="translated">Juster højre</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="da" state="translated">Juster centreret</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="da" state="translated">Juster ligefordelt</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="da" state="translated">Tabel</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve" approved="yes">
+                <source>Column</source>
+                <target xml:lang="da">Kolonne</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="da" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="da" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="da" state="translated">Fjern formattering</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="da" state="translated">Udryk</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="da" state="translated">Indryk</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="da" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="da" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="da" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="da" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="da" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="da" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="da" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="da" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="da" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="da" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="da" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="da" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="da" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="da" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve" approved="yes">
+                <source>Create new</source>
+                <target xml:lang="da">Opret ny</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="da" state="translated">Ingen resultater fundet</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="da" state="translated">Venligst indsæt ###CHARACTERS### flere karakterer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="da" state="needs-translation">
+                <target xml:lang="da" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve" approved="yes">
-				<source>Toggle inspector</source>
-			<target xml:lang="da">Skjul/vis inspektør</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="da" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="da" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="da" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="da" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="da" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="da" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="da" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="da" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="da" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="da" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="da" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="da" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="da" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="da" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="da" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="da" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="da" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="da" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="da" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve" approved="yes">
+                <source>Toggle inspector</source>
+                <target xml:lang="da">Skjul/vis inspektør</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="da" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="da" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="da" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="da" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="da" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="da" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="da" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="da" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="da" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="da" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="da" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="da" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="da" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="da" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="da" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="da" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="da" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="da" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="da" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/da/Main.xlf
+++ b/Resources/Private/Translations/da/Main.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="da">
         <body>
             <trans-unit id="copy__from__to--title" xml:space="preserve">
@@ -112,24 +112,6 @@
             <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
                 <source>Format as email?</source>
                 <target xml:lang="da" state="needs-translation">Format as email?</target>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
                 <source>Ordered list</source>
@@ -343,6 +325,36 @@
                 <source>Unfocus Node</source>
                 <target xml:lang="da" state="needs-translation">Unfocus Node</target>
             </trans-unit>
+            <group id="changesApplied" restype="x-gettext-plurals">
+                <trans-unit id="changesApplied[0]" xml:space="preserve">
+                    <source>{0} change successfully applied.</source>
+                    <target xml:lang="da" state="needs-translation">{0} change successfully applied.</target>
+                </trans-unit>
+                <trans-unit id="changesApplied[1]" xml:space="preserve">
+                    <source>{0} changes successfully applied.</source>
+                    <target xml:lang="da" state="needs-translation">{0} changes successfully applied.</target>
+                </trans-unit>
+            </group>
+            <group id="changesPublished" restype="x-gettext-plurals">
+                <trans-unit id="changesPublished[0]" xml:space="preserve">
+                    <source>Published {0} change to "{1}".</source>
+                    <target xml:lang="da" state="needs-translation">Published {0} change to "{1}".</target>
+                </trans-unit>
+                <trans-unit id="changesPublished[1]" xml:space="preserve">
+                    <source>Published {0} changes to "{1}".</source>
+                    <target xml:lang="da" state="needs-translation">Published {0} changes to "{1}".</target>
+                </trans-unit>
+            </group>
+            <group id="changesDiscarded" restype="x-gettext-plurals">
+                <trans-unit id="changesDiscarded[0]" xml:space="preserve">
+                    <source>Discarded {0} change.</source>
+                    <target xml:lang="da" state="needs-translation">Discarded {0} change.</target>
+                </trans-unit>
+                <trans-unit id="changesDiscarded[1]" xml:space="preserve">
+                    <source>Discarded {0} changes.</source>
+                    <target xml:lang="da" state="needs-translation">Discarded {0} changes.</target>
+                </trans-unit>
+            </group>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="de">
         <body>
             <trans-unit id="copy__from__to--title" xml:space="preserve" approved="yes">
@@ -127,24 +127,6 @@
             <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve" approved="yes">
                 <source>Format as email?</source>
                 <target xml:lang="de">Formatieren als E-Mail?</target>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
                 <source>Ordered list</source>

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -1,297 +1,459 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve" approved="yes">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="de">{source} zu {target} kopieren</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="de" state="translated">{source} zu {target} verschieben</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="de" state="translated">Bitte wählen Sie die Position an der Sie {source} relativ zu {target} Einfügen möchten.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="de" state="translated">Einfügen</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="de" state="translated">Einfügemodus</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="de" state="translated">Wählen Sie ein Seitenverhältnis</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="de" state="translated">Fett</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="de" state="translated">Kursiv</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="de" state="translated">Unterstrichen</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="de" state="translated">Tiefgestellt</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve" approved="yes">
-				<source>Superscript</source>
-			<target xml:lang="de">Hochgestellt</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="de" state="translated">Durchgestrichen</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
-				<source>Link</source>
-			<target xml:lang="de">Link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve" approved="yes">
-				<source>Unlink</source>
-			<target xml:lang="de">Verknüpfung aufheben</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve" approved="yes">
-				<source>Hide link options</source>
-			<target xml:lang="de">Optionen ausblenden</target><alt-trans><target xml:lang="de">Blende mögliche Verbindungen aus</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve" approved="yes">
-				<source>Link options</source>
-			<target xml:lang="de">Verbindungsoptionen</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve" approved="yes">
-				<source>No follow</source>
-			<target xml:lang="de">nicht folgen</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve" approved="yes">
-				<source>Open in new window</source>
-			<target xml:lang="de">Öffne Fenster in neuem Tab</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve" approved="yes">
-				<source>Enter link title</source>
-			<target xml:lang="de">Link Titel eingeben</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
-				<source>Title</source>
-			<target xml:lang="de">Titel</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve" approved="yes">
-				<source>Enter anchor name</source>
-			<target xml:lang="de">Gebe Anker Name ein</target><alt-trans><target xml:lang="de">Gebe Anchor Name ein</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve" approved="yes">
-				<source>Link to anchor</source>
-			<target xml:lang="de">Link zum Anker</target><alt-trans><target xml:lang="de">Verbinde zum Anker</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve" approved="yes">
-				<source>Edit link</source>
-			<target xml:lang="de">Link bearbeiten</target><alt-trans><target xml:lang="de">Bearbeite Link</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve" approved="yes">
-				<source>Apply link</source>
-			<target xml:lang="de">Link anwenden</target><alt-trans><target xml:lang="de">Link ausführen</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve" approved="yes">
-				<source>Paste a link, or search</source>
-			<target xml:lang="de">Link einfügen oder Eingabe zur Suche</target><alt-trans><target xml:lang="de">kopiere einen Link oder suche einen</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve" approved="yes">
-				<source>Format as http link?</source>
-			<target xml:lang="de">Formatieren als http Link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve" approved="yes">
-				<source>Format as email?</source>
-			<target xml:lang="de">Formatieren als E-Mail?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="de" state="translated">Geordnete Liste</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="de" state="translated">Ungeordnete Liste</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="de" state="translated">Linksbündig</target><alt-trans><target xml:lang="de">Links ausrichten</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve" approved="yes">
-				<source>Align right</source>
-			<target xml:lang="de">Rechtsbündig</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve" approved="yes">
-				<source>Align center</source>
-			<target xml:lang="de">Zentriert</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="de" state="translated">Blocksatz</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve" approved="yes">
-				<source>Table</source>
-			<target xml:lang="de">Tabelle</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve" approved="yes">
-				<source>Column</source>
-			<target xml:lang="de">Spalte</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve" approved="yes">
-				<source>Row</source>
-			<target xml:lang="de">Zeile</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve" approved="yes">
-				<source>Merge cells</source>
-			<target xml:lang="de">Zellen verbinden</target><alt-trans><target xml:lang="de">Verbinde Zellen</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="de" state="translated">Format entfernen</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="de" state="translated">Einzug verringern</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="de" state="translated">Einzug vergrößern</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve" approved="yes">
-				<source>Header column</source>
-			<target xml:lang="de">Kopfspalte</target><alt-trans><target xml:lang="de">Kopfzeile Spalte</target></alt-trans><alt-trans><target xml:lang="de">Kopfzeile</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve" approved="yes">
-				<source>Insert column before</source>
-			<target xml:lang="de">Spalte links einfügen</target><alt-trans><target xml:lang="de">füge als erst eine Spalte ein</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve" approved="yes">
-				<source>Insert column after</source>
-			<target xml:lang="de">Spalte rechts einfügen</target><alt-trans><target xml:lang="de">füge Spalte danach ein</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve" approved="yes">
-				<source>Delete column</source>
-			<target xml:lang="de">Spalte löschen</target><alt-trans><target xml:lang="de">Lösche Spalte</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve" approved="yes">
-				<source>Header row</source>
-			<target xml:lang="de">Kopfzeile</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve" approved="yes">
-				<source>Insert row below</source>
-			<target xml:lang="de">Zeile darunter einfügen</target><alt-trans><target xml:lang="de">füge Zeile unten ein</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve" approved="yes">
-				<source>Insert row above</source>
-			<target xml:lang="de">Zeile darüber einfügen</target><alt-trans><target xml:lang="de">Zeile oben einfügen</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve" approved="yes">
-				<source>Delete row</source>
-			<target xml:lang="de">Zeile entfernen</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve" approved="yes">
-				<source>Merge cell up</source>
-			<target xml:lang="de">Verbinde mit Zelle darüber</target><alt-trans><target xml:lang="de">Verbinde Zellen</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve" approved="yes">
-				<source>Merge cell right</source>
-			<target xml:lang="de">Verbinde mit Zelle rechts</target><alt-trans><target xml:lang="de">Verbinde Zeilen rechts</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve" approved="yes">
-				<source>Merge cell down</source>
-			<target xml:lang="de">Verbinde mit Zelle darunter</target><alt-trans><target xml:lang="de">Verbinde Zeilen nach unten</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve" approved="yes">
-				<source>Merge cell left</source>
-			<target xml:lang="de">Verbinde mit Zelle links</target><alt-trans><target xml:lang="de">Verbinde Zeilen nach links</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve" approved="yes">
-				<source>Split cell vertically</source>
-			<target xml:lang="de">Trenne Zelle vertikal</target><alt-trans><target xml:lang="de">Trenne Zellen vertikal</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve" approved="yes">
-				<source>Split cell horizontally</source>
-			<target xml:lang="de">Trenne Zelle horizontal</target><alt-trans><target xml:lang="de">Trenn Zellen horizontal</target></alt-trans></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve" approved="yes">
-				<source>Create new</source>
-			<target xml:lang="de">Neu erstellen</target><alt-trans><target xml:lang="de">Neues Element erstellen</target></alt-trans></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="de" state="translated">Keine Treffer gefunden</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="de" state="translated">Bitte geben Sie ###CHARACTERS### mehr Zeichen ein</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve" approved="yes">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="de">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve" approved="yes">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="de">{source} zu {target} kopieren</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="de" state="translated">{source} zu {target} verschieben</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="de" state="translated">Bitte wählen Sie die Position an der Sie {source} relativ zu {target} Einfügen möchten.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="de" state="translated">Einfügen</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="de" state="translated">Einfügemodus</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="de" state="translated">Wählen Sie ein Seitenverhältnis</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="de" state="translated">Fett</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="de" state="translated">Kursiv</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="de" state="translated">Unterstrichen</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="de" state="translated">Tiefgestellt</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve" approved="yes">
+                <source>Superscript</source>
+                <target xml:lang="de">Hochgestellt</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="de" state="translated">Durchgestrichen</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
+                <source>Link</source>
+                <target xml:lang="de">Link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve" approved="yes">
+                <source>Unlink</source>
+                <target xml:lang="de">Verknüpfung aufheben</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve" approved="yes">
+                <source>Hide link options</source>
+                <target xml:lang="de">Optionen ausblenden</target>
+                <alt-trans>
+                    <target xml:lang="de">Blende mögliche Verbindungen aus</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve" approved="yes">
+                <source>Link options</source>
+                <target xml:lang="de">Verbindungsoptionen</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve" approved="yes">
+                <source>No follow</source>
+                <target xml:lang="de">nicht folgen</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve" approved="yes">
+                <source>Open in new window</source>
+                <target xml:lang="de">Öffne Fenster in neuem Tab</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve" approved="yes">
+                <source>Enter link title</source>
+                <target xml:lang="de">Link Titel eingeben</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
+                <source>Title</source>
+                <target xml:lang="de">Titel</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve" approved="yes">
+                <source>Enter anchor name</source>
+                <target xml:lang="de">Gebe Anker Name ein</target>
+                <alt-trans>
+                    <target xml:lang="de">Gebe Anchor Name ein</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve" approved="yes">
+                <source>Link to anchor</source>
+                <target xml:lang="de">Link zum Anker</target>
+                <alt-trans>
+                    <target xml:lang="de">Verbinde zum Anker</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve" approved="yes">
+                <source>Edit link</source>
+                <target xml:lang="de">Link bearbeiten</target>
+                <alt-trans>
+                    <target xml:lang="de">Bearbeite Link</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve" approved="yes">
+                <source>Apply link</source>
+                <target xml:lang="de">Link anwenden</target>
+                <alt-trans>
+                    <target xml:lang="de">Link ausführen</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve" approved="yes">
+                <source>Paste a link, or search</source>
+                <target xml:lang="de">Link einfügen oder Eingabe zur Suche</target>
+                <alt-trans>
+                    <target xml:lang="de">kopiere einen Link oder suche einen</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve" approved="yes">
+                <source>Format as http link?</source>
+                <target xml:lang="de">Formatieren als http Link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve" approved="yes">
+                <source>Format as email?</source>
+                <target xml:lang="de">Formatieren als E-Mail?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="de" state="translated">Geordnete Liste</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="de" state="translated">Ungeordnete Liste</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="de" state="translated">Linksbündig</target>
+                <alt-trans>
+                    <target xml:lang="de">Links ausrichten</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve" approved="yes">
+                <source>Align right</source>
+                <target xml:lang="de">Rechtsbündig</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve" approved="yes">
+                <source>Align center</source>
+                <target xml:lang="de">Zentriert</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="de" state="translated">Blocksatz</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve" approved="yes">
+                <source>Table</source>
+                <target xml:lang="de">Tabelle</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve" approved="yes">
+                <source>Column</source>
+                <target xml:lang="de">Spalte</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve" approved="yes">
+                <source>Row</source>
+                <target xml:lang="de">Zeile</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve" approved="yes">
+                <source>Merge cells</source>
+                <target xml:lang="de">Zellen verbinden</target>
+                <alt-trans>
+                    <target xml:lang="de">Verbinde Zellen</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="de" state="translated">Format entfernen</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="de" state="translated">Einzug verringern</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="de" state="translated">Einzug vergrößern</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve" approved="yes">
+                <source>Header column</source>
+                <target xml:lang="de">Kopfspalte</target>
+                <alt-trans>
+                    <target xml:lang="de">Kopfzeile Spalte</target>
+                </alt-trans>
+                <alt-trans>
+                    <target xml:lang="de">Kopfzeile</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve" approved="yes">
+                <source>Insert column before</source>
+                <target xml:lang="de">Spalte links einfügen</target>
+                <alt-trans>
+                    <target xml:lang="de">füge als erst eine Spalte ein</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve" approved="yes">
+                <source>Insert column after</source>
+                <target xml:lang="de">Spalte rechts einfügen</target>
+                <alt-trans>
+                    <target xml:lang="de">füge Spalte danach ein</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve" approved="yes">
+                <source>Delete column</source>
+                <target xml:lang="de">Spalte löschen</target>
+                <alt-trans>
+                    <target xml:lang="de">Lösche Spalte</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve" approved="yes">
+                <source>Header row</source>
+                <target xml:lang="de">Kopfzeile</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve" approved="yes">
+                <source>Insert row below</source>
+                <target xml:lang="de">Zeile darunter einfügen</target>
+                <alt-trans>
+                    <target xml:lang="de">füge Zeile unten ein</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve" approved="yes">
+                <source>Insert row above</source>
+                <target xml:lang="de">Zeile darüber einfügen</target>
+                <alt-trans>
+                    <target xml:lang="de">Zeile oben einfügen</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve" approved="yes">
+                <source>Delete row</source>
+                <target xml:lang="de">Zeile entfernen</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve" approved="yes">
+                <source>Merge cell up</source>
+                <target xml:lang="de">Verbinde mit Zelle darüber</target>
+                <alt-trans>
+                    <target xml:lang="de">Verbinde Zellen</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve" approved="yes">
+                <source>Merge cell right</source>
+                <target xml:lang="de">Verbinde mit Zelle rechts</target>
+                <alt-trans>
+                    <target xml:lang="de">Verbinde Zeilen rechts</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve" approved="yes">
+                <source>Merge cell down</source>
+                <target xml:lang="de">Verbinde mit Zelle darunter</target>
+                <alt-trans>
+                    <target xml:lang="de">Verbinde Zeilen nach unten</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve" approved="yes">
+                <source>Merge cell left</source>
+                <target xml:lang="de">Verbinde mit Zelle links</target>
+                <alt-trans>
+                    <target xml:lang="de">Verbinde Zeilen nach links</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve" approved="yes">
+                <source>Split cell vertically</source>
+                <target xml:lang="de">Trenne Zelle vertikal</target>
+                <alt-trans>
+                    <target xml:lang="de">Trenne Zellen vertikal</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve" approved="yes">
+                <source>Split cell horizontally</source>
+                <target xml:lang="de">Trenne Zelle horizontal</target>
+                <alt-trans>
+                    <target xml:lang="de">Trenn Zellen horizontal</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve" approved="yes">
+                <source>Create new</source>
+                <target xml:lang="de">Neu erstellen</target>
+                <alt-trans>
+                    <target xml:lang="de">Neues Element erstellen</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="de" state="translated">Keine Treffer gefunden</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="de" state="translated">Bitte geben Sie ###CHARACTERS### mehr Zeichen ein</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve" approved="yes">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="de">
+                <target xml:lang="de">
                     Dies sind die Tastaturkürzel, die wir anbieten.
                     Drücken sie die Tasten der rechten Seite nacheinander.
                     Befinden sie sich in einem Eingabefeld, werden diese nicht ausgelöst.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve" approved="yes">
-				<source>Toggle inspector</source>
-			<target xml:lang="de">Inspector auf- / zuklappen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve" approved="yes">
-				<source>Toggle full screen</source>
-			<target xml:lang="de">Vollbildmodus umschalten</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve" approved="yes">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="de">Linke Seitenleiste ein-/ausblenden</target><alt-trans><target xml:lang="de">Linke Seitenleiste ein/aus</target></alt-trans></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve" approved="yes">
-				<source>Toggle contenttree</source>
-			<target xml:lang="de">Inhaltsbaum ein-/ausblenden</target><alt-trans><target xml:lang="de">Inhaltsbaum ein/aus</target></alt-trans></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve" approved="yes">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="de">Neue Seite Modal schliessen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve" approved="yes">
-				<source>Toggle Drawer</source>
-			<target xml:lang="de">Leiste ein-/ausblenden</target><alt-trans><target xml:lang="de">Leiste ein/aus</target></alt-trans></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve" approved="yes">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="de">Bearbeiten/Vorschau Panel ein-/ausblenden</target><alt-trans><target xml:lang="de">Bearbeiten/Vorschau Panel ein/aus</target></alt-trans></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve" approved="yes">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="de">InsertionModeModal abbrechen</target><alt-trans><target xml:lang="de">Breche InsertionModeModal ab</target></alt-trans></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve" approved="yes">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="de">InsertionModeModal anwenden</target><alt-trans><target xml:lang="de">Wende InsertionModeModal an</target></alt-trans></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve" approved="yes">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="de">Inhaltsbereich neu laden</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve" approved="yes">
-				<source>Discard Inspector</source>
-			<target xml:lang="de">Inspektoreingaben verwerfen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve" approved="yes">
-				<source>Escape Inspector</source>
-			<target xml:lang="de">Inspektor verlassen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve" approved="yes">
-				<source>Resume Inspector</source>
-			<target xml:lang="de">Bearbeitung fortsetzen im Inspektor</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve" approved="yes">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="de">Neue Seite erstellen Dialog zurück</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve" approved="yes">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="de">Neue Seite erstellen Dialog abbrechen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve" approved="yes">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="de">Neue Seite erstellen Dialog übernehmen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve" approved="yes">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="de">Neue Seite erstellen Dialog abbrechen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve" approved="yes">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="de">Neue Seite erstellen Dialog leere Seite erstellen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve" approved="yes">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="de">Neue Seite erstellen Dialog neue Seite von Kopie erstellen</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve" approved="yes">
-				<source>Unfocus Node</source>
-			<target xml:lang="de">Fokus vom Node entfernen</target></trans-unit>
-        <group id="changesApplied" restype="x-gettext-plurals">
-            <trans-unit id="changesApplied[0]" xml:space="preserve">
-                <source>{0} change successfully applied.</source>
-                <target>{0} Änderung erfolgreich angewendet.</target>
+                </target>
             </trans-unit>
-            <trans-unit id="changesApplied[1]" xml:space="preserve">
-                <source>{0} changes successfully applied.</source>
-                <target>{0} Änderungen erfolgreich angewendet.</target>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve" approved="yes">
+                <source>Toggle inspector</source>
+                <target xml:lang="de">Inspector auf- / zuklappen</target>
             </trans-unit>
-        </group>
-        <group id="changesPublished" restype="x-gettext-plurals">
-            <trans-unit id="changesPublished[0]" xml:space="preserve">
-                <source>Published {0} change to "{1}".</source>
-                <target>{0} Änderung nach "{1}" veröffentlicht.</target>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve" approved="yes">
+                <source>Toggle full screen</source>
+                <target xml:lang="de">Vollbildmodus umschalten</target>
             </trans-unit>
-            <trans-unit id="changesPublished[1]" xml:space="preserve">
-                <source>Published {0} changes to "{1}".</source>
-                <target>{0} Änderungen nach "{1}" veröffentlicht.</target>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve" approved="yes">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="de">Linke Seitenleiste ein-/ausblenden</target>
+                <alt-trans>
+                    <target xml:lang="de">Linke Seitenleiste ein/aus</target>
+                </alt-trans>
             </trans-unit>
-        </group>
-        <group id="changesDiscarded" restype="x-gettext-plurals">
-            <trans-unit id="changesDiscarded[0]" xml:space="preserve">
-                <source>Discarded {0} change.</source>
-                <target>{0} Änderung verworfen.</target>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve" approved="yes">
+                <source>Toggle contenttree</source>
+                <target xml:lang="de">Inhaltsbaum ein-/ausblenden</target>
+                <alt-trans>
+                    <target xml:lang="de">Inhaltsbaum ein/aus</target>
+                </alt-trans>
             </trans-unit>
-            <trans-unit id="changesDiscarded[1]" xml:space="preserve">
-                <source>Discarded {0} changes.</source>
-                <target>{0} Änderungen verworfen.</target>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve" approved="yes">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="de">Neue Seite Modal schliessen</target>
             </trans-unit>
-        </group>
-    </body>
-  </file>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve" approved="yes">
+                <source>Toggle Drawer</source>
+                <target xml:lang="de">Leiste ein-/ausblenden</target>
+                <alt-trans>
+                    <target xml:lang="de">Leiste ein/aus</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve" approved="yes">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="de">Bearbeiten/Vorschau Panel ein-/ausblenden</target>
+                <alt-trans>
+                    <target xml:lang="de">Bearbeiten/Vorschau Panel ein/aus</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve" approved="yes">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="de">InsertionModeModal abbrechen</target>
+                <alt-trans>
+                    <target xml:lang="de">Breche InsertionModeModal ab</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve" approved="yes">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="de">InsertionModeModal anwenden</target>
+                <alt-trans>
+                    <target xml:lang="de">Wende InsertionModeModal an</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve" approved="yes">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="de">Inhaltsbereich neu laden</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve" approved="yes">
+                <source>Discard Inspector</source>
+                <target xml:lang="de">Inspektoreingaben verwerfen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve" approved="yes">
+                <source>Escape Inspector</source>
+                <target xml:lang="de">Inspektor verlassen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve" approved="yes">
+                <source>Resume Inspector</source>
+                <target xml:lang="de">Bearbeitung fortsetzen im Inspektor</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve" approved="yes">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="de">Neue Seite erstellen Dialog zurück</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve" approved="yes">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="de">Neue Seite erstellen Dialog abbrechen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve" approved="yes">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="de">Neue Seite erstellen Dialog übernehmen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve" approved="yes">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="de">Neue Seite erstellen Dialog abbrechen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve" approved="yes">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="de">Neue Seite erstellen Dialog leere Seite erstellen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve" approved="yes">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="de">Neue Seite erstellen Dialog neue Seite von Kopie erstellen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve" approved="yes">
+                <source>Unfocus Node</source>
+                <target xml:lang="de">Fokus vom Node entfernen</target>
+            </trans-unit>
+            <group id="changesApplied" restype="x-gettext-plurals">
+                <trans-unit id="changesApplied[0]" xml:space="preserve">
+                    <source>{0} change successfully applied.</source>
+                    <target>{0} Änderung erfolgreich angewendet.</target>
+                </trans-unit>
+                <trans-unit id="changesApplied[1]" xml:space="preserve">
+                    <source>{0} changes successfully applied.</source>
+                    <target>{0} Änderungen erfolgreich angewendet.</target>
+                </trans-unit>
+            </group>
+            <group id="changesPublished" restype="x-gettext-plurals">
+                <trans-unit id="changesPublished[0]" xml:space="preserve">
+                    <source>Published {0} change to "{1}".</source>
+                    <target>{0} Änderung nach "{1}" veröffentlicht.</target>
+                </trans-unit>
+                <trans-unit id="changesPublished[1]" xml:space="preserve">
+                    <source>Published {0} changes to "{1}".</source>
+                    <target>{0} Änderungen nach "{1}" veröffentlicht.</target>
+                </trans-unit>
+            </group>
+            <group id="changesDiscarded" restype="x-gettext-plurals">
+                <trans-unit id="changesDiscarded[0]" xml:space="preserve">
+                    <source>Discarded {0} change.</source>
+                    <target>{0} Änderung verworfen.</target>
+                </trans-unit>
+                <trans-unit id="changesDiscarded[1]" xml:space="preserve">
+                    <source>Discarded {0} changes.</source>
+                    <target>{0} Änderungen verworfen.</target>
+                </trans-unit>
+            </group>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/el/Main.xlf
+++ b/Resources/Private/Translations/el/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="el">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="el" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="el" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="el" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="el" state="needs-translation">Insert</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="el" state="needs-translation">Insert mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="el" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="el" state="needs-translation">Bold</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="el" state="needs-translation">Italic</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="el" state="needs-translation">Underline</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="el" state="needs-translation">Subscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="el" state="needs-translation">Superscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="el" state="needs-translation">Strikethrough</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="el" state="translated">Σύνδεσμος</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="el" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="el" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="el" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="el" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="el" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="el" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="el" state="translated">Τίτλος</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="el" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="el" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="el" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="el" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="el" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="el" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="el" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="el" state="needs-translation">Ordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="el" state="needs-translation">Unordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="el" state="needs-translation">Align left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="el" state="needs-translation">Align right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="el" state="needs-translation">Align center</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="el" state="needs-translation">Align justify</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="el" state="needs-translation">Table</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="el" state="needs-translation">Column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="el" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="el" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="el" state="needs-translation">Remove format</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="el" state="needs-translation">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="el" state="needs-translation">Indent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="el" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="el" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="el" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="el" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="el" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="el" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="el" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="el" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="el" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="el" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="el" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="el" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="el" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="el" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="el" state="needs-translation">Create new</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="el" state="needs-translation">No matches found</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="el" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="el">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="el" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="el" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="el" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="el" state="needs-translation">Insert</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="el" state="needs-translation">Insert mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="el" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="el" state="needs-translation">Bold</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="el" state="needs-translation">Italic</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="el" state="needs-translation">Underline</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="el" state="needs-translation">Subscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="el" state="needs-translation">Superscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="el" state="needs-translation">Strikethrough</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="el" state="translated">Σύνδεσμος</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="el" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="el" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="el" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="el" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="el" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="el" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="el" state="translated">Τίτλος</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="el" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="el" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="el" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="el" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="el" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="el" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="el" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="el" state="needs-translation">Ordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="el" state="needs-translation">Unordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="el" state="needs-translation">Align left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="el" state="needs-translation">Align right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="el" state="needs-translation">Align center</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="el" state="needs-translation">Align justify</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="el" state="needs-translation">Table</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="el" state="needs-translation">Column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="el" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="el" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="el" state="needs-translation">Remove format</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="el" state="needs-translation">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="el" state="needs-translation">Indent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="el" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="el" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="el" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="el" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="el" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="el" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="el" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="el" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="el" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="el" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="el" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="el" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="el" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="el" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="el" state="needs-translation">Create new</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="el" state="needs-translation">No matches found</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="el" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="el" state="needs-translation">
+                <target xml:lang="el" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="el" state="needs-translation">Toggle inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="el" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="el" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="el" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="el" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="el" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="el" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="el" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="el" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="el" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="el" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="el" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="el" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="el" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="el" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="el" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="el" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="el" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="el" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="el" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="el" state="needs-translation">Toggle inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="el" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="el" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="el" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="el" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="el" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="el" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="el" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="el" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="el" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="el" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="el" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="el" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="el" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="el" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="el" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="el" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="el" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="el" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="el" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -1,196 +1,197 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext">
-		<body>
-			<trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			</trans-unit>
-			<trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			</trans-unit>
-			<trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			</trans-unit>
-			<trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			</trans-unit>
-			<trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			</trans-unit>
-			<trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			</trans-unit>
-			<trans-unit id="" xml:space="preserve">
-				<source></source>
-			</trans-unit>
-			<trans-unit id="" xml:space="preserve">
-				<source></source>
-			</trans-unit>
-			<trans-unit id="" xml:space="preserve">
-				<source></source>
-			</trans-unit>
-			<trans-unit id="" xml:space="preserve">
-				<source></source>
-			</trans-unit>
-			<trans-unit id="" xml:space="preserve">
-				<source></source>
-			</trans-unit>
-			<trans-unit id="" xml:space="preserve">
-				<source></source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			</trans-unit>
-			<trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			</trans-unit>
-			<trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			</trans-unit>
-			<trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			</trans-unit>
-			<trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			</trans-unit>
+<xliff version="1.2"
+    xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source></source>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source></source>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source></source>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source></source>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source></source>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source></source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+            </trans-unit>
             <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
@@ -198,66 +199,66 @@
                     They will not get triggered when you are focusing an input field.
                 </source>
             </trans-unit>
-			<trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			</trans-unit>
-			<trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			</trans-unit>
-			<trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			</trans-unit>
-			<trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			</trans-unit>
-			<trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			</trans-unit>
-			<trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			</trans-unit>
-			<trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			</trans-unit>
-			<trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			</trans-unit>
-			<trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			</trans-unit>
-			<trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			</trans-unit>
-			<trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			</trans-unit>
-			<trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			</trans-unit>
-			<trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			</trans-unit>
-			<trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			</trans-unit>
-			<trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			</trans-unit>
-			<trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			</trans-unit>
-			<trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			</trans-unit>
-			<trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			</trans-unit>
-			<trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			</trans-unit>
-			<trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			</trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+            </trans-unit>
             <group id="changesApplied" restype="x-gettext-plurals">
                 <trans-unit id="changesApplied[0]" xml:space="preserve">
                     <source>{0} change successfully applied.</source>
@@ -282,6 +283,6 @@
                     <source>Discarded {0} changes.</source>
                 </trans-unit>
             </group>
-		</body>
-	</file>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -84,24 +84,6 @@
             <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
                 <source>Format as email?</source>
             </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source></source>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source></source>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source></source>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source></source>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source></source>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source></source>
-            </trans-unit>
             <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
                 <source>Ordered list</source>
             </trans-unit>

--- a/Resources/Private/Translations/es/Main.xlf
+++ b/Resources/Private/Translations/es/Main.xlf
@@ -1,267 +1,387 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="es-ES">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve" approved="yes">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="es-ES">Copiar {source} a {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve" approved="yes">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="es-ES">Mover {source} a {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve" approved="yes">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="es-ES">Por favor, seleccione la posición en la que desea que {source} se encuentre insertado en relación con {target}.</target><alt-trans><target xml:lang="es-ES">Por favor, seleccione la posición en que desea {source} insertado en relación con {target}.</target></alt-trans></trans-unit>
-      <trans-unit id="insert" xml:space="preserve" approved="yes">
-				<source>Insert</source>
-			<target xml:lang="es-ES">Insertar</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve" approved="yes">
-				<source>Insert mode</source>
-			<target xml:lang="es-ES">Insertar modo</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve" approved="yes">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="es-ES">Elija una proporción</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve" approved="yes">
-				<source>Bold</source>
-			<target xml:lang="es-ES">Negrita</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve" approved="yes">
-				<source>Italic</source>
-			<target xml:lang="es-ES">Cursiva</target><alt-trans><target xml:lang="es-ES">Italica</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve" approved="yes">
-				<source>Underline</source>
-			<target xml:lang="es-ES">Subrayada</target><alt-trans><target xml:lang="es-ES">Subrayar</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve" approved="yes">
-				<source>Subscript</source>
-			<target xml:lang="es-ES">Subíndice</target><alt-trans><target xml:lang="es-ES">Subscript</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve" approved="yes">
-				<source>Superscript</source>
-			<target xml:lang="es-ES">Superscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve" approved="yes">
-				<source>Strikethrough</source>
-			<target xml:lang="es-ES">Tachado</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="es-ES" state="translated">Enlace</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="es-ES" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="es-ES" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="es-ES" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="es-ES" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="es-ES" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="es-ES" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
-				<source>Title</source>
-			<target xml:lang="es-ES">Título</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="es-ES" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="es-ES" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="es-ES" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="es-ES" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="es-ES" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="es-ES" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="es-ES" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve" approved="yes">
-				<source>Ordered list</source>
-			<target xml:lang="es-ES">Lista ordenada</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve" approved="yes">
-				<source>Unordered list</source>
-			<target xml:lang="es-ES">Lista no ordenada</target><alt-trans><target xml:lang="es-ES">Lista desordenada</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve" approved="yes">
-				<source>Align left</source>
-			<target xml:lang="es-ES">Alinear a la izquierda</target><alt-trans><target xml:lang="es-ES">Alinear a la izq.</target></alt-trans><alt-trans><target xml:lang="es-ES">Alinear a la izq</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve" approved="yes">
-				<source>Align right</source>
-			<target xml:lang="es-ES">Alinear a la derecha</target><alt-trans><target xml:lang="es-ES">Alinear a la der.</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve" approved="yes">
-				<source>Align center</source>
-			<target xml:lang="es-ES">Alinear al centro</target><alt-trans><target xml:lang="es-ES">Centrar</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve" approved="yes">
-				<source>Align justify</source>
-			<target xml:lang="es-ES">Justificado</target><alt-trans><target xml:lang="es-ES">Justificar</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve" approved="yes">
-				<source>Table</source>
-			<target xml:lang="es-ES">Tabla</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="es-ES" state="translated">Columna</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="es-ES" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="es-ES" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve" approved="yes">
-				<source>Remove format</source>
-			<target xml:lang="es-ES">Eliminar formato</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve" approved="yes">
-				<source>Outdent</source>
-			<target xml:lang="es-ES">Anular indentación</target><alt-trans><target xml:lang="es-ES">Anular sangría</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve" approved="yes">
-				<source>Indent</source>
-			<target xml:lang="es-ES">Indentado</target><alt-trans><target xml:lang="es-ES">Sangría</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="es-ES" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="es-ES" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="es-ES" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="es-ES" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="es-ES" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="es-ES" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="es-ES" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="es-ES" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="es-ES" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="es-ES" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="es-ES" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="es-ES" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="es-ES" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="es-ES" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="es-ES" state="translated">Crear nuevo</target><alt-trans><target xml:lang="es-ES">Crear nueva</target></alt-trans></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve" approved="yes">
-				<source>No matches found</source>
-			<target xml:lang="es-ES">No se encuentran coincidencias</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve" approved="yes">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="es-ES">Por favor introduzca ###CHARACTERS### caràcteres más</target><alt-trans><target xml:lang="es-ES">Introduzca ###CHARACTERS### caràcteres más</target></alt-trans></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="es-ES">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve" approved="yes">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="es-ES">Copiar {source} a {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve" approved="yes">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="es-ES">Mover {source} a {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve" approved="yes">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="es-ES">Por favor, seleccione la posición en la que desea que {source} se encuentre insertado en relación con {target}.</target>
+                <alt-trans>
+                    <target xml:lang="es-ES">Por favor, seleccione la posición en que desea {source} insertado en relación con {target}.</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve" approved="yes">
+                <source>Insert</source>
+                <target xml:lang="es-ES">Insertar</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve" approved="yes">
+                <source>Insert mode</source>
+                <target xml:lang="es-ES">Insertar modo</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve" approved="yes">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="es-ES">Elija una proporción</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve" approved="yes">
+                <source>Bold</source>
+                <target xml:lang="es-ES">Negrita</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve" approved="yes">
+                <source>Italic</source>
+                <target xml:lang="es-ES">Cursiva</target>
+                <alt-trans>
+                    <target xml:lang="es-ES">Italica</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve" approved="yes">
+                <source>Underline</source>
+                <target xml:lang="es-ES">Subrayada</target>
+                <alt-trans>
+                    <target xml:lang="es-ES">Subrayar</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve" approved="yes">
+                <source>Subscript</source>
+                <target xml:lang="es-ES">Subíndice</target>
+                <alt-trans>
+                    <target xml:lang="es-ES">Subscript</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve" approved="yes">
+                <source>Superscript</source>
+                <target xml:lang="es-ES">Superscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve" approved="yes">
+                <source>Strikethrough</source>
+                <target xml:lang="es-ES">Tachado</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="es-ES" state="translated">Enlace</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="es-ES" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="es-ES" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="es-ES" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="es-ES" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="es-ES" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="es-ES" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
+                <source>Title</source>
+                <target xml:lang="es-ES">Título</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="es-ES" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="es-ES" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="es-ES" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="es-ES" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="es-ES" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="es-ES" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="es-ES" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve" approved="yes">
+                <source>Ordered list</source>
+                <target xml:lang="es-ES">Lista ordenada</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve" approved="yes">
+                <source>Unordered list</source>
+                <target xml:lang="es-ES">Lista no ordenada</target>
+                <alt-trans>
+                    <target xml:lang="es-ES">Lista desordenada</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve" approved="yes">
+                <source>Align left</source>
+                <target xml:lang="es-ES">Alinear a la izquierda</target>
+                <alt-trans>
+                    <target xml:lang="es-ES">Alinear a la izq.</target>
+                </alt-trans>
+                <alt-trans>
+                    <target xml:lang="es-ES">Alinear a la izq</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve" approved="yes">
+                <source>Align right</source>
+                <target xml:lang="es-ES">Alinear a la derecha</target>
+                <alt-trans>
+                    <target xml:lang="es-ES">Alinear a la der.</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve" approved="yes">
+                <source>Align center</source>
+                <target xml:lang="es-ES">Alinear al centro</target>
+                <alt-trans>
+                    <target xml:lang="es-ES">Centrar</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve" approved="yes">
+                <source>Align justify</source>
+                <target xml:lang="es-ES">Justificado</target>
+                <alt-trans>
+                    <target xml:lang="es-ES">Justificar</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve" approved="yes">
+                <source>Table</source>
+                <target xml:lang="es-ES">Tabla</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="es-ES" state="translated">Columna</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="es-ES" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="es-ES" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve" approved="yes">
+                <source>Remove format</source>
+                <target xml:lang="es-ES">Eliminar formato</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve" approved="yes">
+                <source>Outdent</source>
+                <target xml:lang="es-ES">Anular indentación</target>
+                <alt-trans>
+                    <target xml:lang="es-ES">Anular sangría</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve" approved="yes">
+                <source>Indent</source>
+                <target xml:lang="es-ES">Indentado</target>
+                <alt-trans>
+                    <target xml:lang="es-ES">Sangría</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="es-ES" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="es-ES" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="es-ES" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="es-ES" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="es-ES" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="es-ES" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="es-ES" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="es-ES" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="es-ES" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="es-ES" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="es-ES" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="es-ES" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="es-ES" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="es-ES" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="es-ES" state="translated">Crear nuevo</target>
+                <alt-trans>
+                    <target xml:lang="es-ES">Crear nueva</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve" approved="yes">
+                <source>No matches found</source>
+                <target xml:lang="es-ES">No se encuentran coincidencias</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve" approved="yes">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="es-ES">Por favor introduzca ###CHARACTERS### caràcteres más</target>
+                <alt-trans>
+                    <target xml:lang="es-ES">Introduzca ###CHARACTERS### caràcteres más</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="es-ES" state="needs-translation">
+                <target xml:lang="es-ES" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="es-ES" state="translated">Alternar inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="es-ES" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="es-ES" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="es-ES" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="es-ES" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="es-ES" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="es-ES" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="es-ES" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="es-ES" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="es-ES" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="es-ES" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="es-ES" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="es-ES" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="es-ES" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="es-ES" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="es-ES" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="es-ES" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="es-ES" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="es-ES" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="es-ES" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="es-ES" state="translated">Alternar inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="es-ES" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="es-ES" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="es-ES" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="es-ES" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="es-ES" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="es-ES" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="es-ES" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="es-ES" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="es-ES" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="es-ES" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="es-ES" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="es-ES" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="es-ES" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="es-ES" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="es-ES" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="es-ES" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="es-ES" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="es-ES" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="es-ES" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/es/Main.xlf
+++ b/Resources/Private/Translations/es/Main.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="es-ES">
         <body>
             <trans-unit id="copy__from__to--title" xml:space="preserve" approved="yes">
@@ -121,24 +121,6 @@
             <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
                 <source>Format as email?</source>
                 <target xml:lang="es-ES" state="needs-translation">Format as email?</target>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve" approved="yes">
                 <source>Ordered list</source>
@@ -382,6 +364,36 @@
                 <source>Unfocus Node</source>
                 <target xml:lang="es-ES" state="needs-translation">Unfocus Node</target>
             </trans-unit>
+            <group id="changesApplied" restype="x-gettext-plurals">
+                <trans-unit id="changesApplied[0]" xml:space="preserve">
+                    <source>{0} change successfully applied.</source>
+                    <target xml:lang="es-ES" state="needs-translation">{0} change successfully applied.</target>
+                </trans-unit>
+                <trans-unit id="changesApplied[1]" xml:space="preserve">
+                    <source>{0} changes successfully applied.</source>
+                    <target xml:lang="es-ES" state="needs-translation">{0} changes successfully applied.</target>
+                </trans-unit>
+            </group>
+            <group id="changesPublished" restype="x-gettext-plurals">
+                <trans-unit id="changesPublished[0]" xml:space="preserve">
+                    <source>Published {0} change to "{1}".</source>
+                    <target xml:lang="es-ES" state="needs-translation">Published {0} change to "{1}".</target>
+                </trans-unit>
+                <trans-unit id="changesPublished[1]" xml:space="preserve">
+                    <source>Published {0} changes to "{1}".</source>
+                    <target xml:lang="es-ES" state="needs-translation">Published {0} changes to "{1}".</target>
+                </trans-unit>
+            </group>
+            <group id="changesDiscarded" restype="x-gettext-plurals">
+                <trans-unit id="changesDiscarded[0]" xml:space="preserve">
+                    <source>Discarded {0} change.</source>
+                    <target xml:lang="es-ES" state="needs-translation">Discarded {0} change.</target>
+                </trans-unit>
+                <trans-unit id="changesDiscarded[1]" xml:space="preserve">
+                    <source>Discarded {0} changes.</source>
+                    <target xml:lang="es-ES" state="needs-translation">Discarded {0} changes.</target>
+                </trans-unit>
+            </group>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Translations/fi/Main.xlf
+++ b/Resources/Private/Translations/fi/Main.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="fi">
         <body>
             <trans-unit id="copy__from__to--title" xml:space="preserve">
@@ -109,24 +109,6 @@
             <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
                 <source>Format as email?</source>
                 <target xml:lang="fi" state="needs-translation">Format as email?</target>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
                 <source>Ordered list</source>
@@ -340,6 +322,36 @@
                 <source>Unfocus Node</source>
                 <target xml:lang="fi" state="needs-translation">Unfocus Node</target>
             </trans-unit>
+            <group id="changesApplied" restype="x-gettext-plurals">
+                <trans-unit id="changesApplied[0]" xml:space="preserve">
+                    <source>{0} change successfully applied.</source>
+                    <target xml:lang="fi" state="needs-translation">{0} change successfully applied.</target>
+                </trans-unit>
+                <trans-unit id="changesApplied[1]" xml:space="preserve">
+                    <source>{0} changes successfully applied.</source>
+                    <target xml:lang="fi" state="needs-translation">{0} changes successfully applied.</target>
+                </trans-unit>
+            </group>
+            <group id="changesPublished" restype="x-gettext-plurals">
+                <trans-unit id="changesPublished[0]" xml:space="preserve">
+                    <source>Published {0} change to "{1}".</source>
+                    <target xml:lang="fi" state="needs-translation">Published {0} change to "{1}".</target>
+                </trans-unit>
+                <trans-unit id="changesPublished[1]" xml:space="preserve">
+                    <source>Published {0} changes to "{1}".</source>
+                    <target xml:lang="fi" state="needs-translation">Published {0} changes to "{1}".</target>
+                </trans-unit>
+            </group>
+            <group id="changesDiscarded" restype="x-gettext-plurals">
+                <trans-unit id="changesDiscarded[0]" xml:space="preserve">
+                    <source>Discarded {0} change.</source>
+                    <target xml:lang="fi" state="needs-translation">Discarded {0} change.</target>
+                </trans-unit>
+                <trans-unit id="changesDiscarded[1]" xml:space="preserve">
+                    <source>Discarded {0} changes.</source>
+                    <target xml:lang="fi" state="needs-translation">Discarded {0} changes.</target>
+                </trans-unit>
+            </group>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Translations/fi/Main.xlf
+++ b/Resources/Private/Translations/fi/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="fi">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="fi" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="fi" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="fi" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="fi" state="needs-translation">Insert</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="fi" state="needs-translation">Insert mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="fi" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="fi" state="needs-translation">Bold</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="fi" state="needs-translation">Italic</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="fi" state="needs-translation">Underline</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="fi" state="needs-translation">Subscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="fi" state="needs-translation">Superscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="fi" state="needs-translation">Strikethrough</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
-				<source>Link</source>
-			<target xml:lang="fi">Linkki</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="fi" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="fi" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="fi" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="fi" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="fi" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="fi" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
-				<source>Title</source>
-			<target xml:lang="fi">Otsikko</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="fi" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="fi" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="fi" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="fi" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="fi" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="fi" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="fi" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="fi" state="needs-translation">Ordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="fi" state="needs-translation">Unordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="fi" state="needs-translation">Align left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="fi" state="needs-translation">Align right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="fi" state="needs-translation">Align center</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="fi" state="needs-translation">Align justify</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="fi" state="needs-translation">Table</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve" approved="yes">
-				<source>Column</source>
-			<target xml:lang="fi">Sarake</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="fi" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="fi" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="fi" state="needs-translation">Remove format</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="fi" state="needs-translation">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="fi" state="needs-translation">Indent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="fi" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="fi" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="fi" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="fi" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="fi" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="fi" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="fi" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="fi" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="fi" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="fi" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="fi" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="fi" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="fi" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="fi" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve" approved="yes">
-				<source>Create new</source>
-			<target xml:lang="fi">Luo uusi</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="fi" state="needs-translation">No matches found</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="fi" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="fi">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="fi" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="fi" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="fi" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="fi" state="needs-translation">Insert</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="fi" state="needs-translation">Insert mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="fi" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="fi" state="needs-translation">Bold</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="fi" state="needs-translation">Italic</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="fi" state="needs-translation">Underline</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="fi" state="needs-translation">Subscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="fi" state="needs-translation">Superscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="fi" state="needs-translation">Strikethrough</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
+                <source>Link</source>
+                <target xml:lang="fi">Linkki</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="fi" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="fi" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="fi" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="fi" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="fi" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="fi" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
+                <source>Title</source>
+                <target xml:lang="fi">Otsikko</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="fi" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="fi" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="fi" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="fi" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="fi" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="fi" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="fi" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="fi" state="needs-translation">Ordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="fi" state="needs-translation">Unordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="fi" state="needs-translation">Align left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="fi" state="needs-translation">Align right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="fi" state="needs-translation">Align center</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="fi" state="needs-translation">Align justify</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="fi" state="needs-translation">Table</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve" approved="yes">
+                <source>Column</source>
+                <target xml:lang="fi">Sarake</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="fi" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="fi" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="fi" state="needs-translation">Remove format</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="fi" state="needs-translation">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="fi" state="needs-translation">Indent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="fi" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="fi" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="fi" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="fi" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="fi" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="fi" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="fi" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="fi" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="fi" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="fi" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="fi" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="fi" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="fi" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="fi" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve" approved="yes">
+                <source>Create new</source>
+                <target xml:lang="fi">Luo uusi</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="fi" state="needs-translation">No matches found</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="fi" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="fi" state="needs-translation">
+                <target xml:lang="fi" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve" approved="yes">
-				<source>Toggle inspector</source>
-			<target xml:lang="fi">Näytä/piilota tarkastelu</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="fi" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="fi" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="fi" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="fi" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="fi" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="fi" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="fi" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="fi" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="fi" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="fi" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="fi" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="fi" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="fi" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="fi" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="fi" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="fi" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="fi" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="fi" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="fi" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve" approved="yes">
+                <source>Toggle inspector</source>
+                <target xml:lang="fi">Näytä/piilota tarkastelu</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="fi" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="fi" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="fi" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="fi" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="fi" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="fi" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="fi" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="fi" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="fi" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="fi" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="fi" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="fi" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="fi" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="fi" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="fi" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="fi" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="fi" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="fi" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="fi" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/fr/Main.xlf
+++ b/Resources/Private/Translations/fr/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="fr" state="translated">Copiez {source} vers {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="fr" state="translated">Déplacer {source} vers {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="fr" state="translated">Veuillez sélectionner la position à laquelle vous souhaitez {source} être inséré par rapport à {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="fr" state="translated">Insérer</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="fr" state="translated">Mode &amp;insertion</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="fr" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="fr" state="translated">Gras</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="fr" state="translated">Italique</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="fr" state="translated">Souligné</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="fr" state="translated">Indice</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="fr" state="translated">Exposant</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="fr" state="translated">Barré</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
-				<source>Link</source>
-			<target xml:lang="fr">Lien</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="fr" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="fr" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="fr" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="fr" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="fr" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="fr" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
-				<source>Title</source>
-			<target xml:lang="fr">Titre</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="fr" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="fr" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="fr" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="fr" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="fr" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="fr" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="fr" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="fr" state="translated">Liste ordonnée</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="fr" state="translated">Liste non-ordonnée</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="fr" state="translated">Aligner à gauche</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="fr" state="translated">Aligner à droite</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="fr" state="translated">Aligner au centre</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="fr" state="translated">Aligner et justifier</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="fr" state="translated">Tableau</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve" approved="yes">
-				<source>Column</source>
-			<target xml:lang="fr">Colonne</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="fr" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="fr" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="fr" state="translated">Supprimer le formatage</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="fr" state="translated">Retrait négatif</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="fr" state="translated">Retrait</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="fr" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="fr" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="fr" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="fr" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="fr" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="fr" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="fr" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="fr" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="fr" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="fr" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="fr" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="fr" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="fr" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="fr" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve" approved="yes">
-				<source>Create new</source>
-			<target xml:lang="fr">Créer un nouveau</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="fr" state="translated">Aucune correspondance trouvée</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="fr" state="translated">S’il vous plaît entrez ###CHARACTERS### plus de caractère</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="fr">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="fr" state="translated">Copiez {source} vers {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="fr" state="translated">Déplacer {source} vers {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="fr" state="translated">Veuillez sélectionner la position à laquelle vous souhaitez {source} être inséré par rapport à {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="fr" state="translated">Insérer</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="fr" state="translated">Mode &amp;insertion</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="fr" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="fr" state="translated">Gras</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="fr" state="translated">Italique</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="fr" state="translated">Souligné</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="fr" state="translated">Indice</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="fr" state="translated">Exposant</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="fr" state="translated">Barré</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
+                <source>Link</source>
+                <target xml:lang="fr">Lien</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="fr" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="fr" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="fr" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="fr" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="fr" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="fr" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
+                <source>Title</source>
+                <target xml:lang="fr">Titre</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="fr" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="fr" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="fr" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="fr" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="fr" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="fr" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="fr" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="fr" state="translated">Liste ordonnée</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="fr" state="translated">Liste non-ordonnée</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="fr" state="translated">Aligner à gauche</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="fr" state="translated">Aligner à droite</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="fr" state="translated">Aligner au centre</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="fr" state="translated">Aligner et justifier</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="fr" state="translated">Tableau</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve" approved="yes">
+                <source>Column</source>
+                <target xml:lang="fr">Colonne</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="fr" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="fr" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="fr" state="translated">Supprimer le formatage</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="fr" state="translated">Retrait négatif</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="fr" state="translated">Retrait</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="fr" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="fr" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="fr" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="fr" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="fr" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="fr" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="fr" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="fr" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="fr" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="fr" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="fr" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="fr" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="fr" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="fr" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve" approved="yes">
+                <source>Create new</source>
+                <target xml:lang="fr">Créer un nouveau</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="fr" state="translated">Aucune correspondance trouvée</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="fr" state="translated">S’il vous plaît entrez ###CHARACTERS### plus de caractère</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="fr" state="needs-translation">
+                <target xml:lang="fr" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve" approved="yes">
-				<source>Toggle inspector</source>
-			<target xml:lang="fr">Basculer l'inspecteur</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="fr" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="fr" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="fr" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="fr" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="fr" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="fr" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="fr" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="fr" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="fr" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="fr" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="fr" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="fr" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="fr" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="fr" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="fr" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="fr" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="fr" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="fr" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="fr" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve" approved="yes">
+                <source>Toggle inspector</source>
+                <target xml:lang="fr">Basculer l'inspecteur</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="fr" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="fr" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="fr" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="fr" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="fr" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="fr" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="fr" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="fr" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="fr" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="fr" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="fr" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="fr" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="fr" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="fr" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="fr" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="fr" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="fr" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="fr" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="fr" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/fr/Main.xlf
+++ b/Resources/Private/Translations/fr/Main.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="fr">
         <body>
             <trans-unit id="copy__from__to--title" xml:space="preserve">
@@ -109,24 +109,6 @@
             <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
                 <source>Format as email?</source>
                 <target xml:lang="fr" state="needs-translation">Format as email?</target>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
                 <source>Ordered list</source>
@@ -340,6 +322,36 @@
                 <source>Unfocus Node</source>
                 <target xml:lang="fr" state="needs-translation">Unfocus Node</target>
             </trans-unit>
+            <group id="changesApplied" restype="x-gettext-plurals">
+                <trans-unit id="changesApplied[0]" xml:space="preserve">
+                    <source>{0} change successfully applied.</source>
+                    <target xml:lang="fr">{0} changement appliqué avec succès.</target>
+                </trans-unit>
+                <trans-unit id="changesApplied[1]" xml:space="preserve">
+                    <source>{0} changes successfully applied.</source>
+                    <target xml:lang="fr">{0} changements appliqués avec succès.</target>
+                </trans-unit>
+            </group>
+            <group id="changesPublished" restype="x-gettext-plurals">
+                <trans-unit id="changesPublished[0]" xml:space="preserve">
+                    <source>Published {0} change to "{1}".</source>
+                    <target xml:lang="fr">Publié {0} changement à "{1}".</target>
+                </trans-unit>
+                <trans-unit id="changesPublished[1]" xml:space="preserve">
+                    <source>Published {0} changes to "{1}".</source>
+                    <target xml:lang="fr">Publication de {0} changements dans "{1}".</target>
+                </trans-unit>
+            </group>
+            <group id="changesDiscarded" restype="x-gettext-plurals">
+                <trans-unit id="changesDiscarded[0]" xml:space="preserve">
+                    <source>Discarded {0} change.</source>
+                    <target xml:lang="fr">Jeter {0} changement.</target>
+                </trans-unit>
+                <trans-unit id="changesDiscarded[1]" xml:space="preserve">
+                    <source>Discarded {0} changes.</source>
+                    <target xml:lang="fr">Jeter {0} changements.</target>
+                </trans-unit>
+            </group>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Translations/fr/Main.xlf
+++ b/Resources/Private/Translations/fr/Main.xlf
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="copy__from__to--title" xml:space="preserve">
                 <source>Copy {source} to {target}</source>
-                <target xml:lang="fr" state="translated">Copiez {source} vers {target}</target>
+                <target xml:lang="fr" state="translated">Copier {source} vers {target}</target>
             </trans-unit>
             <trans-unit id="move__from__to--title" xml:space="preserve">
                 <source>Move {source} to {target}</source>
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="copy__from__to--description" xml:space="preserve">
                 <source>Please select the position at which you want {source} inserted relative to {target}.</source>
-                <target xml:lang="fr" state="translated">Veuillez sélectionner la position à laquelle vous souhaitez {source} être inséré par rapport à {target}.</target>
+                <target xml:lang="fr" state="translated">Veuillez sélectionner la position où vous souhaitez que {source} soit inséré par rapport à {target}.</target>
             </trans-unit>
             <trans-unit id="insert" xml:space="preserve">
                 <source>Insert</source>
@@ -20,11 +20,11 @@
             </trans-unit>
             <trans-unit id="insertMode" xml:space="preserve">
                 <source>Insert mode</source>
-                <target xml:lang="fr" state="translated">Mode &amp;insertion</target>
+                <target xml:lang="fr" state="translated">Mode d'insertion</target>
             </trans-unit>
             <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
                 <source>Choose an Aspect Ratio</source>
-                <target xml:lang="fr" state="needs-translation">Choose an Aspect Ratio</target>
+                <target xml:lang="fr" state="translated">Choisir un ratio</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
                 <source>Bold</source>
@@ -56,27 +56,27 @@
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
                 <source>Unlink</source>
-                <target xml:lang="fr" state="needs-translation">Unlink</target>
+                <target xml:lang="fr" state="translated">Supprimer le lien</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
                 <source>Hide link options</source>
-                <target xml:lang="fr" state="needs-translation">Hide link options</target>
+                <target xml:lang="fr" state="translated">Masquer les options de lien</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
                 <source>Link options</source>
-                <target xml:lang="fr" state="needs-translation">Link options</target>
+                <target xml:lang="fr" state="translated">Options de lien</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
                 <source>No follow</source>
-                <target xml:lang="fr" state="needs-translation">No follow</target>
+                <target xml:lang="fr" state="translated">No follow</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
                 <source>Open in new window</source>
-                <target xml:lang="fr" state="needs-translation">Open in new window</target>
+                <target xml:lang="fr" state="translated">Ouvrir dans une nouvelle fenêtre</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
                 <source>Enter link title</source>
-                <target xml:lang="fr" state="needs-translation">Enter link title</target>
+                <target xml:lang="fr" state="translated">Entrer le titre du lien</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
                 <source>Title</source>
@@ -84,31 +84,31 @@
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
                 <source>Enter anchor name</source>
-                <target xml:lang="fr" state="needs-translation">Enter anchor name</target>
+                <target xml:lang="fr" state="translated">Entrer le nom de l'ancre</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
                 <source>Link to anchor</source>
-                <target xml:lang="fr" state="needs-translation">Link to anchor</target>
+                <target xml:lang="fr" state="translated">Lien vers une ancre</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
                 <source>Edit link</source>
-                <target xml:lang="fr" state="needs-translation">Edit link</target>
+                <target xml:lang="fr" state="translated">Modifier le lien</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
                 <source>Apply link</source>
-                <target xml:lang="fr" state="needs-translation">Apply link</target>
+                <target xml:lang="fr" state="translated">Appliquer le lien</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
                 <source>Paste a link, or search</source>
-                <target xml:lang="fr" state="needs-translation">Paste a link, or search</target>
+                <target xml:lang="fr" state="translated">Coller un lien, ou rechercher</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
                 <source>Format as http link?</source>
-                <target xml:lang="fr" state="needs-translation">Format as http link?</target>
+                <target xml:lang="fr" state="translated">Formater en tant que lien http ?</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
                 <source>Format as email?</source>
-                <target xml:lang="fr" state="needs-translation">Format as email?</target>
+                <target xml:lang="fr" state="translated">Formater en tant qu'email ?</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
                 <source>Ordered list</source>
@@ -144,11 +144,11 @@
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
                 <source>Row</source>
-                <target xml:lang="fr" state="needs-translation">Row</target>
+                <target xml:lang="fr" state="translated">Ligne</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
                 <source>Merge cells</source>
-                <target xml:lang="fr" state="needs-translation">Merge cells</target>
+                <target xml:lang="fr" state="translated">Fusionner les cellules</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
                 <source>Remove format</source>
@@ -164,59 +164,59 @@
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
                 <source>Header column</source>
-                <target xml:lang="fr" state="needs-translation">Header column</target>
+                <target xml:lang="fr" state="translated">Colonne d'entête</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
                 <source>Insert column before</source>
-                <target xml:lang="fr" state="needs-translation">Insert column before</target>
+                <target xml:lang="fr" state="translated">Insérer une colonne avant</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
                 <source>Insert column after</source>
-                <target xml:lang="fr" state="needs-translation">Insert column after</target>
+                <target xml:lang="fr" state="translated">Insérer une colonne après</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
                 <source>Delete column</source>
-                <target xml:lang="fr" state="needs-translation">Delete column</target>
+                <target xml:lang="fr" state="translated">Supprimer la colonne</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
                 <source>Header row</source>
-                <target xml:lang="fr" state="needs-translation">Header row</target>
+                <target xml:lang="fr" state="translated">Ligne d'entête</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
                 <source>Insert row below</source>
-                <target xml:lang="fr" state="needs-translation">Insert row below</target>
+                <target xml:lang="fr" state="translated">Insérer une ligne au-dessus</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
                 <source>Insert row above</source>
-                <target xml:lang="fr" state="needs-translation">Insert row above</target>
+                <target xml:lang="fr" state="translated">Insérer une ligne au-dessous</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
                 <source>Delete row</source>
-                <target xml:lang="fr" state="needs-translation">Delete row</target>
+                <target xml:lang="fr" state="translated">Supprimer la ligne</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
                 <source>Merge cell up</source>
-                <target xml:lang="fr" state="needs-translation">Merge cell up</target>
+                <target xml:lang="fr" state="translated">Fusionner vers le haut</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
                 <source>Merge cell right</source>
-                <target xml:lang="fr" state="needs-translation">Merge cell right</target>
+                <target xml:lang="fr" state="translated">Fusionner vers la droite</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
                 <source>Merge cell down</source>
-                <target xml:lang="fr" state="needs-translation">Merge cell down</target>
+                <target xml:lang="fr" state="translated">Fusionner vers le bas</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
                 <source>Merge cell left</source>
-                <target xml:lang="fr" state="needs-translation">Merge cell left</target>
+                <target xml:lang="fr" state="translated">Fusionner vers la gauche</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
                 <source>Split cell vertically</source>
-                <target xml:lang="fr" state="needs-translation">Split cell vertically</target>
+                <target xml:lang="fr" state="translated">Séparer les cellules verticalement</target>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
                 <source>Split cell horizontally</source>
-                <target xml:lang="fr" state="needs-translation">Split cell horizontally</target>
+                <target xml:lang="fr" state="translated">Séparer les cellules horizontalement</target>
             </trans-unit>
             <trans-unit id="createNew" xml:space="preserve" approved="yes">
                 <source>Create new</source>
@@ -228,7 +228,7 @@
             </trans-unit>
             <trans-unit id="searchBoxLeftToType" xml:space="preserve">
                 <source>Please enter ###CHARACTERS### more character</source>
-                <target xml:lang="fr" state="translated">S’il vous plaît entrez ###CHARACTERS### plus de caractère</target>
+                <target xml:lang="fr" state="translated">Veuillez saisir ###CHARACTERS### caractères de plus</target>
             </trans-unit>
             <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
@@ -236,10 +236,10 @@
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-                <target xml:lang="fr" state="needs-translation">
-                    These are Keyboard-Shortcuts we are providing.
-                    You have to press the keys on the right after each other.
-                    They will not get triggered when you are focusing an input field.
+                <target xml:lang="fr" state="translated">
+                    Voici les raccourcis clavier disponibles.
+                    Vous devez presser séquentiellement les touches sur la droite.
+                    Les raccourcis ne sont pas actifs si un champ de saisie a le focus.
                 </target>
             </trans-unit>
             <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve" approved="yes">
@@ -325,31 +325,31 @@
             <group id="changesApplied" restype="x-gettext-plurals">
                 <trans-unit id="changesApplied[0]" xml:space="preserve">
                     <source>{0} change successfully applied.</source>
-                    <target xml:lang="fr">{0} changement appliqué avec succès.</target>
+                    <target xml:lang="fr">{0} modification appliquée avec succès.</target>
                 </trans-unit>
                 <trans-unit id="changesApplied[1]" xml:space="preserve">
                     <source>{0} changes successfully applied.</source>
-                    <target xml:lang="fr">{0} changements appliqués avec succès.</target>
+                    <target xml:lang="fr">{0} modifications appliquées avec succès.</target>
                 </trans-unit>
             </group>
             <group id="changesPublished" restype="x-gettext-plurals">
                 <trans-unit id="changesPublished[0]" xml:space="preserve">
                     <source>Published {0} change to "{1}".</source>
-                    <target xml:lang="fr">Publié {0} changement à "{1}".</target>
+                    <target xml:lang="fr">{0} modification publiée vers "{1}".</target>
                 </trans-unit>
                 <trans-unit id="changesPublished[1]" xml:space="preserve">
                     <source>Published {0} changes to "{1}".</source>
-                    <target xml:lang="fr">Publication de {0} changements dans "{1}".</target>
+                    <target xml:lang="fr">{0} modifications publiées vers "{1}".</target>
                 </trans-unit>
             </group>
             <group id="changesDiscarded" restype="x-gettext-plurals">
                 <trans-unit id="changesDiscarded[0]" xml:space="preserve">
                     <source>Discarded {0} change.</source>
-                    <target xml:lang="fr">Jeter {0} changement.</target>
+                    <target xml:lang="fr">{0} modification supprimée.</target>
                 </trans-unit>
                 <trans-unit id="changesDiscarded[1]" xml:space="preserve">
                     <source>Discarded {0} changes.</source>
-                    <target xml:lang="fr">Jeter {0} changements.</target>
+                    <target xml:lang="fr">{0} modifications supprimées.</target>
                 </trans-unit>
             </group>
         </body>

--- a/Resources/Private/Translations/he/Main.xlf
+++ b/Resources/Private/Translations/he/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="he">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="he" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="he" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="he" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="he" state="needs-translation">Insert</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="he" state="needs-translation">Insert mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="he" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="he" state="needs-translation">Bold</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="he" state="needs-translation">Italic</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="he" state="needs-translation">Underline</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="he" state="needs-translation">Subscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="he" state="needs-translation">Superscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="he" state="needs-translation">Strikethrough</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="he" state="needs-translation">Link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="he" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="he" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="he" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="he" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="he" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="he" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="he" state="needs-translation">Title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="he" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="he" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="he" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="he" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="he" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="he" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="he" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="he" state="needs-translation">Ordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="he" state="needs-translation">Unordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="he" state="needs-translation">Align left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="he" state="needs-translation">Align right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="he" state="needs-translation">Align center</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="he" state="needs-translation">Align justify</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="he" state="needs-translation">Table</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="he" state="needs-translation">Column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="he" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="he" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="he" state="needs-translation">Remove format</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="he" state="needs-translation">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="he" state="needs-translation">Indent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="he" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="he" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="he" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="he" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="he" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="he" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="he" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="he" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="he" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="he" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="he" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="he" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="he" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="he" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="he" state="needs-translation">Create new</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="he" state="needs-translation">No matches found</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="he" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="he">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="he" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="he" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="he" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="he" state="needs-translation">Insert</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="he" state="needs-translation">Insert mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="he" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="he" state="needs-translation">Bold</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="he" state="needs-translation">Italic</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="he" state="needs-translation">Underline</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="he" state="needs-translation">Subscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="he" state="needs-translation">Superscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="he" state="needs-translation">Strikethrough</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="he" state="needs-translation">Link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="he" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="he" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="he" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="he" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="he" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="he" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="he" state="needs-translation">Title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="he" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="he" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="he" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="he" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="he" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="he" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="he" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="he" state="needs-translation">Ordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="he" state="needs-translation">Unordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="he" state="needs-translation">Align left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="he" state="needs-translation">Align right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="he" state="needs-translation">Align center</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="he" state="needs-translation">Align justify</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="he" state="needs-translation">Table</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="he" state="needs-translation">Column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="he" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="he" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="he" state="needs-translation">Remove format</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="he" state="needs-translation">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="he" state="needs-translation">Indent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="he" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="he" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="he" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="he" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="he" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="he" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="he" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="he" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="he" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="he" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="he" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="he" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="he" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="he" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="he" state="needs-translation">Create new</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="he" state="needs-translation">No matches found</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="he" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="he" state="needs-translation">
+                <target xml:lang="he" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="he" state="needs-translation">Toggle inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="he" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="he" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="he" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="he" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="he" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="he" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="he" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="he" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="he" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="he" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="he" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="he" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="he" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="he" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="he" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="he" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="he" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="he" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="he" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="he" state="needs-translation">Toggle inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="he" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="he" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="he" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="he" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="he" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="he" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="he" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="he" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="he" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="he" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="he" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="he" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="he" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="he" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="he" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="he" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="he" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="he" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="he" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/hu/Main.xlf
+++ b/Resources/Private/Translations/hu/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="hu">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="hu" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="hu" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="hu" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="hu" state="needs-translation">Insert</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="hu" state="needs-translation">Insert mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="hu" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="hu" state="needs-translation">Bold</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="hu" state="needs-translation">Italic</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="hu" state="needs-translation">Underline</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="hu" state="needs-translation">Subscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="hu" state="needs-translation">Superscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="hu" state="needs-translation">Strikethrough</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="hu" state="needs-translation">Link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="hu" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="hu" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="hu" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="hu" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="hu" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="hu" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="hu" state="translated">Cím</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="hu" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="hu" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="hu" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="hu" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="hu" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="hu" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="hu" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="hu" state="needs-translation">Ordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="hu" state="needs-translation">Unordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="hu" state="needs-translation">Align left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="hu" state="needs-translation">Align right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="hu" state="needs-translation">Align center</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="hu" state="needs-translation">Align justify</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="hu" state="needs-translation">Table</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="hu" state="needs-translation">Column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="hu" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="hu" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="hu" state="needs-translation">Remove format</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="hu" state="needs-translation">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="hu" state="needs-translation">Indent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="hu" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="hu" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="hu" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="hu" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="hu" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="hu" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="hu" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="hu" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="hu" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="hu" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="hu" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="hu" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="hu" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="hu" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="hu" state="translated">Új létrehozása</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="hu" state="needs-translation">No matches found</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="hu" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="hu">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="hu" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="hu" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="hu" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="hu" state="needs-translation">Insert</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="hu" state="needs-translation">Insert mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="hu" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="hu" state="needs-translation">Bold</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="hu" state="needs-translation">Italic</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="hu" state="needs-translation">Underline</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="hu" state="needs-translation">Subscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="hu" state="needs-translation">Superscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="hu" state="needs-translation">Strikethrough</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="hu" state="needs-translation">Link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="hu" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="hu" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="hu" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="hu" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="hu" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="hu" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="hu" state="translated">Cím</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="hu" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="hu" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="hu" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="hu" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="hu" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="hu" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="hu" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="hu" state="needs-translation">Ordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="hu" state="needs-translation">Unordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="hu" state="needs-translation">Align left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="hu" state="needs-translation">Align right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="hu" state="needs-translation">Align center</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="hu" state="needs-translation">Align justify</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="hu" state="needs-translation">Table</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="hu" state="needs-translation">Column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="hu" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="hu" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="hu" state="needs-translation">Remove format</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="hu" state="needs-translation">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="hu" state="needs-translation">Indent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="hu" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="hu" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="hu" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="hu" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="hu" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="hu" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="hu" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="hu" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="hu" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="hu" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="hu" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="hu" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="hu" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="hu" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="hu" state="translated">Új létrehozása</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="hu" state="needs-translation">No matches found</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="hu" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="hu" state="needs-translation">
+                <target xml:lang="hu" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="hu" state="translated">Ellenőrző láthatósága</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="hu" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="hu" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="hu" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="hu" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="hu" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="hu" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="hu" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="hu" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="hu" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="hu" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="hu" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="hu" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="hu" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="hu" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="hu" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="hu" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="hu" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="hu" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="hu" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="hu" state="translated">Ellenőrző láthatósága</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="hu" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="hu" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="hu" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="hu" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="hu" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="hu" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="hu" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="hu" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="hu" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="hu" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="hu" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="hu" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="hu" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="hu" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="hu" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="hu" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="hu" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="hu" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="hu" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/id/Main.xlf
+++ b/Resources/Private/Translations/id/Main.xlf
@@ -1,267 +1,348 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="id">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="id" state="translated">Salin {source} ke {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="id" state="translated">Memindahkan {source} ke {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="id" state="translated">Harap pilih posisi yang Anda inginkan {source} dimasukkan relatif terhadap {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="id" state="translated">Memasukkan</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="id" state="translated">Sisipkan mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="id" state="translated">Pilih Rasio Aspek</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="id" state="translated">Berani</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="id" state="translated">Miring</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="id" state="translated">Menggarisbawahi</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="id" state="translated">Tanda tangansss</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="id" state="translated">Tulisan di atas</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="id" state="translated">Dicoret</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
-				<source>Link</source>
-			<target xml:lang="id">Link / tautan</target><alt-trans><target xml:lang="id">Tautan</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="id" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="id" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="id" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="id" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="id" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="id" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="id" state="translated">Judul</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="id" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="id" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="id" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="id" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="id" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="id" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="id" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="id" state="translated">Daftar pesanan</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="id" state="translated">Daftar tak berurutan</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="id" state="translated">Rata kiri</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="id" state="translated">Rata kanan</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="id" state="translated">Pusat sejajar</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="id" state="translated">Align membenarkan</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="id" state="translated">Meja</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="id" state="translated">Kolom</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="id" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="id" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="id" state="translated">Hapus format</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="id" state="translated">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="id" state="translated">Indentasi</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="id" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="id" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="id" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="id" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="id" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="id" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="id" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="id" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="id" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="id" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="id" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="id" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="id" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="id" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="id" state="translated">Buat baru</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="id" state="translated">Tidak ditemukan kecocokan</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="id" state="translated">Silakan masukkan ###KARAKTER### lebih banyak karakter</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="id">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="id" state="translated">Salin {source} ke {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="id" state="translated">Memindahkan {source} ke {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="id" state="translated">Harap pilih posisi yang Anda inginkan {source} dimasukkan relatif terhadap {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="id" state="translated">Memasukkan</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="id" state="translated">Sisipkan mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="id" state="translated">Pilih Rasio Aspek</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="id" state="translated">Berani</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="id" state="translated">Miring</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="id" state="translated">Menggarisbawahi</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="id" state="translated">Tanda tangansss</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="id" state="translated">Tulisan di atas</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="id" state="translated">Dicoret</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
+                <source>Link</source>
+                <target xml:lang="id">Link / tautan</target>
+                <alt-trans>
+                    <target xml:lang="id">Tautan</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="id" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="id" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="id" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="id" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="id" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="id" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="id" state="translated">Judul</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="id" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="id" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="id" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="id" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="id" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="id" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="id" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="id" state="translated">Daftar pesanan</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="id" state="translated">Daftar tak berurutan</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="id" state="translated">Rata kiri</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="id" state="translated">Rata kanan</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="id" state="translated">Pusat sejajar</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="id" state="translated">Align membenarkan</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="id" state="translated">Meja</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="id" state="translated">Kolom</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="id" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="id" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="id" state="translated">Hapus format</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="id" state="translated">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="id" state="translated">Indentasi</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="id" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="id" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="id" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="id" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="id" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="id" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="id" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="id" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="id" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="id" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="id" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="id" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="id" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="id" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="id" state="translated">Buat baru</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="id" state="translated">Tidak ditemukan kecocokan</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="id" state="translated">Silakan masukkan ###KARAKTER### lebih banyak karakter</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="id" state="needs-translation">
+                <target xml:lang="id" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="id" state="translated">Toggle Inspektur</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="id" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="id" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="id" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="id" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="id" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="id" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="id" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="id" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="id" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="id" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="id" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="id" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="id" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="id" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="id" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="id" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="id" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="id" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="id" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="id" state="translated">Toggle Inspektur</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="id" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="id" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="id" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="id" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="id" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="id" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="id" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="id" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="id" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="id" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="id" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="id" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="id" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="id" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="id" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="id" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="id" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="id" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="id" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/it/Main.xlf
+++ b/Resources/Private/Translations/it/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="it" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="it" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="it" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="it" state="translated">Inserisci</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="it" state="translated">Modalità di inserimento</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="it" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="it" state="translated">Grassetto</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="it" state="translated">Corsivo</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="it" state="translated">Sottolineato</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="it" state="translated">Pedice</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="it" state="translated">Apice</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="it" state="translated">Barrato</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="it" state="needs-translation">Link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="it" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="it" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="it" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="it" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="it" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="it" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="it" state="translated">Titolo</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="it" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="it" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="it" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="it" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="it" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="it" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="it" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="it" state="translated">Elenco ordinato</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="it" state="translated">Elenco non ordinato</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="it" state="translated">Allinea a sinistra</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="it" state="translated">Allinea a destra</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="it" state="translated">Allinea al centro</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="it" state="translated">Allineamento giustificato</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="it" state="translated">Tabella</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="it" state="needs-translation">Column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="it" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="it" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="it" state="translated">Rimuovi la formattazione</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="it" state="translated">Annullamento del rientro</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="it" state="translated">Indenta</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="it" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="it" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="it" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="it" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="it" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="it" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="it" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="it" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="it" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="it" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="it" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="it" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="it" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="it" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="it" state="translated">Crea nuovo</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="it" state="translated">Corrispondenza non trovata</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="it" state="translated">Inserisci ###CHARACTERS### più caratteri</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="it">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="it" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="it" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="it" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="it" state="translated">Inserisci</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="it" state="translated">Modalità di inserimento</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="it" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="it" state="translated">Grassetto</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="it" state="translated">Corsivo</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="it" state="translated">Sottolineato</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="it" state="translated">Pedice</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="it" state="translated">Apice</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="it" state="translated">Barrato</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="it" state="needs-translation">Link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="it" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="it" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="it" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="it" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="it" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="it" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="it" state="translated">Titolo</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="it" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="it" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="it" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="it" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="it" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="it" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="it" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="it" state="translated">Elenco ordinato</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="it" state="translated">Elenco non ordinato</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="it" state="translated">Allinea a sinistra</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="it" state="translated">Allinea a destra</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="it" state="translated">Allinea al centro</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="it" state="translated">Allineamento giustificato</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="it" state="translated">Tabella</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="it" state="needs-translation">Column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="it" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="it" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="it" state="translated">Rimuovi la formattazione</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="it" state="translated">Annullamento del rientro</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="it" state="translated">Indenta</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="it" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="it" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="it" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="it" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="it" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="it" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="it" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="it" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="it" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="it" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="it" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="it" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="it" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="it" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="it" state="translated">Crea nuovo</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="it" state="translated">Corrispondenza non trovata</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="it" state="translated">Inserisci ###CHARACTERS### più caratteri</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="it" state="needs-translation">
+                <target xml:lang="it" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="it" state="translated">Apri/Chiudi inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="it" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="it" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="it" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="it" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="it" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="it" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="it" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="it" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="it" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="it" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="it" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="it" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="it" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="it" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="it" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="it" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="it" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="it" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="it" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="it" state="translated">Apri/Chiudi inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="it" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="it" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="it" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="it" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="it" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="it" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="it" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="it" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="it" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="it" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="it" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="it" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="it" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="it" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="it" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="it" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="it" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="it" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="it" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/ja/Main.xlf
+++ b/Resources/Private/Translations/ja/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="ja" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="ja" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="ja" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="ja" state="translated">インサート</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="ja" state="translated">挿入モード</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="ja" state="translated">アスペクト比を選択する</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="ja" state="translated">大胆な</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="ja" state="translated">イタリック</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="ja" state="translated">アンダーライン</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="ja" state="translated">添字</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="ja" state="translated">上付き文字</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="ja" state="translated">打ち間違い</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="ja" state="needs-translation">Link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="ja" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="ja" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="ja" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="ja" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="ja" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="ja" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="ja" state="translated">タイトル</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="ja" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="ja" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="ja" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="ja" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="ja" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="ja" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="ja" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="ja" state="translated">順序付きリスト</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="ja" state="translated">順序付けられていないリスト</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="ja" state="translated">左揃え</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="ja" state="translated">右揃え</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="ja" state="translated">中心合わせ</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="ja" state="translated">正当な理由を整える</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="ja" state="translated">表</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="ja" state="translated">カラム</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="ja" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="ja" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="ja" state="translated">フォーマットを削除</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="ja" state="translated">アウトデント</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="ja" state="translated">インデント</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="ja" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="ja" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="ja" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="ja" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="ja" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="ja" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="ja" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="ja" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="ja" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="ja" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="ja" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="ja" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="ja" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="ja" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="ja" state="translated">新規作成 </target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="ja" state="translated">一致が見つかりません</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="ja" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ja">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="ja" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="ja" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="ja" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="ja" state="translated">インサート</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="ja" state="translated">挿入モード</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="ja" state="translated">アスペクト比を選択する</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="ja" state="translated">大胆な</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="ja" state="translated">イタリック</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="ja" state="translated">アンダーライン</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="ja" state="translated">添字</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="ja" state="translated">上付き文字</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="ja" state="translated">打ち間違い</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="ja" state="needs-translation">Link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="ja" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="ja" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="ja" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="ja" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="ja" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="ja" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="ja" state="translated">タイトル</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="ja" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="ja" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="ja" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="ja" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="ja" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="ja" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="ja" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="ja" state="translated">順序付きリスト</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="ja" state="translated">順序付けられていないリスト</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="ja" state="translated">左揃え</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="ja" state="translated">右揃え</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="ja" state="translated">中心合わせ</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="ja" state="translated">正当な理由を整える</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="ja" state="translated">表</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="ja" state="translated">カラム</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="ja" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="ja" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="ja" state="translated">フォーマットを削除</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="ja" state="translated">アウトデント</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="ja" state="translated">インデント</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="ja" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="ja" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="ja" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="ja" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="ja" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="ja" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="ja" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="ja" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="ja" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="ja" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="ja" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="ja" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="ja" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="ja" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="ja" state="translated">新規作成 </target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="ja" state="translated">一致が見つかりません</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="ja" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="ja" state="needs-translation">
+                <target xml:lang="ja" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="ja" state="translated">インスペクタを切り替える</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="ja" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="ja" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="ja" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="ja" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="ja" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="ja" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="ja" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="ja" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="ja" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="ja" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="ja" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="ja" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="ja" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="ja" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="ja" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="ja" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="ja" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="ja" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="ja" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="ja" state="translated">インスペクタを切り替える</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="ja" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="ja" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="ja" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="ja" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="ja" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="ja" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="ja" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="ja" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="ja" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="ja" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="ja" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="ja" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="ja" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="ja" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="ja" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="ja" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="ja" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="ja" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="ja" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/kk/Main.xlf
+++ b/Resources/Private/Translations/kk/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="kk">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="kk" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="kk" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="kk" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="kk" state="needs-translation">Insert</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="kk" state="needs-translation">Insert mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="kk" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="kk" state="needs-translation">Bold</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="kk" state="needs-translation">Italic</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="kk" state="needs-translation">Underline</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="kk" state="needs-translation">Subscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="kk" state="needs-translation">Superscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="kk" state="needs-translation">Strikethrough</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="kk" state="needs-translation">Link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="kk" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="kk" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="kk" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="kk" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="kk" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="kk" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="kk" state="needs-translation">Title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="kk" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="kk" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="kk" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="kk" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="kk" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="kk" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="kk" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="kk" state="needs-translation">Ordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="kk" state="needs-translation">Unordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="kk" state="needs-translation">Align left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="kk" state="needs-translation">Align right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="kk" state="needs-translation">Align center</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="kk" state="needs-translation">Align justify</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="kk" state="needs-translation">Table</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="kk" state="needs-translation">Column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="kk" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="kk" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="kk" state="needs-translation">Remove format</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="kk" state="needs-translation">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="kk" state="needs-translation">Indent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="kk" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="kk" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="kk" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="kk" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="kk" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="kk" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="kk" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="kk" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="kk" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="kk" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="kk" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="kk" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="kk" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="kk" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="kk" state="translated">Жаңасын құру</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="kk" state="needs-translation">No matches found</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="kk" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="kk">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="kk" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="kk" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="kk" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="kk" state="needs-translation">Insert</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="kk" state="needs-translation">Insert mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="kk" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="kk" state="needs-translation">Bold</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="kk" state="needs-translation">Italic</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="kk" state="needs-translation">Underline</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="kk" state="needs-translation">Subscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="kk" state="needs-translation">Superscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="kk" state="needs-translation">Strikethrough</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="kk" state="needs-translation">Link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="kk" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="kk" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="kk" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="kk" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="kk" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="kk" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="kk" state="needs-translation">Title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="kk" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="kk" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="kk" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="kk" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="kk" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="kk" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="kk" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="kk" state="needs-translation">Ordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="kk" state="needs-translation">Unordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="kk" state="needs-translation">Align left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="kk" state="needs-translation">Align right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="kk" state="needs-translation">Align center</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="kk" state="needs-translation">Align justify</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="kk" state="needs-translation">Table</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="kk" state="needs-translation">Column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="kk" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="kk" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="kk" state="needs-translation">Remove format</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="kk" state="needs-translation">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="kk" state="needs-translation">Indent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="kk" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="kk" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="kk" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="kk" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="kk" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="kk" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="kk" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="kk" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="kk" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="kk" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="kk" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="kk" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="kk" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="kk" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="kk" state="translated">Жаңасын құру</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="kk" state="needs-translation">No matches found</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="kk" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="kk" state="needs-translation">
+                <target xml:lang="kk" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="kk" state="needs-translation">Toggle inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="kk" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="kk" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="kk" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="kk" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="kk" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="kk" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="kk" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="kk" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="kk" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="kk" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="kk" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="kk" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="kk" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="kk" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="kk" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="kk" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="kk" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="kk" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="kk" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="kk" state="needs-translation">Toggle inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="kk" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="kk" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="kk" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="kk" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="kk" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="kk" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="kk" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="kk" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="kk" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="kk" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="kk" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="kk" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="kk" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="kk" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="kk" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="kk" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="kk" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="kk" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="kk" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/km/Main.xlf
+++ b/Resources/Private/Translations/km/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="km">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="km" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="km" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="km" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="km" state="needs-translation">Insert</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="km" state="needs-translation">Insert mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="km" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="km" state="needs-translation">Bold</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="km" state="needs-translation">Italic</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="km" state="needs-translation">Underline</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="km" state="needs-translation">Subscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="km" state="needs-translation">Superscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="km" state="needs-translation">Strikethrough</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
-				<source>Link</source>
-			<target xml:lang="km">តំណភ្ជាប់</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="km" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="km" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="km" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="km" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="km" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="km" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
-				<source>Title</source>
-			<target xml:lang="km">ចំណងជើង</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="km" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="km" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="km" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="km" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="km" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="km" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="km" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="km" state="needs-translation">Ordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="km" state="needs-translation">Unordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="km" state="needs-translation">Align left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="km" state="needs-translation">Align right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="km" state="needs-translation">Align center</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="km" state="needs-translation">Align justify</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="km" state="needs-translation">Table</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve" approved="yes">
-				<source>Column</source>
-			<target xml:lang="km">ជួរឈរ</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="km" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="km" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="km" state="needs-translation">Remove format</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="km" state="needs-translation">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="km" state="needs-translation">Indent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="km" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="km" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="km" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="km" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="km" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="km" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="km" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="km" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="km" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="km" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="km" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="km" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="km" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="km" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve" approved="yes">
-				<source>Create new</source>
-			<target xml:lang="km">បង្កើតថ្មី</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="km" state="needs-translation">No matches found</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="km" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="km">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="km" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="km" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="km" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="km" state="needs-translation">Insert</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="km" state="needs-translation">Insert mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="km" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="km" state="needs-translation">Bold</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="km" state="needs-translation">Italic</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="km" state="needs-translation">Underline</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="km" state="needs-translation">Subscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="km" state="needs-translation">Superscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="km" state="needs-translation">Strikethrough</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
+                <source>Link</source>
+                <target xml:lang="km">តំណភ្ជាប់</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="km" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="km" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="km" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="km" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="km" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="km" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
+                <source>Title</source>
+                <target xml:lang="km">ចំណងជើង</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="km" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="km" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="km" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="km" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="km" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="km" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="km" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="km" state="needs-translation">Ordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="km" state="needs-translation">Unordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="km" state="needs-translation">Align left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="km" state="needs-translation">Align right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="km" state="needs-translation">Align center</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="km" state="needs-translation">Align justify</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="km" state="needs-translation">Table</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve" approved="yes">
+                <source>Column</source>
+                <target xml:lang="km">ជួរឈរ</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="km" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="km" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="km" state="needs-translation">Remove format</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="km" state="needs-translation">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="km" state="needs-translation">Indent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="km" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="km" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="km" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="km" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="km" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="km" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="km" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="km" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="km" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="km" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="km" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="km" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="km" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="km" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve" approved="yes">
+                <source>Create new</source>
+                <target xml:lang="km">បង្កើតថ្មី</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="km" state="needs-translation">No matches found</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="km" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="km" state="needs-translation">
+                <target xml:lang="km" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve" approved="yes">
-				<source>Toggle inspector</source>
-			<target xml:lang="km">ត្រួតពិនិត្យបិទបើក</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="km" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="km" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="km" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="km" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="km" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="km" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="km" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="km" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="km" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="km" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="km" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="km" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="km" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="km" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="km" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="km" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="km" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="km" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="km" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve" approved="yes">
+                <source>Toggle inspector</source>
+                <target xml:lang="km">ត្រួតពិនិត្យបិទបើក</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="km" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="km" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="km" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="km" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="km" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="km" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="km" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="km" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="km" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="km" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="km" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="km" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="km" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="km" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="km" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="km" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="km" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="km" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="km" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/km/Main.xlf
+++ b/Resources/Private/Translations/km/Main.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="km">
         <body>
             <trans-unit id="copy__from__to--title" xml:space="preserve">
@@ -109,24 +109,6 @@
             <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
                 <source>Format as email?</source>
                 <target xml:lang="km" state="needs-translation">Format as email?</target>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
                 <source>Ordered list</source>
@@ -340,6 +322,36 @@
                 <source>Unfocus Node</source>
                 <target xml:lang="km" state="needs-translation">Unfocus Node</target>
             </trans-unit>
+            <group id="changesApplied" restype="x-gettext-plurals">
+                <trans-unit id="changesApplied[0]" xml:space="preserve">
+                    <source>{0} change successfully applied.</source>
+                    <target xml:lang="km" state="needs-translation">{0} change successfully applied.</target>
+                </trans-unit>
+                <trans-unit id="changesApplied[1]" xml:space="preserve">
+                    <source>{0} changes successfully applied.</source>
+                    <target xml:lang="km" state="needs-translation">{0} changes successfully applied.</target>
+                </trans-unit>
+            </group>
+            <group id="changesPublished" restype="x-gettext-plurals">
+                <trans-unit id="changesPublished[0]" xml:space="preserve">
+                    <source>Published {0} change to "{1}".</source>
+                    <target xml:lang="km" state="needs-translation">Published {0} change to "{1}".</target>
+                </trans-unit>
+                <trans-unit id="changesPublished[1]" xml:space="preserve">
+                    <source>Published {0} changes to "{1}".</source>
+                    <target xml:lang="km" state="needs-translation">Published {0} changes to "{1}".</target>
+                </trans-unit>
+            </group>
+            <group id="changesDiscarded" restype="x-gettext-plurals">
+                <trans-unit id="changesDiscarded[0]" xml:space="preserve">
+                    <source>Discarded {0} change.</source>
+                    <target xml:lang="km" state="needs-translation">Discarded {0} change.</target>
+                </trans-unit>
+                <trans-unit id="changesDiscarded[1]" xml:space="preserve">
+                    <source>Discarded {0} changes.</source>
+                    <target xml:lang="km" state="needs-translation">Discarded {0} changes.</target>
+                </trans-unit>
+            </group>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Translations/ko/Main.xlf
+++ b/Resources/Private/Translations/ko/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="ko" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="ko" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="ko" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="ko" state="needs-translation">Insert</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="ko" state="needs-translation">Insert mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="ko" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="ko" state="needs-translation">Bold</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="ko" state="needs-translation">Italic</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="ko" state="needs-translation">Underline</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="ko" state="needs-translation">Subscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="ko" state="needs-translation">Superscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="ko" state="needs-translation">Strikethrough</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="ko" state="needs-translation">Link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="ko" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="ko" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="ko" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="ko" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="ko" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="ko" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="ko" state="needs-translation">Title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="ko" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="ko" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="ko" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="ko" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="ko" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="ko" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="ko" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="ko" state="needs-translation">Ordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="ko" state="needs-translation">Unordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="ko" state="needs-translation">Align left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="ko" state="needs-translation">Align right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="ko" state="needs-translation">Align center</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="ko" state="needs-translation">Align justify</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="ko" state="needs-translation">Table</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="ko" state="needs-translation">Column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="ko" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="ko" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="ko" state="needs-translation">Remove format</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="ko" state="needs-translation">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="ko" state="needs-translation">Indent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="ko" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="ko" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="ko" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="ko" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="ko" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="ko" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="ko" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="ko" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="ko" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="ko" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="ko" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="ko" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="ko" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="ko" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="ko" state="needs-translation">Create new</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="ko" state="needs-translation">No matches found</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="ko" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ko">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="ko" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="ko" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="ko" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="ko" state="needs-translation">Insert</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="ko" state="needs-translation">Insert mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="ko" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="ko" state="needs-translation">Bold</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="ko" state="needs-translation">Italic</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="ko" state="needs-translation">Underline</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="ko" state="needs-translation">Subscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="ko" state="needs-translation">Superscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="ko" state="needs-translation">Strikethrough</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="ko" state="needs-translation">Link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="ko" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="ko" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="ko" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="ko" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="ko" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="ko" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="ko" state="needs-translation">Title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="ko" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="ko" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="ko" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="ko" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="ko" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="ko" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="ko" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="ko" state="needs-translation">Ordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="ko" state="needs-translation">Unordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="ko" state="needs-translation">Align left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="ko" state="needs-translation">Align right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="ko" state="needs-translation">Align center</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="ko" state="needs-translation">Align justify</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="ko" state="needs-translation">Table</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="ko" state="needs-translation">Column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="ko" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="ko" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="ko" state="needs-translation">Remove format</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="ko" state="needs-translation">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="ko" state="needs-translation">Indent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="ko" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="ko" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="ko" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="ko" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="ko" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="ko" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="ko" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="ko" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="ko" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="ko" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="ko" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="ko" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="ko" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="ko" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="ko" state="needs-translation">Create new</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="ko" state="needs-translation">No matches found</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="ko" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="ko" state="needs-translation">
+                <target xml:lang="ko" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="ko" state="needs-translation">Toggle inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="ko" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="ko" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="ko" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="ko" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="ko" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="ko" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="ko" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="ko" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="ko" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="ko" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="ko" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="ko" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="ko" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="ko" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="ko" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="ko" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="ko" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="ko" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="ko" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="ko" state="needs-translation">Toggle inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="ko" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="ko" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="ko" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="ko" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="ko" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="ko" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="ko" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="ko" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="ko" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="ko" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="ko" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="ko" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="ko" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="ko" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="ko" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="ko" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="ko" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="ko" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="ko" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/lv/Main.xlf
+++ b/Resources/Private/Translations/lv/Main.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="lv">
         <body>
             <trans-unit id="copy__from__to--title" xml:space="preserve">
@@ -109,24 +109,6 @@
             <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
                 <source>Format as email?</source>
                 <target xml:lang="lv" state="needs-translation">Format as email?</target>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
                 <source>Ordered list</source>
@@ -343,6 +325,36 @@
                 <source>Unfocus Node</source>
                 <target xml:lang="lv" state="needs-translation">Unfocus Node</target>
             </trans-unit>
+            <group id="changesApplied" restype="x-gettext-plurals">
+                <trans-unit id="changesApplied[0]" xml:space="preserve">
+                    <source>{0} change successfully applied.</source>
+                    <target xml:lang="lv" state="needs-translation">{0} change successfully applied.</target>
+                </trans-unit>
+                <trans-unit id="changesApplied[1]" xml:space="preserve">
+                    <source>{0} changes successfully applied.</source>
+                    <target xml:lang="lv" state="needs-translation">{0} changes successfully applied.</target>
+                </trans-unit>
+            </group>
+            <group id="changesPublished" restype="x-gettext-plurals">
+                <trans-unit id="changesPublished[0]" xml:space="preserve">
+                    <source>Published {0} change to "{1}".</source>
+                    <target xml:lang="lv" state="needs-translation">Published {0} change to "{1}".</target>
+                </trans-unit>
+                <trans-unit id="changesPublished[1]" xml:space="preserve">
+                    <source>Published {0} changes to "{1}".</source>
+                    <target xml:lang="lv" state="needs-translation">Published {0} changes to "{1}".</target>
+                </trans-unit>
+            </group>
+            <group id="changesDiscarded" restype="x-gettext-plurals">
+                <trans-unit id="changesDiscarded[0]" xml:space="preserve">
+                    <source>Discarded {0} change.</source>
+                    <target xml:lang="lv" state="needs-translation">Discarded {0} change.</target>
+                </trans-unit>
+                <trans-unit id="changesDiscarded[1]" xml:space="preserve">
+                    <source>Discarded {0} changes.</source>
+                    <target xml:lang="lv" state="needs-translation">Discarded {0} changes.</target>
+                </trans-unit>
+            </group>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Translations/lv/Main.xlf
+++ b/Resources/Private/Translations/lv/Main.xlf
@@ -1,267 +1,348 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="lv">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="lv" state="translated">Kopēt {source} uz {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="lv" state="translated">Pārvietot {source} uz {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="lv" state="translated">Izvēlieties pozīciju, no kuras {source} ievietota attiecībā pret {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="lv" state="translated">Ievietot</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="lv" state="translated">Ievietot veidu</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="lv" state="translated">Izvēlieties skata proporciju</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="lv" state="translated">Trekns</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="lv" state="translated">Slīps</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="lv" state="translated">Pasvītrots</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="lv" state="translated">Apakšraksts</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="lv" state="translated">Augšraksts</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="lv" state="translated">Pārsvītrojums</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
-				<source>Link</source>
-			<target xml:lang="lv">Saite</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="lv" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="lv" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="lv" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="lv" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="lv" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="lv" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
-				<source>Title</source>
-			<target xml:lang="lv">Virsraksts</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="lv" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="lv" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="lv" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="lv" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="lv" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="lv" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="lv" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="lv" state="translated">Numurēts saraksts</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="lv" state="translated">Nenumurēts saraksts</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="lv" state="translated">Līdzināt pa kreisi</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="lv" state="translated">Līdzināt pa labi</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="lv" state="translated">Līdzināt uz centru</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="lv" state="translated">Izlīdzināts</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="lv" state="translated">Tabula</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve" approved="yes">
-				<source>Column</source>
-			<target xml:lang="lv">Kolonna</target><alt-trans><target xml:lang="lv">Sleja</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="lv" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="lv" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="lv" state="translated">Formatējuma atcelšana</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="lv" state="translated">Negatīvā atkāpe</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="lv" state="translated">Atkāpe</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="lv" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="lv" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="lv" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="lv" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="lv" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="lv" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="lv" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="lv" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="lv" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="lv" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="lv" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="lv" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="lv" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="lv" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve" approved="yes">
-				<source>Create new</source>
-			<target xml:lang="lv">Izveidot jaunu</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="lv" state="translated">Nav atrasta neviena atbilstība</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="lv" state="translated">Lūdzu, ievadiet papildu rakstzīmes # # #CHARACTERS###</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="lv">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="lv" state="translated">Kopēt {source} uz {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="lv" state="translated">Pārvietot {source} uz {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="lv" state="translated">Izvēlieties pozīciju, no kuras {source} ievietota attiecībā pret {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="lv" state="translated">Ievietot</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="lv" state="translated">Ievietot veidu</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="lv" state="translated">Izvēlieties skata proporciju</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="lv" state="translated">Trekns</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="lv" state="translated">Slīps</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="lv" state="translated">Pasvītrots</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="lv" state="translated">Apakšraksts</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="lv" state="translated">Augšraksts</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="lv" state="translated">Pārsvītrojums</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
+                <source>Link</source>
+                <target xml:lang="lv">Saite</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="lv" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="lv" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="lv" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="lv" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="lv" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="lv" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
+                <source>Title</source>
+                <target xml:lang="lv">Virsraksts</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="lv" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="lv" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="lv" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="lv" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="lv" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="lv" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="lv" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="lv" state="translated">Numurēts saraksts</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="lv" state="translated">Nenumurēts saraksts</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="lv" state="translated">Līdzināt pa kreisi</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="lv" state="translated">Līdzināt pa labi</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="lv" state="translated">Līdzināt uz centru</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="lv" state="translated">Izlīdzināts</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="lv" state="translated">Tabula</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve" approved="yes">
+                <source>Column</source>
+                <target xml:lang="lv">Kolonna</target>
+                <alt-trans>
+                    <target xml:lang="lv">Sleja</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="lv" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="lv" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="lv" state="translated">Formatējuma atcelšana</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="lv" state="translated">Negatīvā atkāpe</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="lv" state="translated">Atkāpe</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="lv" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="lv" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="lv" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="lv" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="lv" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="lv" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="lv" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="lv" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="lv" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="lv" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="lv" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="lv" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="lv" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="lv" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve" approved="yes">
+                <source>Create new</source>
+                <target xml:lang="lv">Izveidot jaunu</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="lv" state="translated">Nav atrasta neviena atbilstība</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="lv" state="translated">Lūdzu, ievadiet papildu rakstzīmes # # #CHARACTERS###</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="lv" state="needs-translation">
+                <target xml:lang="lv" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve" approved="yes">
-				<source>Toggle inspector</source>
-			<target xml:lang="lv">Pārslēgšanas inspektors</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="lv" state="translated">Pilnekrāns</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="lv" state="translated">Pārslēgt kreiso sānjoslu</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="lv" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="lv" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="lv" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="lv" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="lv" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="lv" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="lv" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="lv" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="lv" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="lv" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="lv" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="lv" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="lv" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="lv" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="lv" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="lv" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="lv" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve" approved="yes">
+                <source>Toggle inspector</source>
+                <target xml:lang="lv">Pārslēgšanas inspektors</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="lv" state="translated">Pilnekrāns</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="lv" state="translated">Pārslēgt kreiso sānjoslu</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="lv" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="lv" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="lv" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="lv" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="lv" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="lv" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="lv" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="lv" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="lv" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="lv" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="lv" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="lv" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="lv" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="lv" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="lv" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="lv" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="lv" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/mr/Main.xlf
+++ b/Resources/Private/Translations/mr/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="mr">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="mr" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="mr" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="mr" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="mr" state="needs-translation">Insert</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="mr" state="needs-translation">Insert mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="mr" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="mr" state="needs-translation">Bold</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="mr" state="needs-translation">Italic</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="mr" state="needs-translation">Underline</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="mr" state="needs-translation">Subscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="mr" state="needs-translation">Superscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="mr" state="needs-translation">Strikethrough</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="mr" state="needs-translation">Link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="mr" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="mr" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="mr" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="mr" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="mr" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="mr" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="mr" state="needs-translation">Title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="mr" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="mr" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="mr" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="mr" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="mr" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="mr" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="mr" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="mr" state="needs-translation">Ordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="mr" state="needs-translation">Unordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="mr" state="needs-translation">Align left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="mr" state="needs-translation">Align right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="mr" state="needs-translation">Align center</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="mr" state="needs-translation">Align justify</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="mr" state="needs-translation">Table</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="mr" state="needs-translation">Column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="mr" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="mr" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="mr" state="needs-translation">Remove format</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="mr" state="needs-translation">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="mr" state="needs-translation">Indent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="mr" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="mr" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="mr" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="mr" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="mr" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="mr" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="mr" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="mr" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="mr" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="mr" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="mr" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="mr" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="mr" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="mr" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="mr" state="needs-translation">Create new</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="mr" state="needs-translation">No matches found</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="mr" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="mr">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="mr" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="mr" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="mr" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="mr" state="needs-translation">Insert</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="mr" state="needs-translation">Insert mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="mr" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="mr" state="needs-translation">Bold</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="mr" state="needs-translation">Italic</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="mr" state="needs-translation">Underline</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="mr" state="needs-translation">Subscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="mr" state="needs-translation">Superscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="mr" state="needs-translation">Strikethrough</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="mr" state="needs-translation">Link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="mr" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="mr" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="mr" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="mr" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="mr" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="mr" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="mr" state="needs-translation">Title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="mr" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="mr" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="mr" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="mr" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="mr" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="mr" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="mr" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="mr" state="needs-translation">Ordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="mr" state="needs-translation">Unordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="mr" state="needs-translation">Align left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="mr" state="needs-translation">Align right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="mr" state="needs-translation">Align center</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="mr" state="needs-translation">Align justify</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="mr" state="needs-translation">Table</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="mr" state="needs-translation">Column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="mr" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="mr" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="mr" state="needs-translation">Remove format</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="mr" state="needs-translation">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="mr" state="needs-translation">Indent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="mr" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="mr" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="mr" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="mr" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="mr" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="mr" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="mr" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="mr" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="mr" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="mr" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="mr" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="mr" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="mr" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="mr" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="mr" state="needs-translation">Create new</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="mr" state="needs-translation">No matches found</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="mr" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="mr" state="needs-translation">
+                <target xml:lang="mr" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="mr" state="needs-translation">Toggle inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="mr" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="mr" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="mr" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="mr" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="mr" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="mr" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="mr" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="mr" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="mr" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="mr" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="mr" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="mr" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="mr" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="mr" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="mr" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="mr" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="mr" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="mr" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="mr" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="mr" state="needs-translation">Toggle inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="mr" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="mr" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="mr" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="mr" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="mr" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="mr" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="mr" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="mr" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="mr" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="mr" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="mr" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="mr" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="mr" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="mr" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="mr" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="mr" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="mr" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="mr" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="mr" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/nl/Main.xlf
+++ b/Resources/Private/Translations/nl/Main.xlf
@@ -1,267 +1,348 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="nl">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="nl" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="nl" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="nl" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="nl" state="needs-translation">Insert</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="nl" state="needs-translation">Insert mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="nl" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="nl" state="translated">Dikgedrukt</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="nl" state="needs-translation">Italic</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="nl" state="translated">Onderstreept</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="nl" state="translated">Inschrijven</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="nl" state="needs-translation">Superscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="nl" state="needs-translation">Strikethrough</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
-				<source>Link</source>
-			<target xml:lang="nl">Link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="nl" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="nl" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="nl" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="nl" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="nl" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="nl" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
-				<source>Title</source>
-			<target xml:lang="nl">Titel</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="nl" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="nl" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="nl" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="nl" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="nl" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="nl" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="nl" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="nl" state="needs-translation">Ordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="nl" state="needs-translation">Unordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="nl" state="needs-translation">Align left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="nl" state="needs-translation">Align right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="nl" state="needs-translation">Align center</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="nl" state="needs-translation">Align justify</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="nl" state="needs-translation">Table</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve" approved="yes">
-				<source>Column</source>
-			<target xml:lang="nl">Kolom</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="nl" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="nl" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="nl" state="translated">Opmaak Verwijderen</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="nl" state="needs-translation">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="nl" state="needs-translation">Indent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="nl" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="nl" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="nl" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="nl" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="nl" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="nl" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="nl" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="nl" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="nl" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="nl" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="nl" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="nl" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="nl" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="nl" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve" approved="yes">
-				<source>Create new</source>
-			<target xml:lang="nl">Maak nieuw</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="nl" state="translated">Geen overeenkomsten gevonden</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="nl" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="nl">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="nl" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="nl" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="nl" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="nl" state="needs-translation">Insert</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="nl" state="needs-translation">Insert mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="nl" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="nl" state="translated">Dikgedrukt</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="nl" state="needs-translation">Italic</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="nl" state="translated">Onderstreept</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="nl" state="translated">Inschrijven</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="nl" state="needs-translation">Superscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="nl" state="needs-translation">Strikethrough</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
+                <source>Link</source>
+                <target xml:lang="nl">Link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="nl" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="nl" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="nl" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="nl" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="nl" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="nl" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
+                <source>Title</source>
+                <target xml:lang="nl">Titel</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="nl" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="nl" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="nl" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="nl" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="nl" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="nl" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="nl" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="nl" state="needs-translation">Ordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="nl" state="needs-translation">Unordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="nl" state="needs-translation">Align left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="nl" state="needs-translation">Align right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="nl" state="needs-translation">Align center</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="nl" state="needs-translation">Align justify</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="nl" state="needs-translation">Table</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve" approved="yes">
+                <source>Column</source>
+                <target xml:lang="nl">Kolom</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="nl" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="nl" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="nl" state="translated">Opmaak Verwijderen</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="nl" state="needs-translation">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="nl" state="needs-translation">Indent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="nl" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="nl" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="nl" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="nl" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="nl" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="nl" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="nl" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="nl" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="nl" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="nl" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="nl" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="nl" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="nl" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="nl" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve" approved="yes">
+                <source>Create new</source>
+                <target xml:lang="nl">Maak nieuw</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="nl" state="translated">Geen overeenkomsten gevonden</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="nl" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="nl" state="needs-translation">
+                <target xml:lang="nl" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve" approved="yes">
-				<source>Toggle inspector</source>
-			<target xml:lang="nl">Inspector verbergen / tonen</target><alt-trans><target xml:lang="nl">Schakel inspector om</target></alt-trans></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="nl" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="nl" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="nl" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="nl" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="nl" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="nl" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="nl" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="nl" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="nl" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="nl" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="nl" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="nl" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="nl" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="nl" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="nl" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="nl" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="nl" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="nl" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="nl" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve" approved="yes">
+                <source>Toggle inspector</source>
+                <target xml:lang="nl">Inspector verbergen / tonen</target>
+                <alt-trans>
+                    <target xml:lang="nl">Schakel inspector om</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="nl" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="nl" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="nl" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="nl" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="nl" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="nl" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="nl" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="nl" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="nl" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="nl" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="nl" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="nl" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="nl" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="nl" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="nl" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="nl" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="nl" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="nl" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="nl" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/nl/Main.xlf
+++ b/Resources/Private/Translations/nl/Main.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="nl">
         <body>
             <trans-unit id="copy__from__to--title" xml:space="preserve">
@@ -109,24 +109,6 @@
             <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
                 <source>Format as email?</source>
                 <target xml:lang="nl" state="needs-translation">Format as email?</target>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
                 <source>Ordered list</source>
@@ -343,6 +325,36 @@
                 <source>Unfocus Node</source>
                 <target xml:lang="nl" state="needs-translation">Unfocus Node</target>
             </trans-unit>
+            <group id="changesApplied" restype="x-gettext-plurals">
+                <trans-unit id="changesApplied[0]" xml:space="preserve">
+                    <source>{0} change successfully applied.</source>
+                    <target xml:lang="nl" state="needs-translation">{0} change successfully applied.</target>
+                </trans-unit>
+                <trans-unit id="changesApplied[1]" xml:space="preserve">
+                    <source>{0} changes successfully applied.</source>
+                    <target xml:lang="nl" state="needs-translation">{0} changes successfully applied.</target>
+                </trans-unit>
+            </group>
+            <group id="changesPublished" restype="x-gettext-plurals">
+                <trans-unit id="changesPublished[0]" xml:space="preserve">
+                    <source>Published {0} change to "{1}".</source>
+                    <target xml:lang="nl" state="needs-translation">Published {0} change to "{1}".</target>
+                </trans-unit>
+                <trans-unit id="changesPublished[1]" xml:space="preserve">
+                    <source>Published {0} changes to "{1}".</source>
+                    <target xml:lang="nl" state="needs-translation">Published {0} changes to "{1}".</target>
+                </trans-unit>
+            </group>
+            <group id="changesDiscarded" restype="x-gettext-plurals">
+                <trans-unit id="changesDiscarded[0]" xml:space="preserve">
+                    <source>Discarded {0} change.</source>
+                    <target xml:lang="nl" state="needs-translation">Discarded {0} change.</target>
+                </trans-unit>
+                <trans-unit id="changesDiscarded[1]" xml:space="preserve">
+                    <source>Discarded {0} changes.</source>
+                    <target xml:lang="nl" state="needs-translation">Discarded {0} changes.</target>
+                </trans-unit>
+            </group>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Translations/no/Main.xlf
+++ b/Resources/Private/Translations/no/Main.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="no">
         <body>
             <trans-unit id="copy__from__to--title" xml:space="preserve">
@@ -109,24 +109,6 @@
             <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
                 <source>Format as email?</source>
                 <target xml:lang="no" state="needs-translation">Format as email?</target>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
                 <source>Ordered list</source>
@@ -340,6 +322,36 @@
                 <source>Unfocus Node</source>
                 <target xml:lang="no" state="needs-translation">Unfocus Node</target>
             </trans-unit>
+            <group id="changesApplied" restype="x-gettext-plurals">
+                <trans-unit id="changesApplied[0]" xml:space="preserve">
+                    <source>{0} change successfully applied.</source>
+                    <target xml:lang="no" state="needs-translation">{0} change successfully applied.</target>
+                </trans-unit>
+                <trans-unit id="changesApplied[1]" xml:space="preserve">
+                    <source>{0} changes successfully applied.</source>
+                    <target xml:lang="no" state="needs-translation">{0} changes successfully applied.</target>
+                </trans-unit>
+            </group>
+            <group id="changesPublished" restype="x-gettext-plurals">
+                <trans-unit id="changesPublished[0]" xml:space="preserve">
+                    <source>Published {0} change to "{1}".</source>
+                    <target xml:lang="no" state="needs-translation">Published {0} change to "{1}".</target>
+                </trans-unit>
+                <trans-unit id="changesPublished[1]" xml:space="preserve">
+                    <source>Published {0} changes to "{1}".</source>
+                    <target xml:lang="no" state="needs-translation">Published {0} changes to "{1}".</target>
+                </trans-unit>
+            </group>
+            <group id="changesDiscarded" restype="x-gettext-plurals">
+                <trans-unit id="changesDiscarded[0]" xml:space="preserve">
+                    <source>Discarded {0} change.</source>
+                    <target xml:lang="no" state="needs-translation">Discarded {0} change.</target>
+                </trans-unit>
+                <trans-unit id="changesDiscarded[1]" xml:space="preserve">
+                    <source>Discarded {0} changes.</source>
+                    <target xml:lang="no" state="needs-translation">Discarded {0} changes.</target>
+                </trans-unit>
+            </group>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Translations/no/Main.xlf
+++ b/Resources/Private/Translations/no/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="no">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="no" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="no" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="no" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="no" state="needs-translation">Insert</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="no" state="needs-translation">Insert mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="no" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="no" state="needs-translation">Bold</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="no" state="needs-translation">Italic</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="no" state="needs-translation">Underline</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="no" state="needs-translation">Subscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="no" state="needs-translation">Superscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="no" state="needs-translation">Strikethrough</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="no" state="translated">Link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="no" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="no" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="no" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="no" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="no" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="no" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="no" state="translated">Tittel</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="no" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="no" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="no" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="no" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="no" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="no" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="no" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="no" state="needs-translation">Ordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="no" state="needs-translation">Unordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="no" state="needs-translation">Align left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="no" state="needs-translation">Align right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="no" state="needs-translation">Align center</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="no" state="needs-translation">Align justify</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="no" state="needs-translation">Table</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="no" state="translated">Spalte</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="no" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="no" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="no" state="needs-translation">Remove format</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="no" state="needs-translation">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="no" state="needs-translation">Indent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="no" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="no" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="no" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="no" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="no" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="no" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="no" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="no" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="no" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="no" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="no" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="no" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="no" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="no" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="no" state="translated">Opprett ny</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="no" state="needs-translation">No matches found</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="no" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="no">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="no" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="no" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="no" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="no" state="needs-translation">Insert</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="no" state="needs-translation">Insert mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="no" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="no" state="needs-translation">Bold</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="no" state="needs-translation">Italic</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="no" state="needs-translation">Underline</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="no" state="needs-translation">Subscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="no" state="needs-translation">Superscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="no" state="needs-translation">Strikethrough</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="no" state="translated">Link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="no" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="no" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="no" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="no" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="no" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="no" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="no" state="translated">Tittel</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="no" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="no" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="no" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="no" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="no" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="no" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="no" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="no" state="needs-translation">Ordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="no" state="needs-translation">Unordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="no" state="needs-translation">Align left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="no" state="needs-translation">Align right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="no" state="needs-translation">Align center</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="no" state="needs-translation">Align justify</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="no" state="needs-translation">Table</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="no" state="translated">Spalte</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="no" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="no" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="no" state="needs-translation">Remove format</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="no" state="needs-translation">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="no" state="needs-translation">Indent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="no" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="no" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="no" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="no" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="no" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="no" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="no" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="no" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="no" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="no" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="no" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="no" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="no" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="no" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="no" state="translated">Opprett ny</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="no" state="needs-translation">No matches found</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="no" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="no" state="needs-translation">
+                <target xml:lang="no" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="no" state="translated">Vis/skjul inspektør</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="no" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="no" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="no" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="no" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="no" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="no" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="no" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="no" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="no" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="no" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="no" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="no" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="no" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="no" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="no" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="no" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="no" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="no" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="no" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="no" state="translated">Vis/skjul inspektør</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="no" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="no" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="no" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="no" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="no" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="no" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="no" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="no" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="no" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="no" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="no" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="no" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="no" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="no" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="no" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="no" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="no" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="no" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="no" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/pl/Main.xlf
+++ b/Resources/Private/Translations/pl/Main.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="pl">
         <body>
             <trans-unit id="copy__from__to--title" xml:space="preserve" approved="yes">
@@ -109,24 +109,6 @@
             <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
                 <source>Format as email?</source>
                 <target xml:lang="pl" state="needs-translation">Format as email?</target>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve" approved="yes">
                 <source>Ordered list</source>
@@ -340,6 +322,36 @@
                 <source>Unfocus Node</source>
                 <target xml:lang="pl" state="needs-translation">Unfocus Node</target>
             </trans-unit>
+            <group id="changesApplied" restype="x-gettext-plurals">
+                <trans-unit id="changesApplied[0]" xml:space="preserve">
+                    <source>{0} change successfully applied.</source>
+                    <target xml:lang="pl" state="needs-translation">{0} change successfully applied.</target>
+                </trans-unit>
+                <trans-unit id="changesApplied[1]" xml:space="preserve">
+                    <source>{0} changes successfully applied.</source>
+                    <target xml:lang="pl" state="needs-translation">{0} changes successfully applied.</target>
+                </trans-unit>
+            </group>
+            <group id="changesPublished" restype="x-gettext-plurals">
+                <trans-unit id="changesPublished[0]" xml:space="preserve">
+                    <source>Published {0} change to "{1}".</source>
+                    <target xml:lang="pl" state="needs-translation">Published {0} change to "{1}".</target>
+                </trans-unit>
+                <trans-unit id="changesPublished[1]" xml:space="preserve">
+                    <source>Published {0} changes to "{1}".</source>
+                    <target xml:lang="pl" state="needs-translation">Published {0} changes to "{1}".</target>
+                </trans-unit>
+            </group>
+            <group id="changesDiscarded" restype="x-gettext-plurals">
+                <trans-unit id="changesDiscarded[0]" xml:space="preserve">
+                    <source>Discarded {0} change.</source>
+                    <target xml:lang="pl" state="needs-translation">Discarded {0} change.</target>
+                </trans-unit>
+                <trans-unit id="changesDiscarded[1]" xml:space="preserve">
+                    <source>Discarded {0} changes.</source>
+                    <target xml:lang="pl" state="needs-translation">Discarded {0} changes.</target>
+                </trans-unit>
+            </group>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Translations/pl/Main.xlf
+++ b/Resources/Private/Translations/pl/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="pl">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve" approved="yes">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="pl">Skopiuj {source} do {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve" approved="yes">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="pl">Przenieś {source} do {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve" approved="yes">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="pl">Wybierz pozycję na jakiej chcesz wstawić {source} względem {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve" approved="yes">
-				<source>Insert</source>
-			<target xml:lang="pl">Wstaw</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve" approved="yes">
-				<source>Insert mode</source>
-			<target xml:lang="pl">Tryb wstawiania</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve" approved="yes">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="pl">Wybierz współczynnik proporcji</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve" approved="yes">
-				<source>Bold</source>
-			<target xml:lang="pl">Pogrubienie</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve" approved="yes">
-				<source>Italic</source>
-			<target xml:lang="pl">Kursywa</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve" approved="yes">
-				<source>Underline</source>
-			<target xml:lang="pl">Podkreślenie</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve" approved="yes">
-				<source>Subscript</source>
-			<target xml:lang="pl">Indeks dolny</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve" approved="yes">
-				<source>Superscript</source>
-			<target xml:lang="pl">Indeks górny</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve" approved="yes">
-				<source>Strikethrough</source>
-			<target xml:lang="pl">Przekreślenie</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
-				<source>Link</source>
-			<target xml:lang="pl">Odnośnik</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="pl" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="pl" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="pl" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="pl" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="pl" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="pl" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
-				<source>Title</source>
-			<target xml:lang="pl">Tytuł</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="pl" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="pl" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="pl" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="pl" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="pl" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="pl" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="pl" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve" approved="yes">
-				<source>Ordered list</source>
-			<target xml:lang="pl">Lista uporządkowana</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve" approved="yes">
-				<source>Unordered list</source>
-			<target xml:lang="pl">Lista nieuporządkowana</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve" approved="yes">
-				<source>Align left</source>
-			<target xml:lang="pl">Wyrównaj do lewej</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve" approved="yes">
-				<source>Align right</source>
-			<target xml:lang="pl">Wyrównaj do prawej</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve" approved="yes">
-				<source>Align center</source>
-			<target xml:lang="pl">Wyrównaj do środka</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve" approved="yes">
-				<source>Align justify</source>
-			<target xml:lang="pl">Wyjustuj</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve" approved="yes">
-				<source>Table</source>
-			<target xml:lang="pl">Tabela</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve" approved="yes">
-				<source>Column</source>
-			<target xml:lang="pl">Kolumna</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="pl" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="pl" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve" approved="yes">
-				<source>Remove format</source>
-			<target xml:lang="pl">Usuń formatowanie</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve" approved="yes">
-				<source>Outdent</source>
-			<target xml:lang="pl">Zmniejsz wcięcie</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve" approved="yes">
-				<source>Indent</source>
-			<target xml:lang="pl">Wcięcie</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="pl" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="pl" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="pl" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="pl" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="pl" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="pl" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="pl" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="pl" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="pl" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="pl" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="pl" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="pl" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="pl" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="pl" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve" approved="yes">
-				<source>Create new</source>
-			<target xml:lang="pl">Utwórz nowy</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve" approved="yes">
-				<source>No matches found</source>
-			<target xml:lang="pl">Nie znaleziono dopasowań</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve" approved="yes">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="pl">Wprowadź ###CHARACTERS### znaków więcej</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="pl">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve" approved="yes">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="pl">Skopiuj {source} do {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve" approved="yes">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="pl">Przenieś {source} do {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve" approved="yes">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="pl">Wybierz pozycję na jakiej chcesz wstawić {source} względem {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve" approved="yes">
+                <source>Insert</source>
+                <target xml:lang="pl">Wstaw</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve" approved="yes">
+                <source>Insert mode</source>
+                <target xml:lang="pl">Tryb wstawiania</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve" approved="yes">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="pl">Wybierz współczynnik proporcji</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve" approved="yes">
+                <source>Bold</source>
+                <target xml:lang="pl">Pogrubienie</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve" approved="yes">
+                <source>Italic</source>
+                <target xml:lang="pl">Kursywa</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve" approved="yes">
+                <source>Underline</source>
+                <target xml:lang="pl">Podkreślenie</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve" approved="yes">
+                <source>Subscript</source>
+                <target xml:lang="pl">Indeks dolny</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve" approved="yes">
+                <source>Superscript</source>
+                <target xml:lang="pl">Indeks górny</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve" approved="yes">
+                <source>Strikethrough</source>
+                <target xml:lang="pl">Przekreślenie</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
+                <source>Link</source>
+                <target xml:lang="pl">Odnośnik</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="pl" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="pl" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="pl" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="pl" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="pl" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="pl" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
+                <source>Title</source>
+                <target xml:lang="pl">Tytuł</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="pl" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="pl" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="pl" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="pl" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="pl" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="pl" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="pl" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve" approved="yes">
+                <source>Ordered list</source>
+                <target xml:lang="pl">Lista uporządkowana</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve" approved="yes">
+                <source>Unordered list</source>
+                <target xml:lang="pl">Lista nieuporządkowana</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve" approved="yes">
+                <source>Align left</source>
+                <target xml:lang="pl">Wyrównaj do lewej</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve" approved="yes">
+                <source>Align right</source>
+                <target xml:lang="pl">Wyrównaj do prawej</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve" approved="yes">
+                <source>Align center</source>
+                <target xml:lang="pl">Wyrównaj do środka</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve" approved="yes">
+                <source>Align justify</source>
+                <target xml:lang="pl">Wyjustuj</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve" approved="yes">
+                <source>Table</source>
+                <target xml:lang="pl">Tabela</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve" approved="yes">
+                <source>Column</source>
+                <target xml:lang="pl">Kolumna</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="pl" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="pl" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve" approved="yes">
+                <source>Remove format</source>
+                <target xml:lang="pl">Usuń formatowanie</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve" approved="yes">
+                <source>Outdent</source>
+                <target xml:lang="pl">Zmniejsz wcięcie</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve" approved="yes">
+                <source>Indent</source>
+                <target xml:lang="pl">Wcięcie</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="pl" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="pl" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="pl" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="pl" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="pl" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="pl" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="pl" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="pl" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="pl" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="pl" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="pl" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="pl" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="pl" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="pl" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve" approved="yes">
+                <source>Create new</source>
+                <target xml:lang="pl">Utwórz nowy</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve" approved="yes">
+                <source>No matches found</source>
+                <target xml:lang="pl">Nie znaleziono dopasowań</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve" approved="yes">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="pl">Wprowadź ###CHARACTERS### znaków więcej</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="pl" state="needs-translation">
+                <target xml:lang="pl" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve" approved="yes">
-				<source>Toggle inspector</source>
-			<target xml:lang="pl">Pokaż/schowaj inspektor</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="pl" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="pl" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="pl" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="pl" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="pl" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="pl" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="pl" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="pl" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="pl" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="pl" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="pl" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="pl" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="pl" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="pl" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="pl" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="pl" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="pl" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="pl" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="pl" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve" approved="yes">
+                <source>Toggle inspector</source>
+                <target xml:lang="pl">Pokaż/schowaj inspektor</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="pl" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="pl" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="pl" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="pl" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="pl" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="pl" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="pl" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="pl" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="pl" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="pl" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="pl" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="pl" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="pl" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="pl" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="pl" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="pl" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="pl" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="pl" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="pl" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/ps/Main.xlf
+++ b/Resources/Private/Translations/ps/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ps">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="ps" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="ps" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="ps" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="ps" state="needs-translation">Insert</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="ps" state="needs-translation">Insert mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="ps" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="ps" state="needs-translation">Bold</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="ps" state="needs-translation">Italic</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="ps" state="needs-translation">Underline</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="ps" state="needs-translation">Subscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="ps" state="needs-translation">Superscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="ps" state="needs-translation">Strikethrough</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="ps" state="needs-translation">Link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="ps" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="ps" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="ps" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="ps" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="ps" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="ps" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="ps" state="needs-translation">Title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="ps" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="ps" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="ps" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="ps" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="ps" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="ps" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="ps" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="ps" state="needs-translation">Ordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="ps" state="needs-translation">Unordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="ps" state="needs-translation">Align left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="ps" state="needs-translation">Align right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="ps" state="needs-translation">Align center</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="ps" state="needs-translation">Align justify</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="ps" state="needs-translation">Table</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="ps" state="needs-translation">Column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="ps" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="ps" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="ps" state="needs-translation">Remove format</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="ps" state="needs-translation">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="ps" state="needs-translation">Indent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="ps" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="ps" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="ps" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="ps" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="ps" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="ps" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="ps" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="ps" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="ps" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="ps" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="ps" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="ps" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="ps" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="ps" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="ps" state="needs-translation">Create new</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="ps" state="needs-translation">No matches found</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="ps" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ps">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="ps" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="ps" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="ps" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="ps" state="needs-translation">Insert</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="ps" state="needs-translation">Insert mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="ps" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="ps" state="needs-translation">Bold</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="ps" state="needs-translation">Italic</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="ps" state="needs-translation">Underline</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="ps" state="needs-translation">Subscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="ps" state="needs-translation">Superscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="ps" state="needs-translation">Strikethrough</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="ps" state="needs-translation">Link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="ps" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="ps" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="ps" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="ps" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="ps" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="ps" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="ps" state="needs-translation">Title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="ps" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="ps" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="ps" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="ps" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="ps" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="ps" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="ps" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="ps" state="needs-translation">Ordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="ps" state="needs-translation">Unordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="ps" state="needs-translation">Align left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="ps" state="needs-translation">Align right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="ps" state="needs-translation">Align center</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="ps" state="needs-translation">Align justify</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="ps" state="needs-translation">Table</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="ps" state="needs-translation">Column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="ps" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="ps" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="ps" state="needs-translation">Remove format</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="ps" state="needs-translation">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="ps" state="needs-translation">Indent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="ps" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="ps" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="ps" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="ps" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="ps" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="ps" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="ps" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="ps" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="ps" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="ps" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="ps" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="ps" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="ps" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="ps" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="ps" state="needs-translation">Create new</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="ps" state="needs-translation">No matches found</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="ps" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="ps" state="needs-translation">
+                <target xml:lang="ps" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="ps" state="needs-translation">Toggle inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="ps" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="ps" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="ps" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="ps" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="ps" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="ps" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="ps" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="ps" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="ps" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="ps" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="ps" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="ps" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="ps" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="ps" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="ps" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="ps" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="ps" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="ps" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="ps" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="ps" state="needs-translation">Toggle inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="ps" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="ps" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="ps" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="ps" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="ps" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="ps" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="ps" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="ps" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="ps" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="ps" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="ps" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="ps" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="ps" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="ps" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="ps" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="ps" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="ps" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="ps" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="ps" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/pt/Main.xlf
+++ b/Resources/Private/Translations/pt/Main.xlf
@@ -1,267 +1,354 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="pt-BR" state="translated">Copiar {source} para {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="pt-BR" state="translated">Mover {source} para {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="pt-BR" state="translated">Por favor selecione a posição na qual você quer {source} inserido relativo a {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="pt-BR" state="translated">Inserir</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="pt-BR" state="translated">Modo de inserção</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="pt-BR" state="translated">Escolha uma proporção</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="pt-BR" state="translated">Negrito</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="pt-BR" state="translated">Itálico</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="pt-BR" state="translated">Sublinhado</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="pt-BR" state="translated">Subscrito</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="pt-BR" state="translated">Sobrescrito</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="pt-BR" state="translated">Tachado</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="pt-BR" state="translated">Link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="pt-BR" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="pt-BR" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="pt-BR" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="pt-BR" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="pt-BR" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="pt-BR" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="pt-BR" state="translated">Título</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="pt-BR" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="pt-BR" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="pt-BR" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="pt-BR" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="pt-BR" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="pt-BR" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="pt-BR" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="pt-BR" state="translated">Lista ordenada</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="pt-BR" state="translated">Lista desordenada</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="pt-BR" state="translated">Alinhar à esquerda</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="pt-BR" state="translated">Alinhar à direita</target><alt-trans><target xml:lang="pt-BR">Alinhar a direita</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="pt-BR" state="translated">Alinhar ao centro</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="pt-BR" state="translated">Alinhar justificado</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="pt-BR" state="translated">Tabela</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="pt-BR" state="translated">Coluna</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="pt-BR" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="pt-BR" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="pt-BR" state="translated">Remover formatação</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="pt-BR" state="translated">Desindentar</target><alt-trans><target xml:lang="pt-BR">Desidentar</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="pt-BR" state="translated">Indentar</target><alt-trans><target xml:lang="pt-BR">Identar</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="pt-BR" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="pt-BR" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="pt-BR" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="pt-BR" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="pt-BR" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="pt-BR" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="pt-BR" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="pt-BR" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="pt-BR" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="pt-BR" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="pt-BR" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="pt-BR" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="pt-BR" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="pt-BR" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="pt-BR" state="translated">Criar novo</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="pt-BR" state="translated">Nenhuma correspondência encontrada</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="pt-BR" state="translated">Por favor, insira ###CHARACTERS### caracteres a mais</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="pt-BR">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="pt-BR" state="translated">Copiar {source} para {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="pt-BR" state="translated">Mover {source} para {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="pt-BR" state="translated">Por favor selecione a posição na qual você quer {source} inserido relativo a {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="pt-BR" state="translated">Inserir</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="pt-BR" state="translated">Modo de inserção</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="pt-BR" state="translated">Escolha uma proporção</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="pt-BR" state="translated">Negrito</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="pt-BR" state="translated">Itálico</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="pt-BR" state="translated">Sublinhado</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="pt-BR" state="translated">Subscrito</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="pt-BR" state="translated">Sobrescrito</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="pt-BR" state="translated">Tachado</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="pt-BR" state="translated">Link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="pt-BR" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="pt-BR" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="pt-BR" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="pt-BR" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="pt-BR" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="pt-BR" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="pt-BR" state="translated">Título</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="pt-BR" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="pt-BR" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="pt-BR" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="pt-BR" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="pt-BR" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="pt-BR" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="pt-BR" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="pt-BR" state="translated">Lista ordenada</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="pt-BR" state="translated">Lista desordenada</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="pt-BR" state="translated">Alinhar à esquerda</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="pt-BR" state="translated">Alinhar à direita</target>
+                <alt-trans>
+                    <target xml:lang="pt-BR">Alinhar a direita</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="pt-BR" state="translated">Alinhar ao centro</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="pt-BR" state="translated">Alinhar justificado</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="pt-BR" state="translated">Tabela</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="pt-BR" state="translated">Coluna</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="pt-BR" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="pt-BR" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="pt-BR" state="translated">Remover formatação</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="pt-BR" state="translated">Desindentar</target>
+                <alt-trans>
+                    <target xml:lang="pt-BR">Desidentar</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="pt-BR" state="translated">Indentar</target>
+                <alt-trans>
+                    <target xml:lang="pt-BR">Identar</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="pt-BR" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="pt-BR" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="pt-BR" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="pt-BR" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="pt-BR" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="pt-BR" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="pt-BR" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="pt-BR" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="pt-BR" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="pt-BR" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="pt-BR" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="pt-BR" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="pt-BR" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="pt-BR" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="pt-BR" state="translated">Criar novo</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="pt-BR" state="translated">Nenhuma correspondência encontrada</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="pt-BR" state="translated">Por favor, insira ###CHARACTERS### caracteres a mais</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="pt-BR" state="needs-translation">
+                <target xml:lang="pt-BR" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="pt-BR" state="translated">Ativar/Desativar inspetor</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="pt-BR" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="pt-BR" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="pt-BR" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="pt-BR" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="pt-BR" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="pt-BR" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="pt-BR" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="pt-BR" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="pt-BR" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="pt-BR" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="pt-BR" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="pt-BR" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="pt-BR" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="pt-BR" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="pt-BR" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="pt-BR" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="pt-BR" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="pt-BR" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="pt-BR" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="pt-BR" state="translated">Ativar/Desativar inspetor</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="pt-BR" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="pt-BR" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="pt-BR" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="pt-BR" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="pt-BR" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="pt-BR" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="pt-BR" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="pt-BR" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="pt-BR" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="pt-BR" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="pt-BR" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="pt-BR" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="pt-BR" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="pt-BR" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="pt-BR" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="pt-BR" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="pt-BR" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="pt-BR" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="pt-BR" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/pt_PT/Main.xlf
+++ b/Resources/Private/Translations/pt_PT/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="pt-PT">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="pt-PT" state="translated">Copiar {source} para {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="pt-PT" state="translated">Mover {source} para {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="pt-PT" state="translated">Por favor, selecione a posição em que você deseja inserir a {source} em relação a {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="pt-PT" state="translated">Inserir</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="pt-PT" state="translated">Modo de inserção</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="pt-PT" state="translated">Escolha uma proporção</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="pt-PT" state="translated">Negrito</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="pt-PT" state="translated">Itálico</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="pt-PT" state="translated">Sublinhado</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="pt-PT" state="translated">Subscrito</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="pt-PT" state="translated">Sobrescrito</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="pt-PT" state="translated">Rasurado</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="pt-PT" state="needs-translation">Link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="pt-PT" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="pt-PT" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="pt-PT" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="pt-PT" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="pt-PT" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="pt-PT" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="pt-PT" state="needs-translation">Title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="pt-PT" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="pt-PT" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="pt-PT" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="pt-PT" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="pt-PT" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="pt-PT" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="pt-PT" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="pt-PT" state="translated">Lista ordenada</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="pt-PT" state="translated">Lista desordenada</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="pt-PT" state="translated">Alinhar à esquerda</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="pt-PT" state="translated">Alinhar à direita</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="pt-PT" state="translated">Alinhar ao centro</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="pt-PT" state="translated">Justificar</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="pt-PT" state="translated">Tabela</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="pt-PT" state="needs-translation">Column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="pt-PT" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="pt-PT" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="pt-PT" state="translated">Remover a formatação</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="pt-PT" state="translated">Diminuir o recuo</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="pt-PT" state="translated">Aumentar o recuo</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="pt-PT" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="pt-PT" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="pt-PT" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="pt-PT" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="pt-PT" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="pt-PT" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="pt-PT" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="pt-PT" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="pt-PT" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="pt-PT" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="pt-PT" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="pt-PT" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="pt-PT" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="pt-PT" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="pt-PT" state="translated">Criar novo</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="pt-PT" state="translated">Não foram encontradas correspondências</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="pt-PT" state="translated">Por favor, inserir ###CHARACTERS### mais caracteres</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="pt-PT">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="pt-PT" state="translated">Copiar {source} para {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="pt-PT" state="translated">Mover {source} para {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="pt-PT" state="translated">Por favor, selecione a posição em que você deseja inserir a {source} em relação a {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="pt-PT" state="translated">Inserir</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="pt-PT" state="translated">Modo de inserção</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="pt-PT" state="translated">Escolha uma proporção</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="pt-PT" state="translated">Negrito</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="pt-PT" state="translated">Itálico</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="pt-PT" state="translated">Sublinhado</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="pt-PT" state="translated">Subscrito</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="pt-PT" state="translated">Sobrescrito</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="pt-PT" state="translated">Rasurado</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="pt-PT" state="needs-translation">Link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="pt-PT" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="pt-PT" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="pt-PT" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="pt-PT" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="pt-PT" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="pt-PT" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="pt-PT" state="needs-translation">Title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="pt-PT" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="pt-PT" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="pt-PT" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="pt-PT" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="pt-PT" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="pt-PT" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="pt-PT" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="pt-PT" state="translated">Lista ordenada</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="pt-PT" state="translated">Lista desordenada</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="pt-PT" state="translated">Alinhar à esquerda</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="pt-PT" state="translated">Alinhar à direita</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="pt-PT" state="translated">Alinhar ao centro</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="pt-PT" state="translated">Justificar</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="pt-PT" state="translated">Tabela</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="pt-PT" state="needs-translation">Column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="pt-PT" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="pt-PT" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="pt-PT" state="translated">Remover a formatação</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="pt-PT" state="translated">Diminuir o recuo</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="pt-PT" state="translated">Aumentar o recuo</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="pt-PT" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="pt-PT" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="pt-PT" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="pt-PT" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="pt-PT" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="pt-PT" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="pt-PT" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="pt-PT" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="pt-PT" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="pt-PT" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="pt-PT" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="pt-PT" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="pt-PT" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="pt-PT" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="pt-PT" state="translated">Criar novo</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="pt-PT" state="translated">Não foram encontradas correspondências</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="pt-PT" state="translated">Por favor, inserir ###CHARACTERS### mais caracteres</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="pt-PT" state="needs-translation">
+                <target xml:lang="pt-PT" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="pt-PT" state="translated">Ativar/Desativar inspetor</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="pt-PT" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="pt-PT" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="pt-PT" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="pt-PT" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="pt-PT" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="pt-PT" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="pt-PT" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="pt-PT" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="pt-PT" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="pt-PT" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="pt-PT" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="pt-PT" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="pt-PT" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="pt-PT" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="pt-PT" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="pt-PT" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="pt-PT" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="pt-PT" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="pt-PT" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="pt-PT" state="translated">Ativar/Desativar inspetor</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="pt-PT" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="pt-PT" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="pt-PT" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="pt-PT" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="pt-PT" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="pt-PT" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="pt-PT" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="pt-PT" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="pt-PT" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="pt-PT" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="pt-PT" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="pt-PT" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="pt-PT" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="pt-PT" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="pt-PT" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="pt-PT" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="pt-PT" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="pt-PT" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="pt-PT" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/pt_PT/Main.xlf
+++ b/Resources/Private/Translations/pt_PT/Main.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="pt-PT">
         <body>
             <trans-unit id="copy__from__to--title" xml:space="preserve">
@@ -109,24 +109,6 @@
             <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
                 <source>Format as email?</source>
                 <target xml:lang="pt-PT" state="needs-translation">Format as email?</target>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
                 <source>Ordered list</source>
@@ -340,6 +322,36 @@
                 <source>Unfocus Node</source>
                 <target xml:lang="pt-PT" state="needs-translation">Unfocus Node</target>
             </trans-unit>
+            <group id="changesApplied" restype="x-gettext-plurals">
+                <trans-unit id="changesApplied[0]" xml:space="preserve">
+                    <source>{0} change successfully applied.</source>
+                    <target xml:lang="pt-PT" state="needs-translation">{0} change successfully applied.</target>
+                </trans-unit>
+                <trans-unit id="changesApplied[1]" xml:space="preserve">
+                    <source>{0} changes successfully applied.</source>
+                    <target xml:lang="pt-PT" state="needs-translation">{0} changes successfully applied.</target>
+                </trans-unit>
+            </group>
+            <group id="changesPublished" restype="x-gettext-plurals">
+                <trans-unit id="changesPublished[0]" xml:space="preserve">
+                    <source>Published {0} change to "{1}".</source>
+                    <target xml:lang="pt-PT" state="needs-translation">Published {0} change to "{1}".</target>
+                </trans-unit>
+                <trans-unit id="changesPublished[1]" xml:space="preserve">
+                    <source>Published {0} changes to "{1}".</source>
+                    <target xml:lang="pt-PT" state="needs-translation">Published {0} changes to "{1}".</target>
+                </trans-unit>
+            </group>
+            <group id="changesDiscarded" restype="x-gettext-plurals">
+                <trans-unit id="changesDiscarded[0]" xml:space="preserve">
+                    <source>Discarded {0} change.</source>
+                    <target xml:lang="pt-PT" state="needs-translation">Discarded {0} change.</target>
+                </trans-unit>
+                <trans-unit id="changesDiscarded[1]" xml:space="preserve">
+                    <source>Discarded {0} changes.</source>
+                    <target xml:lang="pt-PT" state="needs-translation">Discarded {0} changes.</target>
+                </trans-unit>
+            </group>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Translations/ro/Main.xlf
+++ b/Resources/Private/Translations/ro/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ro">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="ro" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="ro" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="ro" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="ro" state="needs-translation">Insert</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="ro" state="needs-translation">Insert mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="ro" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="ro" state="needs-translation">Bold</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="ro" state="needs-translation">Italic</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="ro" state="needs-translation">Underline</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="ro" state="needs-translation">Subscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="ro" state="needs-translation">Superscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="ro" state="needs-translation">Strikethrough</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="ro" state="needs-translation">Link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="ro" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="ro" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="ro" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="ro" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="ro" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="ro" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="ro" state="needs-translation">Title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="ro" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="ro" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="ro" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="ro" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="ro" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="ro" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="ro" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="ro" state="needs-translation">Ordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="ro" state="needs-translation">Unordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="ro" state="needs-translation">Align left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="ro" state="needs-translation">Align right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="ro" state="needs-translation">Align center</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="ro" state="needs-translation">Align justify</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="ro" state="needs-translation">Table</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="ro" state="needs-translation">Column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="ro" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="ro" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="ro" state="needs-translation">Remove format</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="ro" state="needs-translation">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="ro" state="needs-translation">Indent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="ro" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="ro" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="ro" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="ro" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="ro" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="ro" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="ro" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="ro" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="ro" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="ro" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="ro" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="ro" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="ro" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="ro" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="ro" state="needs-translation">Create new</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="ro" state="needs-translation">No matches found</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="ro" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ro">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="ro" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="ro" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="ro" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="ro" state="needs-translation">Insert</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="ro" state="needs-translation">Insert mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="ro" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="ro" state="needs-translation">Bold</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="ro" state="needs-translation">Italic</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="ro" state="needs-translation">Underline</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="ro" state="needs-translation">Subscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="ro" state="needs-translation">Superscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="ro" state="needs-translation">Strikethrough</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="ro" state="needs-translation">Link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="ro" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="ro" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="ro" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="ro" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="ro" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="ro" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="ro" state="needs-translation">Title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="ro" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="ro" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="ro" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="ro" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="ro" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="ro" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="ro" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="ro" state="needs-translation">Ordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="ro" state="needs-translation">Unordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="ro" state="needs-translation">Align left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="ro" state="needs-translation">Align right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="ro" state="needs-translation">Align center</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="ro" state="needs-translation">Align justify</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="ro" state="needs-translation">Table</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="ro" state="needs-translation">Column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="ro" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="ro" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="ro" state="needs-translation">Remove format</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="ro" state="needs-translation">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="ro" state="needs-translation">Indent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="ro" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="ro" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="ro" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="ro" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="ro" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="ro" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="ro" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="ro" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="ro" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="ro" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="ro" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="ro" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="ro" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="ro" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="ro" state="needs-translation">Create new</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="ro" state="needs-translation">No matches found</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="ro" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="ro" state="needs-translation">
+                <target xml:lang="ro" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="ro" state="needs-translation">Toggle inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="ro" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="ro" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="ro" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="ro" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="ro" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="ro" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="ro" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="ro" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="ro" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="ro" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="ro" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="ro" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="ro" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="ro" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="ro" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="ro" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="ro" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="ro" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="ro" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="ro" state="needs-translation">Toggle inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="ro" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="ro" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="ro" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="ro" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="ro" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="ro" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="ro" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="ro" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="ro" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="ro" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="ro" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="ro" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="ro" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="ro" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="ro" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="ro" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="ro" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="ro" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="ro" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/ru/Main.xlf
+++ b/Resources/Private/Translations/ru/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve" approved="yes">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="ru">Скопировать {source} в {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve" approved="yes">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="ru">Переместить {source} на {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve" approved="yes">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="ru">Пожалуйста, выберите позицию вставки {source} относительно к {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve" approved="yes">
-				<source>Insert</source>
-			<target xml:lang="ru">Вставить</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve" approved="yes">
-				<source>Insert mode</source>
-			<target xml:lang="ru">Режим вставки</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve" approved="yes">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="ru">Выберите соотношение сторон</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve" approved="yes">
-				<source>Bold</source>
-			<target xml:lang="ru">Жирный</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve" approved="yes">
-				<source>Italic</source>
-			<target xml:lang="ru">Курсив</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve" approved="yes">
-				<source>Underline</source>
-			<target xml:lang="ru">Подчёркнутый</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve" approved="yes">
-				<source>Subscript</source>
-			<target xml:lang="ru">Подстрочный</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve" approved="yes">
-				<source>Superscript</source>
-			<target xml:lang="ru">Верхний индекс</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve" approved="yes">
-				<source>Strikethrough</source>
-			<target xml:lang="ru">Зачеркнутый</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
-				<source>Link</source>
-			<target xml:lang="ru">Ссылка</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="ru" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="ru" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="ru" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="ru" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="ru" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="ru" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
-				<source>Title</source>
-			<target xml:lang="ru">Название</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="ru" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="ru" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="ru" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="ru" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="ru" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="ru" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="ru" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve" approved="yes">
-				<source>Ordered list</source>
-			<target xml:lang="ru">Нумерованный список</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve" approved="yes">
-				<source>Unordered list</source>
-			<target xml:lang="ru">Ненумерованный список</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve" approved="yes">
-				<source>Align left</source>
-			<target xml:lang="ru">По левому краю</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve" approved="yes">
-				<source>Align right</source>
-			<target xml:lang="ru">По правому краю</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve" approved="yes">
-				<source>Align center</source>
-			<target xml:lang="ru">По центру</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve" approved="yes">
-				<source>Align justify</source>
-			<target xml:lang="ru">По всей ширине</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve" approved="yes">
-				<source>Table</source>
-			<target xml:lang="ru">Таблица</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve" approved="yes">
-				<source>Column</source>
-			<target xml:lang="ru">Столбец</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="ru" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="ru" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve" approved="yes">
-				<source>Remove format</source>
-			<target xml:lang="ru">Удалить форматирование</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve" approved="yes">
-				<source>Outdent</source>
-			<target xml:lang="ru">Уменьшить выступ</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve" approved="yes">
-				<source>Indent</source>
-			<target xml:lang="ru">Увеличить выступ</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="ru" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="ru" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="ru" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="ru" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="ru" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="ru" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="ru" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="ru" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="ru" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="ru" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="ru" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="ru" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="ru" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="ru" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve" approved="yes">
-				<source>Create new</source>
-			<target xml:lang="ru">Создать новый</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve" approved="yes">
-				<source>No matches found</source>
-			<target xml:lang="ru">Совпадений не найдено</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve" approved="yes">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="ru">Пожалуйста, введите больше символов ## #CHARACTERS###</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ru">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve" approved="yes">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="ru">Скопировать {source} в {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve" approved="yes">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="ru">Переместить {source} на {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve" approved="yes">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="ru">Пожалуйста, выберите позицию вставки {source} относительно к {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve" approved="yes">
+                <source>Insert</source>
+                <target xml:lang="ru">Вставить</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve" approved="yes">
+                <source>Insert mode</source>
+                <target xml:lang="ru">Режим вставки</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve" approved="yes">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="ru">Выберите соотношение сторон</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve" approved="yes">
+                <source>Bold</source>
+                <target xml:lang="ru">Жирный</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve" approved="yes">
+                <source>Italic</source>
+                <target xml:lang="ru">Курсив</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve" approved="yes">
+                <source>Underline</source>
+                <target xml:lang="ru">Подчёркнутый</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve" approved="yes">
+                <source>Subscript</source>
+                <target xml:lang="ru">Подстрочный</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve" approved="yes">
+                <source>Superscript</source>
+                <target xml:lang="ru">Верхний индекс</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve" approved="yes">
+                <source>Strikethrough</source>
+                <target xml:lang="ru">Зачеркнутый</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve" approved="yes">
+                <source>Link</source>
+                <target xml:lang="ru">Ссылка</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="ru" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="ru" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="ru" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="ru" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="ru" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="ru" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve" approved="yes">
+                <source>Title</source>
+                <target xml:lang="ru">Название</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="ru" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="ru" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="ru" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="ru" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="ru" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="ru" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="ru" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve" approved="yes">
+                <source>Ordered list</source>
+                <target xml:lang="ru">Нумерованный список</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve" approved="yes">
+                <source>Unordered list</source>
+                <target xml:lang="ru">Ненумерованный список</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve" approved="yes">
+                <source>Align left</source>
+                <target xml:lang="ru">По левому краю</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve" approved="yes">
+                <source>Align right</source>
+                <target xml:lang="ru">По правому краю</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve" approved="yes">
+                <source>Align center</source>
+                <target xml:lang="ru">По центру</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve" approved="yes">
+                <source>Align justify</source>
+                <target xml:lang="ru">По всей ширине</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve" approved="yes">
+                <source>Table</source>
+                <target xml:lang="ru">Таблица</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve" approved="yes">
+                <source>Column</source>
+                <target xml:lang="ru">Столбец</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="ru" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="ru" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve" approved="yes">
+                <source>Remove format</source>
+                <target xml:lang="ru">Удалить форматирование</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve" approved="yes">
+                <source>Outdent</source>
+                <target xml:lang="ru">Уменьшить выступ</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve" approved="yes">
+                <source>Indent</source>
+                <target xml:lang="ru">Увеличить выступ</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="ru" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="ru" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="ru" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="ru" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="ru" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="ru" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="ru" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="ru" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="ru" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="ru" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="ru" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="ru" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="ru" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="ru" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve" approved="yes">
+                <source>Create new</source>
+                <target xml:lang="ru">Создать новый</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve" approved="yes">
+                <source>No matches found</source>
+                <target xml:lang="ru">Совпадений не найдено</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve" approved="yes">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="ru">Пожалуйста, введите больше символов ## #CHARACTERS###</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="ru" state="needs-translation">
+                <target xml:lang="ru" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve" approved="yes">
-				<source>Toggle inspector</source>
-			<target xml:lang="ru">Переключить инспектор</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="ru" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="ru" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="ru" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="ru" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="ru" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="ru" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="ru" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="ru" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="ru" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="ru" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="ru" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="ru" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="ru" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="ru" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="ru" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="ru" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="ru" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="ru" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="ru" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve" approved="yes">
+                <source>Toggle inspector</source>
+                <target xml:lang="ru">Переключить инспектор</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="ru" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="ru" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="ru" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="ru" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="ru" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="ru" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="ru" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="ru" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="ru" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="ru" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="ru" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="ru" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="ru" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="ru" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="ru" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="ru" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="ru" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="ru" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="ru" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/ru/Main.xlf
+++ b/Resources/Private/Translations/ru/Main.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="ru">
         <body>
             <trans-unit id="copy__from__to--title" xml:space="preserve" approved="yes">
@@ -109,24 +109,6 @@
             <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
                 <source>Format as email?</source>
                 <target xml:lang="ru" state="needs-translation">Format as email?</target>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve" approved="yes">
                 <source>Ordered list</source>
@@ -340,6 +322,36 @@
                 <source>Unfocus Node</source>
                 <target xml:lang="ru" state="needs-translation">Unfocus Node</target>
             </trans-unit>
+            <group id="changesApplied" restype="x-gettext-plurals">
+                <trans-unit id="changesApplied[0]" xml:space="preserve">
+                    <source>{0} change successfully applied.</source>
+                    <target xml:lang="ru" state="needs-translation">{0} change successfully applied.</target>
+                </trans-unit>
+                <trans-unit id="changesApplied[1]" xml:space="preserve">
+                    <source>{0} changes successfully applied.</source>
+                    <target xml:lang="ru" state="needs-translation">{0} changes successfully applied.</target>
+                </trans-unit>
+            </group>
+            <group id="changesPublished" restype="x-gettext-plurals">
+                <trans-unit id="changesPublished[0]" xml:space="preserve">
+                    <source>Published {0} change to "{1}".</source>
+                    <target xml:lang="ru" state="needs-translation">Published {0} change to "{1}".</target>
+                </trans-unit>
+                <trans-unit id="changesPublished[1]" xml:space="preserve">
+                    <source>Published {0} changes to "{1}".</source>
+                    <target xml:lang="ru" state="needs-translation">Published {0} changes to "{1}".</target>
+                </trans-unit>
+            </group>
+            <group id="changesDiscarded" restype="x-gettext-plurals">
+                <trans-unit id="changesDiscarded[0]" xml:space="preserve">
+                    <source>Discarded {0} change.</source>
+                    <target xml:lang="ru" state="needs-translation">Discarded {0} change.</target>
+                </trans-unit>
+                <trans-unit id="changesDiscarded[1]" xml:space="preserve">
+                    <source>Discarded {0} changes.</source>
+                    <target xml:lang="ru" state="needs-translation">Discarded {0} changes.</target>
+                </trans-unit>
+            </group>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Translations/sr/Main.xlf
+++ b/Resources/Private/Translations/sr/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="sr">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="sr" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="sr" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="sr" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="sr" state="needs-translation">Insert</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="sr" state="needs-translation">Insert mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="sr" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="sr" state="needs-translation">Bold</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="sr" state="needs-translation">Italic</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="sr" state="needs-translation">Underline</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="sr" state="needs-translation">Subscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="sr" state="needs-translation">Superscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="sr" state="needs-translation">Strikethrough</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="sr" state="needs-translation">Link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="sr" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="sr" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="sr" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="sr" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="sr" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="sr" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="sr" state="translated">Наслов</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="sr" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="sr" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="sr" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="sr" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="sr" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="sr" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="sr" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="sr" state="needs-translation">Ordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="sr" state="needs-translation">Unordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="sr" state="needs-translation">Align left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="sr" state="needs-translation">Align right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="sr" state="needs-translation">Align center</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="sr" state="needs-translation">Align justify</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="sr" state="needs-translation">Table</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="sr" state="needs-translation">Column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="sr" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="sr" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="sr" state="needs-translation">Remove format</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="sr" state="needs-translation">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="sr" state="needs-translation">Indent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="sr" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="sr" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="sr" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="sr" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="sr" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="sr" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="sr" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="sr" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="sr" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="sr" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="sr" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="sr" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="sr" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="sr" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="sr" state="translated">Креирај нови</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="sr" state="needs-translation">No matches found</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="sr" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="sr">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="sr" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="sr" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="sr" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="sr" state="needs-translation">Insert</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="sr" state="needs-translation">Insert mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="sr" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="sr" state="needs-translation">Bold</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="sr" state="needs-translation">Italic</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="sr" state="needs-translation">Underline</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="sr" state="needs-translation">Subscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="sr" state="needs-translation">Superscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="sr" state="needs-translation">Strikethrough</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="sr" state="needs-translation">Link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="sr" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="sr" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="sr" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="sr" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="sr" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="sr" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="sr" state="translated">Наслов</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="sr" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="sr" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="sr" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="sr" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="sr" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="sr" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="sr" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="sr" state="needs-translation">Ordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="sr" state="needs-translation">Unordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="sr" state="needs-translation">Align left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="sr" state="needs-translation">Align right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="sr" state="needs-translation">Align center</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="sr" state="needs-translation">Align justify</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="sr" state="needs-translation">Table</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="sr" state="needs-translation">Column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="sr" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="sr" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="sr" state="needs-translation">Remove format</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="sr" state="needs-translation">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="sr" state="needs-translation">Indent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="sr" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="sr" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="sr" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="sr" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="sr" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="sr" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="sr" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="sr" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="sr" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="sr" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="sr" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="sr" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="sr" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="sr" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="sr" state="translated">Креирај нови</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="sr" state="needs-translation">No matches found</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="sr" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="sr" state="needs-translation">
+                <target xml:lang="sr" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="sr" state="translated">Укључи/Искључи инспектор</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="sr" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="sr" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="sr" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="sr" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="sr" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="sr" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="sr" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="sr" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="sr" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="sr" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="sr" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="sr" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="sr" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="sr" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="sr" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="sr" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="sr" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="sr" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="sr" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="sr" state="translated">Укључи/Искључи инспектор</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="sr" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="sr" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="sr" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="sr" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="sr" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="sr" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="sr" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="sr" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="sr" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="sr" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="sr" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="sr" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="sr" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="sr" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="sr" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="sr" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="sr" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="sr" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="sr" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/sv/Main.xlf
+++ b/Resources/Private/Translations/sv/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="sv-SE">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="sv-SE" state="translated">Kopiera {source} till {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="sv-SE" state="translated">Flytta {source} till {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="sv-SE" state="translated">Välj vart {source} ska sättas in relativt till {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="sv-SE" state="translated">Infoga</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="sv-SE" state="translated">Infogningsläge</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="sv-SE" state="translated">Välj bildförhållande</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="sv-SE" state="translated">Fetstil</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="sv-SE" state="translated">Kursiv</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="sv-SE" state="translated">Understrykning</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="sv-SE" state="translated">Nedsänkt</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="sv-SE" state="translated">Upphöjt</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="sv-SE" state="translated">Genomstruken</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="sv-SE" state="translated">Länk</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="sv-SE" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="sv-SE" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="sv-SE" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="sv-SE" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="sv-SE" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="sv-SE" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="sv-SE" state="translated">Titel</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="sv-SE" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="sv-SE" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="sv-SE" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="sv-SE" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="sv-SE" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="sv-SE" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="sv-SE" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="sv-SE" state="translated">Sorterad lista</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="sv-SE" state="translated">Osorterad lista</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="sv-SE" state="translated">Vänsterjustera</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="sv-SE" state="translated">Högerjustera</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="sv-SE" state="translated">Centrera</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="sv-SE" state="translated">Justera</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="sv-SE" state="translated">Tabell</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="sv-SE" state="translated">Kolumn</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="sv-SE" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="sv-SE" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="sv-SE" state="translated">Ta bort formatering</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="sv-SE" state="translated">Minska indrag</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="sv-SE" state="translated">Indrag</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="sv-SE" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="sv-SE" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="sv-SE" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="sv-SE" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="sv-SE" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="sv-SE" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="sv-SE" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="sv-SE" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="sv-SE" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="sv-SE" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="sv-SE" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="sv-SE" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="sv-SE" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="sv-SE" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="sv-SE" state="translated">Skapa ny</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="sv-SE" state="translated">Inga träffar hittades</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="sv-SE" state="translated">Vänligen ange ## #CHARACTERS### fler tecken</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="sv-SE">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="sv-SE" state="translated">Kopiera {source} till {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="sv-SE" state="translated">Flytta {source} till {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="sv-SE" state="translated">Välj vart {source} ska sättas in relativt till {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="sv-SE" state="translated">Infoga</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="sv-SE" state="translated">Infogningsläge</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="sv-SE" state="translated">Välj bildförhållande</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="sv-SE" state="translated">Fetstil</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="sv-SE" state="translated">Kursiv</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="sv-SE" state="translated">Understrykning</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="sv-SE" state="translated">Nedsänkt</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="sv-SE" state="translated">Upphöjt</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="sv-SE" state="translated">Genomstruken</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="sv-SE" state="translated">Länk</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="sv-SE" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="sv-SE" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="sv-SE" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="sv-SE" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="sv-SE" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="sv-SE" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="sv-SE" state="translated">Titel</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="sv-SE" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="sv-SE" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="sv-SE" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="sv-SE" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="sv-SE" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="sv-SE" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="sv-SE" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="sv-SE" state="translated">Sorterad lista</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="sv-SE" state="translated">Osorterad lista</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="sv-SE" state="translated">Vänsterjustera</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="sv-SE" state="translated">Högerjustera</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="sv-SE" state="translated">Centrera</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="sv-SE" state="translated">Justera</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="sv-SE" state="translated">Tabell</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="sv-SE" state="translated">Kolumn</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="sv-SE" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="sv-SE" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="sv-SE" state="translated">Ta bort formatering</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="sv-SE" state="translated">Minska indrag</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="sv-SE" state="translated">Indrag</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="sv-SE" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="sv-SE" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="sv-SE" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="sv-SE" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="sv-SE" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="sv-SE" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="sv-SE" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="sv-SE" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="sv-SE" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="sv-SE" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="sv-SE" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="sv-SE" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="sv-SE" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="sv-SE" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="sv-SE" state="translated">Skapa ny</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="sv-SE" state="translated">Inga träffar hittades</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="sv-SE" state="translated">Vänligen ange ## #CHARACTERS### fler tecken</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="sv-SE" state="needs-translation">
+                <target xml:lang="sv-SE" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="sv-SE" state="translated">Visa/dölj inspektör</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="sv-SE" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="sv-SE" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="sv-SE" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="sv-SE" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="sv-SE" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="sv-SE" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="sv-SE" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="sv-SE" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="sv-SE" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="sv-SE" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="sv-SE" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="sv-SE" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="sv-SE" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="sv-SE" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="sv-SE" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="sv-SE" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="sv-SE" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="sv-SE" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="sv-SE" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="sv-SE" state="translated">Visa/dölj inspektör</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="sv-SE" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="sv-SE" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="sv-SE" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="sv-SE" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="sv-SE" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="sv-SE" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="sv-SE" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="sv-SE" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="sv-SE" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="sv-SE" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="sv-SE" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="sv-SE" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="sv-SE" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="sv-SE" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="sv-SE" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="sv-SE" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="sv-SE" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="sv-SE" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="sv-SE" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/tl/Main.xlf
+++ b/Resources/Private/Translations/tl/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="tl">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="tl" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="tl" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="tl" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="tl" state="needs-translation">Insert</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="tl" state="needs-translation">Insert mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="tl" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="tl" state="needs-translation">Bold</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="tl" state="needs-translation">Italic</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="tl" state="needs-translation">Underline</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="tl" state="needs-translation">Subscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="tl" state="needs-translation">Superscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="tl" state="needs-translation">Strikethrough</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="tl" state="translated">Link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="tl" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="tl" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="tl" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="tl" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="tl" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="tl" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="tl" state="translated">Pamagat</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="tl" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="tl" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="tl" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="tl" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="tl" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="tl" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="tl" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="tl" state="needs-translation">Ordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="tl" state="needs-translation">Unordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="tl" state="needs-translation">Align left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="tl" state="needs-translation">Align right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="tl" state="needs-translation">Align center</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="tl" state="needs-translation">Align justify</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="tl" state="needs-translation">Table</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="tl" state="translated">Column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="tl" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="tl" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="tl" state="needs-translation">Remove format</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="tl" state="needs-translation">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="tl" state="needs-translation">Indent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="tl" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="tl" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="tl" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="tl" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="tl" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="tl" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="tl" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="tl" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="tl" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="tl" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="tl" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="tl" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="tl" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="tl" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="tl" state="translated">Lumikha ng bago</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="tl" state="needs-translation">No matches found</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="tl" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="tl">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="tl" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="tl" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="tl" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="tl" state="needs-translation">Insert</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="tl" state="needs-translation">Insert mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="tl" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="tl" state="needs-translation">Bold</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="tl" state="needs-translation">Italic</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="tl" state="needs-translation">Underline</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="tl" state="needs-translation">Subscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="tl" state="needs-translation">Superscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="tl" state="needs-translation">Strikethrough</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="tl" state="translated">Link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="tl" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="tl" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="tl" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="tl" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="tl" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="tl" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="tl" state="translated">Pamagat</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="tl" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="tl" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="tl" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="tl" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="tl" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="tl" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="tl" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="tl" state="needs-translation">Ordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="tl" state="needs-translation">Unordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="tl" state="needs-translation">Align left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="tl" state="needs-translation">Align right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="tl" state="needs-translation">Align center</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="tl" state="needs-translation">Align justify</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="tl" state="needs-translation">Table</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="tl" state="translated">Column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="tl" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="tl" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="tl" state="needs-translation">Remove format</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="tl" state="needs-translation">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="tl" state="needs-translation">Indent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="tl" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="tl" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="tl" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="tl" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="tl" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="tl" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="tl" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="tl" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="tl" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="tl" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="tl" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="tl" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="tl" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="tl" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="tl" state="translated">Lumikha ng bago</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="tl" state="needs-translation">No matches found</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="tl" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="tl" state="needs-translation">
+                <target xml:lang="tl" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="tl" state="needs-translation">Toggle inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="tl" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="tl" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="tl" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="tl" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="tl" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="tl" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="tl" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="tl" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="tl" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="tl" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="tl" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="tl" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="tl" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="tl" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="tl" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="tl" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="tl" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="tl" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="tl" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="tl" state="needs-translation">Toggle inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="tl" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="tl" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="tl" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="tl" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="tl" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="tl" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="tl" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="tl" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="tl" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="tl" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="tl" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="tl" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="tl" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="tl" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="tl" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="tl" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="tl" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="tl" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="tl" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/tr/Main.xlf
+++ b/Resources/Private/Translations/tr/Main.xlf
@@ -1,267 +1,348 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="tr">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="tr" state="translated">{source}'ı, {target}'e kopyala</target><alt-trans><target xml:lang="tr">{source}'ı {target}'e kopyala</target></alt-trans></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="tr" state="translated">{source}'ı, {target}'e taşı</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="tr" state="translated">Lütfen {source} öğesinin {target} ile ilişkili olarak yerleştirilmesini istediğiniz konumu seçin.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="tr" state="translated">Ekle</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="tr" state="translated">Ekleme Modu</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="tr" state="translated">Bir görünüm açısı seç</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="tr" state="translated">Kalın</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="tr" state="translated">İtalik / Eğik</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="tr" state="translated">Altıçizili</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="tr" state="translated">Altsimge</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="tr" state="translated">Üstsimge</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="tr" state="translated">Üstü Çizili</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="tr" state="translated">Bağlantı</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="tr" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="tr" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="tr" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="tr" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="tr" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="tr" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="tr" state="translated">Başlık</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="tr" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="tr" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="tr" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="tr" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="tr" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="tr" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="tr" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="tr" state="translated">Maddeli Liste</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="tr" state="translated">Sırasız Liste</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="tr" state="translated">Sola Hizala</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="tr" state="translated">Sağa Hizala</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="tr" state="translated">Oraya Hizala</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="tr" state="translated">Geniş Hizala</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="tr" state="translated">Tablo</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="tr" state="translated">Sütun</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="tr" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="tr" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="tr" state="translated">Biçimi Sil</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="tr" state="translated">Girintiyi azalt</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="tr" state="translated">Girinti</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="tr" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="tr" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="tr" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="tr" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="tr" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="tr" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="tr" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="tr" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="tr" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="tr" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="tr" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="tr" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="tr" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="tr" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="tr" state="translated">Yeni Oluştur</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="tr" state="translated">Eşleşme Bulunamadı</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="tr" state="translated">Lütfen ###CHARACTERS### daha karakter yazın</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="tr">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="tr" state="translated">{source}'ı, {target}'e kopyala</target>
+                <alt-trans>
+                    <target xml:lang="tr">{source}'ı {target}'e kopyala</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="tr" state="translated">{source}'ı, {target}'e taşı</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="tr" state="translated">Lütfen {source} öğesinin {target} ile ilişkili olarak yerleştirilmesini istediğiniz konumu seçin.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="tr" state="translated">Ekle</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="tr" state="translated">Ekleme Modu</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="tr" state="translated">Bir görünüm açısı seç</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="tr" state="translated">Kalın</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="tr" state="translated">İtalik / Eğik</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="tr" state="translated">Altıçizili</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="tr" state="translated">Altsimge</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="tr" state="translated">Üstsimge</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="tr" state="translated">Üstü Çizili</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="tr" state="translated">Bağlantı</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="tr" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="tr" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="tr" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="tr" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="tr" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="tr" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="tr" state="translated">Başlık</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="tr" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="tr" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="tr" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="tr" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="tr" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="tr" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="tr" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="tr" state="translated">Maddeli Liste</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="tr" state="translated">Sırasız Liste</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="tr" state="translated">Sola Hizala</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="tr" state="translated">Sağa Hizala</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="tr" state="translated">Oraya Hizala</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="tr" state="translated">Geniş Hizala</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="tr" state="translated">Tablo</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="tr" state="translated">Sütun</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="tr" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="tr" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="tr" state="translated">Biçimi Sil</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="tr" state="translated">Girintiyi azalt</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="tr" state="translated">Girinti</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="tr" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="tr" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="tr" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="tr" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="tr" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="tr" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="tr" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="tr" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="tr" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="tr" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="tr" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="tr" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="tr" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="tr" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="tr" state="translated">Yeni Oluştur</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="tr" state="translated">Eşleşme Bulunamadı</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="tr" state="translated">Lütfen ###CHARACTERS### daha karakter yazın</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="tr" state="needs-translation">
+                <target xml:lang="tr" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="tr" state="translated">Denetleyiciyi aç/kapa</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="tr" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="tr" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="tr" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="tr" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="tr" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="tr" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="tr" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="tr" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="tr" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="tr" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="tr" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="tr" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="tr" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="tr" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="tr" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="tr" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="tr" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="tr" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="tr" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="tr" state="translated">Denetleyiciyi aç/kapa</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="tr" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="tr" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="tr" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="tr" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="tr" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="tr" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="tr" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="tr" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="tr" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="tr" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="tr" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="tr" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="tr" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="tr" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="tr" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="tr" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="tr" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="tr" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="tr" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/uk/Main.xlf
+++ b/Resources/Private/Translations/uk/Main.xlf
@@ -1,267 +1,348 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="uk">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="uk" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="uk" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="uk" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="uk" state="needs-translation">Insert</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="uk" state="needs-translation">Insert mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="uk" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="uk" state="needs-translation">Bold</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="uk" state="needs-translation">Italic</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="uk" state="needs-translation">Underline</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="uk" state="needs-translation">Subscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="uk" state="needs-translation">Superscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="uk" state="needs-translation">Strikethrough</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="uk" state="translated">Посилання</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="uk" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="uk" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="uk" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="uk" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="uk" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="uk" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="uk" state="translated">Заголовок</target><alt-trans><target xml:lang="uk">Назва</target></alt-trans></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="uk" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="uk" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="uk" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="uk" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="uk" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="uk" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="uk" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="uk" state="needs-translation">Ordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="uk" state="needs-translation">Unordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="uk" state="needs-translation">Align left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="uk" state="needs-translation">Align right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="uk" state="needs-translation">Align center</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="uk" state="needs-translation">Align justify</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="uk" state="needs-translation">Table</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="uk" state="needs-translation">Column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="uk" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="uk" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="uk" state="needs-translation">Remove format</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="uk" state="needs-translation">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="uk" state="needs-translation">Indent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="uk" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="uk" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="uk" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="uk" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="uk" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="uk" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="uk" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="uk" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="uk" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="uk" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="uk" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="uk" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="uk" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="uk" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="uk" state="translated">Створити новий(у)</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="uk" state="needs-translation">No matches found</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="uk" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="uk">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="uk" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="uk" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="uk" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="uk" state="needs-translation">Insert</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="uk" state="needs-translation">Insert mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="uk" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="uk" state="needs-translation">Bold</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="uk" state="needs-translation">Italic</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="uk" state="needs-translation">Underline</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="uk" state="needs-translation">Subscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="uk" state="needs-translation">Superscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="uk" state="needs-translation">Strikethrough</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="uk" state="translated">Посилання</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="uk" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="uk" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="uk" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="uk" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="uk" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="uk" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="uk" state="translated">Заголовок</target>
+                <alt-trans>
+                    <target xml:lang="uk">Назва</target>
+                </alt-trans>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="uk" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="uk" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="uk" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="uk" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="uk" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="uk" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="uk" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="uk" state="needs-translation">Ordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="uk" state="needs-translation">Unordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="uk" state="needs-translation">Align left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="uk" state="needs-translation">Align right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="uk" state="needs-translation">Align center</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="uk" state="needs-translation">Align justify</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="uk" state="needs-translation">Table</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="uk" state="needs-translation">Column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="uk" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="uk" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="uk" state="needs-translation">Remove format</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="uk" state="needs-translation">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="uk" state="needs-translation">Indent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="uk" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="uk" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="uk" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="uk" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="uk" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="uk" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="uk" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="uk" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="uk" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="uk" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="uk" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="uk" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="uk" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="uk" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="uk" state="translated">Створити новий(у)</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="uk" state="needs-translation">No matches found</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="uk" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="uk" state="needs-translation">
+                <target xml:lang="uk" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="uk" state="translated">Відкрити / закрити інспектор</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="uk" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="uk" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="uk" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="uk" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="uk" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="uk" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="uk" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="uk" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="uk" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="uk" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="uk" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="uk" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="uk" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="uk" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="uk" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="uk" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="uk" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="uk" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="uk" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="uk" state="translated">Відкрити / закрити інспектор</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="uk" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="uk" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="uk" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="uk" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="uk" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="uk" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="uk" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="uk" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="uk" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="uk" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="uk" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="uk" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="uk" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="uk" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="uk" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="uk" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="uk" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="uk" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="uk" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/vi/Main.xlf
+++ b/Resources/Private/Translations/vi/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="vi">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="vi" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="vi" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="vi" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="vi" state="needs-translation">Insert</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="vi" state="needs-translation">Insert mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="vi" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="vi" state="needs-translation">Bold</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="vi" state="needs-translation">Italic</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="vi" state="needs-translation">Underline</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="vi" state="needs-translation">Subscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="vi" state="needs-translation">Superscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="vi" state="needs-translation">Strikethrough</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="vi" state="translated">Liên kết</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="vi" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="vi" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="vi" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="vi" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="vi" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="vi" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="vi" state="translated">Tiêu đề</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="vi" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="vi" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="vi" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="vi" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="vi" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="vi" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="vi" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="vi" state="needs-translation">Ordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="vi" state="needs-translation">Unordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="vi" state="needs-translation">Align left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="vi" state="needs-translation">Align right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="vi" state="needs-translation">Align center</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="vi" state="needs-translation">Align justify</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="vi" state="needs-translation">Table</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="vi" state="translated">Cột</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="vi" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="vi" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="vi" state="needs-translation">Remove format</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="vi" state="needs-translation">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="vi" state="needs-translation">Indent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="vi" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="vi" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="vi" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="vi" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="vi" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="vi" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="vi" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="vi" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="vi" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="vi" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="vi" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="vi" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="vi" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="vi" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="vi" state="translated">Tạo mới</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="vi" state="needs-translation">No matches found</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="vi" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="vi">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="vi" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="vi" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="vi" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="vi" state="needs-translation">Insert</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="vi" state="needs-translation">Insert mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="vi" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="vi" state="needs-translation">Bold</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="vi" state="needs-translation">Italic</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="vi" state="needs-translation">Underline</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="vi" state="needs-translation">Subscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="vi" state="needs-translation">Superscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="vi" state="needs-translation">Strikethrough</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="vi" state="translated">Liên kết</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="vi" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="vi" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="vi" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="vi" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="vi" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="vi" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="vi" state="translated">Tiêu đề</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="vi" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="vi" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="vi" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="vi" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="vi" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="vi" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="vi" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="vi" state="needs-translation">Ordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="vi" state="needs-translation">Unordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="vi" state="needs-translation">Align left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="vi" state="needs-translation">Align right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="vi" state="needs-translation">Align center</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="vi" state="needs-translation">Align justify</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="vi" state="needs-translation">Table</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="vi" state="translated">Cột</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="vi" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="vi" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="vi" state="needs-translation">Remove format</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="vi" state="needs-translation">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="vi" state="needs-translation">Indent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="vi" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="vi" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="vi" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="vi" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="vi" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="vi" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="vi" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="vi" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="vi" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="vi" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="vi" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="vi" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="vi" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="vi" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="vi" state="translated">Tạo mới</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="vi" state="needs-translation">No matches found</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="vi" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="vi" state="needs-translation">
+                <target xml:lang="vi" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="vi" state="needs-translation">Toggle inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="vi" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="vi" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="vi" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="vi" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="vi" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="vi" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="vi" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="vi" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="vi" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="vi" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="vi" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="vi" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="vi" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="vi" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="vi" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="vi" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="vi" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="vi" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="vi" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="vi" state="needs-translation">Toggle inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="vi" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="vi" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="vi" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="vi" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="vi" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="vi" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="vi" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="vi" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="vi" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="vi" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="vi" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="vi" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="vi" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="vi" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="vi" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="vi" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="vi" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="vi" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="vi" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/zh/Main.xlf
+++ b/Resources/Private/Translations/zh/Main.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="zh-CN">
         <body>
             <trans-unit id="copy__from__to--title" xml:space="preserve">
@@ -109,24 +109,6 @@
             <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
                 <source>Format as email?</source>
                 <target xml:lang="zh-CN" state="needs-translation">Format as email?</target>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
-            </trans-unit>
-            <trans-unit id="" xml:space="preserve">
-                <source/>
             </trans-unit>
             <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
                 <source>Ordered list</source>
@@ -340,6 +322,36 @@
                 <source>Unfocus Node</source>
                 <target xml:lang="zh-CN" state="needs-translation">Unfocus Node</target>
             </trans-unit>
+            <group id="changesApplied" restype="x-gettext-plurals">
+                <trans-unit id="changesApplied[0]" xml:space="preserve">
+                    <source>{0} change successfully applied.</source>
+                    <target xml:lang="zh-CN" state="needs-translation">{0} change successfully applied.</target>
+                </trans-unit>
+                <trans-unit id="changesApplied[1]" xml:space="preserve">
+                    <source>{0} changes successfully applied.</source>
+                    <target xml:lang="zh-CN" state="needs-translation">{0} changes successfully applied.</target>
+                </trans-unit>
+            </group>
+            <group id="changesPublished" restype="x-gettext-plurals">
+                <trans-unit id="changesPublished[0]" xml:space="preserve">
+                    <source>Published {0} change to "{1}".</source>
+                    <target xml:lang="zh-CN" state="needs-translation">Published {0} change to "{1}".</target>
+                </trans-unit>
+                <trans-unit id="changesPublished[1]" xml:space="preserve">
+                    <source>Published {0} changes to "{1}".</source>
+                    <target xml:lang="zh-CN" state="needs-translation">Published {0} changes to "{1}".</target>
+                </trans-unit>
+            </group>
+            <group id="changesDiscarded" restype="x-gettext-plurals">
+                <trans-unit id="changesDiscarded[0]" xml:space="preserve">
+                    <source>Discarded {0} change.</source>
+                    <target xml:lang="zh-CN" state="needs-translation">Discarded {0} change.</target>
+                </trans-unit>
+                <trans-unit id="changesDiscarded[1]" xml:space="preserve">
+                    <source>Discarded {0} changes.</source>
+                    <target xml:lang="zh-CN" state="needs-translation">Discarded {0} changes.</target>
+                </trans-unit>
+            </group>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Translations/zh/Main.xlf
+++ b/Resources/Private/Translations/zh/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="zh-CN">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="zh-CN" state="needs-translation">Copy {source} to {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="zh-CN" state="needs-translation">Move {source} to {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="zh-CN" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="zh-CN" state="needs-translation">Insert</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="zh-CN" state="needs-translation">Insert mode</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="zh-CN" state="needs-translation">Choose an Aspect Ratio</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="zh-CN" state="needs-translation">Bold</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="zh-CN" state="needs-translation">Italic</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="zh-CN" state="needs-translation">Underline</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="zh-CN" state="needs-translation">Subscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="zh-CN" state="needs-translation">Superscript</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="zh-CN" state="needs-translation">Strikethrough</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="zh-CN" state="translated">链接</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="zh-CN" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="zh-CN" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="zh-CN" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="zh-CN" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="zh-CN" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="zh-CN" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="zh-CN" state="translated">标题</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="zh-CN" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="zh-CN" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="zh-CN" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="zh-CN" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="zh-CN" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="zh-CN" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="zh-CN" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="zh-CN" state="needs-translation">Ordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="zh-CN" state="needs-translation">Unordered list</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="zh-CN" state="needs-translation">Align left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="zh-CN" state="needs-translation">Align right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="zh-CN" state="needs-translation">Align center</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="zh-CN" state="needs-translation">Align justify</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="zh-CN" state="needs-translation">Table</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="zh-CN" state="translated">列</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="zh-CN" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="zh-CN" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="zh-CN" state="needs-translation">Remove format</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="zh-CN" state="needs-translation">Outdent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="zh-CN" state="needs-translation">Indent</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="zh-CN" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="zh-CN" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="zh-CN" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="zh-CN" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="zh-CN" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="zh-CN" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="zh-CN" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="zh-CN" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="zh-CN" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="zh-CN" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="zh-CN" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="zh-CN" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="zh-CN" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="zh-CN" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="zh-CN" state="translated">新建</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="zh-CN" state="needs-translation">No matches found</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="zh-CN" state="needs-translation">Please enter ###CHARACTERS### more character</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="zh-CN">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="zh-CN" state="needs-translation">Copy {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="zh-CN" state="needs-translation">Move {source} to {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="zh-CN" state="needs-translation">Please select the position at which you want {source} inserted relative to {target}.</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="zh-CN" state="needs-translation">Insert</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="zh-CN" state="needs-translation">Insert mode</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="zh-CN" state="needs-translation">Choose an Aspect Ratio</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="zh-CN" state="needs-translation">Bold</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="zh-CN" state="needs-translation">Italic</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="zh-CN" state="needs-translation">Underline</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="zh-CN" state="needs-translation">Subscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="zh-CN" state="needs-translation">Superscript</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="zh-CN" state="needs-translation">Strikethrough</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="zh-CN" state="translated">链接</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="zh-CN" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="zh-CN" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="zh-CN" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="zh-CN" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="zh-CN" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="zh-CN" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="zh-CN" state="translated">标题</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="zh-CN" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="zh-CN" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="zh-CN" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="zh-CN" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="zh-CN" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="zh-CN" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="zh-CN" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="zh-CN" state="needs-translation">Ordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="zh-CN" state="needs-translation">Unordered list</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="zh-CN" state="needs-translation">Align left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="zh-CN" state="needs-translation">Align right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="zh-CN" state="needs-translation">Align center</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="zh-CN" state="needs-translation">Align justify</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="zh-CN" state="needs-translation">Table</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="zh-CN" state="translated">列</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="zh-CN" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="zh-CN" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="zh-CN" state="needs-translation">Remove format</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="zh-CN" state="needs-translation">Outdent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="zh-CN" state="needs-translation">Indent</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="zh-CN" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="zh-CN" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="zh-CN" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="zh-CN" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="zh-CN" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="zh-CN" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="zh-CN" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="zh-CN" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="zh-CN" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="zh-CN" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="zh-CN" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="zh-CN" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="zh-CN" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="zh-CN" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="zh-CN" state="translated">新建</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="zh-CN" state="needs-translation">No matches found</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="zh-CN" state="needs-translation">Please enter ###CHARACTERS### more character</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="zh-CN" state="needs-translation">
+                <target xml:lang="zh-CN" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="zh-CN" state="translated">显示或隐藏属性编辑器</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="zh-CN" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="zh-CN" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="zh-CN" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="zh-CN" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="zh-CN" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="zh-CN" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="zh-CN" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="zh-CN" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="zh-CN" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="zh-CN" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="zh-CN" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="zh-CN" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="zh-CN" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="zh-CN" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="zh-CN" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="zh-CN" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="zh-CN" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="zh-CN" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="zh-CN" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="zh-CN" state="translated">显示或隐藏属性编辑器</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="zh-CN" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="zh-CN" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="zh-CN" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="zh-CN" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="zh-CN" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="zh-CN" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="zh-CN" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="zh-CN" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="zh-CN" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="zh-CN" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="zh-CN" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="zh-CN" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="zh-CN" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="zh-CN" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="zh-CN" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="zh-CN" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="zh-CN" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="zh-CN" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="zh-CN" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/zh_TW/Main.xlf
+++ b/Resources/Private/Translations/zh_TW/Main.xlf
@@ -1,267 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="zh-TW">
-    <body>
-      <trans-unit id="copy__from__to--title" xml:space="preserve">
-				<source>Copy {source} to {target}</source>
-			<target xml:lang="zh-TW" state="translated">複製 {source} 到 {target}</target></trans-unit>
-      <trans-unit id="move__from__to--title" xml:space="preserve">
-				<source>Move {source} to {target}</source>
-			<target xml:lang="zh-TW" state="translated">移動 {source} 到 {target}</target></trans-unit>
-      <trans-unit id="copy__from__to--description" xml:space="preserve">
-				<source>Please select the position at which you want {source} inserted relative to {target}.</source>
-			<target xml:lang="zh-TW" state="translated">請選擇想要 {source} 插入 {target} 的相對位置。</target></trans-unit>
-      <trans-unit id="insert" xml:space="preserve">
-				<source>Insert</source>
-			<target xml:lang="zh-TW" state="translated">插入</target></trans-unit>
-      <trans-unit id="insertMode" xml:space="preserve">
-				<source>Insert mode</source>
-			<target xml:lang="zh-TW" state="translated">插入模式</target></trans-unit>
-      <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
-				<source>Choose an Aspect Ratio</source>
-			<target xml:lang="zh-TW" state="translated">選擇長寬比</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
-				<source>Bold</source>
-			<target xml:lang="zh-TW" state="translated">粗體</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
-				<source>Italic</source>
-			<target xml:lang="zh-TW" state="translated">斜體</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
-				<source>Underline</source>
-			<target xml:lang="zh-TW" state="translated">底線</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
-				<source>Subscript</source>
-			<target xml:lang="zh-TW" state="translated">下標線</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
-				<source>Superscript</source>
-			<target xml:lang="zh-TW" state="translated">上標線</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
-				<source>Strikethrough</source>
-			<target xml:lang="zh-TW" state="translated">刪除線</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
-				<source>Link</source>
-			<target xml:lang="zh-TW" state="translated">連結</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
-				<source>Unlink</source>
-			<target xml:lang="zh-TW" state="needs-translation">Unlink</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
-				<source>Hide link options</source>
-			<target xml:lang="zh-TW" state="needs-translation">Hide link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
-				<source>Link options</source>
-			<target xml:lang="zh-TW" state="needs-translation">Link options</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
-				<source>No follow</source>
-			<target xml:lang="zh-TW" state="needs-translation">No follow</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
-				<source>Open in new window</source>
-			<target xml:lang="zh-TW" state="needs-translation">Open in new window</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
-				<source>Enter link title</source>
-			<target xml:lang="zh-TW" state="needs-translation">Enter link title</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
-				<source>Title</source>
-			<target xml:lang="zh-TW" state="translated">標題</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
-				<source>Enter anchor name</source>
-			<target xml:lang="zh-TW" state="needs-translation">Enter anchor name</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
-				<source>Link to anchor</source>
-			<target xml:lang="zh-TW" state="needs-translation">Link to anchor</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
-				<source>Edit link</source>
-			<target xml:lang="zh-TW" state="needs-translation">Edit link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
-				<source>Apply link</source>
-			<target xml:lang="zh-TW" state="needs-translation">Apply link</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
-				<source>Paste a link, or search</source>
-			<target xml:lang="zh-TW" state="needs-translation">Paste a link, or search</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
-				<source>Format as http link?</source>
-			<target xml:lang="zh-TW" state="needs-translation">Format as http link?</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
-				<source>Format as email?</source>
-			<target xml:lang="zh-TW" state="needs-translation">Format as email?</target></trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="" xml:space="preserve">
-				<source/>
-			</trans-unit>
-      <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
-				<source>Ordered list</source>
-			<target xml:lang="zh-TW" state="translated">項目清單</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
-				<source>Unordered list</source>
-			<target xml:lang="zh-TW" state="translated">無排序清單</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
-				<source>Align left</source>
-			<target xml:lang="zh-TW" state="translated">靠左對齊</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
-				<source>Align right</source>
-			<target xml:lang="zh-TW" state="translated">靠右對齊</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
-				<source>Align center</source>
-			<target xml:lang="zh-TW" state="translated">置中</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
-				<source>Align justify</source>
-			<target xml:lang="zh-TW" state="translated">分散對齊</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
-				<source>Table</source>
-			<target xml:lang="zh-TW" state="translated">表格</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
-				<source>Column</source>
-			<target xml:lang="zh-TW" state="translated">欄位</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
-				<source>Row</source>
-			<target xml:lang="zh-TW" state="needs-translation">Row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
-				<source>Merge cells</source>
-			<target xml:lang="zh-TW" state="needs-translation">Merge cells</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
-				<source>Remove format</source>
-			<target xml:lang="zh-TW" state="translated">移除格式</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
-				<source>Outdent</source>
-			<target xml:lang="zh-TW" state="translated">減少縮排</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
-				<source>Indent</source>
-			<target xml:lang="zh-TW" state="translated">增加縮排</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
-				<source>Header column</source>
-			<target xml:lang="zh-TW" state="needs-translation">Header column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
-				<source>Insert column before</source>
-			<target xml:lang="zh-TW" state="needs-translation">Insert column before</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
-				<source>Insert column after</source>
-			<target xml:lang="zh-TW" state="needs-translation">Insert column after</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
-				<source>Delete column</source>
-			<target xml:lang="zh-TW" state="needs-translation">Delete column</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
-				<source>Header row</source>
-			<target xml:lang="zh-TW" state="needs-translation">Header row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
-				<source>Insert row below</source>
-			<target xml:lang="zh-TW" state="needs-translation">Insert row below</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
-				<source>Insert row above</source>
-			<target xml:lang="zh-TW" state="needs-translation">Insert row above</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
-				<source>Delete row</source>
-			<target xml:lang="zh-TW" state="needs-translation">Delete row</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
-				<source>Merge cell up</source>
-			<target xml:lang="zh-TW" state="needs-translation">Merge cell up</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
-				<source>Merge cell right</source>
-			<target xml:lang="zh-TW" state="needs-translation">Merge cell right</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
-				<source>Merge cell down</source>
-			<target xml:lang="zh-TW" state="needs-translation">Merge cell down</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
-				<source>Merge cell left</source>
-			<target xml:lang="zh-TW" state="needs-translation">Merge cell left</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
-				<source>Split cell vertically</source>
-			<target xml:lang="zh-TW" state="needs-translation">Split cell vertically</target></trans-unit>
-      <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
-				<source>Split cell horizontally</source>
-			<target xml:lang="zh-TW" state="needs-translation">Split cell horizontally</target></trans-unit>
-      <trans-unit id="createNew" xml:space="preserve">
-				<source>Create new</source>
-			<target xml:lang="zh-TW" state="translated">新增</target></trans-unit>
-      <trans-unit id="noMatchesFound" xml:space="preserve">
-				<source>No matches found</source>
-			<target xml:lang="zh-TW" state="translated">未找到相符項目</target></trans-unit>
-      <trans-unit id="searchBoxLeftToType" xml:space="preserve">
-				<source>Please enter ###CHARACTERS### more character</source>
-			<target xml:lang="zh-TW" state="translated">請輸入 ###CHARACTERS### 更多字元</target></trans-unit>
-      <trans-unit id="Shortcut__Introduction" xml:space="preserve">
+    <file original="" product-name="Neos.Neos.Ui" source-language="en" datatype="plaintext" target-language="zh-TW">
+        <body>
+            <trans-unit id="copy__from__to--title" xml:space="preserve">
+                <source>Copy {source} to {target}</source>
+                <target xml:lang="zh-TW" state="translated">複製 {source} 到 {target}</target>
+            </trans-unit>
+            <trans-unit id="move__from__to--title" xml:space="preserve">
+                <source>Move {source} to {target}</source>
+                <target xml:lang="zh-TW" state="translated">移動 {source} 到 {target}</target>
+            </trans-unit>
+            <trans-unit id="copy__from__to--description" xml:space="preserve">
+                <source>Please select the position at which you want {source} inserted relative to {target}.</source>
+                <target xml:lang="zh-TW" state="translated">請選擇想要 {source} 插入 {target} 的相對位置。</target>
+            </trans-unit>
+            <trans-unit id="insert" xml:space="preserve">
+                <source>Insert</source>
+                <target xml:lang="zh-TW" state="translated">插入</target>
+            </trans-unit>
+            <trans-unit id="insertMode" xml:space="preserve">
+                <source>Insert mode</source>
+                <target xml:lang="zh-TW" state="translated">插入模式</target>
+            </trans-unit>
+            <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
+                <source>Choose an Aspect Ratio</source>
+                <target xml:lang="zh-TW" state="translated">選擇長寬比</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
+                <source>Bold</source>
+                <target xml:lang="zh-TW" state="translated">粗體</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__italic" xml:space="preserve">
+                <source>Italic</source>
+                <target xml:lang="zh-TW" state="translated">斜體</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__underline" xml:space="preserve">
+                <source>Underline</source>
+                <target xml:lang="zh-TW" state="translated">底線</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__subscript" xml:space="preserve">
+                <source>Subscript</source>
+                <target xml:lang="zh-TW" state="translated">下標線</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__superscript" xml:space="preserve">
+                <source>Superscript</source>
+                <target xml:lang="zh-TW" state="translated">上標線</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__strikethrough" xml:space="preserve">
+                <source>Strikethrough</source>
+                <target xml:lang="zh-TW" state="translated">刪除線</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link" xml:space="preserve">
+                <source>Link</source>
+                <target xml:lang="zh-TW" state="translated">連結</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unlink" xml:space="preserve">
+                <source>Unlink</source>
+                <target xml:lang="zh-TW" state="needs-translation">Unlink</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__hideOptions" xml:space="preserve">
+                <source>Hide link options</source>
+                <target xml:lang="zh-TW" state="needs-translation">Hide link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__showOptions" xml:space="preserve">
+                <source>Link options</source>
+                <target xml:lang="zh-TW" state="needs-translation">Link options</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__noFollow" xml:space="preserve">
+                <source>No follow</source>
+                <target xml:lang="zh-TW" state="needs-translation">No follow</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__targetBlank" xml:space="preserve">
+                <source>Open in new window</source>
+                <target xml:lang="zh-TW" state="needs-translation">Open in new window</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__titlePlaceholder" xml:space="preserve">
+                <source>Enter link title</source>
+                <target xml:lang="zh-TW" state="needs-translation">Enter link title</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__title" xml:space="preserve">
+                <source>Title</source>
+                <target xml:lang="zh-TW" state="translated">標題</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchorPlaceholder" xml:space="preserve">
+                <source>Enter anchor name</source>
+                <target xml:lang="zh-TW" state="needs-translation">Enter anchor name</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__anchor" xml:space="preserve">
+                <source>Link to anchor</source>
+                <target xml:lang="zh-TW" state="needs-translation">Link to anchor</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__edit" xml:space="preserve">
+                <source>Edit link</source>
+                <target xml:lang="zh-TW" state="needs-translation">Edit link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__apply" xml:space="preserve">
+                <source>Apply link</source>
+                <target xml:lang="zh-TW" state="needs-translation">Apply link</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__placeholder" xml:space="preserve">
+                <source>Paste a link, or search</source>
+                <target xml:lang="zh-TW" state="needs-translation">Paste a link, or search</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsHttp" xml:space="preserve">
+                <source>Format as http link?</source>
+                <target xml:lang="zh-TW" state="needs-translation">Format as http link?</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
+                <source>Format as email?</source>
+                <target xml:lang="zh-TW" state="needs-translation">Format as email?</target>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="" xml:space="preserve">
+                <source/>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
+                <source>Ordered list</source>
+                <target xml:lang="zh-TW" state="translated">項目清單</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__unordered-list" xml:space="preserve">
+                <source>Unordered list</source>
+                <target xml:lang="zh-TW" state="translated">無排序清單</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-left" xml:space="preserve">
+                <source>Align left</source>
+                <target xml:lang="zh-TW" state="translated">靠左對齊</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-right" xml:space="preserve">
+                <source>Align right</source>
+                <target xml:lang="zh-TW" state="translated">靠右對齊</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-center" xml:space="preserve">
+                <source>Align center</source>
+                <target xml:lang="zh-TW" state="translated">置中</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__align-justify" xml:space="preserve">
+                <source>Align justify</source>
+                <target xml:lang="zh-TW" state="translated">分散對齊</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__table" xml:space="preserve">
+                <source>Table</source>
+                <target xml:lang="zh-TW" state="translated">表格</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableColumn" xml:space="preserve">
+                <source>Column</source>
+                <target xml:lang="zh-TW" state="translated">欄位</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableRow" xml:space="preserve">
+                <source>Row</source>
+                <target xml:lang="zh-TW" state="needs-translation">Row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__tableMergeCells" xml:space="preserve">
+                <source>Merge cells</source>
+                <target xml:lang="zh-TW" state="needs-translation">Merge cells</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__remove-format" xml:space="preserve">
+                <source>Remove format</source>
+                <target xml:lang="zh-TW" state="translated">移除格式</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__outdent" xml:space="preserve">
+                <source>Outdent</source>
+                <target xml:lang="zh-TW" state="translated">減少縮排</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__indent" xml:space="preserve">
+                <source>Indent</source>
+                <target xml:lang="zh-TW" state="translated">增加縮排</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableColumnHeader" xml:space="preserve">
+                <source>Header column</source>
+                <target xml:lang="zh-TW" state="needs-translation">Header column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnLeft" xml:space="preserve">
+                <source>Insert column before</source>
+                <target xml:lang="zh-TW" state="needs-translation">Insert column before</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableColumnRight" xml:space="preserve">
+                <source>Insert column after</source>
+                <target xml:lang="zh-TW" state="needs-translation">Insert column after</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableColumn" xml:space="preserve">
+                <source>Delete column</source>
+                <target xml:lang="zh-TW" state="needs-translation">Delete column</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__setTableRowHeader" xml:space="preserve">
+                <source>Header row</source>
+                <target xml:lang="zh-TW" state="needs-translation">Header row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowBelow" xml:space="preserve">
+                <source>Insert row below</source>
+                <target xml:lang="zh-TW" state="needs-translation">Insert row below</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__insertTableRowAbove" xml:space="preserve">
+                <source>Insert row above</source>
+                <target xml:lang="zh-TW" state="needs-translation">Insert row above</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__removeTableRow" xml:space="preserve">
+                <source>Delete row</source>
+                <target xml:lang="zh-TW" state="needs-translation">Delete row</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellUp" xml:space="preserve">
+                <source>Merge cell up</source>
+                <target xml:lang="zh-TW" state="needs-translation">Merge cell up</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellRight" xml:space="preserve">
+                <source>Merge cell right</source>
+                <target xml:lang="zh-TW" state="needs-translation">Merge cell right</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellDown" xml:space="preserve">
+                <source>Merge cell down</source>
+                <target xml:lang="zh-TW" state="needs-translation">Merge cell down</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__mergeTableCellLeft" xml:space="preserve">
+                <source>Merge cell left</source>
+                <target xml:lang="zh-TW" state="needs-translation">Merge cell left</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellVertically" xml:space="preserve">
+                <source>Split cell vertically</source>
+                <target xml:lang="zh-TW" state="needs-translation">Split cell vertically</target>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__splitTableCellHorizontally" xml:space="preserve">
+                <source>Split cell horizontally</source>
+                <target xml:lang="zh-TW" state="needs-translation">Split cell horizontally</target>
+            </trans-unit>
+            <trans-unit id="createNew" xml:space="preserve">
+                <source>Create new</source>
+                <target xml:lang="zh-TW" state="translated">新增</target>
+            </trans-unit>
+            <trans-unit id="noMatchesFound" xml:space="preserve">
+                <source>No matches found</source>
+                <target xml:lang="zh-TW" state="translated">未找到相符項目</target>
+            </trans-unit>
+            <trans-unit id="searchBoxLeftToType" xml:space="preserve">
+                <source>Please enter ###CHARACTERS### more character</source>
+                <target xml:lang="zh-TW" state="translated">請輸入 ###CHARACTERS### 更多字元</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__Introduction" xml:space="preserve">
                 <source>
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
                 </source>
-            <target xml:lang="zh-TW" state="needs-translation">
+                <target xml:lang="zh-TW" state="needs-translation">
                     These are Keyboard-Shortcuts we are providing.
                     You have to press the keys on the right after each other.
                     They will not get triggered when you are focusing an input field.
-                </target></trans-unit>
-      <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
-				<source>Toggle inspector</source>
-			<target xml:lang="zh-TW" state="translated">切換檢測器</target></trans-unit>
-      <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
-				<source>Toggle full screen</source>
-			<target xml:lang="zh-TW" state="needs-translation">Toggle full screen</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
-				<source>Toggle left sidebar</source>
-			<target xml:lang="zh-TW" state="needs-translation">Toggle left sidebar</target></trans-unit>
-      <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
-				<source>Toggle contenttree</source>
-			<target xml:lang="zh-TW" state="needs-translation">Toggle contenttree</target></trans-unit>
-      <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
-				<source>Close Add-Node-Modal</source>
-			<target xml:lang="zh-TW" state="needs-translation">Close Add-Node-Modal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
-				<source>Toggle Drawer</source>
-			<target xml:lang="zh-TW" state="needs-translation">Toggle Drawer</target></trans-unit>
-      <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
-				<source>Toggle EditModePanel</source>
-			<target xml:lang="zh-TW" state="needs-translation">Toggle EditModePanel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
-				<source>Cancel InsertionModeModal</source>
-			<target xml:lang="zh-TW" state="needs-translation">Cancel InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
-				<source>Apply InsertionModeModal</source>
-			<target xml:lang="zh-TW" state="needs-translation">Apply InsertionModeModal</target></trans-unit>
-      <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
-				<source>Reload ContentCanvas</source>
-			<target xml:lang="zh-TW" state="needs-translation">Reload ContentCanvas</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
-				<source>Discard Inspector</source>
-			<target xml:lang="zh-TW" state="needs-translation">Discard Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
-				<source>Escape Inspector</source>
-			<target xml:lang="zh-TW" state="needs-translation">Escape Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
-				<source>Resume Inspector</source>
-			<target xml:lang="zh-TW" state="needs-translation">Resume Inspector</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
-				<source>NodeCreationDialog Back</source>
-			<target xml:lang="zh-TW" state="needs-translation">NodeCreationDialog Back</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
-				<source>NodeCreationDialog Cancel</source>
-			<target xml:lang="zh-TW" state="needs-translation">NodeCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
-				<source>NodeCreationDialog Apply</source>
-			<target xml:lang="zh-TW" state="needs-translation">NodeCreationDialog Apply</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
-				<source>NodeVariantCreationDialog Cancel</source>
-			<target xml:lang="zh-TW" state="needs-translation">NodeVariantCreationDialog Cancel</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create Empty</source>
-			<target xml:lang="zh-TW" state="needs-translation">NodeVariantCreationDialog Create Empty</target></trans-unit>
-      <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
-				<source>NodeVariantCreationDialog Create and Copy</source>
-			<target xml:lang="zh-TW" state="needs-translation">NodeVariantCreationDialog Create and Copy</target></trans-unit>
-      <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
-				<source>Unfocus Node</source>
-			<target xml:lang="zh-TW" state="needs-translation">Unfocus Node</target></trans-unit>
-    </body>
-  </file>
+                </target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.RightSideBar.toggle" xml:space="preserve">
+                <source>Toggle inspector</source>
+                <target xml:lang="zh-TW" state="translated">切換檢測器</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.FullScreen.toggle" xml:space="preserve">
+                <source>Toggle full screen</source>
+                <target xml:lang="zh-TW" state="needs-translation">Toggle full screen</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggle" xml:space="preserve">
+                <source>Toggle left sidebar</source>
+                <target xml:lang="zh-TW" state="needs-translation">Toggle left sidebar</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.LeftSideBar.toggleContentTree" xml:space="preserve">
+                <source>Toggle contenttree</source>
+                <target xml:lang="zh-TW" state="needs-translation">Toggle contenttree</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.AddNodeModal.close" xml:space="preserve">
+                <source>Close Add-Node-Modal</source>
+                <target xml:lang="zh-TW" state="needs-translation">Close Add-Node-Modal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Drawer.toggle" xml:space="preserve">
+                <source>Toggle Drawer</source>
+                <target xml:lang="zh-TW" state="needs-translation">Toggle Drawer</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.EditModePanel.toggle" xml:space="preserve">
+                <source>Toggle EditModePanel</source>
+                <target xml:lang="zh-TW" state="needs-translation">Toggle EditModePanel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.cancel" xml:space="preserve">
+                <source>Cancel InsertionModeModal</source>
+                <target xml:lang="zh-TW" state="needs-translation">Cancel InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.InsertionModeModal.apply" xml:space="preserve">
+                <source>Apply InsertionModeModal</source>
+                <target xml:lang="zh-TW" state="needs-translation">Apply InsertionModeModal</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.ContentCanvas.reload" xml:space="preserve">
+                <source>Reload ContentCanvas</source>
+                <target xml:lang="zh-TW" state="needs-translation">Reload ContentCanvas</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.discard" xml:space="preserve">
+                <source>Discard Inspector</source>
+                <target xml:lang="zh-TW" state="needs-translation">Discard Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.escape" xml:space="preserve">
+                <source>Escape Inspector</source>
+                <target xml:lang="zh-TW" state="needs-translation">Escape Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.Inspector.resume" xml:space="preserve">
+                <source>Resume Inspector</source>
+                <target xml:lang="zh-TW" state="needs-translation">Resume Inspector</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.back" xml:space="preserve">
+                <source>NodeCreationDialog Back</source>
+                <target xml:lang="zh-TW" state="needs-translation">NodeCreationDialog Back</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.cancel" xml:space="preserve">
+                <source>NodeCreationDialog Cancel</source>
+                <target xml:lang="zh-TW" state="needs-translation">NodeCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeCreationDialog.apply" xml:space="preserve">
+                <source>NodeCreationDialog Apply</source>
+                <target xml:lang="zh-TW" state="needs-translation">NodeCreationDialog Apply</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.cancel" xml:space="preserve">
+                <source>NodeVariantCreationDialog Cancel</source>
+                <target xml:lang="zh-TW" state="needs-translation">NodeVariantCreationDialog Cancel</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createEmpty" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create Empty</source>
+                <target xml:lang="zh-TW" state="needs-translation">NodeVariantCreationDialog Create Empty</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__UI.NodeVariantCreationDialog.createAndCopy" xml:space="preserve">
+                <source>NodeVariantCreationDialog Create and Copy</source>
+                <target xml:lang="zh-TW" state="needs-translation">NodeVariantCreationDialog Create and Copy</target>
+            </trans-unit>
+            <trans-unit id="Shortcut__CR.Nodes.unfocus" xml:space="preserve">
+                <source>Unfocus Node</source>
+                <target xml:lang="zh-TW" state="needs-translation">Unfocus Node</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>


### PR DESCRIPTION
The used language IDs were not in sync and therefore it could happen that the ui could not find a language label. Especially when you have used not english or german as backend language. That lead to a JS error for some users.

What we did
Streamline the indentation of the language files and synchronize the existing language labels with the english base language.
Also update the french translation

Fixes: #2819

Supersedes #2850 
