### PR TITLE
BUGFIX: Fix help message styling

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/style.css
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/style.css
@@ -84,10 +84,19 @@
     border-radius: 2px;
     margin: 1px;
     position: relative;
+    overflow-y: auto;
 }
 
 .helpMessage a {
     color: var(--colors-PrimaryBlue);
+}
+
+.helpMessage ul {
+    padding-left: 40px;
+}
+
+.helpMessage ul li {
+    display: list-item;
 }
 
 .helpMessage a:hover,


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**
* fixed small frontend issues in help messages
*  show lists with bullet points and indents
* fix image overflowing black background

**How I did it**
* changed CSS for help messages

**How to verify it**
* add an image and a help message with a list in markdown style and see how beautiful it looks :)
<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->

### Before:
![grafik](https://user-images.githubusercontent.com/11499598/194098637-c267deff-5d5c-4afa-99aa-ce9c5b29a3a8.png)

### After:
![grafik](https://user-images.githubusercontent.com/11499598/194098407-b964cae0-a300-4b49-960d-1820c1b4a7be.png)

