### PR TITLE
Bugfix: Hover dimensionSwitcher and position of userDropdown

### DIFF
--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/style.css
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/style.css
@@ -4,6 +4,10 @@
 }
 .dropDown__header {
     background-color: transparent;
+
+    &:hover {
+        color: var(--colors-PrimaryBlue);
+    }
 }
 .dropDown__contents {
     width: fit-content;

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/UserDropDown/style.css
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/UserDropDown/style.css
@@ -27,18 +27,18 @@
     }
 }
 .dropDown__contents {
-    position: relative;
+    position: absolute;
     min-width: 160px;
+    right: 0px;
+    left: auto;
     padding: 2px !important;
     margin-top: -2px;
     background: var(--colors-ContrastDarker);
     box-shadow: 0 5px 5px rgba(0, 0, 0, .2);
 
     @media(max-width: 768px) {
-        position: absolute;
         min-width: 240px;
         top: 40px;
-        left: 0;
         margin-top: 0;
     }
 }


### PR DESCRIPTION
closes #3216 


**What I did**
There are two bugs in the upper right toolbar. Those should be fixed now. 

**How I did it**
I added a hover-state to the dimension Menu and set the User dropdown to absolute.

**How to verify it**
Opening the Usermenu should not move the dimensions menu: 
![dropdown_desktop](https://user-images.githubusercontent.com/91674611/195058231-d36f784b-f5ee-41b8-a42f-17aa3202be71.gif)

Opening the usermenu on mobile: 
![dropdown_mobile](https://user-images.githubusercontent.com/91674611/195058274-3559d016-cc6f-4604-af39-fd4c483fe8ec.gif)

Hover on the dimension Menu should color the text blue: 
![Bildschirmfoto 2022-10-11 um 11 10 17](https://user-images.githubusercontent.com/91674611/195050934-872aaced-a36c-4ac8-a5e7-4109ead09a5c.png)


