### PR TITLE
BUGFIX: Allow for rendering of secondary editors in NodeCreationDialog

### DIFF
--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Classes/NodeCreationHandler/ImagePropertyNodeCreationHandler.php
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Classes/NodeCreationHandler/ImagePropertyNodeCreationHandler.php
@@ -1,0 +1,47 @@
+<?php
+namespace Neos\TestNodeTypes\NodeCreationHandler;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Property\PropertyMapper;
+use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Media\Domain\Model\ImageInterface;
+use Neos\Neos\Ui\NodeCreationHandler\NodeCreationHandlerInterface;
+
+class ImagePropertyNodeCreationHandler implements NodeCreationHandlerInterface
+{
+    /**
+     * @Flow\Inject
+     * @var PropertyMapper
+     */
+    protected $propertyMapper;
+
+    /**
+     * Set the node title for the newly created Document node
+     *
+     * @param NodeInterface $node The newly created node
+     * @param array $data incoming data from the creationDialog
+     * @return void
+     */
+    public function handle(NodeInterface $node, array $data)
+    {
+        $propertyMappingConfiguration = $this->propertyMapper->buildPropertyMappingConfiguration();
+        $propertyMappingConfiguration->forProperty('*')->allowAllProperties();
+        $propertyMappingConfiguration->setTypeConverterOption(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED, true);
+
+        if (isset($data['image'])) {
+            $image = $this->propertyMapper->convert($data['image'], ImageInterface::class, $propertyMappingConfiguration);
+            $node->setProperty('image', $image);
+        }
+    }
+}

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Document.PageWithImage.yaml
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/NodeTypes.Document.PageWithImage.yaml
@@ -1,0 +1,72 @@
+'Neos.TestNodeTypes:Document.PageWithImage':
+  superTypes:
+    'Neos.Neos:Document': true
+  options:
+    nodeCreationHandlers:
+      image:
+        nodeCreationHandler: 'Neos\TestNodeTypes\NodeCreationHandler\ImagePropertyNodeCreationHandler'
+  ui:
+    label: PageWithImage_Test
+    icon: icon-file-o
+    position: 100
+    creationDialog:
+      elements:
+        image:
+          type: Neos\Media\Domain\Model\ImageInterface
+          ui:
+            label: Image
+            editor: Neos.Neos/Inspector/Editors/ImageEditor
+            editorOptions:
+              fileUploadLabel: Neos.Neos:Main:choose
+              maximumFileSize:
+              features:
+                crop: true
+                upload: true
+                mediaBrowser: true
+                resize: false
+              crop:
+                aspectRatio:
+                  options:
+                    square:
+                      width: 1
+                      height: 1
+                      label: Square
+                    fourFive:
+                      width: 4
+                      height: 5
+                    fiveSeven:
+                      width: 5
+                      height: 7
+                    twoThree:
+                      width: 2
+                      height: 3
+                    fourThree:
+                      width: 4
+                      height: 3
+                    sixteenNine:
+                      width: 16
+                      height: 9
+                  enableOriginal: true
+                  allowCustom: true
+                  locked:
+                    width: 1
+                    height: 1
+  childNodes:
+    main:
+      type: 'Neos.Neos:ContentCollection'
+  properties:
+    image:
+      type: Neos\Media\Domain\Model\ImageInterface
+      ui:
+        label: 'Image'
+        reloadIfChanged: true
+        inspector:
+          group: 'document'
+          editorOptions:
+            features:
+              crop: true
+            crop:
+              aspectRatio:
+                locked:
+                  width: 1
+                  height: 1

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Resources/Private/Fusion/Document/PageWithImage/PageWithImage.fusion
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Resources/Private/Fusion/Document/PageWithImage/PageWithImage.fusion
@@ -1,0 +1,26 @@
+prototype(Neos.TestNodeTypes:Document.PageWithImage)>
+prototype(Neos.TestNodeTypes:Document.PageWithImage) < prototype(Neos.Neos:Page) {
+    body = Neos.Neos:ContentComponent {
+        titleEditable = Neos.Neos:Editable {
+            property = 'title'
+        }
+        main = Neos.Neos:ContentCollection {
+            nodePath = 'main'
+        }
+        nav = Neos.TestNodeTypes:Navigation
+        imageUri = Neos.Neos:ImageUri {
+            asset = ${node.properties.image}
+            maximumHeight = 100
+        }
+        rte = ${node.properties.rte}
+        renderer = afx`
+            {props.nav}
+            <img class="test-page-image" src={props.imageUri} @if.image={node.properties.image}/>
+            <div class="test-page-rte">{props.rte}</div>
+            <h1>{props.titleEditable}</h1>
+            <main class="main">
+                {props.main}
+            </main>
+        `
+    }
+}

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/composer.json
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/composer.json
@@ -10,5 +10,10 @@
         "neos": {
             "package-key": "Neos.TestNodeTypes"
         }
