### PR TITLE
FEATURE: Adds resource icon component 

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
     "react-motion": "^0.5.0",
     "react-portal": "^4.2.0",
     "react-redux": "^7.1.3",
+    "react-svg": "^11.1.2",
     "react-test-renderer": "^16.12.0",
     "react-textarea-autosize": "^8.3.0",
     "recharts": "^1.0.0-alpha.6",

--- a/packages/react-ui-components/package.json
+++ b/packages/react-ui-components/package.json
@@ -53,6 +53,7 @@
     "react-height": "^3.0.0",
     "react-motion": "^0.5.0",
     "react-portal": "^4.2.0",
+    "react-svg": "^11.1.2",
     "react-textarea-autosize": "^8.3.0"
   },
   "license": "GNU GPLv3",

--- a/packages/react-ui-components/src/CheckBox/__snapshots__/checkBox.spec.tsx.snap
+++ b/packages/react-ui-components/src/CheckBox/__snapshots__/checkBox.spec.tsx.snap
@@ -18,6 +18,7 @@ exports[`<CheckBox/> should render correctly. 1`] = `
     icon="check"
     mapThemrProps={[Function]}
     padded="none"
+    size="sm"
   />
   <div
     className="inputMirrorClassName"

--- a/packages/react-ui-components/src/DateInput/__snapshots__/dateInput.spec.tsx.snap
+++ b/packages/react-ui-components/src/DateInput/__snapshots__/dateInput.spec.tsx.snap
@@ -17,6 +17,7 @@ exports[`<DateInput/> should render correctly. 1`] = `
         icon="far calendar-alt"
         mapThemrProps={[Function]}
         padded="none"
+        size="sm"
       />
     </button>
     <div
@@ -45,6 +46,7 @@ exports[`<DateInput/> should render correctly. 1`] = `
         icon="times"
         mapThemrProps={[Function]}
         padded="none"
+        size="sm"
       />
     </button>
   </div>
@@ -123,6 +125,7 @@ exports[`<DateInput/> should set "utc" on DatePickerComponent if "dateOnly" prop
         icon="far calendar-alt"
         mapThemrProps={[Function]}
         padded="none"
+        size="sm"
       />
     </button>
     <div
@@ -151,6 +154,7 @@ exports[`<DateInput/> should set "utc" on DatePickerComponent if "dateOnly" prop
         icon="times"
         mapThemrProps={[Function]}
         padded="none"
+        size="sm"
       />
     </button>
   </div>

--- a/packages/react-ui-components/src/DropDown/__snapshots__/header.spec.tsx.snap
+++ b/packages/react-ui-components/src/DropDown/__snapshots__/header.spec.tsx.snap
@@ -15,6 +15,7 @@ exports[`<ShallowDropDownHeader/> should render correctly. 1`] = `
     icon="chevron-down"
     mapThemrProps={[Function]}
     padded="none"
+    size="sm"
   />
 </div>
 `;

--- a/packages/react-ui-components/src/Icon/__snapshots__/fontAwesomeIcon.spec.tsx.snap
+++ b/packages/react-ui-components/src/Icon/__snapshots__/fontAwesomeIcon.spec.tsx.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<FontAwesomeIcon/> should render correctly. 1`] = `
+<FontAwesomeIcon
+  border={false}
+  className="iconClassName fooIconClassName"
+  fixedWidth={false}
+  flip={null}
+  icon={
+    Array [
+      "fas",
+      "fooIconClassName",
+    ]
+  }
+  inverse={false}
+  listItem={false}
+  mask={null}
+  pull={null}
+  pulse={false}
+  rotation={null}
+  size="sm"
+  spin={false}
+  swapOpacity={false}
+  symbol={false}
+  title=""
+  transform={null}
+/>
+`;

