### PR TITLE
BUGFIX: SVGs in Sidebar are not shown if they have no height or width

### DIFF
--- a/packages/react-ui-components/src/Icon/style.css
+++ b/packages/react-ui-components/src/Icon/style.css
@@ -34,6 +34,7 @@
 
 .icon--small {
     svg {
+        height: 1em;
         max-height: 1em;
         max-width: 100%;
     }


### PR DESCRIPTION
**What I did**
When using an SVG icon without height or width as a custom icon in the sidebar, it is not show. 
Example SVG icon: 
`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130 42" class="injected-svg" data-src="/_Resources/Static/Packages/Neos.Demo/Images/svg.svg" xmlns:xlink="http://www.w3.org/1999/xlink"><rect x="0.5" y="0.5" width="127" height="41" style="fill:none;stroke:#727272"></rect></svg>`

**How I did it**
I have added a height to SVGs in the left Sidebar. With the maximum height and width the icon will not overflow but still show. 

**How to verify it**
When using the SVG icon above, it will still show in the Sidebar.

closes #3017 