### PR TITLE
BUGFIX: Prevent label from wrapping

### DIFF
--- a/packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/TableDropDown.css
+++ b/packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/TableDropDown.css
@@ -7,10 +7,10 @@
     text-align: left;
 }
 .checkBox {
+    display: flex;
     height: var(--spacing-GoldenUnit);
     border-top: 1px solid var(--colors-ContrastDarker);
     padding-top: var(--spacing-Half);
     padding-left: var(--spacing-Full);
-    display: block;
     cursor: pointer;
 }

--- a/packages/react-ui-components/src/CheckBox/style.css
+++ b/packages/react-ui-components/src/CheckBox/style.css
@@ -1,7 +1,7 @@
 .checkbox {
     composes: reset from './../reset.css';
     position: relative;
-    display: block;
+    display: inline-block;
     width: 20px;
     height: 20px;
     margin-right: 8px;

--- a/packages/react-ui-components/src/CheckBox/style.css
+++ b/packages/react-ui-components/src/CheckBox/style.css
@@ -1,7 +1,7 @@
 .checkbox {
     composes: reset from './../reset.css';
     position: relative;
-    display: inline-block;
+    display: block;
     width: 20px;
     height: 20px;
     margin-right: 8px;


### PR DESCRIPTION
The dropdowns for the column and row settings of the CKEditor tables wrap the label after the checkbox. To prevent that, we now inline the checkbox. So that the text is in the same level.

fixes: #3035
