### PR TITLE
TASK: Disable normal Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,11 @@
 version: 2
 updates:
 
-  # Maintain dependencies for npm
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    target-branch: "5.3"
-    labels:
-      - "dependencies"
-
   # Maintain dependencies for Composer
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
       interval: "daily"
-    target-branch: "5.3"
+    target-branch: "7.3"
     labels:
       - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,16 @@
 version: 2
 updates:
 
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "7.3"
+    open-pull-requests-limit: 0
+    labels:
+      - "security"
+
   # Maintain dependencies for Composer
   - package-ecosystem: "composer"
     directory: "/"


### PR DESCRIPTION
They don't really have any value for us as we run updates manually when needed. Security updates are still enabled separately.