+    },
+    "autoload": {
+      "psr-4": {
+        "Neos\\TestNodeTypes\\": "Classes"
+      }
     }
 }

--- a/Tests/IntegrationTests/e2e.sh
+++ b/Tests/IntegrationTests/e2e.sh
@@ -20,6 +20,7 @@ for fixture in Packages/Application/Neos.Neos.Ui/Tests/IntegrationTests/Fixtures
     ln -s "../${fixture}SitePackage" DistributionPackages/Neos.TestSite
 
     # TODO: optimize this
+    ./flow flow:package:rescan
     ./flow flow:cache:flush
     #./flow flow:cache:flushone Neos_Neos_Fusion
     #./flow flow:cache:flushone Neos_Fusion_Content

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -33,6 +33,7 @@ export default class EditorEnvelope extends PureComponent {
         label: PropTypes.string.isRequired,
         options: PropTypes.object,
         value: PropTypes.any,
+        hooks: PropTypes.object,
         renderSecondaryInspector: PropTypes.func,
         editor: PropTypes.string.isRequired,
         editorRegistry: PropTypes.object.isRequired,

--- a/packages/neos-ui-redux-store/src/UI/NodeCreationDialog/index.ts
+++ b/packages/neos-ui-redux-store/src/UI/NodeCreationDialog/index.ts
@@ -25,10 +25,24 @@ export enum actionTypes {
     APPLY = '@neos/neos-ui/UI/NodeCreationDialog/APPLY'
 }
 
+type Value = any;
+type SaveHookIdentifier = string;
+type SaveHookOptions = any;
+type SaveHooksMap = {
+    [saveHookIdentifier in SaveHookIdentifier]: SaveHookOptions
+};
+interface TransientValue {
+    value: Value;
+    hooks?: SaveHooksMap;
+}
+interface TransientValuesMap {
+    [elementName: string]: TransientValue;
+}
+
 const open = (label: string, configuration: {}) => createAction(actionTypes.OPEN, {label, configuration});
 const back = () => createAction(actionTypes.BACK);
 const cancel = () => createAction(actionTypes.CANCEL);
-const apply = (data: {}) => createAction(actionTypes.APPLY, data);
+const apply = (transientValues: TransientValuesMap) => createAction(actionTypes.APPLY, transientValues);
 
 //
 // Export the actions

--- a/packages/neos-ui-sagas/src/Changes/saveHooks.spec.ts
+++ b/packages/neos-ui-sagas/src/Changes/saveHooks.spec.ts
@@ -1,0 +1,137 @@
+import {
+    applySaveHooksForTransientValue,
+    applySaveHooksForTransientValuesMap
+} from './saveHooks';
+
+test('applySaveHooksForTransientValue does nothing if a given transient value has no specified saveHooks', () => {
+    const transientValue = {value: 1};
+    const saveHooksRegistry = {get: jest.fn()};
+
+    const process = applySaveHooksForTransientValue(transientValue, saveHooksRegistry);
+
+    const { value, done } = process.next();
+
+    expect(done).toBe(true);
+    expect(value).toBe(1);
+});
+
+test('applySaveHooksForTransientValue applies registered save hooks to a given transient value', () => {
+    const transientValue = {
+        value: 1,
+        hooks: {
+            'AddNumber': {
+                number: 2
+            },
+            'SubtractNumber': {
+                number: 1
+            }
+        }
+    };
+    const addNumberHook = jest.fn();
+    const subtractNumberHook = jest.fn();
+    const saveHooksRegistry = {
+        get: jest.fn((id: string) => id === 'AddNumber' ? addNumberHook : subtractNumberHook)
+    };
+
+    const process = applySaveHooksForTransientValue(transientValue, saveHooksRegistry);
+
+    process.next();
+
+    expect(saveHooksRegistry.get).toBeCalledWith('AddNumber');
+    expect(addNumberHook).toBeCalledWith(1, { number: 2 });
+
+    process.next(3);
+
+    expect(saveHooksRegistry.get).toBeCalledWith('SubtractNumber');
+    expect(subtractNumberHook).toBeCalledWith(3, { number: 1 });
+
+    const { value, done } = process.next(2);
+
+    expect(done).toBe(true);
+    expect(value).toBe(2);
+});
+
+test('applySaveHooksForTransientValue will throw an error if a specified saveHook cannot be found', () => {
+    const transientValue = {
+        value: 1,
+        hooks: {
+            'AddNumber': {
+                number: 2
+            }
+        }
+    };
+    const saveHooksRegistry = {
+        get: jest.fn()
+    };
+
+    const process = applySaveHooksForTransientValue(transientValue, saveHooksRegistry);
+
+    expect(() => process.next()).toThrow();
+    expect(saveHooksRegistry.get).toBeCalledWith('AddNumber');
+});
+
+test('applySaveHooksForTransientValue will throw an error if a specified saveHook throws an error', () => {
+    const transientValue = {
+        value: 1,
+        hooks: {
+            'AddNumber': {
+                number: 2
+            }
+        }
+    };
+    const saveHooksRegistry = {
+        get: jest.fn(() => () => { throw new Error(); })
+    };
+
+    const process = applySaveHooksForTransientValue(transientValue, saveHooksRegistry);
+
+    expect(() => process.next()).toThrow();
+    expect(saveHooksRegistry.get).toBeCalledWith('AddNumber');
+});
+
+test('applySaveHooksForTransientValuesMap applies registered save hooks to multiple transient values', () => {
+    const transientValuesMap = {
+        width: {
+            value: 100,
+            hooks: {
+                'Multiply': {
+                    by: 10
+                }
+            }
+        },
+        height: {
+            value: 100,
+            hooks: {
+                'Multiply': {
+                    by: 5
+                }
+            }
+        }
+    };
+    const multiplyHook = jest.fn();
+    const saveHooksRegistry = {
+        get: jest.fn(() => multiplyHook)
+    };
+    const process = applySaveHooksForTransientValuesMap(
+        transientValuesMap,
+        saveHooksRegistry
+    );
+
+    process.next();
+
+    expect(saveHooksRegistry.get).toBeCalledWith('Multiply');
+    expect(multiplyHook).toBeCalledWith(100, { by: 10 });
+
+    process.next(1000);
+
+    expect(saveHooksRegistry.get).toBeCalledWith('Multiply');
+    expect(multiplyHook).toBeCalledWith(100, { by: 5 });
+
+    const { value, done } = process.next(500);
+
+    expect(done).toBe(true);
+    expect(value).toEqual({
+        width: 1000,
+        height: 500
+    });
+});

--- a/packages/neos-ui-sagas/src/Changes/saveHooks.ts
+++ b/packages/neos-ui-sagas/src/Changes/saveHooks.ts
@@ -1,0 +1,67 @@
+type Value = any;
+type SaveHookIdentifier = string;
+type SaveHookOptions = any;
+type SaveHooksMap = {
+    [key in SaveHookIdentifier]: SaveHookOptions
+};
+type SaveHookFunction = (value: Value, saveHookOptions: SaveHookOptions) => Promise<Value>;
+interface SaveHooksRegistry {
+    get: (saveHookIdentifier: SaveHookIdentifier) => SaveHookFunction | undefined;
+}
+interface TransientValue {
+    value: Value;
+    hooks?: SaveHooksMap;
+}
+interface TransientValuesMap {
+    [elementName: string]: TransientValue;
+}
+interface ValuesMap {
+    [elementName: string]: Value;
+}
+
+export function * applySaveHooksForTransientValue(
+    transientValue: TransientValue,
+    saveHooksRegistry: SaveHooksRegistry
+): Generator<Promise<any>, Value, Value> {
+    let value: Value = transientValue.value;
+
+    if (transientValue.hooks) {
+        for (const [saveHookIdentifier, saveHookOptions] of Object.entries(transientValue.hooks)) {
+            const hookFn = saveHooksRegistry.get(saveHookIdentifier);
+
+            if (hookFn) {
+                try {
+                    value = (yield hookFn(value, saveHookOptions)) as Value;
+                } catch (e) {
+                    console.error(`There was an error executing ${saveHookIdentifier}`, e);
+                    throw e;
+                }
+            } else {
+                const message = `There is no registered save hook function for identifier ${saveHookIdentifier}`;
+
+                console.error(message);
+                throw new Error(message);
+            }
+        }
+    }
+
+    return value;
+}
+
+export function * applySaveHooksForTransientValuesMap(
+    transientValues: TransientValuesMap | undefined,
+    saveHooksRegistry: SaveHooksRegistry
+): Generator<Promise<any>, ValuesMap, Value> {
+    const result: ValuesMap = {};
+
+    if (transientValues) {
+        for (const [elementName, transientValue] of Object.entries(transientValues)) {
+            result[elementName] = yield* applySaveHooksForTransientValue(
+                transientValue,
+                saveHooksRegistry
+            );
+        }
+    }
+
+    return result;
+}

--- a/packages/neos-ui-sagas/src/UI/Inspector/index.js
+++ b/packages/neos-ui-sagas/src/UI/Inspector/index.js
@@ -5,6 +5,8 @@ import {findNodeInGuestFrame} from '@neos-project/neos-ui-guest-frame/src/dom';
 
 import {actionTypes, actions, selectors} from '@neos-project/neos-ui-redux-store';
 
+import {applySaveHooksForTransientValue} from '../../Changes/saveHooks';
+
 const getFocusedNode = selectors.CR.Nodes.focusedSelector;
 const getTransientInspectorValues = state => {
     const values = $get(['ui', 'inspector', 'valuesByNodePath'], state);
@@ -94,6 +96,7 @@ function * flushInspector(inspectorRegistry) {
     //
     // Accumulate changes to be persisted
     //
+    const saveHooksRegistry = inspectorRegistry.get('saveHooks');
     const changes = [];
 
     for (const propertyName of Object.keys(transientInspectorValuesForFocusedNodes)) {
@@ -101,23 +104,7 @@ function * flushInspector(inspectorRegistry) {
 
         //
         // Try to run all hooks on the transient value
-        const initialValue = Promise.resolve(transientValue.value);
-        const value = yield transientValue.hooks ?
-            Object.keys(transientValue.hooks).reduce(
-                (valueAsPromise, hookIdentifier) => {
-                    const hookFn = inspectorRegistry.get('saveHooks').get(hookIdentifier);
-
-                    return valueAsPromise.then(value => {
-                        try {
-                            return hookFn(value, transientValue.hooks[hookIdentifier]);
-                        } catch (e) {
-                            console.error(`There was an error executing ${hookIdentifier}`, e);
-                            throw e;
-                        }
-                    });
-                },
-                initialValue
-            ) : initialValue;
+        const value = yield * applySaveHooksForTransientValue(transientValue, saveHooksRegistry);
 
         //
         // Build a property change object

--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/style.css
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/style.css
@@ -1,5 +1,45 @@
 .body {
+    display: flex;
+    height: calc(65vh);
+}
+.primaryColumn {
+    overflow-y: auto;
+    width: 100%;
+    transition: var(--transition-Default) ease width;
     padding: var(--spacing-Full);
+    flex-grow: 0;
+    flex-shrink: 0;
+
+    .expanded & {
+        width: calc(var(--size-SidebarWidth) + 2 * var(--spacing-Full));
+    }
+}
+.secondaryColumn {
+    width: 0;
+    opacity: 0;
+    transition: var(--transition-Default) ease width,
+        var(--transition-Default) ease opacity;
+
+    .expanded & {
+        width: 100%;
+        opacity: 1;
+    }
+}
+.secondaryColumn__contentWrapper {
+    position: relative;
+    height: 100%;
+    padding: var(--spacing-Full);
+    margin-left: var(--spacing-Full);
+    width: calc(100% - var(--spacing-Full));
+    overflow: hidden;
+    box-shadow: inset 0 0 2px #000;
+    background-color: rgba(0, 0, 0, .1);
+}
+.close {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 1;
 }
 .editor {
     margin-bottom: var(--spacing-Full);

--- a/packages/react-ui-components/src/Dialog/__snapshots__/dialog.spec.tsx.snap
+++ b/packages/react-ui-components/src/Dialog/__snapshots__/dialog.spec.tsx.snap
@@ -62,6 +62,7 @@ exports[`<Dialog/> Portal should render correctly. 1`] = `
           Object {
             "dialog": "dialogClassName",
             "dialog--error": "errorClassName",
+            "dialog--jumbo": "jumboClassName",
             "dialog--narrow": "narrowClassName",
             "dialog--success": "successClassName",
             "dialog--warn": "warnClassName",

--- a/packages/react-ui-components/src/Dialog/dialog.spec.tsx
+++ b/packages/react-ui-components/src/Dialog/dialog.spec.tsx
@@ -18,6 +18,7 @@ describe('<Dialog/>', () => {
             'dialog': 'dialogClassName',
             'dialog--narrow': 'narrowClassName',
             'dialog--wide': 'wideClassName',
+            'dialog--jumbo': 'jumboClassName',
             'dialog--success': 'successClassName',
             'dialog--warn': 'warnClassName',
             'dialog--error': 'errorClassName',
@@ -49,6 +50,14 @@ describe('<Dialog/>', () => {
         const section = portal.find('section');
 
         expect(section.prop('className')).toContain('wideClassName');
+    });
+
+    it('should render the "dialog--jumbo" className from the "theme" prop if the style is jumbo.', () => {
+        const wrapper = shallow(<DialogWithEscape {...props} style="jumbo"/>);
+        const portal = wrapper.find(Portal);
+        const section = portal.find('section');
+
+        expect(section.prop('className')).toContain('jumboClassName');
     });
 
     it('should render the "dialog--narrow" className from the "theme" prop if the style is narrow.', () => {

--- a/packages/react-ui-components/src/Dialog/dialog.tsx
+++ b/packages/react-ui-components/src/Dialog/dialog.tsx
@@ -5,7 +5,7 @@ import CloseOnEscape from 'react-close-on-escape';
 import {Portal} from 'react-portal';
 
 type DialogType = 'success' | 'warn' | 'error';
-type DialogStyle = 'wide' | 'narrow';
+type DialogStyle = 'wide' | 'jumbo' | 'narrow';
 
 interface DialogTheme {
     readonly 'dialog': string;
@@ -16,6 +16,7 @@ interface DialogTheme {
     readonly 'dialog__closeBtn': string;
     readonly 'dialog__actions': string;
     readonly 'dialog--wide': string;
+    readonly 'dialog--jumbo': string;
     readonly 'dialog--narrow': string;
     readonly 'dialog--success': string;
     readonly 'dialog--warn': string;
@@ -179,6 +180,7 @@ class DialogWithEscape extends PureComponent<DialogProps> {
             theme.dialog,
             {
                 [theme['dialog--wide']]: style === 'wide',
+                [theme['dialog--jumbo']]: style === 'jumbo',
                 [theme['dialog--narrow']]: style === 'narrow',
             },
             {

--- a/packages/react-ui-components/src/Dialog/style.css
+++ b/packages/react-ui-components/src/Dialog/style.css
@@ -34,9 +34,20 @@
     width: calc(100vw - var(--spacing-GoldenUnit) * 2);
     max-width: calc(var(--spacing-GoldenUnit) * 16);
     border: 2px solid var(--colors-ContrastDark);
+    transition: var(--transition-Default) ease max-width;
 
     .dialog--wide & {
         max-width: calc(var(--spacing-GoldenUnit) * 24);
+
+        @media(max-width: 576px) {
+            max-width: 100vw;
+            width: 100vw;
+        }
+    }
+
+    .dialog--jumbo & {
+        max-width: calc(var(--spacing-GoldenUnit) * 36);
+        width: 90vw;
 
         @media(max-width: 576px) {
             max-width: 100vw;


### PR DESCRIPTION
Hi there,

this PR is an attempt to finally allow secondary editors (like the media selection screen or the image cropper) to be used in the NodeCreationDialog.

The result looks like this:

https://user-images.githubusercontent.com/2522299/104287035-2a932700-54b6-11eb-9ce2-45f8724339f6.mp4

_**EDIT**: Updated video to better reflect the latest style changes._



## What has been done?

- SaveHook-Logic was extracted from the inspector saga and put into "Changes" scope, so it could be shared between inspector and node creation dialog
- General overhaul of NodeCreationDialog to achieve support for SaveHooks and SecondaryInspector
- Additional "jumbo" style for Dialog component was added
- An `ImagePropertyNodeCreationHandler` was added to the Integration Test distribution to decouple this change from an additional change that needs to be done in Neos.Neos in order to support `showInCreationDialog`

## Addional Notes

- Some of the e2e-Tests cover some of the NodeCreationDialog already. A more thorough Test suite would probably exceed the scope of this PR, so I'll leave it at that. If, however, anyone discovers problems with the NodeCreationDialog during manual testing, I'm going to add an e2e-Test for that specific scenario in this PR.
- In order for this change to really make sense, the following PR for `Neos.Neos` needs to be merged as well: https://github.com/neos/neos-development-collection/pull/3270
  - That change re-enables all editors for the NodeCreationDialog

fixes  #1034