### PR TITLE
BUGFIX: Add removeFormat button to CKEditor5 toolbar

### DIFF
--- a/packages/neos-ui-ckeditor5-bindings/package.json
+++ b/packages/neos-ui-ckeditor5-bindings/package.json
@@ -19,6 +19,7 @@
     "@ckeditor/ckeditor5-link": "^11.0.2",
     "@ckeditor/ckeditor5-list": "^12.0.2",
     "@ckeditor/ckeditor5-paragraph": "^11.0.2",
+    "@ckeditor/ckeditor5-remove-format": "^10.0.0",
     "@ckeditor/ckeditor5-table": "^13.0.0",
     "@ckeditor/ckeditor5-widget": "^11.0.2",
     "@neos-project/neos-ui-backend-connector": "5.3.6",

--- a/packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/Helpers/renderToolbarComponents.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/Helpers/renderToolbarComponents.js
@@ -19,7 +19,10 @@ export default richtextToolbarRegistry => {
 
     return (executeCommand, inlineEditorOptions, formattingUnderCursor) => {
         return toolbarComponents
-            .filter(isTopLevelToolbarComponent && isToolbarItemVisible(inlineEditorOptions, formattingUnderCursor))
+            .filter(componentDefinition =>
+                isTopLevelToolbarComponent(componentDefinition)
+                && isToolbarItemVisible(inlineEditorOptions, formattingUnderCursor)(componentDefinition)
+            )
             .map((componentDefinition, index) => {
                 const {component, commandName, commandArgs = [], callbackPropName, ...props} = componentDefinition;
                 if (!component) {

--- a/packages/neos-ui-ckeditor5-bindings/src/manifest.config.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/manifest.config.js
@@ -20,6 +20,7 @@ import List from '@ckeditor/ckeditor5-list/src/list';
 import Alignment from '@ckeditor/ckeditor5-alignment/src/alignment';
 import Table from '@ckeditor/ckeditor5-table/src/table';
 import InsideTable from './plugins/insideTable';
+import RemoveFormat from '@ckeditor/ckeditor5-remove-format/src/removeformat';
 
 const addPlugin = (Plugin, isEnabled) => (ckEditorConfiguration, options) => {
     // we duplicate editorOptions here so it would be possible to write smth like `$get('formatting.sup')`
@@ -108,6 +109,7 @@ export default ckEditorRegistry => {
     config.set('linkTitle', addPlugin(LinkTitle, $get('formatting.a')));
     config.set('table', addPlugin(Table, i => $get('formatting.table', i)));
     config.set('insideTable', addPlugin(InsideTable, i => $get('formatting.table', i)));
+    config.set('removeFormat', addPlugin(RemoveFormat, $get('formatting.removeFormat')));
     config.set('list', addPlugin(List, $or(
         $get('formatting.ul'),
         $get('formatting.ol')

--- a/packages/neos-ui-ckeditor5-bindings/src/manifest.richtextToolbar.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/manifest.richtextToolbar.js
@@ -461,18 +461,19 @@ export default ckEditorRegistry => {
         ]
     });
 
-    // /**
-    //  * Remove formatting
-    //  */
-    // richtextToolbar.set('removeFormat', {
-    //     formattingRule: 'removeFormat',
-    //     component: IconButtonComponent,
-    //     callbackPropName: 'onClick',
+    /**
+     * Remove formatting
+     */
+    richtextToolbar.set('removeFormat', {
+        commandName: 'removeFormat',
+        component: IconButtonComponent,
+        callbackPropName: 'onClick',
 
-    //     icon: 'eraser',
-    //     hoverStyle: 'brand',
-    //     tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__remove-format'
-    // });
+        icon: 'eraser',
+        hoverStyle: 'brand',
+        tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__remove-format',
+        isVisible: $get('formatting.removeFormat')
+    });
 
     return richtextToolbar;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -541,6 +541,16 @@
     "@ckeditor/ckeditor5-ui" "^16.0.0"
     "@ckeditor/ckeditor5-utils" "^16.0.0"
 
+"@ckeditor/ckeditor5-remove-format@^10.0.0":
+  version "10.0.4"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-10.0.4.tgz#232d470b838cb602928ddc0a3bcb2df766a72c5c"
+  integrity sha512-J+9iQywTosKXj90VOOFrE3ERzBkFBwSQykvDTe4TBRZaGhIimxmsNzsTvRpfUdsQhOx2ovF0Y0bNOffIPFfO9g==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "^12.3.0"
+    "@ckeditor/ckeditor5-ui" "^14.0.0"
+    "@ckeditor/ckeditor5-utils" "^14.0.0"
+    eslint-plugin-ckeditor5-rules "^0.0.2"
+
 "@ckeditor/ckeditor5-table@^13.0.0":
   version "13.0.2"
   resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-table/-/ckeditor5-table-13.0.2.tgz#95f985bfb89443aa7ae4d0c2fa56baff8c3171e5"
@@ -6662,6 +6672,11 @@ eslint-plugin-babel@^5.1.0:
   integrity sha512-HPuNzSPE75O+SnxHIafbW5QB45r2w78fxqwK3HmjqIUoPfPzVrq6rD+CINU3yzoDSzEhUkX07VUphbF73Lth/w==
   dependencies:
     eslint-rule-composer "^0.3.0"
+
+eslint-plugin-ckeditor5-rules@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ckeditor5-rules/-/eslint-plugin-ckeditor5-rules-0.0.2.tgz#f6325c6d046b41f05423c3a18bb9794b37c80baf"
+  integrity sha512-bV8w34pQcn1IyfdW1IEgfKuc1/hkTYpLo1DglRp1v4a2ph03PkMjN7vZ6FDrmu5ImVDJsd9022j5waA//MeyKg==
 
 eslint-plugin-eslint-plugin@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Hi there,

this PR adds `@ckeditor/ckeditor5-remove-format` to the dependencies of `@neos-project/neos-ui-ckeditor5-bindings` and uses it to realize the formerly non-functional `removeFormat` option for CK Editor.

solves #2878