### PR TITLE
TASK: Remove lodash.set

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,6 @@
     "lodash.merge": "^4.6.0",
     "lodash.omit": "^4.5.0",
     "lodash.pick": "^4.4.0",
-    "lodash.set": "^4.3.2",
     "lodash.sortby": "^4.7.0",
     "lodash.throttle": "^4.1.1",
     "lodash.unescape": "4.0.1",

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -11,7 +11,6 @@ import Tabs from '@neos-project/react-ui-components/src/Tabs/';
 import Icon from '@neos-project/react-ui-components/src/Icon/';
 import Badge from '@neos-project/react-ui-components/src/Badge/';
 import debounce from 'lodash.debounce';
-import setIn from 'lodash.set';
 
 import {SecondaryInspector} from '@neos-project/neos-ui-inspector';
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
@@ -152,7 +151,7 @@ export default class Inspector extends PureComponent {
                         viewConfiguration = produce(
                             viewConfiguration,
                             draft => {
-                                setIn(draft, newPath, evaluatedValue);
+                                return $set(newPath, evaluatedValue, draft);
                             }
                         );
                     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11103,11 +11103,6 @@ lodash.pick@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
 
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
-
 lodash.some@^4.5.1, lodash.some@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"


### PR DESCRIPTION
We use `lodash.set` only for one case and as it has some security issues we should get rid of that.

**What I did**
- Replaced the usage with `plow-js`.
- removed the `lodash.set` package

**How to verify it**
-  should work like before
