### PR TITLE
BUGFIX: pin devDependencies in utils-helpers to local workspace dependency

### DIFF
--- a/packages/utils-helpers/package.json
+++ b/packages/utils-helpers/package.json
@@ -15,9 +15,9 @@
     "he": "^1.1.1"
   },
   "devDependencies": {
-    "@neos-project/babel-preset-neos-ui": "8.1.1",
-    "@neos-project/build-essentials": "8.1.1",
-    "@neos-project/jest-preset-neos-ui": "8.1.1"
+    "@neos-project/babel-preset-neos-ui": "workspace:*",
+    "@neos-project/build-essentials": "workspace:*",
+    "@neos-project/jest-preset-neos-ui": "workspace:*"
   },
   "license": "GNU GPLv3",
   "jest": {


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**
Pins the devDependencies in `utils-helpers` package to workspace:* otherwise you wouldnt be able to build the neos-ui

**How I did it**
- Changed the dependencies
- Tested if i can build the UI

**How to verify it**
Try to build the neos-ui: `make setup` on the latest `8.2` branch you will get:

```
➤ YN0000: ┌ Resolution step
➤ YN0035: │ @neos-project/babel-preset-neos-ui@npm:8.1.1: The remote server failed to provide the requested resource
➤ YN0035: │   Response Code: 404 (Not Found)
➤ YN0035: │   Request Method: GET
➤ YN0035: │   Request URL: https://registry.yarnpkg.com/@neos-project%2fbabel-preset-neos-ui
➤ YN0000: └ Completed in 0s 515ms
➤ YN0000: Failed with errors in 0s 518ms
➤ YN0061: babel-eslint@npm:7.2.3 is deprecated: babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.
```

Try to build the neos-ui again, on my branch.
