### PR TITLE
BUGFIX: Clicking on top menu SVG now triggers menu close

### DIFF
--- a/packages/react-ui-components/src/DropDown/style.css
+++ b/packages/react-ui-components/src/DropDown/style.css
@@ -25,6 +25,10 @@
     &:focus{
         outline: 1px solid var(--colors-PrimaryBlue);
     }
+
+    svg{
+        pointer-events: none;
+    }
 }
 .dropDown__btn--withChevron {
     padding-right: var(--spacing-GoldenUnit);


### PR DESCRIPTION
closes #3222 

**What I did**
When clicking on any of the svgs in the right topmenu bar, other dropdowns were not closed. For example, after opening the  Language menu and clicking on the "down" or "user" icons to open the usermenu, the language menu would stay open. 
This should not happen anymore. 

**How I did it**
As far as I understood, SVGs have a pointer-event called: visiblePainted.  Apparently, this stops the click element from traveling. Setting the pointer-event to "none" allows the event to travel to the parents and children. I tried out different selectors, but this was the only one that worked. 
Since in the dimensions menu the svg is wrapped inside a span, I had to use a very broad selector to catch all SVGs inside the dropdown header. 
Also, I was not sure if this is the right place for adding the new CSS-declaration. If this should be placed anywhere else, suggestions are welcome 😸 

Link to documentation: https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events

**How to verify it**
Clicking on any SVG in the right topmenu now closes all other open menus. 
![dropdown_right_mouse](https://user-images.githubusercontent.com/91674611/195523547-4d69ef38-7fc3-4485-a44c-723280902c08.gif)

