### PR TITLE
BUGFIX: Check $fullPresetConfig before use

### DIFF
--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -499,7 +499,9 @@ class BackendServiceController extends ActionController
         $presetCombo = [];
         foreach ($targetPresets as $dimensionName => $presetConfig) {
             $fullPresetConfig = $this->contentDimensionsPresetSource->findPresetByDimensionValues($dimensionName, $presetConfig['values']);
-            $presetCombo[$dimensionName] = $fullPresetConfig['identifier'];
+            if ($fullPresetConfig !== null) {
+                $presetCombo[$dimensionName] = $fullPresetConfig['identifier'];
+            }
         }
         return $presetCombo;
     }


### PR DESCRIPTION
The method `findPresetByDimensionValues(…)` may return `null` if no preset is found. This rarely happens, but if it does, it leads to a failure when requesting node data, (partly) breaking the UI.

Fixes #3188
