### PR TITLE
BUGFIX: Always try to re-render content by re-evaluating its closest ContentCase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,26 @@ jobs:
       - store_artifacts:
           path: /home/circleci/app/Data/Logs
 
+  php-unittests:
+    environment:
+      FLOW_CONTEXT: Production
+    docker:
+      - image: quay.io/yeebase/ci-build:7.2
+      - image: circleci/mariadb:10.2
+        environment:
+          MYSQL_DATABASE: neos
+          MYSQL_ROOT_PASSWORD: not_a_real_password
+    working_directory: *workspace_root
+    steps:
+      - attach_workspace: *attach_workspace
+      - restore_cache: *restore_app_cache
+
+      - run: rm -rf /home/circleci/app/Packages/Application/Neos.Neos.Ui
+      - run: cd /home/circleci/app/Packages/Application && mv ~/neos-ui-workspace Neos.Neos.Ui
+      - run: |
+          cd /home/circleci/app/
+          bin/phpunit -c Build/BuildEssentials/PhpUnit/UnitTests.xml Packages/Application/Neos.Neos.Ui/Tests/Unit
+
 workflows:
   version: 2
   build_and_test:
@@ -157,5 +177,8 @@ workflows:
           requires:
             - checkout
       - e2e:
+          requires:
+            - build_flow_app
+      - php-unittests:
           requires:
             - build_flow_app

--- a/Classes/Domain/Model/Feedback/Operations/ReloadContentOutOfBand.php
+++ b/Classes/Domain/Model/Feedback/Operations/ReloadContentOutOfBand.php
@@ -161,7 +161,7 @@ class ReloadContentOutOfBand extends AbstractFeedback
         $fusionView->setControllerContext($controllerContext);
 
         $fusionView->assign('value', $this->getNode());
-        $fusionView->setFusionPath($nodeDomAddress->getFusionPath());
+        $fusionView->setFusionPath($nodeDomAddress->getFusionPathForContentRendering());
 
         return $fusionView->render();
     }

--- a/Classes/Domain/Model/RenderedNodeDomAddress.php
+++ b/Classes/Domain/Model/RenderedNodeDomAddress.php
@@ -80,7 +80,7 @@ class RenderedNodeDomAddress implements \JsonSerializable
      *
      * @return string
      */
