### PR TITLE
BUGFIX: Fix dropdown spacings for reset button

### DIFF
--- a/packages/react-ui-components/src/DropDown/style.scss
+++ b/packages/react-ui-components/src/DropDown/style.scss
@@ -23,6 +23,10 @@
     white-space: nowrap;
     line-height: var(--spacing-GoldenUnit);
     background: var(--colors-ContrastNeutral);
+
+    &.dropDown__btn--withChevron {
+        padding-right: var(--spacing-GoldenUnit);
+    }
 }
 
 .dropDown__btn:focus{


### PR DESCRIPTION
Since the esbuild change, the dropdown reset button is moved into the space from the chevron. This did not happen before because the styles from dropdown and the reset were combined with composes. Right now, we don’t use composes anymore and the rewrite had issues here so that padding clashed a bit.

Fixes: #3281

