### PR TITLE
TASK: Refactor controller to not use static fusion path

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -120,12 +120,6 @@ class BackendController extends ActionController
      */
     protected $splashScreenPartial;
 
-    public function initializeView(ViewInterface $view)
-    {
-        /** @var FusionView $view */
-        $view->setFusionPath('backend');
-    }
-
     /**
      * Displays the backend interface
      *

--- a/Resources/Private/Fusion/Backend/Root.fusion
+++ b/Resources/Private/Fusion/Backend/Root.fusion
@@ -13,6 +13,6 @@ include: ./Application.fusion
 #
 # Neos UI (Content Module) entry point
 #
-backend = Neos.Neos.Ui:Application {
+Neos.Neos.Ui.BackendController.index = Neos.Neos.Ui:Application {
     title = 'Neos CMS'
 }


### PR DESCRIPTION
The fusion path is now dynamically determined by controller / action
This enables additional actions with separate templates for that controller.

The path `Neos.Neos.Ui.BackendController.index` is used instead and the `initializeView` hook with `$view->setFusionPath('backend');` was removed.