### PR TITLE
FEATURE: Allow setting the position of backend modules

### DIFF
--- a/Resources/Private/Fusion/Backend/Component/ModuleMenu.fusion
+++ b/Resources/Private/Fusion/Backend/Component/ModuleMenu.fusion
@@ -39,17 +39,20 @@ prototype(Neos.Neos.Ui:Component.ModuleMenu) < prototype(Neos.Fusion:Map) {
                     itemKey = 'submoduleName'
                     iterationName = 'iteration'
 
-                    keyRenderer = ${iteration.index}
+                    keyRenderer = ${submoduleName}
                     itemRenderer = Neos.Fusion:DataStructure {
                         @if.moduleNotHidden = ${submodule.hideInMenu != true}
                         icon = ${submodule.icon}
                         label = ${submodule.label}
                         uri = ${submodule.uri}
+                        position = ${submodule.position}
                         isActive = true
                         target = 'Window'
                     }
 
-                    @process.filterHiddenSubmodules = ${Array.values(Array.filter(value, (x, index) => x != null))}
+                    @process.filterHiddenSubmodules = ${Array.filter(value, (x, index) => x != null)}
+                    @process.sort = ${Array.slice(Neos.Ui.PositionalArraySorter.sort(value), 0)}
+                    @process.values = ${Array.values(value)}
                 }
             }
         }


### PR DESCRIPTION
**What I did**

This change only makes it possible for the menu when displayed inside the content module.

Relates: https://github.com/neos/neos-development-collection/issues/3433

**How I did it**

Call the PositionalArraySorter on the array of submodules for each group.

**How to verify it**

Try the following setting to move the media module after the workspace module:

```yaml
Neos:
  Neos:
    modules:
      management:
        submodules:
          media:
            position: 'after workspaces'
```
