### PR TITLE
BUGFIX: fallback to a defined edit mode if edit mode is undefined

### DIFF
--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -80,7 +80,7 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
     const editPreviewMode = $get(['ui', 'editPreviewMode'], state);
     const editPreviewModes = globalRegistry.get('frontendConfiguration').get('editPreviewModes');
     const isWorkspaceReadOnly = selectors.CR.Workspaces.isWorkspaceReadOnlySelector(state);
-    const currentEditMode = editPreviewModes[editPreviewMode];
+    const currentEditMode = editPreviewModes[editPreviewMode] || editPreviewModes[Object.keys(editPreviewModes)[0]];
     if (!currentEditMode.isEditingMode || isWorkspaceReadOnly) {
         return;
     }

--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -86,7 +86,7 @@ export default class ContentCanvas extends PureComponent {
             [style['contentCanvas--isHidden']]: !isVisible
         });
         const InlineUI = guestFrameRegistry.get('InlineUIComponent');
-        const currentEditPreviewModeConfiguration = editPreviewModes[currentEditPreviewMode];
+        const currentEditPreviewModeConfiguration = editPreviewModes[currentEditPreviewMode] || editPreviewModes[Object.keys(editPreviewModes)[0]];
 
         const width = $get('width', currentEditPreviewModeConfiguration);
         const height = $get('height', currentEditPreviewModeConfiguration);

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/EditPreviewDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/EditPreviewDropDown/index.js
@@ -42,7 +42,7 @@ export default class EditPreviewModeDropDown extends PureComponent {
             i18nRegistry
         } = this.props;
 
-        const currentEditMode = editPreviewModes[editPreviewMode];
+        const currentEditMode = editPreviewModes[editPreviewMode] || editPreviewModes[Object.keys(editPreviewModes)[0]];
 
         const editPreviewModesList = Object.keys(editPreviewModes).map(key => {
             const element = editPreviewModes[key];


### PR DESCRIPTION
**What I did**

Whenever an edit mode is removed and a user has still selected set mode the backend would crash.
Now it can keep loading allowing the user to select another edit mode.  

see #3129

**How I did it**

I added a fallback whenever I found `editPreviewMode[currentPreviewMode] `being requested.
I chose to use a non hard-coded fallback in case the edit modes get renamed or removed.

I tested it on the master branch. But committed to 5.3.
I did not find other occurences of  `editPreviewMode[` but I can't garantee the issue is completly fixed on older versions. 

**How to verify it**

change an entry in the table `neos_neos_domain_model_userpreferences` for example to `a:1:{s:30:"contentEditing.editPreviewMode";s:7:"inPlXXX";}`

Previous behaviour was recieving a blank page. Now the backend is at least shown:

![Screenshot 2022-07-01 at 21-42-04 Neos Error](https://user-images.githubusercontent.com/55744962/176961420-e3648df5-c909-45c9-99d5-3d16096cc69a.png)