### PR TITLE
BUGFIX: Allow zero as value in selectbox

### DIFF
--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -257,7 +257,7 @@ export default class SelectBox extends PureComponent {
 
         if (
             displaySearchBox && (
-                !value ||
+                (!value && value !== 0) ||
                 this.state.isExpanded ||
                 plainInputMode
             )


### PR DESCRIPTION
**What I did**
When using the 'Neos.Neos/Inspector/Editors/SelectBoxEditor' with a value 0, the label is not displayed in the field when loading a page

**How I did it**
The value is currently checked for javascript 'falsy' values, which includes 0. This leads to the SelectBox_HeaderWithSearchInput always being displayed if the value is 0. 

**How to verify it**
1. Use the following property 
`autoplay:
      type: integer
      defaultValue: ''
      ui:
        label: 'Autoplay'
        reloadPageIfChanged: true
        inspector:
          group: 'image'
          editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
          editorOptions:
            values:
              '0':
                label: 'No Autoplay'
              '1000':
                label: '1 Second'`

2. Chose 'No Autoplay' as a option in the dropdown
3. Reload Page
4. 'No Autoplay' is shown as the active option

Old behavior:
https://user-images.githubusercontent.com/91674611/157832243-e729df73-435d-4006-af4f-e85ed0f858c3.mov


