### PR TITLE
BUGFIX: add larger min-width to dimension switcher dropdown to prevent long options from clipping to early

### DIFF
--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/index.js
@@ -97,6 +97,7 @@ class DimensionSelector extends PureComponent {
                     searchBoxLeftToTypeLabel={i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
                     threshold={0}
                     ListPreviewElement={DimensionSelectorOption}
+                    className={style.dimensionSwitcherDropDown}
                 />
             </li>
         );

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/style.css
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/style.css
@@ -1,5 +1,5 @@
 .dropDown {
-    max-width: 296px;
+    max-width: 320px;
     width: auto;
 }
 .dropDown__header {
@@ -18,6 +18,10 @@
 .dimensionCategory {
     background-color: var(--colors-ContrastDarkest);
     padding: var(--spacing-Full);
+}
+
+.dimensionSwitcherDropDown {
+    min-width: 240px;
 }
 
 .dimensionCategory + .dimensionCategory {


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**
* fixed issue #3013 

**How I did it**
* added a new min-width for the dimension switcher dropdown
* increased the max-width of the closed dropdown button

**How to verify it**
1. Configure some dimension presets with both long and short labels
2. Select a preset in the Neos UI with a short label
3. Open Dropdown

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
