### PR TITLE
BUGFIX: Make e2e tests run via docker again

### DIFF
--- a/Tests/IntegrationTests/Fixtures/1Dimension/selectBoxes.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/selectBoxes.e2e.js
@@ -23,6 +23,7 @@ test('SelectBox opens below and breaks out of the creation dialog if there\'s en
 
 test('SelectBox opens above in creation dialog if there\'s not enough space below.', async t => {
     await t
+        .resizeWindow(1200, 768)
         .click(Selector('#neos-PageTree-AddNode'))
         .click(ReactSelector('NodeTypeItem').withText('SelectBox opens above'))
         .click(ReactSelector('NodeCreationDialog SelectBox'));

--- a/Tests/IntegrationTests/TestDistribution/composer.json
+++ b/Tests/IntegrationTests/TestDistribution/composer.json
@@ -4,7 +4,10 @@
     "description": "Neos test distribution. Change this number if you need to break CircleCI's cache: 14",
     "config": {
         "vendor-dir": "Packages/Libraries",
-        "bin-dir": "bin"
+        "bin-dir": "bin",
+        "allow-plugins": {
+          "neos/composer-plugin": true
+        }
     },
     "minimum-stability": "dev",
     "require": {

--- a/Tests/IntegrationTests/e2e-docker.sh
+++ b/Tests/IntegrationTests/e2e-docker.sh
@@ -28,6 +28,8 @@ echo "##########################################################################
 echo "# Install dependencies...                                                   #"
 echo "#############################################################################"
 dc exec -T php bash <<-'BASH'
+    cd /usr/src/app
+    sudo chown -R docker:docker .
     cd TestDistribution
     composer install
 BASH
@@ -77,8 +79,11 @@ for fixture in $(pwd)/Tests/IntegrationTests/Fixtures/*/; do
 
         # TODO: optimize this
         cd TestDistribution
+        composer reinstall neos/test-nodetypes
+        composer reinstall neos/test-site
         ./flow flow:package:rescan > /dev/null
         ./flow flow:cache:flush > /dev/null
+
         if ./flow site:list | grep -q 'Node name'; then
             ./flow site:prune '*' > /dev/null
         fi


### PR DESCRIPTION
**What I did**

Backported the fix from the 8.x branch.

Also makes the select box dropdown test run more reliable on various screen sizes.

**How to verify it**

Run `make test-e2e-docker`
