### PR TITLE
TASK: Removes lodash.upperfirst

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,6 @@
     "lodash.sortby": "^4.7.0",
     "lodash.throttle": "^4.1.1",
     "lodash.unescape": "4.0.1",
-    "lodash.upperfirst": "^4.3.0",
     "moment": "^2.20.1",
     "monet": "^0.9.2",
     "mousetrap": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "node": "~14"
   },
   "devDependencies": {
-    "@neos-project/brand": "^1.1.0",
     "@neos-project/build-essentials": "*",
     "@neos-project/eslint-config-neos": "^2.3.0",
     "@types/classnames": "^2.2.9",
@@ -114,7 +113,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@fortawesome/react-fontawesome": "^0.1.14",
     "@friendsofreactjs/react-css-themr": "^4.1.0",
-    "@neos-project/brand": "^1.1.0",
+    "@neos-project/brand": "^1.3.0",
     "@sindresorhus/slugify": "^2.1.0",
     "@types/lodash.assignin": "^4.2.6",
     "amator": "^1.0.1",

--- a/packages/build-essentials/package.json
+++ b/packages/build-essentials/package.json
@@ -32,7 +32,6 @@
     "cross-env": "^6.0.3",
     "css-loader": "^3.4.1",
     "eslint": "^5.3.0",
-    "lodash.upperfirst": "^4.3.0",
     "mini-css-extract-plugin": "^0.5.0",
     "postcss-css-variables": "^0.14.0",
     "postcss-hexrgba": "^1.0.1",

--- a/packages/build-essentials/src/styles/styleConstants.js
+++ b/packages/build-essentials/src/styles/styleConstants.js
@@ -1,4 +1,4 @@
-const upperFirst = value => `${value.charAt(0).toUpperCase()}${value.slice(1)}`
+const upperFirst = value => `${value.charAt(0).toUpperCase()}${value.slice(1)}`;
 
 // Global CSS variables for Neos.Ui
 const config = {

--- a/packages/build-essentials/src/styles/styleConstants.js
+++ b/packages/build-essentials/src/styles/styleConstants.js
@@ -1,4 +1,4 @@
-const upperFirst = require('lodash.upperfirst');
+const upperFirst = value => `${value.charAt(0).toUpperCase()}${value.slice(1)}`
 
 // Global CSS variables for Neos.Ui
 const config = {

--- a/packages/neos-ui-views/package.json
+++ b/packages/neos-ui-views/package.json
@@ -18,7 +18,7 @@
     "@neos-project/jest-preset-neos-ui": "7.3.3"
   },
   "dependencies": {
-    "@neos-project/brand": "^1.1.0",
+    "@neos-project/brand": "^1.3.0",
     "@neos-project/neos-ui-extensibility": "7.3.3",
     "@neos-project/neos-ui-i18n": "7.3.3",
     "@neos-project/neos-ui-inspector": "7.3.3",

--- a/packages/neos-ui/package.json
+++ b/packages/neos-ui/package.json
@@ -21,7 +21,7 @@
     "redux-saga-test-plan": "^3.6.0"
   },
   "dependencies": {
-    "@neos-project/brand": "^1.1.0",
+    "@neos-project/brand": "^1.3.0",
     "@neos-project/neos-ui-backend-connector": "7.3.3",
     "@neos-project/neos-ui-ckeditor-bindings": "7.3.3",
     "@neos-project/neos-ui-ckeditor5-bindings": "7.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2274,7 +2274,7 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@neos-project/brand@^1.1.0":
+"@neos-project/brand@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@neos-project/brand/-/brand-1.3.0.tgz#64c34fc378fb875c1bb0434c7afacd4a1b2d8aa3"
   integrity sha512-MwWcZSUI89X+uX39df3pa3aHPD3ZAD04QEVOoMgqtf3HdqH3A+P/kLKV6ZW9CNpuYxVHtoYHoQEVn9ZGceO41g==
@@ -12245,6 +12245,11 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
+
+lodash.upperfirst@^4.3.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
+  integrity sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=
 
 "lodash@4.6.1 || ^4.16.1", lodash@^4.0.0, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.14.2, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.17.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@~4.17.4:
   version "4.17.20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2275,11 +2275,9 @@
     glob-to-regexp "^0.3.0"
 
 "@neos-project/brand@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@neos-project/brand/-/brand-1.1.0.tgz#13159ee7b330b1d7f969f70a5dea7fec03b7fb8a"
-  integrity sha1-ExWe57Mwsdf5afcKXep/7AO3+4o=
-  dependencies:
-    lodash.upperfirst "^4.3.0"
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@neos-project/brand/-/brand-1.3.0.tgz#64c34fc378fb875c1bb0434c7afacd4a1b2d8aa3"
+  integrity sha512-MwWcZSUI89X+uX39df3pa3aHPD3ZAD04QEVOoMgqtf3HdqH3A+P/kLKV6ZW9CNpuYxVHtoYHoQEVn9ZGceO41g==
 
 "@neos-project/build-essentials@5.2.5":
   version "5.2.5"
@@ -12247,11 +12245,6 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
-
-lodash.upperfirst@^4.3.0:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
-  integrity sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=
 
 "lodash@4.6.1 || ^4.16.1", lodash@^4.0.0, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.14.2, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.17.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@~4.17.4:
   version "4.17.20"


### PR DESCRIPTION
**What I did**
Removed `lodash.upperfirst` as dependency.

**How I did it**
- removed the dependency `lodash.upperfirst`
- upgraded @neos-project/brand to 1.3.0 as it also used the `lodash.upperfirst`

**How to verify it**
Run the UI ;)