### PR TITLE
TASK: Add CACHE_VERSION parameter to CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,34 +3,34 @@ version: 2.0
 aliases:
   - &workspace_root ~/neos-ui-workspace
   - &store_yarn_package_cache
-    key: yarn-cache-v1-{{ checksum "yarn.lock" }}
+    key: yarn-cache-v{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
     paths:
       - ~/.cache/yarn
 
   - &restore_yarn_package_cache
     keys:
-      - yarn-cache-v1-{{ checksum "yarn.lock" }}
+      - yarn-cache-v{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
 
   - &store_app_cache
-    key: full-app-cache-v1-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}-{{ checksum "Tests/IntegrationTests/TestDistribution/Configuration/Settings.yaml" }}
+    key: full-app-cache-v{{ .Environment.CACHE_VERSION }}-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}-{{ checksum "Tests/IntegrationTests/TestDistribution/Configuration/Settings.yaml" }}
     paths:
       - /home/circleci/app
 
   - &restore_app_cache
     keys:
-      - full-app-cache-v1-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}-{{ checksum "Tests/IntegrationTests/TestDistribution/Configuration/Settings.yaml" }}
-      - full-app-cache-v1-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}-
-      - full-app-cache-v1-
+      - full-app-cache-v{{ .Environment.CACHE_VERSION }}-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}-{{ checksum "Tests/IntegrationTests/TestDistribution/Configuration/Settings.yaml" }}
+      - full-app-cache-v{{ .Environment.CACHE_VERSION }}-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}-
+      - full-app-cache-v{{ .Environment.CACHE_VERSION }}-
 
   - &save_composer_cache
-    key: composer-cache-v1-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}
+    key: composer-cache-v{{ .Environment.CACHE_VERSION }}-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}
     paths:
       - /composer/cache-dir
 
   - &restore_composer_cache
     keys:
-      - composer-cache-v1-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}
-      - composer-cache-v1-
+      - composer-cache-v{{ .Environment.CACHE_VERSION }}-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}
+      - composer-cache-v{{ .Environment.CACHE_VERSION }}-
 
   - &attach_workspace
     at: *workspace_root


### PR DESCRIPTION
Sometimes it is helpful to be able to flush the circle ci caches manually instead of changing something in the composer.json.
So we add the CACHE_VERSION parameter in the cache identifier and this can be defined in the CircleCI environment settings.
