### PR TITLE
Revert "BUGFIX: Prevent error when trying to edit a node during discard"

### DIFF
--- a/packages/neos-ui-guest-frame/src/InlineUI/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/index.js
@@ -46,14 +46,14 @@ export default class InlineUI extends PureComponent {
             return null;
         }
 
-        const focusedNodeContextPath = focusedNode ? focusedNode.contextPath : null;
+        const focusedNodeContextPath = focusedNode.contextPath;
         const isDocument = nodeTypesRegistry.hasRole($get('nodeType', focusedNode), 'document');
         const allFocusedNodesAreInClipboard = isEqualSet(focusedNodesContextPaths, clipboardNodesContextPaths);
         const isCut = allFocusedNodesAreInClipboard && clipboardMode === 'Move';
         const isCopied = allFocusedNodesAreInClipboard && clipboardMode === 'Copy';
-        const canBeDeleted = $get('policy.canRemove', focusedNode) || false;
-        const canBeEdited = $get('policy.canEdit', focusedNode) || false;
-        const visibilityCanBeToggled = !$contains('_hidden', 'policy.disallowedProperties', focusedNode);
+        const canBeDeleted = $get('policy.canRemove', this.props.focusedNode) || false;
+        const canBeEdited = $get('policy.canEdit', this.props.focusedNode) || false;
+        const visibilityCanBeToggled = !$contains('_hidden', 'policy.disallowedProperties', this.props.focusedNode);
 
         return (
             <div className={style.inlineUi} data-__neos__inline-ui="TRUE">

--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -19,9 +19,7 @@ import style from './style.css';
     backgroundColor: $get('ui.contentCanvas.backgroundColor'),
     src: $get('ui.contentCanvas.src'),
     baseNodeType: $get('ui.pageTree.filterNodeType'),
-    currentEditPreviewMode: selectors.UI.EditPreviewMode.currentEditPreviewMode,
-    isDiscarding: $get('ui.remote.isDiscarding'),
-    isLoading: $get('ui.contentCanvas.isLoading')
+    currentEditPreviewMode: selectors.UI.EditPreviewMode.currentEditPreviewMode
 }), {
     startLoading: actions.UI.ContentCanvas.startLoading,
     stopLoading: actions.UI.ContentCanvas.stopLoading,
@@ -73,8 +71,6 @@ export default class ContentCanvas extends PureComponent {
             isFringeLeft,
             isFringeRight,
             isFullScreen,
-            isDiscarding,
-            isLoading,
             src,
             currentEditPreviewMode,
             editPreviewModes,
@@ -87,7 +83,6 @@ export default class ContentCanvas extends PureComponent {
             [style['contentCanvas--isFringeLeft']]: isFringeLeft,
             [style['contentCanvas--isFringeRight']]: isFringeRight,
             [style['contentCanvas--isFullScreen']]: isFullScreen,
-            [style['contentCanvas--isTemporaryDisabled']]: isDiscarding || isLoading,
             [style['contentCanvas--isHidden']]: !isVisible
         });
         const InlineUI = guestFrameRegistry.get('InlineUIComponent');

--- a/packages/neos-ui/src/Containers/ContentCanvas/style.css
+++ b/packages/neos-ui/src/Containers/ContentCanvas/style.css
@@ -32,21 +32,6 @@
         background-color: white;
     }
 }
-
-.contentCanvas--isTemporaryDisabled {
-    &::before {
-        position: absolute;
-        display: flex;
-        content: ' ';
-        width: inherit;
-        height: inherit;
-        background: var(--colors-ContrastDarkest);
-        z-index: var(--zIndex-Dialog-Context);
-        opacity: .1;
-        transition: var(--transition-Fast)  ease opacity;
-        cursor: wait;
-    }
-}
 .contentCanvas__itemWrapper {
     width: 100%;
     height: 100%;


### PR DESCRIPTION
Reverts neos/neos-ui#2942

This change leads to the regression that the navigation in the guest frame is not working anymore.
When navigating to a page within the guest frame, this ends up in an endless loading. 
The `@neos/neos-ui/UI/ContentCanvas/STOP_LOADING` is fired but as `@neos/neos-ui/UI/ContentCanvas/START_LOADING` occurs multiple times we can not succeed.