### PR TITLE
BUGFIX: Check canEdit policy instead of hidden property

### DIFF
--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
@@ -277,7 +277,7 @@ const visibilityToggleAllowed = (focusedNodesContextPaths, state) => focusedNode
 const editingAllowed = (focusedNodesContextPaths, state) => focusedNodesContextPaths.every(contextPath => {
     const getNodeByContextPathSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector(contextPath);
     const focusedNode = getNodeByContextPathSelector(state);
-    return !$contains('_hidden', 'policy.disallowedProperties', focusedNode);
+    return $get('policy.canEdit', focusedNode);
 });
 
 const makeMapStateToProps = isDocument => (state, {nodeTypesRegistry}) => {


### PR DESCRIPTION
**What I did**

Fix the copy & paste error by checking if a node is allowed to be edited instead of checking for the hidden property which was actually meant for the `visibilityToggleAllowed` check.

**How to verify it**

Create a `Policy.yaml` with the following content:

```yaml
privilegeTargets:
  'Neos\ContentRepository\Security\Authorization\Privilege\Node\EditNodePropertyPrivilege':
    'My.Site:DisableHidden':
      matcher: nodeIsOfType("Neos.Neos:Document") && nodePropertyIsIn(["_hidden", "hidden"])
```

Without the fix, no actions are possible on the selected document node. With the fix, only the visibility is disabled.