### PR TITLE
!!!BUGFIX: AssetProxies wrongly reimport assets

### DIFF
--- a/packages/neos-ui-backend-connector/src/Endpoints/index.ts
+++ b/packages/neos-ui-backend-connector/src/Endpoints/index.ts
@@ -280,12 +280,13 @@ export default (routes: Routes) => {
                 const assetSourceIdentifier = getElementInnerText(assetProxy, '.asset-source-identifier');
                 const assetSourceLabel = getElementInnerText(assetProxy, '.asset-source-label');
                 const assetProxyIdentifier = getElementInnerText(assetProxy, '.asset-proxy-identifier');
+                const identifier = getElementInnerText(assetProxy, '.local-asset-identifier') || (assetSourceIdentifier + '/' + assetProxyIdentifier);
                 return {
                     dataType: 'Neos.Media:Asset',
-                    loaderUri: 'assetProxy://' + assetSourceIdentifier + '/' + assetProxyIdentifier,
+                    loaderUri: 'assetProxy://' + identifier,
                     label: getElementInnerText(assetProxy, '.asset-proxy-label'),
                     preview: getElementAttributeValue(assetProxy, '[rel=thumbnail]', 'href'),
-                    identifier: getElementInnerText(assetProxy, '.local-asset-identifier') || (assetSourceIdentifier + '/' + assetProxyIdentifier),
+                    identifier,
                     assetSourceIdentifier,
                     assetSourceLabel,
                     assetProxyIdentifier

--- a/packages/neos-ui-editors/src/Library/LinkInput.js
+++ b/packages/neos-ui-editors/src/Library/LinkInput.js
@@ -218,9 +218,8 @@ export default class LinkInput extends PureComponent {
             return value;
         }
 
-        // Return identifier with asset source prefix except the local neos source
-        const proxyIdentifier = value.replace('assetProxy://', '');
-        return proxyIdentifier.replace('neos/', '');
+        // Strip loader uri prefix
+        return value.replace('assetProxy://', '');
     }
 
     handleValueChange = value => {
@@ -231,29 +230,17 @@ export default class LinkInput extends PureComponent {
             const proxyIdentifier = this.getProxyIdentifier(value);
             this.setState({isLoading: true});
             this.props.lockPublishing();
-            if (proxyIdentifier.indexOf('/') === -1) {
-                this.props.onLinkChange(`asset://${proxyIdentifier}` || '');
+
+            const valuePromise = (proxyIdentifier.indexOf('/') === -1) ? Promise.resolve(proxyIdentifier) : assetProxyImport(proxyIdentifier);
+            valuePromise.then(value => {
+                const assetProxyIdentifier = this.getIdentity(value);
+                this.props.onLinkChange(`asset://${assetProxyIdentifier}` || ''));
                 this.setState({
                     isLoading: false,
                     isEditMode: false
                 });
                 this.props.unlockPublishing();
-            } else {
-                const valuePromise = assetProxyImport(proxyIdentifier);
-                valuePromise.then(value => {
-                    const assetProxyIdentifier = this.getIdentity(value);
-                    this.props.assetLookupDataLoader.resolveValue(this.state.options, assetProxyIdentifier)
-                        .then(options => {
-                            const assetUri = options && options[0] ? $get('0.loaderUri', options) : '';
-                            this.props.onLinkChange(assetUri || '');
-                            this.setState({
-                                isLoading: false,
-                                isEditMode: false
-                            });
-                            this.props.unlockPublishing();
-                        });
-                });
-            }
+            });
         } else if (isInternalLink(value)) {
             const options = this.state.searchOptions.reduce((current, option) =>
                 (option.loaderUri === value) ? [Object.assign({}, option)] : current

--- a/packages/neos-ui-editors/src/Library/LinkInput.js
+++ b/packages/neos-ui-editors/src/Library/LinkInput.js
@@ -234,7 +234,7 @@ export default class LinkInput extends PureComponent {
             const valuePromise = (proxyIdentifier.indexOf('/') === -1) ? Promise.resolve(proxyIdentifier) : assetProxyImport(proxyIdentifier);
             valuePromise.then(value => {
                 const assetProxyIdentifier = this.getIdentity(value);
-                this.props.onLinkChange(`asset://${assetProxyIdentifier}` || ''));
+                this.props.onLinkChange(`asset://${assetProxyIdentifier}` || '');
                 this.setState({
                     isLoading: false,
                     isEditMode: false


### PR DESCRIPTION
The link editor handles assets differently from the asset editor and doesn't correctly check if an asset is already available locally, this leads to unnecessary calls to import proxies and can lead to duplicates if a given proxy is implemented similarly to the Neos asset source. This change addresses the issue, and prevents duplicate imports.

A minor breaking change had to be made though to preserve the rest of the functionality. IF you use the asset proxy search or detail endpoints of our React UI the `loaderUri` (which is an internal implementation detail specifically for the link editor) has changed format and will now include only `assetProxy://<UUID>` for any asset that is already local (regardless if it comes from a proxy or not).

Further refactoring in this area is recommended in future versions.

Fixes: #3165
