### PR TITLE
BUGFIX: Resolve JS menu warning

### DIFF
--- a/Resources/Private/Fusion/Backend/Component/ModuleMenu.fusion
+++ b/Resources/Private/Fusion/Backend/Component/ModuleMenu.fusion
@@ -26,7 +26,7 @@ prototype(Neos.Neos.Ui:Component.ModuleMenu) < prototype(Neos.Fusion:Map) {
                         uri = ${currentSiteInMenu.uri}
                         target = 'Window'
                         isActive = ${currentSiteInMenu.active}
-                        skipI18n = ${true}
+                        skipI18n = true
                     }
                 }
             }
@@ -48,6 +48,7 @@ prototype(Neos.Neos.Ui:Component.ModuleMenu) < prototype(Neos.Fusion:Map) {
                         position = ${submodule.position}
                         isActive = true
                         target = 'Window'
+                        skipI18n = false
                     }
 
                     @process.filterHiddenSubmodules = ${Array.filter(value, (x, index) => x != null)}

--- a/packages/neos-ui/src/Containers/Drawer/index.js
+++ b/packages/neos-ui/src/Containers/Drawer/index.js
@@ -46,8 +46,8 @@ export default class Drawer extends PureComponent {
                         label: PropTypes.string.isRequired,
                         uri: PropTypes.string,
                         target: PropTypes.string,
-                        isActive: PropTypes.bool.isReqired,
-                        skipI18n: PropTypes.bool.isReqired
+                        isActive: PropTypes.bool.isRequired,
+                        skipI18n: PropTypes.bool.isRequired
                     })
                 )
             })

--- a/packages/neos-ui/src/Containers/Root.js
+++ b/packages/neos-ui/src/Containers/Root.js
@@ -49,8 +49,8 @@ Root.propTypes = {
                     label: PropTypes.string.isRequired,
                     uri: PropTypes.string,
                     target: PropTypes.string,
-                    isActive: PropTypes.bool.isReqired,
-                    skipI18n: PropTypes.bool.isReqired
+                    isActive: PropTypes.bool.isRequired,
+                    skipI18n: PropTypes.bool.isRequired
                 })
             )
         })


### PR DESCRIPTION
The proptypes in the UI complained about the missing `skip18n` property for menu entries. Additionally there were a few typos in the proptypes.

```
react_devtools_backend.js:4026 Warning: Failed prop type: The prop `menu[1].children[0].skipI18n` is marked as required in `App`, but its value is `undefined`.
    in App (created by ConnectFunction)
    in ConnectFunction (created by Root)
    in Neos (created by Root)
    in Unknown (created by Root)
    in Provider (created by Root)
    in div (created by Root)
    in Root
```
