### PR TITLE
BUGFIX: Add maximum width to custom SVG icon in left sidebar

### DIFF
--- a/packages/react-ui-components/src/Icon/style.css
+++ b/packages/react-ui-components/src/Icon/style.css
@@ -34,7 +34,8 @@
 
 .icon--small {
     svg {
-        height: 1em;
+        max-height: 1em;
+        max-width: 100%;
     }
 }
 


### PR DESCRIPTION
closes #3017 

**What I did**
![Bildschirmfoto 2022-02-21 um 14 45 03](https://user-images.githubusercontent.com/91674611/154966961-e78f8a5f-0870-4d94-b2d7-159283920ccc.png)

When using very wide Custom SVGs in the left sidebar, the svg does not overlay the Text anymore. 

**How I did it**
I gave the svg a maximum width and a maximum height. 

**How to verify it**
When using a very wide SVG, the SVG does not overlay the text anymore (see issue)


