### PR TITLE
BUGFIX: Load content tree without waiting for guest frame

### DIFF
--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -69,14 +69,19 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
     // Remove the inline scripts after initialization
     Array.prototype.forEach.call(guestFrameWindow.document.querySelectorAll('script[data-neos-nodedata]'), element => element.parentElement.removeChild(element));
 
-    yield put(actions.CR.Nodes.setDocumentNode(documentInformation.metaData.documentNode, documentInformation.metaData.siteNode));
+    const state = store.getState();
+
+    // Set the current document node to the one that is rendered in the guest frame which might be different from the one that is currently selected in the page tree
+    const currentDocumentNodeContextPath = yield select($get('cr.nodes.documentNode'));
+    if (currentDocumentNodeContextPath !== documentInformation.metaData.documentNode) {
+        yield put(actions.CR.Nodes.setDocumentNode(documentInformation.metaData.documentNode, documentInformation.metaData.siteNode));
+    }
     yield put(actions.UI.ContentCanvas.setPreviewUrl(documentInformation.metaData.previewUrl));
     yield put(actions.CR.ContentDimensions.setActive(documentInformation.metaData.contentDimensions.active));
     // The user may have navigated by clicking an inline link - that's why we need to update the contentCanvas URL to be in sync with the shown content.
-    // We need to set the src to the actual src of the iframe, and not retrive it from documentInformation, as it may differ, e.g. contain additional arguments.
+    // We need to set the src to the actual src of the iframe, and not retrieve it from documentInformation, as it may differ, e.g. contain additional arguments.
     yield put(actions.UI.ContentCanvas.setSrc(guestFrameWindow.document.location.href));
 
-    const state = store.getState();
     const editPreviewMode = $get(['ui', 'editPreviewMode'], state);
     const editPreviewModes = globalRegistry.get('frontendConfiguration').get('editPreviewModes');
     const isWorkspaceReadOnly = selectors.CR.Workspaces.isWorkspaceReadOnlySelector(state);

--- a/packages/neos-ui-sagas/src/CR/NodeOperations/reloadState.js
+++ b/packages/neos-ui-sagas/src/CR/NodeOperations/reloadState.js
@@ -13,6 +13,7 @@ export default function * watchReloadState({configuration}) {
         const toggledNodes = yield select($get('ui.pageTree.toggled'));
         const siteNodeContextPath = $get('payload.siteNodeContextPath', action) || currentSiteNodeContextPath;
         const documentNodeContextPath = yield $get('payload.documentNodeContextPath', action) || select($get('cr.nodes.documentNode'));
+        yield put(actions.CR.Nodes.setDocumentNode(documentNodeContextPath, currentSiteNodeContextPath));
         yield put(actions.UI.PageTree.setAsLoading(currentSiteNodeContextPath));
         const nodes = yield q([siteNodeContextPath, documentNodeContextPath]).neosUiDefaultNodes(
             configuration.nodeTree.presets.default.baseNodeType,


### PR DESCRIPTION
**What I did**

The content tree loads even when the guest frame crashes.

**How I did it**

The information from the guest frame is not needed anymore since #2927 so the action required for the content tree to load is now immediately triggered when the document node context path is available instead of waiting for the guest frame to fully initialise.
This also make the UI more responsive as the content tree now loads at the same time as the document tree.

**How to verify it**

Open the Neos UI and the content tree should load before a page has been rendered. When breaking the rendering it should also still load.

Resolves: #3251