### PR TITLE
FEATURE: Consumer Api for @neos-project/neos-ui-guest-frame

### DIFF
--- a/packages/neos-ui-extensibility/scripts/helpers/webpack.config.js
+++ b/packages/neos-ui-extensibility/scripts/helpers/webpack.config.js
@@ -70,6 +70,7 @@ module.exports = function (neosPackageJson) {
                 '@neos-project/neos-ui-i18n': '@neos-project/neos-ui-extensibility/src/shims/neosProjectPackages/neos-ui-i18n/index',
                 '@neos-project/neos-ui-redux-store': '@neos-project/neos-ui-extensibility/src/shims/neosProjectPackages/neos-ui-redux-store/index',
                 '@neos-project/neos-ui-views': '@neos-project/neos-ui-extensibility/src/shims/neosProjectPackages/neos-ui-views/index',
+                '@neos-project/neos-ui-guest-frame': '@neos-project/neos-ui-extensibility/src/shims/neosProjectPackages/neos-ui-guest-frame/index',
                 '@neos-project/utils-redux': '@neos-project/neos-ui-extensibility/src/shims/neosProjectPackages/utils-redux/index'
             }
         }

--- a/packages/neos-ui-extensibility/src/shims/neosProjectPackages/neos-ui-guest-frame/index.js
+++ b/packages/neos-ui-extensibility/src/shims/neosProjectPackages/neos-ui-guest-frame/index.js
@@ -1,0 +1,3 @@
+import readFromConsumerApi from '../../../../dist/readFromConsumerApi';
+
+module.exports = readFromConsumerApi('NeosProjectPackages')().NeosUiGuestFrameDom;

--- a/packages/neos-ui/src/apiExposureMap.js
+++ b/packages/neos-ui/src/apiExposureMap.js
@@ -21,6 +21,7 @@ import NeosUiI18n from '@neos-project/neos-ui-i18n';
 import * as CkEditorApi from '@neos-project/neos-ui-ckeditor5-bindings/src/ckEditorApi';
 import NeosUiBackendConnectorDefault, * as NeosUiBackendConnector from '@neos-project/neos-ui-backend-connector';
 import * as NeosUiViews from '@neos-project/neos-ui-views';
+import * as NeosUiGuestFrameDom from '@neos-project/neos-ui-guest-frame/src/dom';
 
 // We export most needed components from CKE5 to be used when making custom plugins.
 // It's not safe to just install CKE5 packages from the extension because then then "instanceof" checks will no longer work,
@@ -144,6 +145,7 @@ export default {
         NeosUiI18n,
         NeosUiReduxStore,
         NeosUiViews,
+        NeosUiGuestFrameDom,
         // react-proptypes (optional)
         ReactUiComponents,
         UtilsRedux


### PR DESCRIPTION
This makes it possible to reuse the guest iframe api for getting the guest iframe and fx. dispatching events.

you can then create a custom extension and import from '@neos-project/neos-ui-guest-frame' as if you have this file '@neos-project/neos-ui-guest-frame/src/dom' https://github.com/neos/neos-ui/blob/master/packages/neos-ui-guest-frame/src/dom.js installed.

```js
import {getGuestFrameDocument, dispatchCustomEvent} from '@neos-project/neos-ui-guest-frame'
```

slack discussion over here: https://neos-project.slack.com/archives/C0U0KEGDQ/p1629923508013600

> **Note:**
> 
> Internally it seems that to access the ./dom file of the @neos-project/neos-ui-guest-frame one need to import directly from it like:
> 
> ```js
> import {getGuestFrameDocument, dispatchCustomEvent} from '@neos-project/neos-ui-guest-frame/src/dom'
> ```
> (i hope that its not to confusing that its now aliased by '@neos-project/neos-ui-guest-frame'.
> I took an examle from the '@neos-project/neos-ui-ckeditor5-bindings/src/ckEditorApi' wich is accessible like '@neos-project/neos-ui-ckeditor5-bindings' through the consumer api)
> 

**What I did**
The already compliled neos ui sets on the window object imported code from certain modules: https://github.com/neos/neos-ui/blob/master/packages/neos-ui/src/apiExposureMap.js
I added here an Object which contains everything from the '@neos-project/neos-ui-guest-frame/src/dom'

The "@neos-project/neos-ui-extensibility" package allows to use 'normal' imports, which will be resolved by getting the object set on the window.
