### PR TITLE
Bugfix: Add scroll to errors

### DIFF
--- a/packages/neos-ui/src/Containers/FlashMessages/FlashMessage/style.css
+++ b/packages/neos-ui/src/Containers/FlashMessages/FlashMessage/style.css
@@ -8,6 +8,10 @@
     overflow: hidden;
     box-sizing: border-box;
     box-shadow: 0 0 14px rgba(#000, .15);
+
+    &:last-child {
+        margin-bottom: 0px;
+    }
 }
 
 .flashMessage--success {

--- a/packages/neos-ui/src/Containers/FlashMessages/style.css
+++ b/packages/neos-ui/src/Containers/FlashMessages/style.css
@@ -3,9 +3,11 @@
     z-index: var(--zIndex-FlashMessageContainer);
     top: 0;
     left: 50%;
-    width: 512px;
-    padding-top: 8px;
+    width: 516px;
+    margin-top: 8px;
     transform: translate(-50%, 0);
+    max-height: calc(100% - 16px);
+    overflow: auto;
 
     &:empty {
         display: none;


### PR DESCRIPTION
similar neos/neos-development-collection#3917 

**What I did**
Error Messages in the UI were not scrollable, since they have a fixed position. Now they are.  

**How I did it**
I added a max-height to the UI error messages and made them scroll if there is too much content. 

**How to verify it**
Since I did not have an error message, I forced an error message on saving page changes. The long content can also be created with the devtools. 

New behavior for one long message: 

![big_message](https://user-images.githubusercontent.com/91674611/195024109-5fdc992b-80c8-4051-a03d-5aef356888c9.gif)

New behavior for multiple messages: 
![multiple_messages](https://user-images.githubusercontent.com/91674611/195024180-0a6ec4bf-baa6-4beb-872f-a749fbd124c1.gif)

New behavior for one single small message:
![Bildschirmfoto 2022-10-11 um 09 26 56](https://user-images.githubusercontent.com/91674611/195024296-52d4c92a-c18f-4b88-b852-ccbb405f879a.png)


