### PR TITLE
TASK: Improve rendering of outlines for focused or hovered nodes

### DIFF
--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/AddNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/AddNode/index.js
@@ -68,12 +68,11 @@ export default class AddNode extends PureComponent {
         if (preferredMode === 'before' || preferredMode === 'after') {
             return isAllowedToAddSiblingNodes;
         }
-        else if (preferredMode === 'into') {
+        if (preferredMode === 'into') {
             return isAllowedToAddChildNodes;
         }
-        else {
-            return isAllowedToAddChildOrSiblingNodes;
-        }
+
+        return isAllowedToAddChildOrSiblingNodes;
     }
 
     render() {

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
@@ -167,17 +167,17 @@ export default class NodeToolbar extends PureComponent {
 
         const addNodeBeforePosition = {
             top: top - TOOLBAR_HEIGHT,
-            left: left
+            left
         };
 
         const addNodeIntoPosition = {
-            top: top,
-            left: left
+            top,
+            left
         };
 
         const addNodeAfterPosition = {
             top: top + height + 10,
-            left: left
+            left
         };
 
         // The data attribute data-ignore_click_outside is used to disable the enhanceWithClickOutside

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
@@ -11,6 +11,8 @@ import {
     getGuestFrameWindow
 } from '@neos-project/neos-ui-guest-frame/src/dom';
 
+import AddNode from './Buttons/AddNode/index';
+
 import {neos} from '@neos-project/neos-ui-decorators';
 import style from './style.css';
 
@@ -140,7 +142,7 @@ export default class NodeToolbar extends PureComponent {
             return null;
         }
 
-        const {top, width, rightAsMeasuredFromRightDocumentBorder} = getAbsolutePositionOfElementInGuestFrame(nodeElement);
+        const {top, left, width, height, rightAsMeasuredFromRightDocumentBorder} = getAbsolutePositionOfElementInGuestFrame(nodeElement);
 
         // TODO: hardcoded dimensions
         const TOOLBAR_WIDTH = 200;
@@ -163,14 +165,40 @@ export default class NodeToolbar extends PureComponent {
 
         const NodeToolbarButtons = guestFrameRegistry.getChildren('NodeToolbar/Buttons');
 
+        const addNodeBeforePosition = {
+            top: top - TOOLBAR_HEIGHT,
+            left: left
+        };
+
+        const addNodeIntoPosition = {
+            top: top,
+            left: left
+        };
+
+        const addNodeAfterPosition = {
+            top: top + height + 10,
+            left: left
+        };
+
         // The data attribute data-ignore_click_outside is used to disable the enhanceWithClickOutside
         // handling. For the special case that the outOfBandRender returns an empty rendered content
         // we need to disable the enhanceWithClickOutside handling to prevent hick ups in the event
         // registration after guest frame reload.
         return (
-            <div className={classNames} data-ignore_click_outside="true" style={toolbarPosition}>
-                <div className={style.toolBar__btnGroup}>
-                    {NodeToolbarButtons.map((Item, key) => <Item key={key} {...props} />)}
+            <div>
+                <div className={style.addNodeBefore} style={addNodeBeforePosition}>
+                    <AddNode {...props} preferredMode="before" />
+                </div>
+                <div className={classNames} data-ignore_click_outside="true" style={toolbarPosition}>
+                    <div className={style.toolBar__btnGroup}>
+                        {NodeToolbarButtons.map((Item, key) => <Item key={key} {...props} />)}
+                    </div>
+                </div>
+                <div className={style.addNodeInto} style={addNodeIntoPosition}>
+                    <AddNode {...props} preferredMode="into" />
+                </div>
+                <div className={style.addNodeAfter} style={addNodeAfterPosition}>
+                    <AddNode {...props} preferredMode="after" />
                 </div>
             </div>
         );

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/style.css
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/style.css
@@ -1,3 +1,34 @@
+.addNodeBefore {
+    position: absolute;
+    background: var(--colors-ContrastDarker);
+    z-index: var(--zIndex-NodeToolBar);
+    margin: -2px 5px 0 5px;
+    border: 2px solid var(--colors-PrimaryBlue);
+    border-bottom: 0;
+    transition: var(--transition-Fast) margin;
+}
+.addNodeInto {
+    position: absolute;
+    background: var(--colors-ContrastDarker);
+    z-index: var(--zIndex-NodeToolBar);
+    margin: 0px 5px 0 5px;
+    border: 2px solid var(--colors-PrimaryBlue);
+    transition: var(--transition-Fast) margin;
+}
+.addNodeAfter {
+    position: absolute;
+    background: var(--colors-ContrastDarker);
+    z-index: var(--zIndex-NodeToolBar);
+    margin: 0px 5px 0 5px;
+    border: 2px solid var(--colors-PrimaryBlue);
+    border-top: 0;
+    transition: var(--transition-Fast) margin;
+}
+.addNodeBefore:empty,
+.addNodeInto:empty,
+.addNodeAfter:empty {
+    display: none;
+}
 .toolBar {
     position: absolute;
     background: var(--colors-ContrastDarker);

--- a/packages/neos-ui-guest-frame/src/manifest.js
+++ b/packages/neos-ui-guest-frame/src/manifest.js
@@ -47,7 +47,6 @@ manifest('@neos-project/neos-ui-guestframe', {}, globalRegistry => {
     guestFrameRegistry.set('makeInitializeGuestFrame', makeInitializeGuestFrame);
     guestFrameRegistry.set('InlineUIComponent', InlineUI);
 
-    guestFrameRegistry.set('NodeToolbar/Buttons/AddNode', AddNode);
     guestFrameRegistry.set('NodeToolbar/Buttons/HideSelectedNode', HideSelectedNode);
     guestFrameRegistry.set('NodeToolbar/Buttons/CopySelectedNode', CopySelectedNode);
     guestFrameRegistry.set('NodeToolbar/Buttons/CutSelectedNode', CutSelectedNode);

--- a/packages/neos-ui-guest-frame/src/manifest.js
+++ b/packages/neos-ui-guest-frame/src/manifest.js
@@ -6,7 +6,6 @@ import makeInitializeGuestFrame from './initializeGuestFrame';
 import InlineUI from './InlineUI';
 
 import {
-    AddNode,
     CopySelectedNode,
     CutSelectedNode,
     DeleteSelectedNode,

--- a/packages/neos-ui-guest-frame/src/style.css
+++ b/packages/neos-ui-guest-frame/src/style.css
@@ -1,4 +1,9 @@
-.markHoveredNodeAsHovered {
+:global(.neos-inline-editable:focus) {
+    outline: none;
+}
+
+.markHoveredNodeAsHovered,
+.markHoveredNodeAsHovered:focus {
     outline-offset: 10px;
     outline: 2px solid rgba(#000, .2);
 }
@@ -12,7 +17,8 @@
     outline: 2px solid var(--colors-ContrastBrighter);
 }
 
-.markActiveNodeAsFocused--focusedNode {
+.markActiveNodeAsFocused--focusedNode,
+.markActiveNodeAsFocused--focusedNode:focus {
     outline-offset: 10px;
     outline: 2px solid var(--colors-PrimaryBlue);
 }
@@ -22,12 +28,13 @@
     outline-color: var(--colors-Warn);
 }
 
-:global(.neos-inline-editable:focus) {
-    outline: none;
+:global([data-neos-inline-editor-is-initialized]:hover) {
+    outline-offset: 10px;
+    outline: 2px dashed rgba(#000, .2);
 }
 
-:global([data-neos-inline-editor-is-initialized]:hover) {
-    outline-offset: 5px;
+:global([data-neos-inline-editor-is-initialized]:focus) {
+    outline-offset: 10px;
     outline: 2px dashed var(--colors-PrimaryBlue);
 }
 


### PR DESCRIPTION
Sometimes, the outlines of selected or hovered nodes in inline editing were not correctly rendered – due to CSS 
specificity issues. That lead to nodes being selected and then the toolbar floating around not really visually connected to the node.

Also, different gaps for hovering (dashed) and selected (solid) made these lines "seem jumping around" sometimes. This PR fixes it.

**What I did**

Fix strange outline rendering for selected nodes.

**How I did it**

Adjusting CSS for better specificity and equalize outline offset.

**How to verify it**

Selecting nodes in inline editing should now always render the correct outlines.

<img width="833" alt="Bildschirmfoto 2022-07-07 um 13 17 49" src="https://user-images.githubusercontent.com/3976405/177761576-2a79c993-1698-4312-b189-0fde73521055.png">
<img width="862" alt="Bildschirmfoto 2022-07-07 um 13 17 44" src="https://user-images.githubusercontent.com/3976405/177761582-5b298340-752b-49ec-a6cc-1c345fafb5e2.png">

