### PR TITLE
BUGFIX: Don't render check mark for unchecked checkbox

### DIFF
--- a/packages/react-ui-components/src/CheckBox/__snapshots__/checkBox.spec.tsx.snap
+++ b/packages/react-ui-components/src/CheckBox/__snapshots__/checkBox.spec.tsx.snap
@@ -11,14 +11,6 @@ exports[`<CheckBox/> should render correctly. 1`] = `
     onChange={[Function]}
     type="checkbox"
   />
-  <ThemedIcon
-    className="checkboxIconClassName"
-    color="default"
-    composeTheme="deeply"
-    icon="check"
-    mapThemrProps={[Function]}
-    padded="none"
-  />
   <div
     className="inputMirrorClassName"
   />

--- a/packages/react-ui-components/src/CheckBox/checkBox.tsx
+++ b/packages/react-ui-components/src/CheckBox/checkBox.tsx
@@ -77,10 +77,7 @@ class CheckBox extends PureComponent<CheckBoxProps> {
                     onChange={this.handleChange}
                     disabled={disabled}
                     />
-                <Icon
-                    className={theme.checkbox__icon}
-                    icon="check"
-                    />
+                {isChecked ? <Icon className={theme.checkbox__icon} icon="check"/> : null}
                 <div className={mirrorClassNames}/>
             </div>
         );

--- a/packages/react-ui-components/src/CheckBox/style.css
+++ b/packages/react-ui-components/src/CheckBox/style.css
@@ -24,7 +24,7 @@
     top: 50%;
     left: 50%;
     transform: translateX(-50%) translateY(-50%);
-    opacity: .2;
+    opacity: 0;
 }
 .checkbox__inputMirror {
     composes: reset from './../reset.css';


### PR DESCRIPTION
For editors, it can be confusing that the checkbox renders a checkmark even when the checkbox is unchecked. The editor need to know that a gray out checkmark means that the checkbox is unchecked.

**What I did**
Conditionally render the checkmark icon.

**How to verify it**
Login to the backend and look for a checkbox in the right inspector.

resolves: #2978