### PR TITLE
BUGFIX: SearchOperation must use the NodeSearchServiceInterface

### DIFF
--- a/Classes/FlowQueryOperations/SearchOperation.php
+++ b/Classes/FlowQueryOperations/SearchOperation.php
@@ -18,7 +18,7 @@ use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Eel\FlowQuery\Operations\AbstractOperation;
 use Neos\Flow\Annotations as Flow;
-use Neos\Neos\Domain\Service\NodeSearchService;
+use Neos\Neos\Domain\Service\NodeSearchServiceInterface;
 
 /**
  */
@@ -26,7 +26,7 @@ class SearchOperation extends AbstractOperation
 {
     /**
      * @Flow\Inject
-     * @var NodeSearchService
+     * @var NodeSearchServiceInterface
      */
     protected $nodeSearchService;
 


### PR DESCRIPTION
Thanks to @dfeyer for creating the PR #2876
I was not able to change the PR so I created this one based on the 4.0 branch with @dfeyer commit.

Thanks for this bugfix ❤️ 