### PR TITLE
BUGFIX: Reset padding for empty dropdown contents

### DIFF
--- a/packages/react-ui-components/src/SelectBox/__snapshots__/selectBox.spec.js.snap
+++ b/packages/react-ui-components/src/SelectBox/__snapshots__/selectBox.spec.js.snap
@@ -40,6 +40,7 @@ exports[`<SelectBox/> should render correctly. 1`] = `
     />
   </Component>
   <Component
+    className="undefined"
     scrollable={true}
   >
     <ul>

--- a/packages/react-ui-components/src/SelectBox/__snapshots__/selectBox.spec.js.snap
+++ b/packages/react-ui-components/src/SelectBox/__snapshots__/selectBox.spec.js.snap
@@ -40,7 +40,7 @@ exports[`<SelectBox/> should render correctly. 1`] = `
     />
   </Component>
   <Component
-    className="undefined"
+    className=""
     scrollable={true}
   >
     <ul>

--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -205,13 +205,17 @@ export default class SelectBox extends PureComponent {
 
         const searchTermLeftToType = displaySearchBox ? threshold - searchTerm.length : 0;
         const noMatchesFound = searchTermLeftToType > 0 || displayLoadingIndicator ? false : !options.length;
+        const dropDownContentsClassName = mergeClassNames({
+            [theme.selectBox__contents]: true,
+            [theme['selectBox__contents--empty']]: noMatchesFound
+        });
 
         return (
             <DropDown.Stateless className={theme.selectBox} isOpen={isExpanded} onToggle={this.handleToggleExpanded} onClose={this.handleClose}>
                 <DropDown.Header className={headerClassName} shouldKeepFocusState={false} showDropDownToggle={showDropDownToggle && Boolean(options.length)}>
                     {this.renderHeader()}
                 </DropDown.Header>
-                <DropDown.Contents className={theme.selectBox__contents} scrollable={true}>
+                <DropDown.Contents className={dropDownContentsClassName} scrollable={true}>
                     {!plainInputMode && <ul className={theme.selectBox__list}>
                         <SelectBox_ListPreview
                             {...this.props}

--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -207,7 +207,7 @@ export default class SelectBox extends PureComponent {
         const noMatchesFound = searchTermLeftToType > 0 || displayLoadingIndicator ? false : !options.length;
         const dropDownContentsClassName = mergeClassNames({
             [theme.selectBox__contents]: true,
-            [theme['selectBox__contents--empty']]: noMatchesFound
+            [theme['selectBox__contents--hasItems']]: !noMatchesFound
         });
 
         return (

--- a/packages/react-ui-components/src/SelectBox/style.css
+++ b/packages/react-ui-components/src/SelectBox/style.css
@@ -32,12 +32,11 @@
     min-width: 160px;
     box-shadow: 0 5px 5px rgba(#000, .2);
     z-index: var(--zIndex-SelectBoxContents);
-    padding: 2px !important;
     margin-top: -2px;
 }
 
-.selectBox__contents--empty {
-    padding: 0 !important;
+.selectBox__contents--hasItems {
+    padding: 2px !important;
 }
 
 .selectBox__item {

--- a/packages/react-ui-components/src/SelectBox/style.css
+++ b/packages/react-ui-components/src/SelectBox/style.css
@@ -36,6 +36,10 @@
     margin-top: -2px;
 }
 
+.selectBox__contents--empty {
+    padding: 0 !important;
+}
+
 .selectBox__item {
     border-top: 1px solid var(--colors-ContrastDarker);
     background: var(--colors-ContrastDarkest);


### PR DESCRIPTION
**What I did**
Adds an extra class of the select box contents section when the content is empty to reset the padding.

**How to verify it**

![Screenshot 2021-12-28 at 19 50 20](https://user-images.githubusercontent.com/1014126/147597623-0f71df7a-647d-4eed-ab41-c9396197789c.png)


Resolves: #3005