### PR TITLE
BUGFIX: enable "disabled"-property for DataSourceBasedSelectBoxEditor

### DIFF
--- a/packages/neos-ui-editors/src/Editors/SelectBox/DataSourceBasedSelectBoxEditor.js
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/DataSourceBasedSelectBoxEditor.js
@@ -34,6 +34,7 @@ export default class DataSourceBasedSelectBoxEditor extends PureComponent {
         options: PropTypes.shape({
             allowEmpty: PropTypes.bool,
             placeholder: PropTypes.string,
+            disabled: PropTypes.bool,
 
             multiple: PropTypes.bool,
 
@@ -66,7 +67,8 @@ export default class DataSourceBasedSelectBoxEditor extends PureComponent {
     static defaultOptions = {
         // Use "5" as minimum result for search default; same as with old UI
         minimumResultsForSearch: 5,
-        threshold: 0
+        threshold: 0,
+        disabled: false
     };
 
     state = {
@@ -123,6 +125,7 @@ export default class DataSourceBasedSelectBoxEditor extends PureComponent {
                 noMatchesFoundLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}
                 searchBoxLeftToTypeLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
                 threshold={options.threshold}
+                disabled={options.disabled}
                 />);
         }
 
@@ -141,6 +144,7 @@ export default class DataSourceBasedSelectBoxEditor extends PureComponent {
             noMatchesFoundLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}
             searchBoxLeftToTypeLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
             threshold={options.threshold}
+            disabled={options.disabled}
             />);
     }
 


### PR DESCRIPTION
**What I did**
The SelectBoxEditor in the Backend can be disabled as documented in https://neos.readthedocs.io/en/stable/References/PropertyEditorReference.html#property-type-string-array-string-selectboxeditor-dropdown-select-editor 
This does not work if the SelectBox has a datasource configured, but it would be helpful in a specific case:
We want to show a required selectBox in the node creation dialog that gets it's data from a dataSource. This property should not be editable in the inspector afterwards, but we still want to show the selected Option so the editor knows what was selected during node creation. (We can not use a disabled input field, because it would show the selected value and not the selected label)

**How I did it**
I added the disabled property in the DataSourceBasedSelectBoxEditor.js equivalent to the SimpleSelectBoxEditor.js

**How to verify it**
Add a disabled SelectBoxEditor with a dataSource e.g.:
```
    myProperty:
      type: string
      ui:
        inspector:
          editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
          editorOptions:
            disabled: true
            dataSourceIdentifier: 'my-data-source'
```
With the current code it should not be disabled in the inspector – with my changes it is.
