### PR TITLE
BUGFIX: Prevent cache clearing of backend info in frontend context

### DIFF
--- a/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -41,7 +41,7 @@ prototype(Neos.Neos:Page) {
                 }
                 entryTags {
                     1 = ${Neos.Caching.nodeTag(documentNode)}
-                    2 = ${Neos.Caching.descendantOfTag(documentNode)}
+                    2 = ${documentNode.context.inBackend ? Neos.Caching.descendantOfTag(documentNode) : null}
                 }
             }
         }


### PR DESCRIPTION
Only apply a 'descendantOf' cache tag when we are in backend context.
This fixes unnecessary clearing of the cache of all parent nodes in frontend context
whenever some content in child nodes is modified.

Fixes #3107