--- a/packages/react-ui-components/src/Icon/__snapshots__/icon.spec.tsx.snap
+++ b/packages/react-ui-components/src/Icon/__snapshots__/icon.spec.tsx.snap
@@ -2,27 +2,23 @@
 
 exports[`<Icon/> should render correctly. 1`] = `
 <FontAwesomeIcon
-  border={false}
-  className="iconClassName fooIconClassName"
-  fixedWidth={false}
-  flip={null}
-  icon={
-    Array [
-      "fas",
-      "fooIconClassName",
-    ]
+  color="default"
+  icon="fooIconClassName"
+  padded="none"
+  size="sm"
+  theme={
+    Object {
+      "icon": "iconClassName",
+      "icon--big": "bigClassName",
+      "icon--color-error": "color-errorClassName",
+      "icon--color-primaryBlue": "color-primaryBlueClassName",
+      "icon--color-warn": "color-warnClassName",
+      "icon--paddedLeft": "paddedLeftClassName",
+      "icon--paddedRight": "paddedRightClassName",
+      "icon--small": "smallClassName",
+      "icon--spin": "spinClassName",
+      "icon--tiny": "tinyClassName",
+    }
   }
-  inverse={false}
-  listItem={false}
-  mask={null}
-  pull={null}
-  pulse={false}
-  rotation={null}
-  size={null}
-  spin={false}
-  swapOpacity={false}
-  symbol={false}
-  title=""
-  transform={null}
 />
 `;

--- a/packages/react-ui-components/src/Icon/fontAwesomeIcon.spec.tsx
+++ b/packages/react-ui-components/src/Icon/fontAwesomeIcon.spec.tsx
@@ -2,9 +2,10 @@ import {shallow} from 'enzyme';
 import toJson from 'enzyme-to-json';
 import React from 'react';
 
-import Icon, {defaultProps, IconProps} from './icon';
+import {defaultProps, IconProps} from './icon';
+import FontAwesomeIcon from './fontAwesomeIcon';
 
