### PR TITLE
BUGFIX: Auto-publish menu alignment 

### DIFF
--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/style.css
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/style.css
@@ -59,10 +59,6 @@
         }
     }
 
-    > label {
-        margin-bottom: 0;
-    }
-
     > a,
     > label,
     > button {
@@ -80,6 +76,12 @@
         > input {
             margin-right: .5em;
         }
+    }
+
+    > label {
+        margin-bottom: 0;
+        display: flex;
+        align-items: center;
     }
 
     .badge {

--- a/packages/react-ui-components/src/CheckBox/style.css
+++ b/packages/react-ui-components/src/CheckBox/style.css
@@ -32,7 +32,7 @@
     width: 20px;
     height: 20px;
     border-radius: 2px;
-    vertical-align: text-bottom;
+    vertical-align: top;
     background: var(--colors-ContrastDark);
     font-size: 20px;
     font-weight: bold;


### PR DESCRIPTION
closes #2993 

**What I did**
The checkbox for the Auto-publish option in the primary menu was not correctly aligned. 
Should work now.

**How I did it**
I used flexbox to align the items next to each other, just like the other checkboxes in the backend do. 

To align the check svg in the checkbox I changed the alignment of the blue box background. I tested this on other instances of the checkbox in the backend and the changes did not break any checkbox as far as I could see. 

**How to verify it**

Previous: 
![Bildschirmfoto 2022-10-04 um 16 08 13](https://user-images.githubusercontent.com/91674611/193843160-e9b8b645-1d07-42f6-8a5a-ed81a2994225.png)

Now: 
![Bildschirmfoto 2022-10-04 um 16 07 28](https://user-images.githubusercontent.com/91674611/193843298-eac90b0d-0660-421b-a849-f887d0311afe.png)

