### PR TITLE
BUGFIX: Prevent pasting an empty clipboard

### DIFF
--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
@@ -249,12 +249,15 @@ const makeMapStateToProps = isDocument => (state, {nodeTypesRegistry}) => {
         const getNodeByContextPathSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector(focusedNodeContextPath);
         const focusedNode = getNodeByContextPathSelector(state);
         const clipboardNodesContextPaths = selectors.CR.Nodes.clipboardNodesContextPathsSelector(state);
-        const canBePasted = clipboardNodesContextPaths.every(clipboardNodeContextPath => {
-            return canBePastedSelector(state, {
-                subject: clipboardNodeContextPath,
-                reference: focusedNodeContextPath
+        let canBePasted = false;
+        if (clipboardNodesContextPaths && clipboardNodesContextPaths.length) {
+            canBePasted = clipboardNodesContextPaths.every(clipboardNodeContextPath => {
+                return canBePastedSelector(state, {
+                    subject: clipboardNodeContextPath,
+                    reference: focusedNodeContextPath
+                });
             });
-        });
+        }
 
         const selectionHasNestedNodes = hasNestedNodes(focusedNodesContextPaths);
 


### PR DESCRIPTION
It is possible to paste a node even when the clipboard is empty.
The reason is that the every function always returns true on empty arrays.
The clipboardNodesContextPaths array is empty when we have nothing in the clipboard, and so the canBePasted flag is true.

Resolves: #2917