### PR TITLE
TASK: Use yarn versions to increase the version numbers

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -20,3 +20,8 @@ packageExtensions:
   "isemail@3.2.0":
     dependencies:
       "buffer": "^5.0.0"
+
+# Needed for the yarn version comparison
+changesetBaseRefs:
+  - origin/8.2
+  - composer/8.2

--- a/Build/bumpVersion.sh
+++ b/Build/bumpVersion.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# abort script if any command returns non-zero
+set -e
+
+# Bump version of packages
+if [[ $VERSION ]]; then
+    yarn version $VERSION
+    for name in packages/*; do
+      if [ -d "$name" ] && [ ! -L "$name" ]; then
+        printf 'Change version of %s to %s \n' "$name" "$VERSION"
+        cd $name && yarn version $VERSION
+        cd ../..
+      fi
+    done
+fi
+
+exit 0

--- a/Makefile
+++ b/Makefile
@@ -169,14 +169,12 @@ called-with-version:
 ifeq ($(VERSION),)
 	@echo No version information given.
 	@echo Please run this command like this:
-	@echo VERSION=1.0.0 make release
+	@echo VERSION=1.0.0 make bump-version
 	@false
 endif
 
 bump-version: called-with-version
-	yarn workspaces foreach run publish \
-		--skip-git --exact --repo-version=$(VERSION) \
-		--yes --force-publish --skip-npm
+	./Build/bumpVersion.sh
 	./Build/createVersionFile.sh
 
 publish-npm: called-with-version

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "bugs": "https://github.com/neos/neos-ui/issues",
   "homepage": "https://github.com/neos/neos-ui/blob/master/README.md",
   "license": "GNU GPLv3",
+  "version": "8.1.2",
   "private": true,
   "resolutions": {
     "moment": "^2.20.1",


### PR DESCRIPTION
Since we removed `lerna`, we need to change the version numbers in another way. Yarn offers the version plugin.

**What I did**
Yarn version needs a version in all `package.json` files to be able to reference the changes. Normally, the reference branch is main or master. We are using 8.2 currently and therefore I also needed to configure yarn to use this as reference. So, we have to change the `changesetBaseRefs` value on each minor release in the config.