### PR TITLE
BUGFIX: Ensure that auto-created child nodes cannot be hidden via the inspector

### DIFF
--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/InspectorEditorEnvelope/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/InspectorEditorEnvelope/index.js
@@ -38,6 +38,16 @@ export default class InspectorEditorEnvelope extends PureComponent {
         commit: PropTypes.func.isRequired
     };
 
+    get options() {
+        // This makes sure that auto-created child nodes cannot be hidden
+        // via the insprector (see: #2282)
+        if ($get('isAutoCreated', this.props.node) === true && this.props.id === '_hidden') {
+            return {...this.props.options, disabled: true};
+        }
+
+        return this.props.options;
+    }
+
     commit = (value, hooks = null) => {
         const {transientValueRaw, id, commit} = this.props;
 
@@ -63,6 +73,7 @@ export default class InspectorEditorEnvelope extends PureComponent {
             <div className={style.wrap}>
                 <EditorEnvelope
                     {...otherProps}
+                    options={this.options}
                     highlight={transientValue && transientValue.value !== sourceValue}
                     identifier={id}
                     value={transientValue ? transientValue.value : sourceValue}

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -228,6 +228,12 @@ export default class Inspector extends PureComponent {
             return true;
         }
 
+        if ($get('isAutoCreated', focusedNode) === true && item.id === '_hidden') {
+            // This accounts for the fact that auto-created child nodes cannot
+            // be hidden via the insprector (see: #2282)
+            return false;
+        }
+
         return $get(['policy', 'canEdit'], focusedNode) && !$contains(item.id, 'policy.disallowedProperties', focusedNode);
     };
 


### PR DESCRIPTION
Hello there,

this is a small fix to prevent auto-created child nodes from being hidden via the inspector and thus make that prevention consistent with the node tree toolbars.

**What I did**

I added an explicit check to the `InspectorEditorEnvelope` to see, whether we're currently looking at an auto-created child node and whether we're currently rendering the editor for the `_hidden` property. If so, the editor will be initialized with the option `disabled` set invariably to `true`.

That condition is also considered in the `isPropertyEnabled` method of the `Inspector` component (though I'm not sure about whether that makes sense).

**How to verify it**

Add this NodeType configuration to your setup:

```yaml
'Neos.Neos:ContentCollection':
  superTypes:
    'Neos.Neos:Hidable': true
```
And then check, whether the default page main content collection can still be hidden via the inspector.

solves: #2282