-describe('<Icon/>', () => {
+describe('<FontAwesomeIcon/>', () => {
     const props: IconProps = {
         ...defaultProps,
         icon: 'fooIconClassName',
@@ -23,15 +24,25 @@ describe('<Icon/>', () => {
     };
 
     it('should render correctly.', () => {
-        const wrapper = shallow(<Icon {...props}/>);
+        const wrapper = shallow(<FontAwesomeIcon {...props}/>);
 
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     it('should allow the propagation of "className" with the "className" prop.', () => {
-        const wrapper = shallow(<Icon {...props} className="fooClassName"/>);
+        const wrapper = shallow(<FontAwesomeIcon {...props} className="fooClassName"/>);
 
         expect(wrapper.prop('className')).toContain('fooClassName');
+    });
+
+    it('should call the "fontAwesome.getClassName" api method and render the returned className.', () => {
+        const wrapper = shallow(<FontAwesomeIcon {...props}/>);
+        expect(wrapper.hasClass('fooIconClassName')).toBeTruthy();
+    });
+
+    it('should allow the propagation of custom "icon" with the "icon" prop.', () => {
+        const wrapper = shallow(<FontAwesomeIcon {...props} icon="bazIconClassName"/>);
+        expect(wrapper.hasClass('bazIconClassName')).toBeTruthy();
     });
 });
 

--- a/packages/react-ui-components/src/Icon/fontAwesomeIcon.tsx
+++ b/packages/react-ui-components/src/Icon/fontAwesomeIcon.tsx
@@ -1,0 +1,58 @@
+import {config, IconName, IconPrefix, library} from '@fortawesome/fontawesome-svg-core';
+import '@fortawesome/fontawesome-svg-core/styles.css';
+import {fab} from '@fortawesome/free-brands-svg-icons';
+import {far} from '@fortawesome/free-regular-svg-icons';
+import {fas} from '@fortawesome/free-solid-svg-icons';
+
+import {FontAwesomeIcon as FontAwesomeIconOriginComponent} from '@fortawesome/react-fontawesome';
+import mergeClassNames from 'classnames';
+import React, {PureComponent} from 'react';
+
+import {IconProps, defaultProps} from './icon';
+import mapper from './mapper';
+
+// tslint:disable:no-object-mutation
+config.autoAddCss = false;
+config.familyPrefix = 'neos-fa' as IconPrefix;
+config.replacementClass = 'neos-svg-inline--fa';
+// tslint:enable:no-object-mutation
+
+library.add(fab, fas, far);
+
+class FontAwesomeIcon extends PureComponent<IconProps> {
+    public static readonly defaultProps = defaultProps;
+
+    public render(): JSX.Element | null {
+        const {padded, theme, label, icon, className, color, ...rest} = this.props;
+        const iconClassName = icon;
+        const classNames = mergeClassNames(
+            theme!.icon,
+            iconClassName,
+            className,
+            {
+                [theme!['icon--paddedLeft']]: padded === 'left',
+                [theme!['icon--paddedRight']]: padded === 'right',
+                [theme!['icon--color-warn']]: color === 'warn',
+                [theme!['icon--color-error']]: color === 'error',
+                [theme!['icon--color-primaryBlue']]: color === 'primaryBlue',
+            }
+        );
+
+        return <FontAwesomeIconOriginComponent icon={icon ? this.getIconProp(icon) as any : 'question'} aria-label={label} className={classNames} {...rest} />;
+    }
+
+    private readonly getIconProp = (icon: string): any => {
+        const mappedIcon = mapper(icon);
+        const iconArray = mappedIcon.split(' ');
+        if (iconArray.length > 1) {
+            const prefix = iconArray[0];
+            const processedIcon = iconArray[1].startsWith('fa-') ? iconArray[1].substr(3) : iconArray[1];
+            return [prefix as IconPrefix, processedIcon as IconName];
+        } else {
+            const prefix: IconPrefix = 'fas';
+            return [prefix, mappedIcon as IconName];
+        }
+    }
+}
+
+export default FontAwesomeIcon;

--- a/packages/react-ui-components/src/Icon/icon.tsx
+++ b/packages/react-ui-components/src/Icon/icon.tsx
@@ -1,15 +1,15 @@
-import {IconName, IconPrefix, IconProp} from '@fortawesome/fontawesome-svg-core';
-import {FontAwesomeIcon, Props} from '@fortawesome/react-fontawesome';
-import mergeClassNames from 'classnames';
 import React, {PureComponent} from 'react';
 
+import {FontAwesomeIconProps} from '@fortawesome/react-fontawesome';
 import {PickDefaultProps, Omit} from '../../types';
-import mapper from './mapper';
+import FontAwesomeIcon from './fontAwesomeIcon';
+import ResourceIcon, {ResourceIconProps} from './resourceIcon';
 
+type IconSize = 'xs' | 'sm' | 'lg';
 type IconPadding = 'none' | 'left' | 'right';
 type IconColor = 'default' | 'warn' | 'error' | 'primaryBlue';
 
-interface IconTheme {
+export interface IconTheme {
     readonly icon: string;
     readonly 'icon--big': string;
     readonly 'icon--small': string;
@@ -22,7 +22,7 @@ interface IconTheme {
     readonly 'icon--color-primaryBlue': string;
 }
 
-export interface IconProps extends Omit<Props, 'icon'> {
+export interface IconProps extends Omit<FontAwesomeIconProps, 'icon'> {
     /**
      * We use the react component FortAwesome provides to render icons.
      * we will pass down all props to the component via {...rest} to expose it's api
@@ -30,7 +30,8 @@ export interface IconProps extends Omit<Props, 'icon'> {
      */
 
     /**
-     * The ID of the icon to render.
+     * The identifier of the icon to render.
+     * Can be a font-awesome icon identifier or a asset resource.
      */
     readonly icon?: string;
 
@@ -55,50 +56,34 @@ export interface IconProps extends Omit<Props, 'icon'> {
     readonly color?: IconColor;
 
     /**
+     *  Adjust the size of the icon
+     */
+    readonly size?: IconSize;
+
+    /**
      *  An optional css theme to be injected.
      */
     readonly theme?: IconTheme;
 }
 
-type DefaultProps = PickDefaultProps<IconProps, 'color' | 'padded'>;
+type DefaultProps = PickDefaultProps<IconProps, 'color' | 'padded' | 'size'>;
 
 export const defaultProps: DefaultProps = {
     color: 'default',
-    padded: 'none'
+    padded: 'none',
+    size: 'sm'
 };
 
 class Icon extends PureComponent<IconProps> {
     public static readonly defaultProps = defaultProps;
 
     public render(): JSX.Element | null {
-        const {padded, theme, label, icon, className, color, ...rest} = this.props;
-        const iconClassName = icon;
-        const classNames = mergeClassNames(
-            theme!.icon,
-            iconClassName,
-            className,
-            {
-                [theme!['icon--paddedLeft']]: padded === 'left',
-                [theme!['icon--paddedRight']]: padded === 'right',
-                [theme!['icon--color-warn']]: color === 'warn',
-                [theme!['icon--color-error']]: color === 'error',
-                [theme!['icon--color-primaryBlue']]: color === 'primaryBlue',
-            }
-        );
+        const {icon} = this.props;
 
-        return <FontAwesomeIcon icon={icon ? this.getIconProp(icon) as any : 'question'} aria-label={label} className={classNames} {...rest} />;
-    }
-
-    private readonly getIconProp = (icon: string): IconProp => {
-        const mappedIcon = mapper(icon);
-        const iconArray = mappedIcon.split(' ');
-        if (iconArray.length > 1) {
-            const prefix = iconArray[0];
-            const processedIcon = iconArray[1].startsWith('fa-') ? iconArray[1].substr(3) : iconArray[1];
-            return [prefix as IconPrefix, processedIcon as IconName];
+        if (icon && icon.substr(0, 11) === 'resource://') {
+            return <ResourceIcon {...this.props as ResourceIconProps} />;
         } else {
-            const prefix: IconPrefix = 'fas';
-            return [prefix, mappedIcon as IconName];
+            return <FontAwesomeIcon {...this.props} />;
         }
     }
 }

--- a/packages/react-ui-components/src/Icon/index.ts
+++ b/packages/react-ui-components/src/Icon/index.ts
@@ -1,21 +1,8 @@
-import {config, IconPrefix, library} from '@fortawesome/fontawesome-svg-core';
-import '@fortawesome/fontawesome-svg-core/styles.css';
-import {fab} from '@fortawesome/free-brands-svg-icons';
-import {far} from '@fortawesome/free-regular-svg-icons';
-import {fas} from '@fortawesome/free-solid-svg-icons';
 import {themr} from '@friendsofreactjs/react-css-themr';
 
 import identifiers from '../identifiers';
 import Icon from './icon';
 
 import style from './style.css';
-
-// tslint:disable:no-object-mutation
-config.autoAddCss = false;
-config.familyPrefix = 'neos-fa' as IconPrefix;
-config.replacementClass = 'neos-svg-inline--fa';
-// tslint:enable:no-object-mutation
-
-library.add(fab, fas, far);
 
 export default themr(identifiers.icon, style)(Icon);

--- a/packages/react-ui-components/src/Icon/resourceIcon.tsx
+++ b/packages/react-ui-components/src/Icon/resourceIcon.tsx
@@ -1,0 +1,47 @@
+import mergeClassNames from 'classnames';
+import React, {PureComponent} from 'react';
+import { ReactSVG } from 'react-svg';
+
+import {IconProps, IconTheme, defaultProps} from './icon';
+import {Omit} from '../../types';
+
+interface ResourceIconTheme extends IconTheme {
+    readonly 'icon--resource': string;
+}
+
+export interface ResourceIconProps extends Omit<IconProps, 'theme'> {
+    readonly theme?: ResourceIconTheme;
+}
+
+class ResourceIcon extends PureComponent<ResourceIconProps> {
+    public static readonly defaultProps = defaultProps;
+
+    public render(): JSX.Element | null {
+        const {padded, theme, label, icon, className, color, size} = this.props;
+
+        if (!icon || icon.substr(0, 11) !== 'resource://') {
+            return null;
+        }
+
+        const iconResourcePath = '/_Resources/Static/Packages/' + icon.substr(11);
+        const classNames = mergeClassNames(
+            theme!.icon,
+            className,
+            {
+                [theme!['icon--resource']]: icon,
+                [theme!['icon--paddedLeft']]: padded === 'left',
+                [theme!['icon--paddedRight']]: padded === 'right',
+                [theme!['icon--color-warn']]: color === 'warn',
+                [theme!['icon--color-error']]: color === 'error',
+                [theme!['icon--color-primaryBlue']]: color === 'primaryBlue',
+                [theme!['icon--big']]: size === 'lg',
+                [theme!['icon--small']]: size === 'sm',
+                [theme!['icon--tiny']]: size === 'xs'
+            }
+        );
+
+        return <ReactSVG src={iconResourcePath} aria-label={label} className={classNames} wrapper="span" />;
+    }
+}
+
+export default ResourceIcon;

--- a/packages/react-ui-components/src/Icon/style.css
+++ b/packages/react-ui-components/src/Icon/style.css
@@ -25,3 +25,27 @@
 .icon--color-primaryBlue {
     color: var(--colors-PrimaryBlue);
 }
+
+.icon--big {
+    svg {
+        height: 1.33em;
+    }
+}
+
+.icon--small {
+    svg {
+        height: 1em;
+    }
+}
+
+.icon--tiny {
+    svg {
+        height: .75em;
+    }
+}
+
+.icon--resource {
+    display: inline-grid;
+    width: 100%;
+    justify-content: center;
+}

--- a/packages/react-ui-components/src/IconButton/__snapshots__/iconButton.spec.tsx.snap
+++ b/packages/react-ui-components/src/IconButton/__snapshots__/iconButton.spec.tsx.snap
@@ -20,6 +20,7 @@ exports[`<IconButton/> should render correctly. 1`] = `
     icon="fooIconName"
     mapThemrProps={[Function]}
     padded="none"
+    size="sm"
   />
 </ThemedButton>
 `;

--- a/packages/react-ui-components/src/IconButtonDropDown/__snapshots__/iconButtonDropDown.spec.tsx.snap
+++ b/packages/react-ui-components/src/IconButtonDropDown/__snapshots__/iconButtonDropDown.spec.tsx.snap
@@ -30,6 +30,7 @@ exports[`<IconButtonDropDown/> should render correctly. 1`] = `
       icon="fooModeIcon"
       mapThemrProps={[Function]}
       padded="none"
+      size="sm"
     />
     <ThemedIcon
       className="baseBtnIconClassName"
@@ -38,6 +39,7 @@ exports[`<IconButtonDropDown/> should render correctly. 1`] = `
       icon="barGeneralIcon"
       mapThemrProps={[Function]}
       padded="none"
+      size="sm"
     />
   </ThemedButton>
   <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,6 +220,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.13":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.0.tgz#e27b977f2e2088ba24748bf99b5e1dece64e4f0b"
+  integrity sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -1289,6 +1296,15 @@
   dependencies:
     remark "^13.0.0"
     unist-util-find-all-after "^3.0.2"
+
+"@tanem/svg-injector@^8.2.4":
+  version "8.2.5"
+  resolved "https://registry.yarnpkg.com/@tanem/svg-injector/-/svg-injector-8.2.5.tgz#49d957b6c51bdd5d505f82aaadb5cb72ff05f7ac"
+  integrity sha512-jQ6UPPY2oSu2d0YLngtvnOIoKheYsB/s2bNP/QdsLrsvlz+PzUUO4RUWBN3+8clZPi2SI5OMF/YoTiTKt5v2xw==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
+    content-type "^1.0.4"
+    tslib "^2.1.0"
 
 "@types/agent-base@^4.2.0":
   version "4.2.0"
@@ -4912,7 +4928,7 @@ content-disposition@0.5.3:
   dependencies:
     safe-buffer "5.1.2"
 
-content-type@~1.0.4:
+content-type@^1.0.4, content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
@@ -13847,6 +13863,15 @@ react-style-proptype@^3.0.0:
   dependencies:
     prop-types "^15.5.4"
 
+react-svg@^11.1.2:
+  version "11.2.5"
+  resolved "https://registry.yarnpkg.com/react-svg/-/react-svg-11.2.5.tgz#41ddfd96818a54a3a69dfa3903ed40d4fb32a122"
+  integrity sha512-uUMhRVdU//5qktiTSO2W6nQeHRLwYA1FsWANQFB5O33UgT2uT0V5wVapu46+wz1mx6wt1j53+1aA8QuNn4lJ6A==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
+    "@tanem/svg-injector" "^8.2.4"
+    prop-types "^15.7.2"
+
 react-test-renderer@^16.0.0-0, react-test-renderer@^16.12.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.12.0.tgz#11417ffda579306d4e841a794d32140f3da1b43f"
@@ -16889,6 +16914,11 @@ tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tslib@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tslint-config-prettier@^1.15.0:
   version "1.18.0"


### PR DESCRIPTION
With these change, the icon component from a font-awesome only version to a more flexible component.
The idea is to have the possibility to use all icons the integrator wants.

In the first step, this change extracts the current icon behavior to an own FontAwesomeIcon component and adds a new ResourceIcon component. The icon component acts then as a de facto factory that checks if the icon property contains a resource URI or just a regular icon string.

The font-awesome icons are the default, and Neos will come now with an additional resource based SVG Icon.
In future, it would be nice to have something like Icon Providers so that people are able to easily register another IconProvider. For instance, a MaterialUIIconProivder.

The regular icons will work like before, but we are able to use now also resources like that:

```
'Neos.Demo:Document.Chapter':
  ui:
    icon: 'resource://Neos.Demo/Images/screen-heart.svg'
```

The integrators should now just be aware of colors and viewports of the SVG files.
