### PR TITLE
BUGFIX: Including the default language of the UI

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -173,7 +173,7 @@ Neos:
             otherName: '${q(user).property(''name.otherName'')}'
             fullName: '${q(user).property(''name.fullName'')}'
           preferences:
-            interfaceLanguage: '${q(user).property(''preferences.interfaceLanguage'')}'
+            interfaceLanguage: '${q(user).property(''preferences.interfaceLanguage'') || Configuration.setting(''Neos.Neos.userInterface.defaultLanguage'')}'
           settings:
             isAutoPublishingEnabled: false
             targetWorkspace: 'live'


### PR DESCRIPTION
The DateTime editor sets the locale according to user.preferences.interfaceLanguage from the store and apparently ignores the Neos.Neos.userInterface.defaultLanguage setting.

**Before:**
<img width="803" alt="Screenshot 2021-10-12 at 21 11 57" src="https://user-images.githubusercontent.com/1014126/137016967-fcec2a1d-3363-4934-9289-d1cf3705a789.png">

**After:**
<img width="731" alt="Screenshot 2021-10-12 at 21 26 52" src="https://user-images.githubusercontent.com/1014126/137017093-f2a4714e-b8af-474f-85ea-0c0b8265f6e9.png">

Thanks to @PRGfx for reporting that issue.

Resolves: #2912