-    public function getFusionPathForContentRendering()
+    public function getFusionPathForContentRendering(): string
     {
         $fusionPathForContentRendering = $this->getFusionPath();
         $fusionPathForContentRendering = preg_replace(

--- a/Classes/Domain/Model/RenderedNodeDomAddress.php
+++ b/Classes/Domain/Model/RenderedNodeDomAddress.php
@@ -84,7 +84,7 @@ class RenderedNodeDomAddress implements \JsonSerializable
     {
         $fusionPathForContentRendering = $this->getFusionPath();
         $fusionPathForContentRendering = preg_replace(
-            '/(\/itemRenderer\<Neos\.\Neos\:ContentCase\>)\/default\<Neos\.Fusion\:Matcher\>\/element(\<.*\>)$/',
+            '/(\/itemRenderer<Neos\.Neos:ContentCase>)\/default<Neos\.Fusion:Matcher>\/element(<[^>]+>)$/',
             '$1',
             $fusionPathForContentRendering
         );

--- a/Classes/Domain/Model/RenderedNodeDomAddress.php
+++ b/Classes/Domain/Model/RenderedNodeDomAddress.php
@@ -73,6 +73,26 @@ class RenderedNodeDomAddress implements \JsonSerializable
     }
 
     /**
+     * Get the fusion path that should be used for rendering the addressed
+     * content. For most contents that would be the closest `Neos.Neos:ContentCase`
+     * within the path rather than the actual prototype that was used to
+     * render the content.
+     *
+     * @return string
+     */
+    public function getFusionPathForContentRendering()
+    {
+        $fusionPathForContentRendering = $this->getFusionPath();
+        $fusionPathForContentRendering = preg_replace(
+            '/(\/itemRenderer\<Neos\.\Neos\:ContentCase\>)\/default\<Neos\.Fusion\:Matcher\>\/element(\<.*\>)$/',
+            '$1',
+            $fusionPathForContentRendering
+        );
+
+        return $fusionPathForContentRendering;
+    }
+
+    /**
      * Serialize to json
      *
      * @return array

--- a/Tests/IntegrationTests/TestDistribution/composer.json
+++ b/Tests/IntegrationTests/TestDistribution/composer.json
@@ -12,6 +12,11 @@
       "neos/test-site": "@dev",
       "neos/test-nodetypes": "@dev"
     },
+    "require-dev": {
+      "neos/buildessentials": "@dev",
+      "mikey179/vfsstream": "^1.6",
+      "phpunit/phpunit": "^8.1"
+    },
     "repositories": {
         "distribution": {
             "type": "path",

--- a/Tests/Unit/Domain/Model/RenderedNodeDomAddressTest.php
+++ b/Tests/Unit/Domain/Model/RenderedNodeDomAddressTest.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Neos\Ui\Tests\Unit\Domain\Model;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Tests\UnitTestCase;
+use Neos\Neos\Ui\Domain\Model\RenderedNodeDomAddress;
+
+final class RenderedNodeDomAddressTest extends UnitTestCase
+{
+    /**
+     * @param string $contextPath
+     * @param string $fusionPath
+     * @return RenderedNodeDomAddress
+     */
+    private function createRenderedNodeDomAddress(string $contextPath, string $fusionPath): RenderedNodeDomAddress
+    {
+        $renderedNodeDomAddress = new RenderedNodeDomAddress();
+        $renderedNodeDomAddress->setContextPath($contextPath);
+        $renderedNodeDomAddress->setFusionPath($fusionPath);
+
+        return $renderedNodeDomAddress;
+    }
+
+    /**
+     * @return array
+     */
+    public function fusionPathsForRenderingProvider(): array
+    {
+        return [
+            '(Simple) Content Element via first-level ContentCase' => [
+                '/itemRenderer<Neos.Neos:ContentCase>/default<Neos.Fusion:Matcher>/element<Vendor.Site:Content.2767.Reproduction.TwoColumn>',
+                '/itemRenderer<Neos.Neos:ContentCase>'
+            ],
+            '(Simple) Content Element via second-level ContentCase' => [
+                '/itemRenderer<Neos.Neos:ContentCase>/default<Neos.Fusion:Matcher>/element<First>/itemRenderer<Neos.Neos:ContentCase>/default<Neos.Fusion:Matcher>/element<Second>',
+                '/itemRenderer<Neos.Neos:ContentCase>/default<Neos.Fusion:Matcher>/element<First>/itemRenderer<Neos.Neos:ContentCase>'
+            ],
+            '(Full) Content Element via first-level ContentCase' => [
+                'root<Neos.Fusion:Case>/documentType<Neos.Fusion:Matcher>/element<Vendor.Site:Document.HomePage>/renderer<Vendor.Site:Document.Base>/body<Vendor.Site:Component.Template.Page>/content<Neos.Neos:ContentCollection>/content<Neos.Neos:ContentCollectionRenderer>/itemRenderer<Neos.Neos:ContentCase>/default<Neos.Fusion:Matcher>/element<Vendor.Site:Content.2767.Reproduction.FourColumn>',
+                'root<Neos.Fusion:Case>/documentType<Neos.Fusion:Matcher>/element<Vendor.Site:Document.HomePage>/renderer<Vendor.Site:Document.Base>/body<Vendor.Site:Component.Template.Page>/content<Neos.Neos:ContentCollection>/content<Neos.Neos:ContentCollectionRenderer>/itemRenderer<Neos.Neos:ContentCase>'
+            ],
+            '(Full) Content Element via second-level ContentCase' => [
+                'root<Neos.Fusion:Case>/documentType<Neos.Fusion:Matcher>/element<Vendor.Site:Document.HomePage>/renderer<Vendor.Site:Document.Base>/body<Vendor.Site:Component.Template.Page>/content<Neos.Neos:ContentCollection>/content<Neos.Neos:ContentCollectionRenderer>/itemRenderer<Neos.Neos:ContentCase>/default<Neos.Fusion:Matcher>/element<Vendor.Site:Content.2767.Reproduction.TwoColumn>/column0<Neos.Neos:ContentCollection>/content<Neos.Neos:ContentCollectionRenderer>/itemRenderer<Neos.Neos:ContentCase>/default<Neos.Fusion:Matcher>/element<Vendor.Site:Content.2767.Reproduction.TwoColumn>',
+                'root<Neos.Fusion:Case>/documentType<Neos.Fusion:Matcher>/element<Vendor.Site:Document.HomePage>/renderer<Vendor.Site:Document.Base>/body<Vendor.Site:Component.Template.Page>/content<Neos.Neos:ContentCollection>/content<Neos.Neos:ContentCollectionRenderer>/itemRenderer<Neos.Neos:ContentCase>/default<Neos.Fusion:Matcher>/element<Vendor.Site:Content.2767.Reproduction.TwoColumn>/column0<Neos.Neos:ContentCollection>/content<Neos.Neos:ContentCollectionRenderer>/itemRenderer<Neos.Neos:ContentCase>'
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider fusionPathsForRenderingProvider
+     * @test
+     */
+    public function providesCorrectFusionPathForContentRendering(string $fusionPath, string $fusionPathForRendering): void
+    {
+        $renderedNodeDomAddress = $this->createRenderedNodeDomAddress('/some/node@live', $fusionPath);
+        $this->assertEquals($fusionPathForRendering, $renderedNodeDomAddress->getFusionPathForContentRendering());
+    }
+}


### PR DESCRIPTION
Hi there,

out-of-band rendering in the UI works via so-called DomAddresses that contain the information what fusion path needs to be used to re-render a certain content element. That fusion path usually leads through a `Neos.Neos:ContentCase` ending up at a NodeType-specific fusion prototype.

Out-of-band rendering happens when a node properties change and a rendered content element needs to be updated. If the property that was changes was the NodeType of that content element, the behavior described above runs into a problem. The prototype used for rendering is no longer the prototype that `Neos.Neos:ContentCase` would lead to. This problem is described in issue  #2767.

This PR is an attempt at solving that problem by manipulating the above mentioned fusion path, so that it always tries to render the appropriate ContentCase instead of the final prototype.

**Before:**

https://user-images.githubusercontent.com/2522299/112519158-63932600-8d9a-11eb-8fae-bbd9eb8982b7.mp4

**After:**

https://user-images.githubusercontent.com/2522299/112519178-67bf4380-8d9a-11eb-8908-ec91b5c36833.mp4

**How to verify it**

Follow the reproduction steps in #2767.

solves: #2767