### PR TITLE
BUGFIX: Range editor styling issues

### DIFF
--- a/packages/neos-ui-editors/src/Editors/Range/index.js
+++ b/packages/neos-ui-editors/src/Editors/Range/index.js
@@ -68,7 +68,7 @@ class RangeEditor extends PureComponent {
     };
 
     render() {
-        const options = Object.assign({}, this.constructor.defaultProps.options, this.props.options);
+        const options = {...this.constructor.defaultProps.options, ...this.props.options};
         const {value} = this.state;
 
         return (

--- a/packages/neos-ui-editors/src/Editors/Range/index.js
+++ b/packages/neos-ui-editors/src/Editors/Range/index.js
@@ -72,7 +72,7 @@ class RangeEditor extends PureComponent {
         const {value} = this.state;
 
         return (
-            <div className={style.rangeEditor + (options.disabled ? ' ' + style.rangeEditorDisabled : '' )}>
+            <div className={style.rangeEditor + (options.disabled ? ' ' + style.rangeEditorDisabled : '')}>
                 <input
                     type="range"
                     min={options.min}

--- a/packages/neos-ui-editors/src/Editors/Range/index.js
+++ b/packages/neos-ui-editors/src/Editors/Range/index.js
@@ -68,7 +68,7 @@ class RangeEditor extends PureComponent {
     };
 
     render() {
-        const {options} = this.props;
+        const options = Object.assign({}, this.constructor.defaultOptions, this.props.options);
         const {value} = this.state;
 
         return (

--- a/packages/neos-ui-editors/src/Editors/Range/index.js
+++ b/packages/neos-ui-editors/src/Editors/Range/index.js
@@ -68,7 +68,7 @@ class RangeEditor extends PureComponent {
     };
 
     render() {
-        const options = Object.assign({}, this.constructor.defaultOptions, this.props.options);
+        const options = Object.assign({}, this.constructor.defaultProps.options, this.props.options);
         const {value} = this.state;
 
         return (

--- a/packages/neos-ui-editors/src/Editors/Range/index.js
+++ b/packages/neos-ui-editors/src/Editors/Range/index.js
@@ -72,7 +72,7 @@ class RangeEditor extends PureComponent {
         const {value} = this.state;
 
         return (
-            <div className={style.rangeEditor}>
+            <div className={style.rangeEditor + (options.disabled ? ' ' + style.rangeEditorDisabled : '' )}>
                 <input
                     type="range"
                     min={options.min}

--- a/packages/neos-ui-editors/src/Editors/Range/style.css
+++ b/packages/neos-ui-editors/src/Editors/Range/style.css
@@ -15,7 +15,6 @@
     cursor: pointer;
     height: 20px;
     opacity: .7;
-    transition: opacity .2s;
     width: 20px;
 }
 
@@ -27,7 +26,6 @@
     cursor: pointer;
     height: 25px;
     opacity: .7;
-    transition: opacity .2s;
     width: 25px;
 }
 

--- a/packages/neos-ui-editors/src/Editors/Range/style.css
+++ b/packages/neos-ui-editors/src/Editors/Range/style.css
@@ -53,6 +53,7 @@
     padding: 0 .3rem;
     text-align: right;
     box-sizing: content-box;
+    margin-right: var(--spacing-Quarter);
 }
 
 .rangeEditorValue input:focus {

--- a/packages/neos-ui-editors/src/Editors/Range/style.css
+++ b/packages/neos-ui-editors/src/Editors/Range/style.css
@@ -70,3 +70,21 @@
 .rangeEditorValue input:focus {
     outline: 1px solid var(--colors-PrimaryBlue);
 }
+
+.rangeEditorDisabled {
+    opacity: .65;
+}
+
+.rangeEditorDisabled input[disabled] {
+    cursor: not-allowed;
+}
+
+.rangeEditorDisabled input[type='range']::-webkit-slider-thumb {
+    cursor: not-allowed;
+    background: var(--colors-contrastBright);
+}
+
+.rangeEditorDisabled input[type='range']::-moz-range-thumb {
+    cursor: not-allowed;
+    background: var(--colors-contrastBright);
+}

--- a/packages/neos-ui-editors/src/Editors/Range/style.css
+++ b/packages/neos-ui-editors/src/Editors/Range/style.css
@@ -20,6 +20,11 @@
     border: none;
 }
 
+.rangeEditor input[type='range']::-webkit-slider-thumb:hover,
+.rangeEditor input[type='range']::-webkit-slider-thumb:focus {
+    background: var(--colors-primaryBlueHover);
+}
+
 .rangeEditor input[type='range']::-moz-range-thumb {
     appearance: none;
     background: var(--colors-PrimaryBlue);
@@ -30,6 +35,11 @@
     opacity: .7;
     width: 25px;
     border: none;
+}
+
+.rangeEditor input[type='range']::-moz-range-thumb:hover,
+.rangeEditor input[type='range']::-moz-range-thumb:focus {
+    background: var(--colors-primaryBlueHover);
 }
 
 .rangeEditorValue {

--- a/packages/neos-ui-editors/src/Editors/Range/style.css
+++ b/packages/neos-ui-editors/src/Editors/Range/style.css
@@ -1,6 +1,6 @@
 .rangeEditor input[type='range'] {
     appearance: none;
-    background: #323232;
+    background: var(--colors-contrastNeutral);
     cursor: pointer;
     height: 25px;
     outline: none;
@@ -10,7 +10,7 @@
 
 .rangeEditor input[type='range']::-webkit-slider-thumb {
     appearance: none;
-    background: #00adee;
+    background: var(--colors-PrimaryBlue);
     border-radius: 5px;
     box-shadow: 0 0 0 #000, 0 0 0 #0d0d0d;
     cursor: pointer;
@@ -22,7 +22,7 @@
 
 .rangeEditor input[type='range']::-moz-range-thumb {
     appearance: none;
-    background: #00adee;
+    background: var(--colors-PrimaryBlue);
     border-radius: 5px;
     box-shadow: 0 0 0 #000, 0 0 0 #0d0d0d;
     cursor: pointer;
@@ -47,7 +47,7 @@
 
 .rangeEditorValue input {
     appearance: none;
-    background: #323232;
+    background: var(--colors-contrastNeutral);
     border: 0;
     color: #fff;
     display: inline-block;
@@ -58,5 +58,5 @@
 }
 
 .rangeEditorValue input:focus {
-    outline: 1px solid #00adee;
+    outline: 1px solid var(--colors-PrimaryBlue);
 }

--- a/packages/neos-ui-editors/src/Editors/Range/style.css
+++ b/packages/neos-ui-editors/src/Editors/Range/style.css
@@ -17,6 +17,7 @@
     height: 20px;
     opacity: .7;
     width: 20px;
+    border: none;
 }
 
 .rangeEditor input[type='range']::-moz-range-thumb {
@@ -28,6 +29,7 @@
     height: 25px;
     opacity: .7;
     width: 25px;
+    border: none;
 }
 
 .rangeEditorValue {

--- a/packages/neos-ui-editors/src/Editors/Range/style.css
+++ b/packages/neos-ui-editors/src/Editors/Range/style.css
@@ -1,6 +1,6 @@
 .rangeEditor input[type='range'] {
     appearance: none;
-    background: var(--colors-contrastNeutral);
+    background: var(--colors-ContrastNeutral);
     cursor: pointer;
     height: 25px;
     outline: none;
@@ -22,7 +22,7 @@
 
 .rangeEditor input[type='range']::-webkit-slider-thumb:hover,
 .rangeEditor input[type='range']::-webkit-slider-thumb:focus {
-    background: var(--colors-primaryBlueHover);
+    background: var(--colors-PrimaryBlueHover);
 }
 
 .rangeEditor input[type='range']::-moz-range-thumb {
@@ -39,7 +39,7 @@
 
 .rangeEditor input[type='range']::-moz-range-thumb:hover,
 .rangeEditor input[type='range']::-moz-range-thumb:focus {
-    background: var(--colors-primaryBlueHover);
+    background: var(--colors-PrimaryBlueHover);
 }
 
 .rangeEditorValue {
@@ -57,7 +57,7 @@
 
 .rangeEditorValue input {
     appearance: none;
-    background: var(--colors-contrastNeutral);
+    background: var(--colors-ContrastNeutral);
     border: 0;
     color: #fff;
     display: inline-block;
@@ -80,11 +80,9 @@
 }
 
 .rangeEditorDisabled input[type='range']::-webkit-slider-thumb {
-    cursor: not-allowed;
-    background: var(--colors-contrastBright);
+    background: var(--colors-ContrastBright);
 }
 
 .rangeEditorDisabled input[type='range']::-moz-range-thumb {
-    cursor: not-allowed;
-    background: var(--colors-contrastBright);
+    background: var(--colors-ContrastBright);
 }

--- a/packages/neos-ui-editors/src/Editors/Range/style.css
+++ b/packages/neos-ui-editors/src/Editors/Range/style.css
@@ -5,6 +5,7 @@
     height: 25px;
     outline: none;
     width: 100%;
+    border-radius: 2px;
 }
 
 .rangeEditor input[type='range']::-webkit-slider-thumb {

--- a/packages/neos-ui-editors/src/Editors/Range/style.css
+++ b/packages/neos-ui-editors/src/Editors/Range/style.css
@@ -80,9 +80,11 @@
 }
 
 .rangeEditorDisabled input[type='range']::-webkit-slider-thumb {
+    pointer-events: none;
     background: var(--colors-ContrastBright);
 }
 
 .rangeEditorDisabled input[type='range']::-moz-range-thumb {
+    pointer-events: none;
     background: var(--colors-ContrastBright);
 }


### PR DESCRIPTION
* Pass default options to the editor
* Remove transition of thumb (opacity gets never changed)
* Add more space between the unit and the input field
* Add border-radius (Similar to a text field)
* Remove border from thumb
* Use Neos constants
* Add hover and focus state to thumb
* Style disabled state

#### Enabled state
<img width="302" alt="Enabled state of range editor" src="https://user-images.githubusercontent.com/4510166/146365126-a31f4e06-d244-4e20-baf6-f5459dc25b2c.png">

#### Disabled state
<img width="304" alt="Disabled state of range editor" src="https://user-images.githubusercontent.com/4510166/146365081-83eef8f8-609e-4147-b24d-683b5bf892b6.png">

