### PR TITLE
BUGFIX: Use full height in selectbox preview element

### DIFF
--- a/packages/neos-ui-editors/src/Library/PreviewOption.js
+++ b/packages/neos-ui-editors/src/Library/PreviewOption.js
@@ -7,6 +7,8 @@ export default class PreviewOption extends PureComponent {
     static propTypes = {
         option: PropTypes.shape({
             label: PropTypes.string.isRequired,
+            secondaryLabel: PropTypes.string,
+            tertiaryLabel: PropTypes.string,
             icon: PropTypes.string,
             preview: PropTypes.string
         })
@@ -16,7 +18,7 @@ export default class PreviewOption extends PureComponent {
         const {option} = this.props;
 
         return (
-            <SelectBox_Option_MultiLineWithThumbnail {...this.props} imageUri={option.preview} icon={option.icon} label={option.label}/>
+            <SelectBox_Option_MultiLineWithThumbnail {...this.props} imageUri={option.preview} icon={option.icon} label={option.label} secondaryLabel={option.secondaryLabel} tertiaryLabel={option.tertiaryLabel}/>
         );
     }
 }

--- a/packages/react-ui-components/src/ListPreviewElement/style.css
+++ b/packages/react-ui-components/src/ListPreviewElement/style.css
@@ -16,7 +16,7 @@
     cursor: not-allowed;
 }
 .listPreviewElement--isHighlighted {
-    background: var(--colors-PrimaryBlue);
+    background-color: var(--colors-PrimaryBlue) !important;
 }
 
 .listPreviewElement--isHighlighted > span {

--- a/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/selectBox_Option_MultiLineWithThumbnail.js
+++ b/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/selectBox_Option_MultiLineWithThumbnail.js
@@ -16,6 +16,7 @@ class SelectBox_Option_MultiLineWithThumbnail extends PureComponent {
 
         theme: PropTypes.shape({
             multiLineWithThumbnail__item: PropTypes.string.isRequired,
+            'multiLineWithThumbnail__item--multiLine': PropTypes.string.isRequired,
             multiLineWithThumbnail__secondaryLabel: PropTypes.string.isRequired,
             multiLineWithThumbnail__tertiaryLabel: PropTypes.string.isRequired,
             multiLineWithThumbnail__image: PropTypes.string.isRequired
@@ -36,6 +37,7 @@ class SelectBox_Option_MultiLineWithThumbnail extends PureComponent {
 
         const finalClassNames = mergeClassNames({
             [theme.multiLineWithThumbnail__item]: true,
+            [theme['multiLineWithThumbnail__item--multiLine']]: secondaryLabel || tertiaryLabel,
             [className]: className
         });
 

--- a/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/style.css
+++ b/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/style.css
@@ -1,7 +1,10 @@
 .multiLineWithThumbnail__item {
     box-sizing: content-box;
+    background-color: var(--colors-ContrastDarkest);
+}
+
+.multiLineWithThumbnail__item--multiLine {
     line-height: 20px;
-    background: var(--colors-ContrastDarkest);
 }
 
 .multiLineWithThumbnail__secondaryLabel {


### PR DESCRIPTION
If the secondary or tertiary label is not set the preview element wouldn’t cover the whole selectbox which will then show a graphical glitch.
This problem currently surfaces when using a custom data source as then the `PreviewOption` is used since Neos 7.3 to allow the display of custom icons.
This is not a problem when the secondary or tertiary label is set for the component because it will stretch the preview high enough.

**What I did**

Introduce a class to unset the reduced line-height if the secondary and tertiary label are not set.
Then the 40px line-height of the parent element will be used and therefore the box filled.

**How to verify it**

Use a select box editor with a custom data source.

Before:
<img width="317" alt="Bildschirmfoto 2022-06-13 um 10 58 27" src="https://user-images.githubusercontent.com/596967/173323193-d6a37dfe-9579-422e-973f-df7362480d37.png">

After:
<img width="316" alt="Bildschirmfoto 2022-06-13 um 11 25 52" src="https://user-images.githubusercontent.com/596967/173323224-fdc0b7e8-0b9e-49c3-b108-2874282ddadf.png">