### PR TITLE
TASK: translate rte toolbar style-select options

### DIFF
--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -20,6 +20,30 @@
             <trans-unit id="imageCropper__aspect-ratio-placeholder" xml:space="preserve">
                 <source>Choose an Aspect Ratio</source>
             </trans-unit>
+            <trans-unit id="ckeditor__toolbar__style__p" xml:space="preserve">
+                <source>Paragraph</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__style__h1" xml:space="preserve">
+                <source>Headline 1</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__style__h2" xml:space="preserve">
+                <source>Headline 2</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__style__h3" xml:space="preserve">
+                <source>Headline 3</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__style__h4" xml:space="preserve">
+                <source>Headline 4</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__style__h5" xml:space="preserve">
+                <source>Headline 5</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__style__h6" xml:space="preserve">
+                <source>Headline 6</source>
+            </trans-unit>
+            <trans-unit id="ckeditor__toolbar__style__pre" xml:space="preserve">
+                <source>Preformatted</source>
+            </trans-unit>
             <trans-unit id="ckeditor__toolbar__bold" xml:space="preserve">
                 <source>Bold</source>
             </trans-unit>

--- a/packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/StyleSelect.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/StyleSelect.js
@@ -14,6 +14,7 @@ const startsWith = prefix => element => element.id.startsWith(prefix);
  * The Actual StyleSelect component
  */
 @neos(globalRegistry => ({
+    i18nRegistry: globalRegistry.get('i18n'),
     nodeTypesRegistry: globalRegistry.get('@neos-project/neos-ui-contentrepository'),
     toolbarRegistry: globalRegistry.get('ckEditor5').get('richtextToolbar')
 }))
@@ -32,6 +33,7 @@ export default class StyleSelect extends PureComponent {
             PropTypes.object
         ])),
         executeCommand: PropTypes.func.isRequired,
+        i18nRegistry: PropTypes.object.isRequired,
         nodeTypesRegistry: PropTypes.object.isRequired,
         toolbarRegistry: PropTypes.object.isRequired
     };
@@ -53,7 +55,7 @@ export default class StyleSelect extends PureComponent {
             .filter(isToolbarItemVisible(inlineEditorOptions || []));
 
         const options = nestedStyles.map(style => ({
-            label: style.label,
+            label: this.props.i18nRegistry.translate(style.label, style.label),
             value: style.id
         }));
 

--- a/packages/neos-ui-ckeditor5-bindings/src/manifest.richtextToolbar.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/manifest.richtextToolbar.js
@@ -157,7 +157,7 @@ export default ckEditorRegistry => {
         commandArgs: [{
             value: 'paragraph'
         }],
-        label: 'Paragraph',
+        label: 'Neos.Neos.Ui:Main:ckeditor__toolbar__style__p',
         isVisible: $get('formatting.p'),
         isActive: formattingUnderCursor => !$get('heading', formattingUnderCursor)
     });
@@ -168,7 +168,7 @@ export default ckEditorRegistry => {
         commandArgs: [{
             value: 'heading1'
         }],
-        label: 'Headline 1',
+        label: 'Neos.Neos.Ui:Main:ckeditor__toolbar__style__h1',
         isVisible: $get('formatting.h1'),
         isActive: formattingUnderCursor => $get('heading', formattingUnderCursor) === 'heading1'
     });
@@ -179,7 +179,7 @@ export default ckEditorRegistry => {
         commandArgs: [{
             value: 'heading2'
         }],
-        label: 'Headline 2',
+        label: 'Neos.Neos.Ui:Main:ckeditor__toolbar__style__h2',
         isVisible: $get('formatting.h2'),
         isActive: formattingUnderCursor => $get('heading', formattingUnderCursor) === 'heading2'
     });
@@ -190,7 +190,7 @@ export default ckEditorRegistry => {
         commandArgs: [{
             value: 'heading3'
         }],
-        label: 'Headline 3',
+        label: 'Neos.Neos.Ui:Main:ckeditor__toolbar__style__h3',
         isVisible: $get('formatting.h3'),
         isActive: formattingUnderCursor => $get('heading', formattingUnderCursor) === 'heading3'
     });
@@ -201,7 +201,7 @@ export default ckEditorRegistry => {
         commandArgs: [{
             value: 'heading4'
         }],
-        label: 'Headline 4',
+        label: 'Neos.Neos.Ui:Main:ckeditor__toolbar__style__h4',
         isVisible: $get('formatting.h4'),
         isActive: formattingUnderCursor => $get('heading', formattingUnderCursor) === 'heading4'
     });
@@ -212,7 +212,7 @@ export default ckEditorRegistry => {
         commandArgs: [{
             value: 'heading5'
         }],
-        label: 'Headline 5',
+        label: 'Neos.Neos.Ui:Main:ckeditor__toolbar__style__h5',
         isVisible: $get('formatting.h5'),
         isActive: formattingUnderCursor => $get('heading', formattingUnderCursor) === 'heading5'
     });
@@ -223,7 +223,7 @@ export default ckEditorRegistry => {
         commandArgs: [{
             value: 'heading6'
         }],
-        label: 'Headline 6',
+        label: 'Neos.Neos.Ui:Main:ckeditor__toolbar__style__h6',
         isVisible: $get('formatting.h6'),
         isActive: formattingUnderCursor => $get('heading', formattingUnderCursor) === 'heading6'
     });
@@ -234,7 +234,7 @@ export default ckEditorRegistry => {
         commandArgs: [{
             value: 'pre'
         }],
-        label: 'Preformatted',
+        label: 'Neos.Neos.Ui:Main:ckeditor__toolbar__style__pre',
         isVisible: $get('formatting.pre'),
         isActive: formattingUnderCursor => $get('heading', formattingUnderCursor) === 'pre'
     });


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**
The StyleSelect dropdown in the RTE toolbar now tries to translate the option labels.

**How I did it**
Rather than configuring a translated string in the toolbar manifest, the dopdown tries to translate the label itself to be more in line with the other configured toolbar items.

**How to verify it**
Enable formatting options on a node-type and try overwriting the translation
```
ui:
  inline:
    editorOptions:
      formatting:
        p: true
        h1: true
        h2: true
        h3: true
        h4: true
        h5: true
        h6: true
        pre: true
```

Regarding the translation workflow I found https://www.neos.io/community/participate/translating-neos.html but I'm not completely sure what to make of it.