### PR TITLE
BUGFIX: Provide propertyname on asset upload

### DIFF
--- a/packages/neos-ui-editors/src/Editors/AssetEditor/index.js
+++ b/packages/neos-ui-editors/src/Editors/AssetEditor/index.js
@@ -202,7 +202,7 @@ export default class AssetEditor extends PureComponent {
         const mediaTypeConstraint = $get('options.constraints.mediaTypes', this.props);
         const accept = $get('options.accept', this.props) || (mediaTypeConstraint && mediaTypeConstraint.join(','));
         const multiple = $get('options.multiple', this.props);
-        const {className, imagesOnly, value} = this.props;
+        const {className, imagesOnly, value, identifier} = this.props;
 
         if (!this.isFeatureEnabled('upload')) {
             return this.renderAssetSelect();
@@ -218,6 +218,7 @@ export default class AssetEditor extends PureComponent {
                 isLoading={false}
                 imagesOnly={imagesOnly}
                 accept={accept}
+                propertyName={identifier}
             >
                 {this.renderAssetSelect()}
             </AssetUpload>


### PR DESCRIPTION
**What I did**

The AssetEditor receives the `propertyName` as in its `identifier` prop. This prop had to be forwarded to the `AssetUpload` component.

Resolves: #2867 

**How to verify it**

See #2867 