### PR TITLE
BUGFIX: Prevent drag and drop across trees

### DIFF
--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -136,7 +136,7 @@ export default class Node extends PureComponent {
         const {node, currentlyDraggedNodes, canBeInsertedAlongside, canBeInsertedInto} = this.props;
         const canBeInserted = mode === 'into' ? canBeInsertedInto : canBeInsertedAlongside;
 
-        return canBeInserted && !currentlyDraggedNodes.includes(getContextPath(node));
+        return currentlyDraggedNodes.length > 0 && canBeInserted && !currentlyDraggedNodes.includes(getContextPath(node));
     }
 
     handleNodeDrag = () => {


### PR DESCRIPTION
Hi there,

this PR contains a small bugfix to prevent drag and drop across the Document and Content trees. This never actually worked in the first place, but the UI gave visual indication that this would be a valid operation.

**Before:**

https://user-images.githubusercontent.com/2522299/115692548-62382780-a35f-11eb-8936-f41082e5b067.mp4 

**After:**

https://user-images.githubusercontent.com/2522299/115692594-6bc18f80-a35f-11eb-8be9-50bd42ce4c86.mp4

fixes: #2741 