### PR TITLE
TASK: Update docker setup for end to end tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ test-e2e:
 
 ## Executes integration tests locally in a docker-compose setup.
 test-e2e-docker:
-	@bash Tests/IntegrationTests/e2e-docker.sh $(or $(browser),chromium)
+	@bash Tests/IntegrationTests/e2e-docker.sh $(or $(browser),chrome)
 
 ## Executes make lint-js and make lint-editorconfig.
 lint: lint-js lint-editorconfig

--- a/Tests/IntegrationTests/docker-compose.yaml
+++ b/Tests/IntegrationTests/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 services:
 
   php:
-    image: cimg/php:8.0-node
+    image: thecodingmachine/php:8.0-v4-cli-node16
     command: tail -f /dev/null
     ports:
       - 8081:8081
@@ -13,7 +13,7 @@ services:
       PHP_EXTENSION_GD: 1
 
   db:
-    image: cimg/mariadb:10.6
+    image: arm64v8/mysql:8
     environment:
       MYSQL_DATABASE: neos
       MYSQL_ROOT_PASSWORD: not_a_real_password

--- a/Tests/IntegrationTests/docker-compose.yaml
+++ b/Tests/IntegrationTests/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 services:
 
   php:
-    image: thecodingmachine/php:7.4-v4-cli
+    image: cimg/php:8.0-node
     command: tail -f /dev/null
     ports:
       - 8081:8081
@@ -13,7 +13,7 @@ services:
       PHP_EXTENSION_GD: 1
 
   db:
-    image: circleci/mariadb:10.2
+    image: cimg/mariadb:10.6
     environment:
       MYSQL_DATABASE: neos
       MYSQL_ROOT_PASSWORD: not_a_real_password

--- a/Tests/IntegrationTests/e2e-docker.sh
+++ b/Tests/IntegrationTests/e2e-docker.sh
@@ -18,9 +18,9 @@ echo "##########################################################################
 dc down
 dc up -d
 dc exec -T php bash <<-'BASH'
-    rm -rf /usr/src/app/*
+    rm -rf /home/circleci/project/*
 BASH
-docker cp $(pwd)/Tests/IntegrationTests/. $(dc ps -q php):/usr/src/app
+docker cp $(pwd)/Tests/IntegrationTests/. $(dc ps -q php):/home/circleci/project
 sleep 2
 
 echo ""
@@ -28,6 +28,7 @@ echo "##########################################################################
 echo "# Install dependencies...                                                   #"
 echo "#############################################################################"
 dc exec -T php bash <<-'BASH'
+    sudo chown -R circleci:circleci /home/circleci
     cd TestDistribution
     composer install
 BASH
@@ -36,7 +37,7 @@ echo ""
 echo "#############################################################################"
 echo "# Initialize Neos...                                                        #"
 echo "#############################################################################"
-docker cp $(pwd)/. $(dc ps -q php):/usr/src/app/TestDistribution/Packages/Application/neos-ui
+docker cp $(pwd)/. $(dc ps -q php):/home/circleci/project/TestDistribution/Packages/Application/neos-ui
 dc exec -T php bash <<-'BASH'
     cd TestDistribution
     rm -rf Packages/Application/Neos.Neos.Ui
@@ -77,13 +78,17 @@ for fixture in $(pwd)/Tests/IntegrationTests/Fixtures/*/; do
 
         # TODO: optimize this
         cd TestDistribution
-        ./flow flow:package:rescan > /dev/null
-        ./flow flow:cache:flush > /dev/null
+        composer reinstall neos/test-nodetypes
+        composer reinstall neos/test-site
+        ./flow flow:cache:flush --force
+        ./flow flow:cache:warmup
+        ./flow configuration:show --path Neos.ContentRepository.contentDimensions
+
         if ./flow site:list | grep -q 'Node name'; then
-            ./flow site:prune '*' > /dev/null
+            ./flow site:prune '*'
         fi
         ./flow site:import --package-key=Neos.TestSite
-        ./flow resource:publish > /dev/null
+        ./flow resource:publish
 BASH
 
     yarn run testcafe "$1" "${fixture}*.e2e.js" \

--- a/Tests/IntegrationTests/e2e-docker.sh
+++ b/Tests/IntegrationTests/e2e-docker.sh
@@ -18,9 +18,9 @@ echo "##########################################################################
 dc down
 dc up -d
 dc exec -T php bash <<-'BASH'
-    rm -rf /home/circleci/project/*
+    rm -rf /usr/src/app/*
 BASH
-docker cp $(pwd)/Tests/IntegrationTests/. $(dc ps -q php):/home/circleci/project
+docker cp $(pwd)/Tests/IntegrationTests/. $(dc ps -q php):/usr/src/app
 sleep 2
 
 echo ""
@@ -28,7 +28,8 @@ echo "##########################################################################
 echo "# Install dependencies...                                                   #"
 echo "#############################################################################"
 dc exec -T php bash <<-'BASH'
-    sudo chown -R circleci:circleci /home/circleci
+    cd /usr/src/app
+    sudo chown -R docker:docker .
     cd TestDistribution
     composer install
 BASH
@@ -37,7 +38,7 @@ echo ""
 echo "#############################################################################"
 echo "# Initialize Neos...                                                        #"
 echo "#############################################################################"
-docker cp $(pwd)/. $(dc ps -q php):/home/circleci/project/TestDistribution/Packages/Application/neos-ui
+docker cp $(pwd)/. $(dc ps -q php):/usr/src/app/TestDistribution/Packages/Application/neos-ui
 dc exec -T php bash <<-'BASH'
     cd TestDistribution
     rm -rf Packages/Application/Neos.Neos.Ui


### PR DESCRIPTION
**What I did**
The images of the end 2 end tests were outdated and the latest Neos versions did not run.
So changed now the images to use newer PHP versions. The images are also ARM-based so that we have more performance on Apple Silicon Macs.

**How to verify it**
Execute `make test-e2e-docker`