### PR TITLE
BUGFIX: Remove width restriction from editor labels

### DIFF
--- a/packages/react-ui-components/src/Label/style.css
+++ b/packages/react-ui-components/src/Label/style.css
@@ -4,11 +4,15 @@
     -webkit-font-smoothing: antialiased;
     font-size: var(--fontSize-Base);
     cursor: pointer;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    max-width: 288px;
     padding: 0;
     margin-bottom: 4px;
     user-select: none;
+
+    &,
+    span {
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        max-width: 100%;
+    }
 }


### PR DESCRIPTION
Hi there,

this PR removes the width restriction from editor labels and also applies `text-overflow: ellipsis;` to the `<span>` tags that are usually rendered as their children. This allows for longer labels in the node creation dialog.

solves: #2889