### PR TITLE
TASK: Temporary disable of 2 dimension tests

### DIFF
--- a/Tests/IntegrationTests/e2e.sh
+++ b/Tests/IntegrationTests/e2e.sh
@@ -32,8 +32,7 @@ mkdir DistributionPackages
     ./flow resource:publish
 
     cd Packages/Application/Neos.Neos.Ui
-    yarn run testcafe "$1" "../../../${fixture}*.e2e.js" \
-            --selector-timeout=10000 --assertion-timeout=30000
+    yarn run testcafe "$1" "../../../Packages/Application/Neos.Neos.Ui/Tests/IntegrationTests/Fixtures/1Dimension/*.e2e.js" --selector-timeout=10000 --assertion-timeout=30000
     cd ../../..
     rm -f DistributionPackages/Neos.TestSite
 

--- a/Tests/IntegrationTests/e2e.sh
+++ b/Tests/IntegrationTests/e2e.sh
@@ -13,11 +13,12 @@ rm -rf DummyDistributionPackages || true
 mv DistributionPackages DummyDistributionPackages
 mkdir DistributionPackages
 
-for fixture in Packages/Application/Neos.Neos.Ui/Tests/IntegrationTests/Fixtures/*/; do
-    echo "$fixture"
+# Currently just run the 1 dimension tests as we have issues with the 2 dimension tests on circleci
+#for fixture in Packages/Application/Neos.Neos.Ui/Tests/IntegrationTests/Fixtures/1Dimension/; do
+#    echo "$fixture"
 
     ln -s "../Packages/Application/Neos.Neos.Ui/Tests/IntegrationTests/SharedNodeTypesPackage" DistributionPackages/Neos.TestNodeTypes
-    ln -s "../${fixture}SitePackage" DistributionPackages/Neos.TestSite
+    ln -s "../Packages/Application/Neos.Neos.Ui/Tests/IntegrationTests/Fixtures/1Dimension/SitePackage" DistributionPackages/Neos.TestSite
 
     # TODO: optimize this
     ./flow flow:package:rescan
@@ -36,7 +37,7 @@ for fixture in Packages/Application/Neos.Neos.Ui/Tests/IntegrationTests/Fixtures
     cd ../../..
     rm -f DistributionPackages/Neos.TestSite
 
-done
+#done
 
 rm -rf DistributionPackages
 mv DummyDistributionPackages DistributionPackages


### PR DESCRIPTION
We have some issue on CircleCI since the PHP8 image. The switch of the dimension fixture is not working and then the 2dimension test is always running on the data of the 1 dimension fixture. As we have just one test case for the 2 dimensions, and it works locally, we disable that for a while and investigate the issue.
