### PR TITLE
BUGFIX: Prevent custom image ratios when disabled

### DIFF
--- a/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/index.js
+++ b/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/index.js
@@ -8,7 +8,7 @@ import TextInput from '@neos-project/react-ui-components/src/TextInput/';
 import {neos} from '@neos-project/neos-ui-decorators';
 
 import AspectRatioDropDown from './AspectRatioDropDown/index';
-import CropConfiguration, {LockedAspectRatioStrategy} from './model.js';
+import CropConfiguration, {CustomAspectRatioOption, LockedAspectRatioStrategy} from './model.js';
 import style from './style.css';
 
 /* eslint-disable no-unused-vars */
@@ -139,6 +139,7 @@ export default class ImageCropper extends PureComponent {
     render() {
         const {cropConfiguration} = this.state;
         const aspectRatioLocked = cropConfiguration.aspectRatioStrategy instanceof LockedAspectRatioStrategy;
+        const allowCustomRatios = cropConfiguration.aspectRatioOptions.some(option => option instanceof CustomAspectRatioOption);
         const {sourceImage, onComplete, i18nRegistry} = this.props;
         const src = sourceImage.previewUri || '/_Resources/Static/Packages/Neos.Neos/Images/dummy-image.svg';
 
@@ -175,6 +176,7 @@ export default class ImageCropper extends PureComponent {
                     {!aspectRatioLocked && <div className={style.dimensions}>
                         {cropConfiguration.aspectRatioDimensions.map((props, index) => (
                             <AspectRatioItem
+                                isLocked={!allowCustomRatios}
                                 {...props}
                                 onFlipAspectRatio={this.handleFlipAspectRatio}
                                 onChange={this.handleSetCustomAspectRatioDimensions}


### PR DESCRIPTION
The option `allowCustom` hides the dropdown selection
for a custom ratio, but without this patch the controlls still
allowed setting a custom ratio by modifying the numbers.

Now the ratio controls are disabled if the custom ratio is disabled.

Resolves: #2909

<img width="567" alt="Bildschirmfoto 2021-08-11 um 13 23 48" src="https://user-images.githubusercontent.com/596967/129020760-1d7d62fc-b9ea-414e-a840-20eda3460de0.png">
