### PR TITLE
 BUGFIX: Handle asset proxy for inline links

### DIFF
--- a/packages/neos-ui-backend-connector/src/Endpoints/index.ts
+++ b/packages/neos-ui-backend-connector/src/Endpoints/index.ts
@@ -291,7 +291,7 @@ export default (routes: Routes) => {
                     assetProxyIdentifier
                 };
             });
-            return mappedAssetProxies.filter((assetProxy: {identifier?: string}) => assetProxy.identifier && options.assetsToExclude.indexOf(assetProxy.identifier) === -1);
+            return mappedAssetProxies.filter((assetProxy: {identifier?: string}) => assetProxy.identifier && options?.assetsToExclude?.indexOf(assetProxy.identifier) === -1);
         });
 
     const assetProxyDetail = (assetSourceIdentifier: string, assetProxyIdentifier: string) => fetchWithErrorHandling.withCsrfToken(() => ({

--- a/packages/neos-ui-editors/src/Library/LinkInput.js
+++ b/packages/neos-ui-editors/src/Library/LinkInput.js
@@ -218,7 +218,7 @@ export default class LinkInput extends PureComponent {
                 const assetProxyIdentifier = this.getIdentity(value);
                 this.props.assetLookupDataLoader.resolveValue(this.state.options, assetProxyIdentifier)
                     .then(options => {
-                        const assetUri = options.map((item) => item.loaderUri);
+                        const assetUri = options.map(item => item.loaderUri);
                         this.props.onLinkChange(assetUri || '');
                         this.setState({
                             isLoading: false,

--- a/packages/neos-ui-editors/src/Library/LinkInput.js
+++ b/packages/neos-ui-editors/src/Library/LinkInput.js
@@ -174,9 +174,13 @@ export default class LinkInput extends PureComponent {
             this.props.linkLookupDataLoader.search(this.getDataLoaderOptions(), searchTerm)
                 .then(searchOptions => {
                     if (searchTermWhenLookupWasTriggered === this.state.searchTerm) {
+                        const groupedSearchOption = searchOptions.map(searchOption => {
+                            searchOption.group = 'assetSourceLabel' in searchOption ? searchOption.assetSourceLabel : this.props.i18nRegistry.translate('Neos.Neos:Main:document');
+                            return searchOption;
+                        });
                         this.setState({
                             isLoading: false,
-                            searchOptions
+                            searchOptions: groupedSearchOption
                         });
                     }
                 });

--- a/packages/neos-ui-editors/src/Library/LinkInput.js
+++ b/packages/neos-ui-editors/src/Library/LinkInput.js
@@ -101,6 +101,7 @@ export default class LinkInput extends PureComponent {
             asset: $get('assets', options),
             node: $get('nodes', options),
             startingPoint: $get('startingPoint', options),
+            constraints: $get('constraints', options),
             contextForNodeLinking
         };
     }

--- a/packages/neos-ui-redux-store/src/UI/Remote/index.ts
+++ b/packages/neos-ui-redux-store/src/UI/Remote/index.ts
@@ -22,6 +22,8 @@ export const defaultState: State = {
 export enum actionTypes {
     START_SAVING = '@neos/neos-ui/UI/Remote/START_SAVING',
     FINISH_SAVING = '@neos/neos-ui/UI/Remote/FINISH_SAVING',
+    LOCK_PUBLISHING = '@neos/neos-ui/UI/Remote/LOCK_PUBLISHING',
+    UNLOCK_PUBLISHING = '@neos/neos-ui/UI/Remote/UNLOCK_PUBLISHING',
     START_PUBLISHING = '@neos/neos-ui/UI/Remote/START_PUBLISHING',
     FINISH_PUBLISHING = '@neos/neos-ui/UI/Remote/FINISH_PUBLISHING',
     START_DISCARDING = '@neos/neos-ui/UI/Remote/START_DISCARDING',
@@ -60,6 +62,16 @@ const startDiscarding = () => createAction(actionTypes.START_DISCARDING);
 const finishDiscarding = () => createAction(actionTypes.FINISH_DISCARDING);
 
 /**
+ * Marks that an publishing process has been locked.
+ */
+const lockPublishing = () => createAction(actionTypes.LOCK_PUBLISHING);
+
+/**
+ * Marks that an publishing process has been unlocked.
+ */
+const unlockPublishing = () => createAction(actionTypes.UNLOCK_PUBLISHING);
+
+/**
  * Should be called once the server informs the client that a node has been created.
  */
 const documentNodeCreated = (contextPath: NodeContextPath) => createAction(actionTypes.DOCUMENT_NODE_CREATED, {contextPath});
@@ -70,6 +82,8 @@ const documentNodeCreated = (contextPath: NodeContextPath) => createAction(actio
 export const actions = {
     startSaving,
     finishSaving,
+    lockPublishing,
+    unlockPublishing,
     startPublishing,
     finishPublishing,
     startDiscarding,
@@ -89,6 +103,14 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
             break;
         }
         case actionTypes.FINISH_SAVING: {
+            draft.isSaving = false;
+            break;
+        }
+        case actionTypes.LOCK_PUBLISHING: {
+            draft.isSaving = true;
+            break;
+        }
+        case actionTypes.UNLOCK_PUBLISHING: {
             draft.isSaving = false;
             break;
         }

--- a/packages/neos-ui/src/manifest.dataloaders.js
+++ b/packages/neos-ui/src/manifest.dataloaders.js
@@ -206,7 +206,13 @@ manifest('main.dataloaders', {}, globalRegistry => {
             if (!searchTerm) {
                 return Promise.resolve([]);
             }
-            const cacheKey = makeCacheKey('search', {options, searchTerm});
+            if (!('assetsToExclude' in options)) {
+                options.assetsToExclude = [];
+            }
+            if (!('constraints' in options)) {
+                options.constraints = {};
+            }
+            const cacheKey = makeCacheKey("search", { options, searchTerm });
 
             if (this._lru().has(cacheKey)) {
                 return this._lru().get(cacheKey);
@@ -388,7 +394,7 @@ manifest('main.dataloaders', {}, globalRegistry => {
         dataLoaders() {
             return [
                 {prefix: 'node', dataLoader: dataLoadersRegistry.get('NodeLookup')},
-                {prefix: 'asset', dataLoader: dataLoadersRegistry.get('NeosAssetLookup')}
+                {prefix: 'asset', dataLoader: dataLoadersRegistry.get('AssetLookup')}
             ];
         },
 
@@ -409,8 +415,9 @@ manifest('main.dataloaders', {}, globalRegistry => {
         },
 
         search(options, searchTerm) {
-            return Promise.all(this.dataLoaders().map(dataLoaderInfo =>
-                options[dataLoaderInfo.prefix] === false ? [] : dataLoaderInfo.dataLoader.search(options, searchTerm)
+            return Promise.all(this.dataLoaders().map(dataLoaderInfo => {
+                return options[dataLoaderInfo.prefix] === false ? [] : dataLoaderInfo.dataLoader.search(options, searchTerm)
+            }
             )).then(values => {
                 return values.reduce((runningValues, singleDataLoaderValues) =>
                     runningValues.concat(singleDataLoaderValues)

--- a/packages/neos-ui/src/manifest.dataloaders.js
+++ b/packages/neos-ui/src/manifest.dataloaders.js
@@ -212,7 +212,7 @@ manifest('main.dataloaders', {}, globalRegistry => {
             if (!('constraints' in options)) {
                 options.constraints = {};
             }
-            const cacheKey = makeCacheKey("search", { options, searchTerm });
+            const cacheKey = makeCacheKey('search', {options, searchTerm});
 
             if (this._lru().has(cacheKey)) {
                 return this._lru().get(cacheKey);
@@ -416,7 +416,7 @@ manifest('main.dataloaders', {}, globalRegistry => {
 
         search(options, searchTerm) {
             return Promise.all(this.dataLoaders().map(dataLoaderInfo => {
-                return options[dataLoaderInfo.prefix] === false ? [] : dataLoaderInfo.dataLoader.search(options, searchTerm)
+                return options[dataLoaderInfo.prefix] === false ? [] : dataLoaderInfo.dataLoader.search(options, searchTerm);
             }
             )).then(values => {
                 return values.reduce((runningValues, singleDataLoaderValues) =>


### PR DESCRIPTION
The inline link handing uses the LinkLookup data loader to fetch node and asset data.
The LinkLookup is a combination of the NodeLookup and NeosAssetLookup data loaders.

As the whole backend can work with asset proxies, the usage of NeosAssetLookup needs to be replaced by the AssetLookup data loader.

**How I did it**
Replaced the NeosAssetLookUp with the AssetLookup in the LinkLookup data loader.
So that we not search only for local assets. Additionally, we need some adjustments to handle asset proxies for the link input component.

**How to verify it**
Activate an asset source that is not the local Neos source, Unsplash for instance.
When the asset source is working, you are able to find assets in the asset editor from Unsplash.

When you now create an inline link and search for an image,  you should also see Unsplash results.
That was not possible before.


https://user-images.githubusercontent.com/1014126/151379459-fbba3c49-423b-4f39-9a0b-d874b5d4dfb9.mp4

