### PR TITLE
BUGFIX: Issue #2976 adjust handling of long labels for boolean editor

### DIFF
--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -19,7 +19,7 @@ import {Icon} from '@neos-project/react-ui-components';
 }))
 export default class EditorEnvelope extends PureComponent {
     state = {
-        showHelpmessage: false
+        showHelpMessage: false
     };
 
     static defaultProps = {
@@ -113,10 +113,10 @@ export default class EditorEnvelope extends PureComponent {
         );
     }
 
-    toggleHelmpessage = event => {
+    toggleHelpMessage = event => {
         event.preventDefault();
         this.setState({
-            showHelpmessage: !this.state.showHelpmessage
+            showHelpMessage: !this.state.showHelpMessage
         });
     };
 
@@ -128,7 +128,7 @@ export default class EditorEnvelope extends PureComponent {
         return thumbnail;
     }
 
-    renderHelpmessage() {
+    renderHelpMessage() {
         const {i18nRegistry, helpMessage, helpThumbnail, label} = this.props;
 
         const translatedHelpMessage = i18nRegistry.translate(helpMessage);
@@ -145,7 +145,7 @@ export default class EditorEnvelope extends PureComponent {
     renderHelpIcon = () => {
         if (this.props.helpMessage || this.props.helpThumbnail) {
             return (
-                <span role="button" onClick={this.toggleHelmpessage} className={style.envelope__tooltipButton}>
+                <span role="button" onClick={this.toggleHelpMessage} className={style.envelope__tooltipButton}>
                     <Icon icon="question-circle" />
                 </span>
             );
@@ -170,7 +170,7 @@ export default class EditorEnvelope extends PureComponent {
                     {this.renderLabel()}
                 </span>
                 {this.renderEditorComponent()}
-                {this.state.showHelpmessage ? this.renderHelpmessage() : ''}
+                {this.state.showHelpMessage ? this.renderHelpMessage() : ''}
                 {this.isInvalid() && <Tooltip renderInline asError><ul>{validationErrors.map((error, index) => <li key={index}>{error}</li>)}</ul></Tooltip>}
             </Fragment>
         );

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -113,7 +113,8 @@ export default class EditorEnvelope extends PureComponent {
         );
     }
 
-    toggleHelmpessage = () => {
+    toggleHelmpessage = event => {
+        event.preventDefault();
         this.setState({
             showHelpmessage: !this.state.showHelpmessage
         });

--- a/packages/neos-ui-editors/src/Editors/Boolean/index.js
+++ b/packages/neos-ui-editors/src/Editors/Boolean/index.js
@@ -47,9 +47,11 @@ const BooleanEditor = props => {
         <div className={wrapperClassName}>
             <Label className={finalClassName}>
                 <CheckBox isChecked={toBoolean(value)} disabled={finalOptions.disabled} onChange={commit}/>
-                <I18n id={label}/>
+                <span>
+                    <I18n id={label}/>
+                    {props.renderHelpIcon ? props.renderHelpIcon() : ''}
+                </span>
             </Label>
-            {props.renderHelpIcon ? props.renderHelpIcon() : ''}
         </div>
     );
 };

--- a/packages/neos-ui-editors/src/Editors/Boolean/style.css
+++ b/packages/neos-ui-editors/src/Editors/Boolean/style.css
@@ -13,5 +13,5 @@
 
 .boolean__label {
     max-width: none;
-    display: inline;
+    display: flex;
 }

--- a/packages/react-ui-components/src/CheckBox/style.css
+++ b/packages/react-ui-components/src/CheckBox/style.css
@@ -1,7 +1,9 @@
 .checkbox {
     composes: reset from './../reset.css';
     position: relative;
-    display: inline-block;
+    display: block;
+    width: 20px;
+    height: 20px;
     margin-right: 8px;
     vertical-align: middle;
 }

--- a/packages/react-ui-components/src/Label/style.css
+++ b/packages/react-ui-components/src/Label/style.css
@@ -10,9 +10,6 @@
 
     &,
     span {
-        overflow: hidden;
-        white-space: nowrap;
-        text-overflow: ellipsis;
         max-width: 100%;
     }
 }


### PR DESCRIPTION
**What I did**
I adjust the handling of long labels for the boolean editor

**How I did it**
i adjusted the styling for the label, the checkbox and the boolean editor. I adjusted the rendering of the label and help message icon. I adjusted the toogleHelpMessage function.

**How to verify it**

Old:

![old](https://user-images.githubusercontent.com/23524251/140730028-6d497d11-8c78-4933-bc1e-56a8207032ec.png)

New:

![new](https://user-images.githubusercontent.com/23524251/140730852-76b37dc9-c10d-453e-9096-f87186a3c1f3.png)

