### PR TITLE
BUGFIX: Fix position of guestFrameApplication in Page prototype

### DIFF
--- a/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -47,7 +47,7 @@ prototype(Neos.Neos:Page) {
         }
 
         guestFrameApplication = Neos.Fusion:Template {
-            @position = 'after javascriptDocumentInformation'
+            @position = 'after javascriptBackendInformation'
 
             templatePath = 'resource://Neos.Neos.Ui/Private/Templates/Backend/Guest.html'
             compiledResourcePackage = ${Neos.Ui.StaticResources.compiledResourcePackage()}


### PR DESCRIPTION
The `head.javascriptDocumentInformation` path was renamed to  `...javascriptBackendInformation`
a long time ago (#98) but the `@position` of `head.guestFrameApplication` part was never updated accordingly.

With the current Flow version this led to an exception:
```
The positional string "after javascriptDocumentInformation" (defined for key "guestFrameApplication") references a non-existing key.
```