### PR TITLE
FEATURE: Improve help of the make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ clean:
 # help command as default
 ################################################################################
 
-# define indention for desciptions
+# define indention for descriptions
 TARGET_MAX_CHAR_NUM=40
 
 ## Show help


### PR DESCRIPTION
The old make help missed some commands and was not very nice, as the spacing for long commands did not exist and therefore the command floats into the description.

With these change, we get all commands rendered and can define the space between the commands and the description. Additionally, we have a colorful output.

Resolves: #2972