### PR TITLE
BUGFIX: label of checkbox "auto-publishing" is now clickable and looks nice

### DIFF
--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -214,15 +214,18 @@ export default class PublishDropDown extends PureComponent {
                             </a>
                         </li>)}
                         <li className={autoPublishWrapperClassNames}>
-                            <Label htmlFor="neos-PublishDropDown-AutoPublish">
+                            <Label htmlFor="neos-PublishDropDown-AutoPublish" className={style.dropdownOptionCheckbox}>
                                 <
 // @ts-ignore
                                 CheckBox
                                     id="neos-PublishDropDown-AutoPublish"
                                     onChange={toggleAutoPublishing}
                                     isChecked={isAutoPublishingEnabled}
+                                    className={style.dropdownOptionCheckbox__input}
                                     />
-                                <I18n id="Neos.Neos:Main:autoPublish" fallback="Auto-Publish"/>
+                                <span className={style.dropdownOptionCheckbox__label}>
+                                    <I18n id="Neos.Neos:Main:autoPublish" fallback="Auto-Publish"/>
+                                </span>
                             </Label>
                         </li>
                         <li className={style.dropDown__item}>

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/style.css
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/style.css
@@ -46,6 +46,31 @@
     margin-right: 5px;
 }
 
+.dropdownOptionCheckbox {
+    position: relative;
+    min-height: 40px;
+}
+
+.dropdownOptionCheckbox__input {
+    width: 100%;
+    padding-top: 10px;
+}
+
+.dropdownOptionCheckbox__input > input {
+    width: 100%;
+}
+
+.dropdownOptionCheckbox__input > svg {
+    left: 10px;
+    top: 20px;
+}
+
+.dropdownOptionCheckbox__label {
+    position: absolute;
+    top: 0;
+    left: 45px;
+}
+
 .dropDown__item {
     position: relative;
     border-top: 1px solid var(--colors-ContrastDarker);
@@ -60,9 +85,13 @@
     }
 
     > a,
-    > label,
     > button {
         display: block;
+    }
+
+    > a,
+    > label,
+    > button {
         width: 100%;
         border: 0;
         padding: 0 var(--spacing-Full);
@@ -80,7 +109,6 @@
 
     > label {
         margin-bottom: 0;
-        display: flex;
         align-items: center;
     }
 


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

**What I did**
* fix issue #3140 
* made label of checkbox "auto-publishing" clickable and fixed its styling

**How I did it**
* used a pure css solution with absolute positioned label because the react-ui-component checkbox inside the react-ui-component select is buggy

**How to verify it**
* open the publish dropdown and see how it looks now
* click the "auto publish label" - the checkbox will be toggled and the dropdown closed
<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->

### Before:
![grafik](https://user-images.githubusercontent.com/11499598/194331430-cf067c3c-0d78-4d05-8a6c-e676e4c26564.png)

### After:
![grafik](https://user-images.githubusercontent.com/11499598/194331321-c9be9e0b-ddba-445d-83d7-e14d0907b086.png)

