### PR TITLE
BUGFIX: Do not allow null in CountValidation

### DIFF
--- a/packages/neos-ui-validators/src/Count/index.tsx
+++ b/packages/neos-ui-validators/src/Count/index.tsx
@@ -26,7 +26,7 @@ const Count = (value: any, validatorOptions: CountOptions) => {
         return 'The maximum is less than the minimum.';
     }
 
-    if (typeof value !== 'object') {
+    if (typeof value !== 'object' || value === null) {
         return <I18n id="content.inspector.validators.countValidator.notCountable"/>;
     }
 


### PR DESCRIPTION
closes #2999 

**What I did**
Since passing null to the CountValidator makes the page go white, null should throw an error message that it cannot be counted 

**How I did it**
If the value passed to the CountValidator is not an object or is null, an error message is shown. 

**How to verify it**
Validating a property of type integer does not make the page go white anymore, but shows an error message below the input field 

![Bildschirmfoto 2021-12-16 um 13 34 24](https://user-images.githubusercontent.com/91674611/146373002-d9757afe-9fcc-4a86-a172-93cc7e0a0d63.png)



![Bildschirmfoto 2021-12-16 um 13 30 38](https://user-images.githubusercontent.com/91674611/146372698-61501485-5bdf-4fd5-9eb1-41f3fa9c493b.png)


