### PR TITLE
BUGFIX: Fix yarn npm auth token

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -27,6 +27,6 @@ changesetBaseRefs:
   - composer/8.2
 
 # NPM publish config
-npmAlwaysAuth: true
-npmAuthToken: "${NPM_TOKEN}"
+npmAlwaysAuth: false
+npmAuthToken: "${NPM_TOKEN-}"
 npmPublishAccess: "public"


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

Fixes #3283 

**What I did**
Use empty fallback for `NPM_TOKEN` env variable.

**How I did it**
Live with @ahaeslich.

**How to verify it**
`yarn --version` should _not_ show missing NPM Token error.

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
