### PR TITLE
BUGFIX: Remove unused props of RestoreButtonItem

### DIFF
--- a/packages/neos-ui/src/Containers/PrimaryToolbar/UserDropDown/RestoreButtonItem.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/UserDropDown/RestoreButtonItem.js
@@ -12,11 +12,9 @@ import buttonTheme from './style.css';
 
 @connect(
     $transform({
-        originUser: $get('user.impersonate.origin'),
-        user: $get('user.impersonate.user')
+        originUser: $get('user.impersonate.origin')
     }),
     {
-        addFlashMessage: actions.UI.FlashMessages.add,
         impersonateRestore: actions.User.Impersonate.restore
     }
 )
@@ -26,8 +24,6 @@ import buttonTheme from './style.css';
 export default class RestoreButtonItem extends React.PureComponent {
     static propTypes = {
         originUser: PropTypes.object,
-        user: PropTypes.object,
-        addFlashMessage: PropTypes.func.isRequired,
         impersonateRestore: PropTypes.func.isRequired,
         i18nRegistry: PropTypes.object.isRequired
     };


### PR DESCRIPTION
The restore button has some props that are not used and can be removed.

**What I did**
Removed the unused props of `user` and `addFlashMessage`.