### PR TITLE
BUGFIX: Allow to copy node without edit privilege

### DIFF
--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
@@ -205,11 +205,7 @@ export default class NodeTreeToolBar extends PureComponent {
                             focusedNodeContextPath={focusedNodeContextPath}
                             onClick={this.handleCopyNodes}
                             isActive={isCopied}
-                            disabled={
-                                isWorkspaceReadOnly ||
-                                destructiveOperationsAreDisabled ||
-                                !canBeEdited
-                            }
+                            disabled={isWorkspaceReadOnly}
                             id={`neos-${treeType}-CopySelectedNode`}
                         />
                         <CutSelectedNode


### PR DESCRIPTION
This changes the logic for disabling the copy button to only consider read-only workspaces as blocking for a copy operation.

`canBeEdited` and `destructiveOperationsAreDisabled` have no relevance for copying, as that is a read operation.

Fixes #3244
