### PR TITLE
BUGFIX: Open links in new window

### DIFF
--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -136,7 +136,7 @@ export default class EditorEnvelope extends PureComponent {
 
         return (
             <Tooltip renderInline className={style.envelope__helpmessage}>
-                {helpMessage ? <ReactMarkdown source={translatedHelpMessage} /> : ''}
+                {helpMessage ? <ReactMarkdown source={translatedHelpMessage} linkTarget="_blank" /> : ''}
                 {helpThumbnail ? <img alt={label} src={helpThumbnailSrc} className={style.envelope__helpThumbnail} /> : ''}
             </Tooltip>
         );

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeGroupPanel.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeGroupPanel.js
@@ -98,7 +98,7 @@ class NodeTypeGroupPanel extends PureComponent {
                         <I18n id={label} fallback={label}/>
                     </span>
                     {thumbnail ? <img alt={label} src={thumbnail} className={style.helpThumbnail} /> : ''}
-                    <ReactMarkdown source={message} />
+                    <ReactMarkdown source={message} linkTarget="_blank" />
                 </div>
 
                 <IconButton className={style.helpMessage__closeButton} icon="times" onClick={onCloseHelpMessage} />


### PR DESCRIPTION
When links are defined in the help message, they open currently always in the same window. With this fix, the will open in a new window