### PR TITLE
BUGFIX: Enable help messages and thumbnails in creation dialog

### DIFF
--- a/Tests/IntegrationTests/Fixtures/1Dimension/createNewNodes.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/createNewNodes.e2e.js
@@ -123,7 +123,7 @@ test('Supports secondary inspector view for element editors', async t => {
         .click(ReactSelector('NodeTypeItem').find('button>span>span').withText('PageWithImage_Test'))
         .typeText(Selector('#neos-NodeCreationDialog-Body input'), 'TestPage with Image');
 
-    const imageEditor = await ReactSelector('NodeCreationDialog ImageEditor').withProps('id', '__neos__editor__property---image');
+    const imageEditor = await ReactSelector('NodeCreationDialog ImageEditor').withProps('id', '__neos__editor__property---image--creation-dialog');
     await t
         .click(imageEditor.findReact('IconButton').withProps('icon', 'camera'))
         .switchToIframe(Selector('[name="neos-media-selection-screen"]', {timeout: 2000}))

--- a/Tests/IntegrationTests/Fixtures/1Dimension/selectBoxes.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/selectBoxes.e2e.js
@@ -36,7 +36,7 @@ test('SelectBox opens above in creation dialog if there\'s not enough space belo
         .eql('block');
 
     subSection('SelectBox contents disappear when SelectBox is scrolled out of sight.');
-    await t.hover(Selector('#neos-NodeCreationDialog [for="__neos__editor__property---title"]'));
+    await t.hover(Selector('#neos-NodeCreationDialog [for="__neos__editor__property---title--creation-dialog"]'));
 
     await t
         .expect(await ReactSelector('NodeCreationDialog SelectBox ShallowDropDownContents').getStyleProperty('display'))

--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
@@ -235,9 +235,11 @@ export default class NodeCreationDialog extends PureComponent {
         return (
             <div key={elementName} className={style.editor}>
                 <EditorEnvelope
-                    identifier={elementName}
+                    identifier={`${elementName}--creation-dialog`}
                     label={$get('ui.label', element)}
                     editor={$get('ui.editor', element)}
+                    helpMessage={$get('ui.help.message', element) || ''}
+                    helpThumbnail={$get('ui.help.thumbnail', element) || ''}
                     options={options}
                     commit={this.handleDialogEditorValueChange(elementName)}
                     validationErrors={validationErrorsForElement}


### PR DESCRIPTION
Hi there,

this PR enables help messages and thumbnails for the Creation Dialog by passing both properties through to the respective EditorEnvelope.

https://user-images.githubusercontent.com/2522299/115356138-a4286880-a1bb-11eb-8705-8eba378b1852.mp4

This feature works out-of-the-box for properties that have the `showInCreationDialog` flag. For custom Creation Dialog elements a help message and/or thumbnail can be configured in the `ui` section like this:

```yaml
'Vendor.Site:SomeNode':
  # ...
  ui:
    # ...
    creationDialog:
      elements:
        'someElement':
          type: string
          ui:
            label: 'Some Label'
            editor: 'Neos.Neos/Inspector/Editors/TextFieldEditor'
            help:
              thumbnail: resource://Vendor.Site/Images/help.jpg
              message: >
                This is a help message
```

resolves: #2862