### PR TITLE
BUGFIX: hide big ckeditor icon when table is inserted

### DIFF
--- a/packages/neos-ui-guest-frame/src/style.css
+++ b/packages/neos-ui-guest-frame/src/style.css
@@ -47,6 +47,10 @@
     border: 1px solid gray;
 }
 
+:global(.ck-widget__selection-handle .ck-icon) {
+    display: none;
+}
+
 :global body::-webkit-scrollbar {
     width: 8px;
     height: 8px;


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

**What I did**
* CkEditor 5 inserts an icon with 100% width, when the user inserts a table
* this error appears only in version 8.2
* I hide this icon, because it's useless

**How I did it**
* CSS only

**How to verify it**
* simply insert a table with ckeditor and see how no icon appears 🤡

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->

### Before
![grafik](https://user-images.githubusercontent.com/11499598/194362388-809d0790-c6d6-435d-bc58-c057876f026d.png)

### After
![grafik](https://user-images.githubusercontent.com/11499598/194358396-d1405a9e-0a22-4699-9c80-9bdbaefb5c0b.png)
