### PR TITLE
BUGFIX: Perform commit of image crop only if crop adjustments have changed

### DIFF
--- a/packages/neos-ui-editors/src/Editors/Image/index.js
+++ b/packages/neos-ui-editors/src/Editors/Image/index.js
@@ -127,15 +127,25 @@ export default class ImageEditor extends Component {
 
         const imageWidth = $get('originalDimensions.width', image);
         const imageHeight = $get('originalDimensions.height', image);
-        const cropAdjustments = {
+        const currentCropAdjustments = $get(CROP_IMAGE_ADJUSTMENT, image);
+        const nextCropAdjustments = {
             x: Math.round(cropArea.x / 100 * imageWidth),
             y: Math.round(cropArea.y / 100 * imageHeight),
             width: Math.round(cropArea.width / 100 * imageWidth),
             height: Math.round(cropArea.height / 100 * imageHeight)
         };
-        const nextimage = $set(CROP_IMAGE_ADJUSTMENT, cropAdjustments, image);
+        const cropAdjustmentsHaveChanged = !currentCropAdjustments ||
+            currentCropAdjustments.x !== nextCropAdjustments.x ||
+            currentCropAdjustments.y !== nextCropAdjustments.y ||
+            currentCropAdjustments.width !== nextCropAdjustments.width ||
+            currentCropAdjustments.height !== nextCropAdjustments.height;
 
-        commit(value, {'Neos.UI:Hook.BeforeSave.CreateImageVariant': nextimage});
+        if (cropAdjustmentsHaveChanged) {
+            const nextimage = $set(CROP_IMAGE_ADJUSTMENT, nextCropAdjustments, image);
+
+            commit(value, {'Neos.UI:Hook.BeforeSave.CreateImageVariant': nextimage});
+        }
+
         this.setState({isImageCropperOpen: false});
     }
 


### PR DESCRIPTION
fixes: #3242 

**What I did**

The `handleMediaCrop` method of the Image editor now performs a check on the crop adjustments it receives. It will now only commit a change, if the received crop adjustments differ from the crop adjustments that are already present.

**How to verify it**

If you're able to reproduce the issue described in #3242, then check out this change and the issue should disappear. Otherwise, the Image Editor (and the Image Cropper in particular) should not behave any different than before.
