### PR TITLE
!!! BUGFIX: CKEditor now uses em for italic

### DIFF
--- a/packages/neos-ui-ckeditor5-bindings/src/manifest.config.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/manifest.config.js
@@ -12,6 +12,7 @@ import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
 import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+import ItalicWithEm from './plugins/italicWithEm';
 import Underline from '@ckeditor/ckeditor5-basic-styles/src/underline';
 import Strikethrough from '@ckeditor/ckeditor5-basic-styles/src/strikethrough';
 import Heading from '@ckeditor/ckeditor5-heading/src/heading';
@@ -128,6 +129,10 @@ export default ckEditorRegistry => {
         $get('formatting.h5'),
         $get('formatting.h6')
     )));
+
+    // Custom Plugin that automatically converts <i> to <em> for italics
+    // @fixes https://github.com/neos/neos-ui/issues/2906
+    config.set('italicWithEm', addPlugin(ItalicWithEm, $get('formatting.em')));
 
     //
     // @see https://docs.ckeditor.com/ckeditor5/latest/features/headings.html#configuring-heading-levels

--- a/packages/neos-ui-ckeditor5-bindings/src/plugins/italicWithEm.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/plugins/italicWithEm.js
@@ -1,0 +1,19 @@
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import ItalicWithEmEditing from './italicWithEmEditing';
+
+export default class ItalicWithEm extends Plugin {
+    /**
+     * @inheritDoc
+     */
+    static get requires() {
+        return [ItalicWithEmEditing];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    static get pluginName() {
+        return 'ItalicWithEm';
+    }
+}
+

--- a/packages/neos-ui-ckeditor5-bindings/src/plugins/italicWithEmEditing.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/plugins/italicWithEmEditing.js
@@ -1,0 +1,30 @@
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+
+// same as ItalicEditing Plugin from CKEditor5
+const ITALIC = 'italic';
+
+/**
+ * Custom Plugin to replace <i> with <em> tags.
+ * @fixes https://github.com/neos/neos-ui/issues/2906
+ *
+ * Original Italic Plugin at '@ckeditor/ckeditor5-basic-styles/src/italic/italicediting.js'
+ */
+export default class ItalicWithEmEditing extends Plugin {
+    /**
+     * @inheritDoc
+     */
+    static get pluginName() {
+        return 'ItalicWithEmEditing';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    init() {
+        this.editor.conversion.for('downcast').attributeToElement({
+            model: ITALIC,
+            view: 'em',
+            converterPriority: 'high'
+        });
+    }
+}


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

**What I did**
Fixed #2906 
**How I did it**
Created a new CKEditor Plugin replaces `<i>` tags with `<em>` tags.
**How to verify it**
- Open Neos. 
- Open a Page where you can use CKEditor to edit Text.
- Mark text and make it Italic.
- Inspect this text in Devtools.
- The text should be wrapped in an *em* tag
<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
<img width="879" alt="Screenshot 2022-10-04 at 6 29 37 PM" src="https://user-images.githubusercontent.com/1615332/193874466-58ccbff3-2163-49c8-b484-f07ccf5dd71d.png">
