### PR TITLE
BUGFIX: Use correct hotel icon mapping

### DIFF
--- a/packages/react-ui-components/src/Icon/mapper.ts
+++ b/packages/react-ui-components/src/Icon/mapper.ts
@@ -145,7 +145,7 @@ const map: {readonly [key: string]: string} = {
     'header': 'fas fa-heading',
     'heart-o': 'far fa-heart',
     'hospital-o': 'far fa-hospital',
-    'hotel': 'fas fa-bed',
+    'hotel': 'fas fa-hotel',
     'hourglass-1': 'fas fa-hourglass-start',
     'hourglass-2': 'fas fa-hourglass-half',
     'hourglass-3': 'fas fa-hourglass-end',


### PR DESCRIPTION
Show the hotel icon instead of the bed

Resolves: #2697 
