### PR TITLE
TASK: Replace circleci image for neos 5.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - run: curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
       - run: chmod +x ~/.nvm/nvm.sh
       - run: ~/.nvm/nvm.sh install && ~/.nvm/nvm.sh use
-      - run: sudo apt-get update && sudo apt-get install -y rsync
+      - run: sudo apt-get update --allow-releaseinfo-change && sudo apt-get install -y rsync
       - run: make install && make build-production
 
       - save_cache: *store_yarn_package_cache


### PR DESCRIPTION
The current Linux version from the 5.3 container is not stable anymore and therefore the tests fail.

**What I did**
Changed the image from `quay.io/yeebase/ci-build:7.2` to `quay.io/yeebase/ci-build:7.4`
We also need to add the  `--allow-releaseinfo-change` as the Linux distribution changed from stable to old stable