### PR TITLE
BUGFIX: Prevent text overflow in delete confirm modal

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/DeleteNode/index.js
+++ b/packages/neos-ui/src/Containers/Modals/DeleteNode/index.js
@@ -55,7 +55,7 @@ export default class DeleteNodeModal extends PureComponent {
             const nodeType = $get('nodeType', node);
             const nodeTypeLabel = $get('ui.label', nodeTypesRegistry.get(nodeType)) || 'Neos.Neos:Main:node';
             return (
-                <div>
+                <div class={style.modalTitleContainer}>
                     <Icon icon="exclamation-triangle"/>
                     <span className={style.modalTitle}>
                         <I18n id="Neos.Neos:Main:delete" fallback="Delete"/>

--- a/packages/neos-ui/src/Containers/Modals/DeleteNode/style.css
+++ b/packages/neos-ui/src/Containers/Modals/DeleteNode/style.css
@@ -1,9 +1,14 @@
 .modalTitle {
     margin-left: var(--spacing-Full);
+    word-break: break-all;
 }
 .modalContents {
     padding: var(--spacing-Full);
+    word-break: break-all;
 }
 .buttonIcon {
     margin-right: var(--spacing-Half);
+}
+.modalTitleContainer {
+    display: flex;
 }


### PR DESCRIPTION
closes #3295 

**How I did it**
I added some word wrap and styling so that words wrap and go to the next line. 

**How to verify it**

1. Create a new text element, for example of type 'Neos.Demo:Content.Text'
2. Add content "DingedingeDingedingeDingedingeDingedinge" to text element
3. Delete new text element
4. Text does not overflow heading anymore 

![Bildschirmfoto 2022-12-13 um 15 55 49](https://user-images.githubusercontent.com/91674611/207367003-799ab946-fde2-4447-9d9c-2f8d5546e8be.png)

