### PR TITLE
FEATURE: Hide read only workspaces

### DIFF
--- a/Classes/ContentRepository/Service/WorkspaceService.php
+++ b/Classes/ContentRepository/Service/WorkspaceService.php
@@ -61,6 +61,12 @@ class WorkspaceService
     protected $hideReadOnlyWorkspaces;
 
     /**
+     * @Flow\InjectConfiguration(path="initialState.user.settings.targetWorkspace", package="Neos.Neos.Ui")
+     * @var boolean
+     */
+    protected $initialUserTargetWorkspace;
+
+    /**
      * Get all publishable node context paths for a workspace
      *
      * @param Workspace $workspace
@@ -155,8 +161,16 @@ class WorkspaceService
     /**
      * @return bool
      */
-    public function shouldHideReadOnlyWorkspaces()
+    public function shouldHideReadOnlyWorkspaces(): bool
     {
         return $this->hideReadOnlyWorkspaces;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInitialUserTargetWorkspace(): string
+    {
+        return $this->initialUserTargetWorkspace;
     }
 }

--- a/Classes/Fusion/Helper/WorkspaceHelper.php
+++ b/Classes/Fusion/Helper/WorkspaceHelper.php
@@ -91,7 +91,7 @@ class WorkspaceHelper implements ProtectedContextAwareInterface
         }
 
         // Live as fallback
-        return $this->workspaceService->getWorkspaceByName('live');
+        return $this->workspaceService->getWorkspaceByName($this->workspaceService->getInitialUserTargetWorkspace());
     }
 
     public function getAllowedTargetWorkspaces()

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -178,7 +178,7 @@ Neos:
           settings:
             isAutoPublishingEnabled: false
             targetWorkspace: 'live'
-            hideReadOnlyWorkspaces: true
+            hideReadOnlyWorkspaces: false
       changes:
         types:
           'Neos.Neos.Ui:Property': Neos\Neos\Ui\Domain\Model\Changes\Property

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -178,6 +178,7 @@ Neos:
           settings:
             isAutoPublishingEnabled: false
             targetWorkspace: 'live'
+            hideReadOnlyWorkspaces: true
       changes:
         types:
           'Neos.Neos.Ui:Property': Neos\Neos\Ui\Domain\Model\Changes\Property

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -117,6 +117,13 @@ export default class PublishDropDown extends PureComponent {
         });
         const publishableNodesInDocumentCount = publishableNodesInDocument ? publishableNodesInDocument.length : 0;
         const publishableNodesCount = publishableNodes ? publishableNodes.length : 0;
+
+        // check if the basework space is also part of the allowed workspaces
+        const allowedBaseWorkspace = (baseWorkspace in allowedWorkspaces);
+        const firstAllowedWorkspace = Object.values(allowedWorkspaces)[0];
+        if (!allowedBaseWorkspace && 'name' in firstAllowedWorkspace) {
+            changeBaseWorkspaceAction(firstAllowedWorkspace.name);
+        }
         return (
             <div id="neos-PublishDropDown" className={style.wrapper}>
                 <AbstractButton

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -117,13 +117,6 @@ export default class PublishDropDown extends PureComponent {
         });
         const publishableNodesInDocumentCount = publishableNodesInDocument ? publishableNodesInDocument.length : 0;
         const publishableNodesCount = publishableNodes ? publishableNodes.length : 0;
-
-        // check if the basework space is also part of the allowed workspaces
-        const allowedBaseWorkspace = (baseWorkspace in allowedWorkspaces);
-        const firstAllowedWorkspace = Object.values(allowedWorkspaces)[0];
-        if (!allowedBaseWorkspace && 'name' in firstAllowedWorkspace) {
-            changeBaseWorkspaceAction(firstAllowedWorkspace.name);
-        }
         return (
             <div id="neos-PublishDropDown" className={style.wrapper}>
                 <AbstractButton


### PR DESCRIPTION
When you work with countless backend users and workspaces, it may happen that the restricted editors maybe are confused by all the available workspaces. And sometimes select a workspace that is read only. Then they can not edit content since the latest bug-fixes and before that, they run into an error while publishing.

This feature should enable the developers and integrators to hide all none writable workspaces in the selection. That should improve the user experience for the editors. By default, the setting is false and therefore everything is like before that feature.

When you enable it with the setting 
`initialState.user.settings.hideReadOnlyWorkspaces` the user will see only writable workspaces in the publishing dropdown, except there are no writable workspaces. Then we use the default target workspace as fallback. This is often live.

Resolves: #3012