### PR TITLE
TASK: Change the CircleCI image to PHP 7.4.32

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
     environment:
       COMPOSER_CACHE_DIR: /composer/cache-dir
     docker:
-      - image: quay.io/yeebase/ci-build:7.4
+      - image: cimg/php:7.4.32-node
     steps:
       - attach_workspace: *attach_workspace
       - restore_cache: *restore_composer_cache
@@ -99,7 +99,7 @@ jobs:
     environment:
       FLOW_CONTEXT: Production
     docker:
-      - image: quay.io/yeebase/ci-build:7.4
+      - image: cimg/php:7.4.32-node
       - image: circleci/mariadb:10.2
         environment:
           MYSQL_DATABASE: neos
@@ -138,7 +138,7 @@ jobs:
     environment:
       FLOW_CONTEXT: Production
     docker:
-      - image: quay.io/yeebase/ci-build:7.4
+      - image: cimg/php:7.4.32-node
       - image: circleci/mariadb:10.2
         environment:
           MYSQL_DATABASE: neos


### PR DESCRIPTION
Updates the PHP container image to use PHP `7.4.32` with composer 2, as composer 1 is deprecated and the build pipeline did not succeed anymore.

**What I did**
Changed the PHP container image