### PR TITLE
BUGFIX: Hide empty tabs and groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "lodash.unescape": "4.0.1",
     "lodash.upperfirst": "^4.3.0",
     "moment": "^2.20.1",
-    "monet": "^0.9.0",
+    "monet": "^0.9.2",
     "mousetrap": "^1.6.3",
     "normalize.css": "^8.0.0",
     "plow-js": "^2.2.0",

--- a/packages/neos-ui-editors/src/_lib/testUtils.js
+++ b/packages/neos-ui-editors/src/_lib/testUtils.js
@@ -38,6 +38,7 @@ export const MockDataSourceDataLoader = {
         return this._currentPromise;
     }
 };
+globalRegistry.set('inspector', new SynchronousRegistry());
 globalRegistry.set('dataLoaders', new SynchronousRegistry());
 globalRegistry.get('dataLoaders').set('DataSources', MockDataSourceDataLoader);
 

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.js
@@ -16,6 +16,7 @@ export default class PropertyGroup extends PureComponent {
     static propTypes = {
         label: PropTypes.string.isRequired,
         icon: PropTypes.string,
+        items: PropTypes.array,
         collapsed: PropTypes.bool,
         properties: PropTypes.object,
         views: PropTypes.object,
@@ -31,13 +32,14 @@ export default class PropertyGroup extends PureComponent {
         collapsed: false
     };
 
-    render() {
-        const {items, label, icon, collapsed, handlePanelToggle, handleInspectorApply, renderSecondaryInspector, node, commit} = this.props;
+    renderPropertyGroup = items => {
+        const {label, icon, collapsed, handlePanelToggle, handleInspectorApply, renderSecondaryInspector, node, commit} = this.props;
+
         const headerTheme = {
             panel__headline: style.propertyGroupLabel // eslint-disable-line camelcase
         };
 
-        const propertyGroup = items => (
+        return (
             <ToggablePanel onPanelToggle={handlePanelToggle} isOpen={!collapsed} className={sidebarStyle.rightSideBar__section}>
                 <ToggablePanel.Header theme={headerTheme}>
                     {icon && <div className={style.iconWrapper}><Icon icon={icon}/></div>} <I18n id={label}/>
@@ -48,9 +50,6 @@ export default class PropertyGroup extends PureComponent {
                         const itemType = $get('type', item);
                         const label = $get('label', item) || '';
 
-                        if ($get('hidden', item)) {
-                            return null;
-                        }
                         if (itemType === 'editor') {
                             return (
                                 <InspectorEditorEnvelope
@@ -65,7 +64,7 @@ export default class PropertyGroup extends PureComponent {
                                     onEnterKey={handleInspectorApply}
                                     helpMessage={$get('helpMessage', item)}
                                     helpThumbnail={$get('helpThumbnail', item)}
-                                    />);
+                                />);
                         }
                         if (itemType === 'view') {
                             return (
@@ -78,15 +77,20 @@ export default class PropertyGroup extends PureComponent {
                                     renderSecondaryInspector={renderSecondaryInspector}
                                     node={node}
                                     commit={commit}
-                                    />);
+                                />);
                         }
                         return null;
                     })}
                 </ToggablePanel.Contents>
             </ToggablePanel>
         );
-        const fallback = () => (<div>...</div>);
+    }
 
-        return Maybe.fromNull(items).map(propertyGroup).orSome(fallback());
+    render() {
+        const {items} = this.props;
+
+        const visibleItems = items ? items.filter(item => !$get('hidden', item)) : [];
+
+        return Maybe.fromEmpty(visibleItems).map(this.renderPropertyGroup).orSome(null);
     }
 }

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.spec.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.spec.js
@@ -1,3 +1,78 @@
-test(`write tests`, () => {
-    expect(true).toBe(true);
+import React from 'react';
+import {Provider} from 'react-redux';
+import {createStore} from 'redux';
+import {mount} from 'enzyme';
+import PropertyGroup from './index';
+import {WrapWithMockGlobalRegistry} from '@neos-project/neos-ui-editors/src/_lib/testUtils';
+
+const store = createStore(state => state, {});
+
+test(`PropertyGroup > is rendered`, () => {
+    const items = [
+        {
+            id: '1',
+            type: 'editor',
+            label: 'Foo',
+            hidden: false
+        },
+        {
+            id: '2',
+            type: 'editor',
+            label: 'Bar',
+            hidden: true
+        }
+    ];
+
+    const component = mount(
+        <WrapWithMockGlobalRegistry>
+            <Provider store={store}>
+                <PropertyGroup
+                    label="Foo group"
+                    icon="question"
+                    renderSecondaryInspector={() => {}}
+                    node={{}}
+                    items={items}
+                    handlePanelToggle={() => {}}
+                    commit={() => {}}
+                />
+            </Provider>
+        </WrapWithMockGlobalRegistry>
+    );
+
+    expect(component.find('Headline').text()).toEqual(expect.stringContaining('Foo group'));
+});
+
+test(`PropertyGroup > is not rendered when all items are hidden`, () => {
+    const items = [
+        {
+            id: '1',
+            type: 'editor',
+            label: 'Foo',
+            hidden: true
+        },
+        {
+            id: '2',
+            type: 'editor',
+            label: 'Bar',
+            hidden: true
+        }
+    ];
+
+    const component = mount(
+        <WrapWithMockGlobalRegistry>
+            <Provider store={store}>
+                <PropertyGroup
+                    label="Foo group"
+                    icon="question"
+                    renderSecondaryInspector={() => {}}
+                    node={{}}
+                    items={items}
+                    handlePanelToggle={() => {}}
+                    commit={() => {}}
+                />
+            </Provider>
+        </WrapWithMockGlobalRegistry>
+    );
+
+    expect(component.find('Headline').length).toEqual(0);
 });

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
@@ -26,36 +26,42 @@ export default class TabPanel extends PureComponent {
             return true;
         }
 
+        if ($get('hidden', item)) {
+            return false;
+        }
+
         return $get(['policy', 'canEdit'], node) && !$contains(item.id, 'policy.disallowedProperties', node);
     };
 
-    render() {
-        const {handlePanelToggle, handleInspectorApply, toggledPanels, groups, renderSecondaryInspector, node, commit} = this.props;
-
-        if (!groups) {
-            return (<div>...</div>);
-        }
+    renderTabPanel = groups => {
+        const {handlePanelToggle, handleInspectorApply, toggledPanels, renderSecondaryInspector, node, commit} = this.props;
 
         return (
             <Tabs.Panel theme={{panel: style.inspectorTabPanel}}>
-                {
-                    groups.filter(g => ($get('items', g) && $get('items', g).filter(this.isPropertyEnabled).length)).map(group => (
-                        <PropertyGroup
-                            handlePanelToggle={() => handlePanelToggle([$get('id', group)])}
-                            handleInspectorApply={handleInspectorApply}
-                            key={$get('id', group)}
-                            label={$get('label', group)}
-                            icon={$get('icon', group)}
-                            // Overlay default collapsed state over current state
-                            collapsed={Boolean($get($get('id', group), toggledPanels)) !== Boolean($get('collapsed', group))}
-                            items={$get('items', group).filter(this.isPropertyEnabled)}
-                            renderSecondaryInspector={renderSecondaryInspector}
-                            node={node}
-                            commit={commit}
-                            />
-                    ))
-                }
+                {groups.map(group => (
+                    <PropertyGroup
+                        handlePanelToggle={() => handlePanelToggle([$get('id', group)])}
+                        handleInspectorApply={handleInspectorApply}
+                        key={$get('id', group)}
+                        label={$get('label', group)}
+                        icon={$get('icon', group)}
+                        // Overlay default collapsed state over current state
+                        collapsed={Boolean($get($get('id', group), toggledPanels)) !== Boolean($get('collapsed', group))}
+                        items={$get('items', group).filter(this.isPropertyEnabled)}
+                        renderSecondaryInspector={renderSecondaryInspector}
+                        node={node}
+                        commit={commit}
+                    />
+                ))}
             </Tabs.Panel>
         );
+    }
+
+    render() {
+        const {groups} = this.props;
+
+        const visibleGroups = groups ? groups.filter(group => $get('items', group) && $get('items', group).some(this.isPropertyEnabled)) : [];
+
+        return this.renderTabPanel(visibleGroups);
     }
 }

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -228,7 +228,7 @@ export default class Inspector extends PureComponent {
             return true;
         }
 
-        if ($get('isAutoCreated', focusedNode) === true && item.id === '_hidden') {
+        if ($get('hidden', item) || ($get('isAutoCreated', focusedNode) === true && item.id === '_hidden')) {
             // This accounts for the fact that auto-created child nodes cannot
             // be hidden via the insprector (see: #2282)
             return false;
@@ -352,10 +352,9 @@ export default class Inspector extends PureComponent {
                         //
                         // Only display tabs, that have groups and these groups have properties
                         //
-                        .filter(t => $get('groups', t) && $get('groups', t).length > 0 && $get('groups', t).reduce((acc, group) => (
-                            acc ||
-                            $get('items', group).filter(this.isPropertyEnabled).length > 0
-                        ), false))
+                        .filter(tab => $get('groups', tab) && $get('groups', tab).some(group => (
+                            $get('items', group).some(this.isPropertyEnabled)
+                        )))
 
                         //
                         // Render each tab as a TabPanel

--- a/yarn.lock
+++ b/yarn.lock
@@ -11165,9 +11165,9 @@ moment@*, moment@^2.10.3, moment@^2.14.1, moment@^2.19.2, moment@^2.20.1, moment
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 monet@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/monet/-/monet-0.9.0.tgz#77a5d112950243ac89189fadb745fb542313cbdb"
-  integrity sha512-63UOb3RD3zXP3F2kMhYDKZD0V4HBxWgaIHNkp1p+BBCS1AYX51o0o9JJ31KZKuX4aISw4lUwaH4oFbyiKsswgg==
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/monet/-/monet-0.9.2.tgz#c59d4390937a1b021126844b50b993963c6b0ec7"
+  integrity sha512-1InBkZov47As5vn2zyp5mMysip1627Bj0z1yCJyWegeAOnwKOWmIzBd+4tx7ajrALoZdtgx7L0qVwSBP6J7FRQ==
 
 moo@^0.4.3:
   version "0.4.3"


### PR DESCRIPTION
Relates: #2285

**What I did**

Inspector tabs and groups are now skipped during rendering if they don't contain visible items. Before three dots were rendered if `items` are null, or just the header for an empty item array.

**How I did it**

There were already checks whether items were accessible, this was extended to also check whether the `hidden` prop is set (supports `ClientEval`).
Additionally before a tab or group is rendered a check was added whether the items array contains an item. 

The new implementation should also be slightly faster, as the check for visible items was optimised and the render function of 
PropertyGroups is not created dynamically all the time anymore.

**How to verify it**

A jest test was added for the groups.

To verify manually you can use this document type which allows toggling various tabs and groups

<details>
  <summary>Click to view test nodetype</summary>

```yaml
Test.Test:Document.Test:
  superTypes:
    Neos.Neos:Document: true
  ui:
    label: Testpage
    icon: hotel
    inspector:
      tabs:
        test:
          icon: hotel
          label: Test
        leer:
          icon: question
          label: Leer
      groups:
        test:
          icon: hotel
          label: Test
          tab: test
        test2:
          icon: hotel
          label: Test 2
          tab: test
        test3:
          icon: hotel
          label: Test 3
          tab: leer
  properties:
    someCheck1:
      type: boolean
      ui:
        label: Test 1 anzeigen ?
        inspector:
          group: test
    someCheck2:
      type: boolean
      ui:
        label: Test 2 anzeigen ?
        inspector:
          group: test
    someCheck3:
      type: boolean
      ui:
        label: Test 3 anzeigen ?
        inspector:
          group: test
    someString1:
      type: string
      ui:
        label: Test text 1
        inspector:
          hidden: 'ClientEval: !node.properties.someCheck1'
          group: test2
    someString2:
      type: string
      ui:
        label: Test text 2
        inspector:
          hidden: 'ClientEval: !node.properties.someCheck2'
          group: test2
    someString3:
      type: string
      ui:
        label: Test text 3
        inspector:
          hidden: 'ClientEval: !node.properties.someCheck3'
          group: test3
```

</details>