### PR TITLE
BUGFIX: EditNodePrivilege combined with EditNodePropertyPrivilege

### DIFF
--- a/Classes/Aspects/AugmentationAspect.php
+++ b/Classes/Aspects/AugmentationAspect.php
@@ -174,9 +174,10 @@ class AugmentationAspect
         $node = $joinPoint->getMethodArgument('node');
         $content = $joinPoint->getMethodArgument('content');
 
+        $disallowedProperties = $this->nodePolicyService->getDisallowedProperties($node);
         /** @var ContentContext $contentContext */
         $contentContext = $node->getContext();
-        if (!$contentContext->isInBackend()) {
+        if (!$contentContext->isInBackend() || in_array($property, $disallowedProperties, true)) {
             return $content;
         }
 

--- a/Classes/Service/NodePolicyService.php
+++ b/Classes/Service/NodePolicyService.php
@@ -11,16 +11,11 @@ namespace Neos\Neos\Ui\Service;
  * source code.
  */
 
-use Neos\ContentRepository\Domain\Service\NodeTypeManager;
-use Neos\ContentRepository\Security\Authorization\Privilege\Node\CreateNodePrivilege;
-use Neos\ContentRepository\Security\Authorization\Privilege\Node\CreateNodePrivilegeSubject;
-use Neos\ContentRepository\Security\Authorization\Privilege\Node\EditNodePrivilege;
-use Neos\ContentRepository\Security\Authorization\Privilege\Node\EditNodePropertyPrivilege;
-use Neos\ContentRepository\Security\Authorization\Privilege\Node\NodePrivilegeSubject;
-use Neos\ContentRepository\Security\Authorization\Privilege\Node\PropertyAwareNodePrivilegeSubject;
-use Neos\ContentRepository\Security\Authorization\Privilege\Node\RemoveNodePrivilege;
-use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+use Neos\ContentRepository\Security\Authorization\Privilege\Node\NodePrivilegeSubject;
+use Neos\ContentRepository\Service\AuthorizationService;
+use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Security\Authorization\Privilege\PrivilegeInterface;
 use Neos\Flow\Security\Authorization\PrivilegeManagerInterface;
@@ -32,6 +27,11 @@ use Neos\Neos\Security\Authorization\Privilege\NodeTreePrivilege;
  */
 class NodePolicyService
 {
+    /**
+     * @Flow\Inject
+     * @var AuthorizationService
+     */
+    protected $authorizationService;
 
     /**
      * @Flow\Inject
@@ -104,30 +104,11 @@ class NodePolicyService
 
     /**
      * @param NodeInterface $node
-     * @return array
+     * @return string[]
      */
     public function getDisallowedNodeTypes(NodeInterface $node): array
     {
-        $disallowedNodeTypes = [];
-
-        if (!isset(self::getUsedPrivilegeClassNames($this->objectManager)[CreateNodePrivilege::class])) {
-            return $disallowedNodeTypes;
-        }
-
-        $filter = function ($nodeType) use ($node) {
-            return !$this->privilegeManager->isGranted(
-                CreateNodePrivilege::class,
-                new CreateNodePrivilegeSubject($node, $nodeType)
-            );
-        };
-
-        $disallowedNodeTypeObjects = array_filter($this->nodeTypeManager->getNodeTypes(), $filter);
-
-        $mapper = function ($nodeType) {
-            return $nodeType->getName();
-        };
-
-        return array_values(array_map($mapper, $disallowedNodeTypeObjects));
+        return array_values($this->authorizationService->getNodeTypeNamesDeniedForCreation($node));
     }
 
     /**
@@ -136,12 +117,7 @@ class NodePolicyService
      */
     public function canRemoveNode(NodeInterface $node): bool
     {
-        $canRemove = true;
-        if (isset(self::getUsedPrivilegeClassNames($this->objectManager)[RemoveNodePrivilege::class])) {
-            $canRemove = $this->privilegeManager->isGranted(RemoveNodePrivilege::class, new NodePrivilegeSubject($node));
-        }
-
-        return $canRemove;
+        return $this->authorizationService->isGrantedToRemoveNode($node);
     }
 
     /**
@@ -150,34 +126,15 @@ class NodePolicyService
      */
     public function canEditNode(NodeInterface $node): bool
     {
-        $canEdit = true;
-        if (isset(self::getUsedPrivilegeClassNames($this->objectManager)[EditNodePrivilege::class])) {
-            $canEdit = $this->privilegeManager->isGranted(EditNodePrivilege::class, new NodePrivilegeSubject($node));
-        }
-
-        return $canEdit;
+        return $this->authorizationService->isGrantedToEditNode($node);
     }
 
     /**
      * @param NodeInterface $node
-     * @return array
+     * @return string[]
      */
     public function getDisallowedProperties(NodeInterface $node): array
     {
-        $disallowedProperties = [];
-
-        if (!isset(self::getUsedPrivilegeClassNames($this->objectManager)[EditNodePropertyPrivilege::class])) {
-            return $disallowedProperties;
-        }
-
-        $filter = function ($propertyName) use ($node) {
-            return !$this->privilegeManager->isGranted(
-                EditNodePropertyPrivilege::class,
-                new PropertyAwareNodePrivilegeSubject($node, null, $propertyName)
-            );
-        };
-
-        $disallowedProperties = array_filter(array_keys($node->getNodeType()->getProperties()), $filter);
-        return $disallowedProperties;
+        return $this->authorizationService->getDeniedNodePropertiesForEditing($node);
     }
 }

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/HideSelectedNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/HideSelectedNode/index.js
@@ -19,29 +19,28 @@ export default class HideSelectedNode extends PureComponent {
         hideNode: PropTypes.func.isRequired,
         showNode: PropTypes.func.isRequired,
         destructiveOperationsAreDisabled: PropTypes.bool.isRequired,
-        canBeEdited: PropTypes.bool.isRequired,
         visibilityCanBeToggled: PropTypes.bool.isRequired,
         i18nRegistry: PropTypes.object.isRequired
     };
 
     handleHideNode = () => {
-        const {node, hideNode, canBeEdited, visibilityCanBeToggled} = this.props;
+        const {node, hideNode, visibilityCanBeToggled} = this.props;
 
-        if (canBeEdited && visibilityCanBeToggled) {
+        if (visibilityCanBeToggled) {
             hideNode($get('contextPath', node));
         }
     }
 
     handleShowNode = () => {
-        const {node, showNode, canBeEdited, visibilityCanBeToggled} = this.props;
+        const {node, showNode, visibilityCanBeToggled} = this.props;
 
-        if (canBeEdited && visibilityCanBeToggled) {
+        if (visibilityCanBeToggled) {
             showNode($get('contextPath', node));
         }
     }
 
     render() {
-        const {className, node, destructiveOperationsAreDisabled, canBeEdited, visibilityCanBeToggled, i18nRegistry} = this.props;
+        const {className, node, destructiveOperationsAreDisabled, visibilityCanBeToggled, i18nRegistry} = this.props;
         const isHidden = $get('properties._hidden', node);
 
         return (
@@ -49,7 +48,7 @@ export default class HideSelectedNode extends PureComponent {
                 id="neos-InlineToolbar-HideSelectedNode"
                 className={className}
                 isActive={isHidden}
-                disabled={destructiveOperationsAreDisabled || !canBeEdited || !visibilityCanBeToggled}
+                disabled={destructiveOperationsAreDisabled || !visibilityCanBeToggled}
                 onClick={isHidden ? this.handleShowNode : this.handleHideNode}
                 icon="eye-slash"
                 hoverStyle="brand"

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -290,7 +290,7 @@ export default class Node extends PureComponent {
         const labelTitle = decodeLabel($get('label', node)) + ' (' + this.getNodeTypeLabel() + ')';
 
         // Autocreated or we have nested nodes and the node that we are dragging belongs to the selection
-        const dragForbidden = node.isAutoCreated || (hasNestedNodes(focusedNodesContextPaths) && focusedNodesContextPaths.includes(node.contextPath));
+        const dragForbidden = (node.isAutoCreated && !$get('policy.canEdit', node)) || (hasNestedNodes(focusedNodesContextPaths) && focusedNodesContextPaths.includes(node.contextPath));
 
         return (
             <Tree.Node aria-expanded={this.isCollapsed() ? 'false' : 'true'} aria-labelledby={labelIdentifier}>

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
@@ -64,16 +64,16 @@ export default class NodeTreeToolBar extends PureComponent {
     }
 
     handleHideNode = () => {
-        const {hideNodes, canBeEdited, visibilityCanBeToggled, focusedNodesContextPaths} = this.props;
-        if (canBeEdited && visibilityCanBeToggled) {
+        const {hideNodes, visibilityCanBeToggled, focusedNodesContextPaths} = this.props;
+        if (visibilityCanBeToggled) {
             hideNodes(focusedNodesContextPaths);
         }
     }
 
     handleShowNode = () => {
-        const {showNodes, canBeEdited, visibilityCanBeToggled, focusedNodesContextPaths} = this.props;
+        const {showNodes, visibilityCanBeToggled, focusedNodesContextPaths} = this.props;
 
-        if (canBeEdited && visibilityCanBeToggled) {
+        if (visibilityCanBeToggled) {
             showNodes(focusedNodesContextPaths);
         }
     }
@@ -164,7 +164,7 @@ export default class NodeTreeToolBar extends PureComponent {
                             i18nRegistry={i18nRegistry}
                             className={style.toolBar__btnGroup__btn}
                             focusedNodeContextPath={focusedNodeContextPath}
-                            disabled={destructiveOperationsAreDisabled || !canBeEdited || !visibilityCanBeToggled}
+                            disabled={destructiveOperationsAreDisabled || !visibilityCanBeToggled}
                             isHidden={isHidden}
                             onClick={isHidden ? this.handleShowNode : this.handleHideNode}
                             id={`neos-${treeType}-HideSelectedNode`}

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
@@ -30,7 +30,7 @@ export default class TabPanel extends PureComponent {
             return false;
         }
 
-        return $get(['policy', 'canEdit'], node) && !$contains(item.id, 'policy.disallowedProperties', node);
+        return $get(['policy', 'canEdit'], node) && !$contains($get('id', item), 'policy.disallowedProperties', node);
     };
 
     renderTabPanel = groups => {

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -242,11 +242,11 @@ export default class Inspector extends PureComponent {
 
         if ($get('hidden', item) || ($get('isAutoCreated', focusedNode) === true && item.id === '_hidden')) {
             // This accounts for the fact that auto-created child nodes cannot
-            // be hidden via the insprector (see: #2282)
+            // be hidden via the inspector (see: #2282)
             return false;
         }
 
-        return $get(['policy', 'canEdit'], focusedNode) && !$contains(item.id, 'policy.disallowedProperties', focusedNode);
+        return $get(['policy', 'canEdit'], focusedNode) && !$contains($get('id', item), 'policy.disallowedProperties', focusedNode);
     };
 
     /**


### PR DESCRIPTION
This is a rebased version of #2165:

> This PR contains multiple fixes to get to the point where the behavior of the UI corresponds to the behavior of the ContentRepository.
>
> When you get an abstaining EditNodePrivilege (resulting in a "soft" DENY) in combination with an EditNodePropertyPrivilege GRANT, the UI ignores the latter and denies editing. The ContentRepository on the other hand (or rather Flows SecurityInterceptor) sees both privileges matching, one abstaining and the other granting, so it will allow access to the editProperty method.

Please cautiously check if the rebased version still works as intended as I only rebased this "blindly" (i.e. no running Neos instance) since I currently don't have a running dev environment and unfortunately not enough time to set it up atm.