### PR TITLE
BUGFIX: remove unused case "test" for nonexistent script

### DIFF
--- a/packages/neos-ui-extensibility/bin/neos-react-scripts.js
+++ b/packages/neos-ui-extensibility/bin/neos-react-scripts.js
@@ -6,7 +6,6 @@ var args = process.argv.slice(3);
 switch (script) {
     case 'build':
     case 'watch':
-    case 'test':
         var result = spawn.sync(
             'node',
             [require.resolve('../scripts/' + script)].concat(args),


### PR DESCRIPTION
resolves https://github.com/neos/neos-ui/issues/2335

**What I did**
Since the there is no script called test.js there should not be a case where the script can be called. 

**How I did it**
I removed the case "test" in the list of scripts that can be called

**How to verify it**
see issue https://github.com/neos/neos-ui/issues/2335
