### PR TITLE
BUGFIX: Allow auto-created child nodes to be hidden

### DIFF
--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -220,7 +220,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
         $parent = $node->getParent();
         $isAutoCreated = $node->isTethered();
         $parentConfiguration = $parent ? $parent->getNodeType()->getFullConfiguration() : [];
-        $isHidableAutoCreatedChild = (bool)$parentConfiguration['childNodes'][$node->getName()]['hideable'] ?? false;
+        $isHidableAutoCreatedChild = (bool)$parentConfiguration['childNodes'][(string)$node->getNodeName()]['hideable'] ?? false;
         $policyForbidsHiding = in_array('_hidden', $this->nodePolicyService->getDisallowedProperties($node));
         return [
             'contextPath' => $node->getContextPath(),

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -220,7 +220,8 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
         $parent = $node->getParent();
         $isAutoCreated = $node->isAutoCreated();
         $parentOptions = $parent ? $parent->getNodeType()->getOptions() : [];
-
+        $hasAllowHideAutoCreatedOption = isset($parentOptions['allowHideAutoCreatedChildNodes']) && $parentOptions['allowHideAutoCreatedChildNodes'] === true;
+        $policyForbidsHiding = in_array('_hidden', $this->nodePolicyService->getDisallowedProperties($node));
         return [
             'contextPath' => $node->getContextPath(),
             'name' => $node->getName(),
@@ -228,7 +229,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
             'nodeType' => $node->getNodeType()->getName(),
             'label' => $node->getLabel(),
             'isAutoCreated' => $isAutoCreated,
-            'disableChangeVisibility' => $isAutoCreated && !(isset($parentOptions['allowHideAutoCreatedChildren']) && $parentOptions['allowHideAutoCreatedChildren'] === true),
+            'disableChangeVisibility' => $policyForbidsHiding || ($isAutoCreated && !$hasAllowHideAutoCreatedOption),
             'depth' => $node->getDepth(),
             'children' => [],
             // In some rare cases the parent node cannot be resolved properly

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -219,8 +219,8 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
     {
         $parent = $node->getParent();
         $isAutoCreated = $node->isAutoCreated();
-        $parentOptions = $parent ? $parent->getNodeType()->getOptions() : [];
-        $hasAllowHideAutoCreatedOption = isset($parentOptions['allowHideAutoCreatedChildNodes']) && $parentOptions['allowHideAutoCreatedChildNodes'] === true;
+        $parentConfiguration = $parent ? $parent->getNodeType()->getFullConfiguration() : [];
+        $isHidableAutoCreatedChild = $parentConfiguration['childNodes'][$node->getName()]['hideable'] ?? false;
         $policyForbidsHiding = in_array('_hidden', $this->nodePolicyService->getDisallowedProperties($node));
         return [
             'contextPath' => $node->getContextPath(),
@@ -229,7 +229,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
             'nodeType' => $node->getNodeType()->getName(),
             'label' => $node->getLabel(),
             'isAutoCreated' => $isAutoCreated,
-            'disableChangeVisibility' => $policyForbidsHiding || ($isAutoCreated && !$hasAllowHideAutoCreatedOption),
+            'disableChangeVisibility' => $policyForbidsHiding || ($isAutoCreated && !($isHidableAutoCreatedChild === true)),
             'depth' => $node->getDepth(),
             'children' => [],
             // In some rare cases the parent node cannot be resolved properly

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -217,17 +217,22 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
      */
     protected function getBasicNodeInformation(NodeInterface $node): array
     {
+        $parent = $node->getParent();
+        $isAutoCreated = $node->isAutoCreated();
+        $parentOptions = $parent ? $parent->getNodeType()->getOptions() : [];
+
         return [
             'contextPath' => $node->getContextPath(),
             'name' => $node->getName(),
             'identifier' => $node->getIdentifier(),
             'nodeType' => $node->getNodeType()->getName(),
             'label' => $node->getLabel(),
-            'isAutoCreated' => $node->isAutoCreated(),
+            'isAutoCreated' => $isAutoCreated,
+            'disableChangeVisibility' => $isAutoCreated && !(isset($parentOptions['allowHideAutoCreatedChildren']) && $parentOptions['allowHideAutoCreatedChildren'] === true),
             'depth' => $node->getDepth(),
             'children' => [],
             // In some rare cases the parent node cannot be resolved properly
-            'parent' => ($node->getParent() ? $node->getParent()->getContextPath() : null),
+            'parent' => ($parent ? $parent->getContextPath() : null),
             'matchesCurrentDimensions' => ($node instanceof Node && $node->dimensionsAreMatchingTargetDimensionValues())
         ];
     }

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -218,9 +218,9 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
     protected function getBasicNodeInformation(NodeInterface $node): array
     {
         $parent = $node->getParent();
-        $isAutoCreated = $node->isAutoCreated();
+        $isAutoCreated = $node->isTethered();
         $parentConfiguration = $parent ? $parent->getNodeType()->getFullConfiguration() : [];
-        $isHidableAutoCreatedChild = $parentConfiguration['childNodes'][$node->getName()]['hideable'] ?? false;
+        $isHidableAutoCreatedChild = (bool)$parentConfiguration['childNodes'][$node->getName()]['hideable'] ?? false;
         $policyForbidsHiding = in_array('_hidden', $this->nodePolicyService->getDisallowedProperties($node));
         return [
             'contextPath' => $node->getContextPath(),
@@ -229,7 +229,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
             'nodeType' => $node->getNodeType()->getName(),
             'label' => $node->getLabel(),
             'isAutoCreated' => $isAutoCreated,
-            'disableChangeVisibility' => $policyForbidsHiding || ($isAutoCreated && !($isHidableAutoCreatedChild === true)),
+            'disableChangeVisibility' => $policyForbidsHiding || ($isAutoCreated && $isHidableAutoCreatedChild === false),
             'depth' => $node->getDepth(),
             'children' => [],
             // In some rare cases the parent node cannot be resolved properly

--- a/packages/neos-ts-interfaces/src/index.ts
+++ b/packages/neos-ts-interfaces/src/index.ts
@@ -63,6 +63,7 @@ export interface Node {
     nodeType: NodeTypeName;
     label: string;
     isAutoCreated: boolean;
+    disableChangeVisibility: boolean;
     depth: number;
     children: NodeChildren;
     matchesCurrentDimensions: boolean;

--- a/packages/neos-ui-guest-frame/src/InlineUI/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/index.js
@@ -65,7 +65,7 @@ export default class InlineUI extends PureComponent {
         const isCopied = allFocusedNodesAreInClipboard && clipboardMode === 'Copy';
         const canBeDeleted = $get('policy.canRemove', this.props.focusedNode) || false;
         const canBeEdited = $get('policy.canEdit', this.props.focusedNode) || false;
-        const visibilityCanBeToggled = !$contains('_hidden', 'policy.disallowedProperties', this.props.focusedNode);
+        const visibilityCanBeToggled = !$contains('_hidden', 'policy.disallowedProperties', this.props.focusedNode) && !$get('disableChangeVisibility', this.props.focusedNode);
 
         return (
             <div className={style.inlineUi} data-__neos__inline-ui="TRUE">

--- a/packages/neos-ui-guest-frame/src/InlineUI/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/index.js
@@ -1,7 +1,7 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-import {$transform, $get, $contains} from 'plow-js';
+import {$transform, $get} from 'plow-js';
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {neos} from '@neos-project/neos-ui-decorators';
 
@@ -65,7 +65,7 @@ export default class InlineUI extends PureComponent {
         const isCopied = allFocusedNodesAreInClipboard && clipboardMode === 'Copy';
         const canBeDeleted = $get('policy.canRemove', this.props.focusedNode) || false;
         const canBeEdited = $get('policy.canEdit', this.props.focusedNode) || false;
-        const visibilityCanBeToggled = !$contains('_hidden', 'policy.disallowedProperties', this.props.focusedNode) && !$get('disableChangeVisibility', this.props.focusedNode);
+        const visibilityCanBeToggled = !$get('disableChangeVisibility', this.props.focusedNode);
 
         return (
             <div className={style.inlineUi} data-__neos__inline-ui="TRUE">

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
@@ -1,7 +1,7 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-import {$transform, $get, $contains} from 'plow-js';
+import {$transform, $get} from 'plow-js';
 
 import {isEqualSet} from '@neos-project/utils-helpers';
 import {neos} from '@neos-project/neos-ui-decorators';

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
@@ -268,7 +268,7 @@ const removeAllowed = (focusedNodesContextPaths, state) => focusedNodesContextPa
 const visibilityToggleAllowed = (focusedNodesContextPaths, state) => focusedNodesContextPaths.every(contextPath => {
     const getNodeByContextPathSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector(contextPath);
     const focusedNode = getNodeByContextPathSelector(state);
-    return !$contains('_hidden', 'policy.disallowedProperties', focusedNode) && !$get('disableChangeVisibility', focusedNode);
+    return !$get('disableChangeVisibility', focusedNode);
 });
 const editingAllowed = (focusedNodesContextPaths, state) => focusedNodesContextPaths.every(contextPath => {
     const getNodeByContextPathSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector(contextPath);

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
@@ -189,7 +189,6 @@ export default class NodeTreeToolBar extends PureComponent {
                             focusedNodeContextPath={focusedNodeContextPath}
                             disabled={
                                 isWorkspaceReadOnly ||
-                                destructiveOperationsAreDisabled ||
                                 !canBeEdited ||
                                 !visibilityCanBeToggled
                             }
@@ -269,7 +268,7 @@ const removeAllowed = (focusedNodesContextPaths, state) => focusedNodesContextPa
 const visibilityToggleAllowed = (focusedNodesContextPaths, state) => focusedNodesContextPaths.every(contextPath => {
     const getNodeByContextPathSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector(contextPath);
     const focusedNode = getNodeByContextPathSelector(state);
-    return !$contains('_hidden', 'policy.disallowedProperties', focusedNode);
+    return !$contains('_hidden', 'policy.disallowedProperties', focusedNode) && !$get('disableChangeVisibility', focusedNode);
 });
 const editingAllowed = (focusedNodesContextPaths, state) => focusedNodesContextPaths.every(contextPath => {
     const getNodeByContextPathSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector(contextPath);

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/InspectorEditorEnvelope/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/InspectorEditorEnvelope/index.js
@@ -43,7 +43,7 @@ export default class InspectorEditorEnvelope extends PureComponent {
     get options() {
         // This makes sure that auto-created child nodes cannot be hidden
         // via the insprector (see: #2282)
-        if (this.props.isWorkspaceReadOnly || ($get('isAutoCreated', this.props.node) === true && this.props.id === '_hidden')) {
+        if (this.props.isWorkspaceReadOnly || ($get('disableChangeVisibility', this.props.node) === true && this.props.id === '_hidden')) {
             return {...this.props.options, disabled: true};
         }
 

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -245,9 +245,9 @@ export default class Inspector extends PureComponent {
             return true;
         }
 
-        if ($get('hidden', item) || ($get('isAutoCreated', focusedNode) === true && item.id === '_hidden')) {
+        if ($get('hidden', item) || ($get('disableChangeVisibility', focusedNode) === true && item.id === '_hidden')) {
             // This accounts for the fact that auto-created child nodes cannot
-            // be hidden via the insprector (see: #2282)
+            // be hidden via the insprector (see: #2282) if not explicitly allowed
             return false;
         }
 


### PR DESCRIPTION
As a continuation to #2282 and https://neos-project.slack.com/archives/C050C8FEK/p1633943023444000?thread_ts=1633942822.443900&cid=C050C8FEK, there should be a possibility to activate visibility toggles for auto created child nodes, although hiding them is forbidden by default.

I introduced a new option for the parent element `allowHideAutoCreatedChildNodes`. This option is taken into account in the NodeInfoHelper in a new property `disableChangeVisibility`. This new property also takes the policy of the node property `_hidden` into account to prevent further mismatches between Inspector and NodeTree, which triggered the initial Bug.

~By questioning this property from the UI it is again possible to hide auto created child nodes by adding~

~`options.allowHideAutoCreatedChildNodes: true`~

~to the Node creating these children (aka the parent node).~


Edit:

It was suggested to rather configure the behaviour via parent node:

```yaml
'Some.Package:Some.NodeType':
  childNodes:
    'childnode1':
      type: 'Some.Package:Some.NodeType'
      hideable: true
```


Resolves: #2282