### PR TITLE
BUGFIX: Load neos backend path after restoring user impersonation

### DIFF
--- a/packages/neos-ui-sagas/src/UI/Impersonate/index.js
+++ b/packages/neos-ui-sagas/src/UI/Impersonate/index.js
@@ -38,7 +38,7 @@ export function * impersonateRestore({globalRegistry}) {
             } else {
                 yield put(actions.UI.FlashMessages.add('restoreUserImpersonateUser', errorMessage, 'error'));
             }
-            window.location.reload();
+            window.location.pathname = '/neos';
         } catch (error) {
             yield put(actions.UI.FlashMessages.add('restoreUserImpersonateUser', errorMessage, 'error'));
         }


### PR DESCRIPTION
Instead of reloading the same page, which leads to an access denied error caused by the wrong workspace, we now load the /neos path like in the rest of the Neos backend.

Fixes: #3237