### PR TITLE
TASK: Remove legacy "neos!" route

### DIFF
--- a/Configuration/Routes.yaml
+++ b/Configuration/Routes.yaml
@@ -27,14 +27,3 @@
     'ServiceSubRoutes':
       package: 'Neos.Neos.Ui'
       suffix:  'Service'
-
-##
-# Deprecated fallback for users used to that URI
--
-  name: 'Backend Login New UI Route'
-  uriPattern: 'neos!'
-  defaults:
-    '@package':    'Neos.Neos.Ui'
-    '@controller': 'Backend'
-    '@action':     'index'
-    '@format':     'html'


### PR DESCRIPTION
Removes the deprecated "Backend Login New UI Route" that was added
in order to explicitly switch between "classic" and "new" UI.

Related: #2360