### PR TITLE
BUGFIX: Use option highlightingMode for the code mirror component

### DIFF
--- a/packages/neos-ui-editors/src/Editors/CodeMirror/index.js
+++ b/packages/neos-ui-editors/src/Editors/CodeMirror/index.js
@@ -55,10 +55,12 @@ export default class CodeMirror extends PureComponent {
 
     handleOpenCodeEditor = () => {
         const {secondaryEditorsRegistry} = this.props;
+        const highlightingModeFromOptions = $get('options.highlightingMode', this.props);
+        const highlightingMode = highlightingModeFromOptions ? highlightingModeFromOptions : this.props.highlightingMode;
         const {component: CodeMirrorWrap} = secondaryEditorsRegistry.get('Neos.Neos/Inspector/Secondary/Editors/CodeMirrorWrap');
 
         this.props.renderSecondaryInspector('CODEMIRROR_EDIT', () =>
-            <CodeMirrorWrap onChange={this.handleChange} value={this.props.value} highlightingMode={this.props.highlightingMode}/>
+            <CodeMirrorWrap onChange={this.handleChange} value={this.props.value} highlightingMode={highlightingMode}/>
         );
     }
 }


### PR DESCRIPTION
The option from the nodetype was not used in the code, and so we always had the default value.
Now we use the option and the prop work again.

**What I did**
Check if the highlight mode is part of the options and use this value when it is enabled.

**How to verify it**
Use a config like this and checkout if it is still mixed HTML or your own type.

```
'code':
      type: string
      ui:
        label: 'Code'
        inspector:
          group: 'foo'
          editor: Neos.Neos/Inspector/Editors/CodeEditor
          editorOptions:
            highlightingMode: 'text/javascript'
```

Resolves: #2959