### PR TITLE
Fix injection conf in ChangeCollectionConverter

### DIFF
--- a/Classes/TypeConverter/ChangeCollectionConverter.php
+++ b/Classes/TypeConverter/ChangeCollectionConverter.php
@@ -48,7 +48,7 @@ class ChangeCollectionConverter extends AbstractTypeConverter
     protected $priority = 1;
 
     /**
-     * @Flow\Inject
+     * @Flow\Inject(lazy=false)
      * @var PersistenceManagerInterface
      */
     protected $persistenceManager;


### PR DESCRIPTION
The injected Persistence Manager is injected into the "changeClassInstance" during conversion. If `injectPersistenceManager` uses a `PersistenceManagerInterface` type hint, this injection will fail if `$this->persistenceManager` hasn't been used yet, because it will be a `DependencyInjectionProxy` instead of the real thing.

Therefore: Always disable lazy injection in these cases.

See also: https://github.com/neos/flow-development-collection/pull/2423