### PR TITLE
BUGFIX: Fallback to a defined edit mode if the selected edit mode is undefined

### DIFF
--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -80,8 +80,8 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
     const editPreviewMode = $get(['ui', 'editPreviewMode'], state);
     const editPreviewModes = globalRegistry.get('frontendConfiguration').get('editPreviewModes');
     const isWorkspaceReadOnly = selectors.CR.Workspaces.isWorkspaceReadOnlySelector(state);
-    const currentEditMode = editPreviewModes[editPreviewMode] || editPreviewModes[Object.keys(editPreviewModes)[0]];
-    if (!currentEditMode.isEditingMode || isWorkspaceReadOnly) {
+    const currentEditMode = editPreviewModes[editPreviewMode];
+    if (!currentEditMode || !currentEditMode.isEditingMode || isWorkspaceReadOnly) {
         return;
     }
 

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -80,7 +80,7 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
     const editPreviewMode = $get(['ui', 'editPreviewMode'], state);
     const editPreviewModes = globalRegistry.get('frontendConfiguration').get('editPreviewModes');
     const isWorkspaceReadOnly = selectors.CR.Workspaces.isWorkspaceReadOnlySelector(state);
-    const currentEditMode = editPreviewModes[editPreviewMode];
+    const currentEditMode = editPreviewModes[editPreviewMode] || editPreviewModes[Object.keys(editPreviewModes)[0]];
     if (!currentEditMode.isEditingMode || isWorkspaceReadOnly) {
         return;
     }

--- a/packages/neos-ui-sagas/src/UI/EditPreviewMode/index.js
+++ b/packages/neos-ui-sagas/src/UI/EditPreviewMode/index.js
@@ -1,4 +1,5 @@
-import {takeLatest} from 'redux-saga/effects';
+import {takeLatest, select} from 'redux-saga/effects';
+import {$get} from 'plow-js';
 
 import {actionTypes} from '@neos-project/neos-ui-redux-store';
 import backend from '@neos-project/neos-ui-backend-connector';
@@ -10,8 +11,10 @@ import {getGuestFrameWindow} from '@neos-project/neos-ui-guest-frame/src/dom';
 export function * watchEditPreviewModesChanged() {
     yield takeLatest(actionTypes.UI.EditPreviewMode.SET, function * editPreviewModeSet(action) {
         const {editPreviewMode} = action.payload;
+        const currentIframeUrl = yield select($get('ui.contentCanvas.src'));
 
         yield backend.get().endpoints.setUserPreferences('contentEditing.editPreviewMode', editPreviewMode);
-        getGuestFrameWindow().location.reload();
+
+        getGuestFrameWindow().location.href = currentIframeUrl;
     });
 }

--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -86,7 +86,7 @@ export default class ContentCanvas extends PureComponent {
             [style['contentCanvas--isHidden']]: !isVisible
         });
         const InlineUI = guestFrameRegistry.get('InlineUIComponent');
-        const currentEditPreviewModeConfiguration = editPreviewModes[currentEditPreviewMode];
+        const currentEditPreviewModeConfiguration = editPreviewModes[currentEditPreviewMode] || editPreviewModes[Object.keys(editPreviewModes)[0]];
 
         const width = $get('width', currentEditPreviewModeConfiguration);
         const height = $get('height', currentEditPreviewModeConfiguration);

--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -105,7 +105,7 @@ export default class ContentCanvas extends PureComponent {
             canvasContentOnlyStyle.overflow = 'auto';
         }
 
-        if (currentEditPreviewModeConfiguration.backgroundColor) {
+        if (currentEditPreviewModeConfiguration && currentEditPreviewModeConfiguration.backgroundColor) {
             canvasContentStyle.background = currentEditPreviewModeConfiguration.backgroundColor;
         } else if (backgroundColor) {
             canvasContentStyle.background = backgroundColor;

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/EditPreviewDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/EditPreviewDropDown/index.js
@@ -35,6 +35,16 @@ export default class EditPreviewModeDropDown extends PureComponent {
         setEditPreviewMode(mode);
     });
 
+    componentDidMount() {
+        const {editPreviewMode, editPreviewModes, setEditPreviewMode} = this.props;
+
+        // Switch edit preview mode to the first one if the current one is not available
+        if (!editPreviewModes[editPreviewMode]) {
+            const fallbackEditPreviewMode = Object.values(editPreviewModes)[0];
+            setEditPreviewMode(fallbackEditPreviewMode.id);
+        }
+    }
+
     render() {
         const {
             editPreviewMode,
@@ -42,7 +52,7 @@ export default class EditPreviewModeDropDown extends PureComponent {
             i18nRegistry
         } = this.props;
 
-        const currentEditMode = editPreviewModes[editPreviewMode] || editPreviewModes[Object.keys(editPreviewModes)[0]];
+        const currentEditMode = editPreviewModes[editPreviewMode] || Object.values(editPreviewModes)[0];
 
         const editPreviewModesList = Object.keys(editPreviewModes).map(key => {
             const element = editPreviewModes[key];

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/EditPreviewDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/EditPreviewDropDown/index.js
@@ -42,7 +42,7 @@ export default class EditPreviewModeDropDown extends PureComponent {
             i18nRegistry
         } = this.props;
 
-        const currentEditMode = editPreviewModes[editPreviewMode];
+        const currentEditMode = editPreviewModes[editPreviewMode] || editPreviewModes[Object.keys(editPreviewModes)[0]];
 
         const editPreviewModesList = Object.keys(editPreviewModes).map(key => {
             const element = editPreviewModes[key];


### PR DESCRIPTION
**What I did**

Whenever an edit mode is removed and a user has still selected set mode the backend would crash.
Now it makes sure that no errors occur and falls back to the first selectable mode.

see #3129
replaces #3130

**How I did it**

All occurrences of the edit mode have been enhanced with additional checks to prevent errors.
In addition the selector will check that the selected one exists and will fallback if not.
The new mode will then be stored and the guest frame reloaded.

**How to verify it**

change an entry in the table `neos_neos_domain_model_userpreferences` for example to `a:1:{s:30:"contentEditing.editPreviewMode";s:7:"inPlXXX";}`

Previous behaviour was recieving a blank page. Now the backend will reload with a viable mode.