### PR TITLE
FEATURE: Expose parentNode for ClientEval in right side bar

### DIFF
--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -36,13 +36,13 @@ import style from './style.css';
         const shouldShowUnappliedChangesOverlay = isDirty && !shouldPromptToHandleUnappliedChanges;
         const shouldShowSecondaryInspector = selectors.UI.Inspector.shouldShowSecondaryInspector(state);
         const focusedNode = selectors.CR.Nodes.focusedSelector(state);
-        const parentNode = selectors.CR.Nodes.nodeByContextPath(state)(focusedNode.parent)
+        const parentNode = selectors.CR.Nodes.nodeByContextPath(state)(focusedNode.parent);
 
         return {
-            focusedNode: focusedNode,
+            focusedNode,
             focusedContentNodesContextPaths: selectors.CR.Nodes.focusedNodePathsSelector(state),
             focusedDocumentNodesContextPaths: selectors.UI.PageTree.getAllFocused(state),
-            parentNode: parentNode,
+            parentNode,
             validationErrors: validationErrorsSelector(state),
             isApplyDisabled: isApplyDisabledSelector(state),
             transientValues: selectors.UI.Inspector.transientValues(state),


### PR DESCRIPTION
In some circumstances, we need to use ClientEval to hide a property, for instance. Actually it is just possible to use the current node data or some child information. But we have not much information about the parent.

As the neos-ui knows which node is the parent, it is quite helpful to use also parent node information in ClientEval. This PR adds the parent node to the context so that we have `node` and `parentNode` available in ClientEval.

**What I did**
Added the parentNode of the current focused node to the props, and therefore it is possible to use the parentNode also in the context of ClientEval.

**How to verify it**
If you have a node type property, you are able to use node and parentNode in the ClientEval.

```
'chapterImage':
      type: 'Neos\Media\Domain\Model\ImageInterface'
      ui:
        inspector:
          hidden: 'ClientEval:console.log(parentNode)'
```

Resolves: #2990