### PR TITLE
BUGFIX: Prevent proptype error for menu and menuData

### DIFF
--- a/packages/neos-ui/src/Containers/App.js
+++ b/packages/neos-ui/src/Containers/App.js
@@ -35,7 +35,25 @@ const App = ({globalRegistry, menu}) => {
 };
 App.propTypes = {
     globalRegistry: PropTypes.object.isRequired,
-    menu: PropTypes.object.isRequired
+    menu: PropTypes.arrayOf(
+        PropTypes.shape({
+            icon: PropTypes.string,
+            label: PropTypes.string.isRequired,
+            uri: PropTypes.string.isRequired,
+            target: PropTypes.string,
+
+            children: PropTypes.arrayOf(
+                PropTypes.shape({
+                    icon: PropTypes.string,
+                    label: PropTypes.string.isRequired,
+                    uri: PropTypes.string,
+                    target: PropTypes.string,
+                    isActive: PropTypes.bool.isReqired,
+                    skipI18n: PropTypes.bool.isReqired
+                })
+            )
+        })
+    ).isRequired
 };
 
 export default App;

--- a/packages/neos-ui/src/Containers/Drawer/index.js
+++ b/packages/neos-ui/src/Containers/Drawer/index.js
@@ -33,7 +33,7 @@ export default class Drawer extends PureComponent {
 
         containerRegistry: PropTypes.object.isRequired,
 
-        menuData: PropTypes.objectOf(
+        menuData: PropTypes.arrayOf(
             PropTypes.shape({
                 icon: PropTypes.string,
                 label: PropTypes.string.isRequired,

--- a/packages/neos-ui/src/Containers/Root.js
+++ b/packages/neos-ui/src/Containers/Root.js
@@ -36,7 +36,25 @@ Root.propTypes = {
     store: PropTypes.object.isRequired,
     globalRegistry: PropTypes.object.isRequired,
     configuration: PropTypes.object.isRequired,
-    menu: PropTypes.object.isRequired,
+    menu: PropTypes.arrayOf(
+        PropTypes.shape({
+            icon: PropTypes.string,
+            label: PropTypes.string.isRequired,
+            uri: PropTypes.string.isRequired,
+            target: PropTypes.string,
+
+            children: PropTypes.arrayOf(
+                PropTypes.shape({
+                    icon: PropTypes.string,
+                    label: PropTypes.string.isRequired,
+                    uri: PropTypes.string,
+                    target: PropTypes.string,
+                    isActive: PropTypes.bool.isReqired,
+                    skipI18n: PropTypes.bool.isReqired
+                })
+            )
+        })
+    ).isRequired,
     routes: PropTypes.object.isRequired
 };
 


### PR DESCRIPTION
The menu and menuData property is an array with objects, but it was defined as an object.
Seems that it works a long time, but now it is a prop type error.

So we should define that correct.

Fixes: #2950