### PR TITLE
BUGFIX: Render correct JSON when a module is hidden

### DIFF
--- a/Resources/Private/Fusion/Backend/Component/ModuleMenu.fusion
+++ b/Resources/Private/Fusion/Backend/Component/ModuleMenu.fusion
@@ -49,12 +49,12 @@ prototype(Neos.Neos.Ui:Component.ModuleMenu) < prototype(Neos.Fusion:Map) {
                         target = 'Window'
                     }
 
-                    @process.filterHiddenSubmodules = ${Array.filter(value, (x, index) => x != null)}
+                    @process.filterHiddenSubmodules = ${Array.values(Array.filter(value, (x, index) => x != null))}
                 }
             }
         }
     }
 
-    @process.filterHiddenModules = ${Array.filter(value, (x, index) => x != null)}
+    @process.filterHiddenModules = ${Array.values(Array.filter(value, (x, index) => x != null))}
     @process.json = ${Json.stringify(value)}
 }


### PR DESCRIPTION
Fixes: https://github.com/neos/neos-development-collection/issues/3287

Needs the `Array.values()` Eel helper introduced with latest Neos 7.0 bugfix.