### PR TITLE
BUGFIX: Close help message when closing dialog

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
@@ -118,6 +118,7 @@ export default class SelectNodeType extends PureComponent {
         this.setState({
             filterSearchTerm: ''
         });
+        this.handleCloseHelpMessage();
         cancel();
     }
 


### PR DESCRIPTION
The help message closes when the create dialog getting closed.
Before, the help message was still open when the create dialog reopens.

Resolves: #2576