### PR TITLE
BUGFIX: Set color of links in help messages

### DIFF
--- a/packages/neos-ui-editors/src/EditorEnvelope/style.css
+++ b/packages/neos-ui-editors/src/EditorEnvelope/style.css
@@ -13,6 +13,16 @@
     z-index: var(--zIndex-NodeToolBar);
     max-width: 100%;
 }
+
+.envelope__helpmessage a {
+    color: var(--colors-PrimaryBlue);
+}
+
+.envelope__helpmessage a:hover,
+.envelope__helpmessage a:focus {
+    color: var(--colors-PrimaryBlueHover);
+}
+
 .envelope--invalid {
     box-shadow: 0 0 0 2px var(--colors-Error);
     border-radius: 2px;

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/style.css
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/style.css
@@ -86,6 +86,15 @@
     position: relative;
 }
 
+.helpMessage a {
+    color: var(--colors-PrimaryBlue);
+}
+
+.helpMessage a:hover,
+.helpMessage a:focus {
+    color: var(--colors-PrimaryBlueHover);
+}
+
 .helpMessage__label {
     display: block;
     margin-bottom: var(--spacing-Half);


### PR DESCRIPTION
Links in help messages are very hard to read, so I set the color.

### Before (creation dialog):
<img width="952" alt="CleanShot 2021-11-22 at 11 06 49@2x" src="https://user-images.githubusercontent.com/4510166/142843523-493af5de-a7ae-49eb-a010-122265def6a1.png">

### After (creation dialog):
<img width="956" alt="CleanShot 2021-11-22 at 11 07 03@2x" src="https://user-images.githubusercontent.com/4510166/142843647-502b5b26-e5e4-4ba7-8b62-370c16ce74c6.png">

### Before (inspector):
<img width="299" alt="CleanShot 2021-11-22 at 11 07 19@2x" src="https://user-images.githubusercontent.com/4510166/142843547-a3748f17-86fd-4486-b9d0-fbbeaa5a4863.png">

### After (inspector):
<img width="312" alt="CleanShot 2021-11-22 at 11 07 30@2x" src="https://user-images.githubusercontent.com/4510166/142843672-c0631686-6da9-4fe9-a1b2-ed46f86f4f31.png">


