### PR TITLE
BUGFIX: Render search also for empty string

### DIFF
--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -259,6 +259,7 @@ export default class SelectBox extends PureComponent {
         if (
             displaySearchBox && (
                 isNil(value) ||
+                value === '' ||
                 this.state.isExpanded ||
                 plainInputMode
             )


### PR DESCRIPTION
With the introduction of `isNil()` the check for empty strings fail. So, we need to check also for empty strings and render the select box with search header.