### PR TITLE
FEATURE: adjust image editor to allow a custom upload screen component

### DIFF
--- a/packages/neos-ui-editors/src/Editors/Image/index.js
+++ b/packages/neos-ui-editors/src/Editors/Image/index.js
@@ -216,12 +216,12 @@ export default class ImageEditor extends Component {
 
     handleChooseFile = () => {
         const {secondaryEditorsRegistry, options} = this.props;
-        const {component: MediaUploadScreen} = secondaryEditorsRegistry.get('Neos.Neos/Inspector/Secondary/Editors/MediaUploadScreen');
+        const {component: AssetUploadScreen} = secondaryEditorsRegistry.get('Neos.Neos/Inspector/Secondary/Editors/AssetUploadScreen');
 
-        if (MediaUploadScreen) {
+        if (AssetUploadScreen) {
             // set media type constraint to "image/*" if it is not explicitly specified via options.constraints.mediaTypes
             const constraints = {...options.constraints, mediaTypes: (options.constraints && options.constraints.mediaTypes) || ['image/*']};
-            this.props.renderSecondaryInspector('IMAGE_UPLOAD_MEDIA', () => <MediaUploadScreen type="images" constraints={constraints || {}} onComplete={this.afterUpload}/>);
+            this.props.renderSecondaryInspector('IMAGE_UPLOAD_MEDIA', () => <MediaUploadScreen type="images" constraints={constraints} onComplete={this.afterUpload}/>);
         } else {
             this.previewScreen.chooseFromLocalFileSystem();
             this.setState({isAssetLoading: true});

--- a/packages/neos-ui-editors/src/Editors/Image/index.js
+++ b/packages/neos-ui-editors/src/Editors/Image/index.js
@@ -215,8 +215,17 @@ export default class ImageEditor extends Component {
     }
 
     handleChooseFile = () => {
-        this.previewScreen.chooseFromLocalFileSystem();
-        this.setState({isAssetLoading: true});
+        const {secondaryEditorsRegistry, options} = this.props;
+        const {component: MediaUploadScreen} = secondaryEditorsRegistry.get('Neos.Neos/Inspector/Secondary/Editors/MediaUploadScreen');
+
+        if (MediaUploadScreen) {
+            // set media type constraint to "image/*" if it is not explicitly specified via options.constraints.mediaTypes
+            const constraints = {...options.constraints, mediaTypes: (options.constraints && options.constraints.mediaTypes) || ['image/*']};
+            this.props.renderSecondaryInspector('IMAGE_UPLOAD_MEDIA', () => <MediaUploadScreen type="images" constraints={constraints || {}} onComplete={this.afterUpload}/>);
+        } else {
+            this.previewScreen.chooseFromLocalFileSystem();
+            this.setState({isAssetLoading: true});
+        }
     }
 
     handleChooseFromMedia = () => {

--- a/packages/neos-ui-editors/src/Editors/Image/index.js
+++ b/packages/neos-ui-editors/src/Editors/Image/index.js
@@ -216,11 +216,10 @@ export default class ImageEditor extends Component {
 
     handleChooseFile = () => {
         const {secondaryEditorsRegistry, options} = this.props;
-        const {component: AssetUploadScreen} = secondaryEditorsRegistry.get('Neos.Neos/Inspector/Secondary/Editors/AssetUploadScreen');
-
-        if (AssetUploadScreen) {
+        if (secondaryEditorsRegistry.get('Neos.Neos/Inspector/Secondary/Editors/AssetUploadScreen')) {
             // set media type constraint to "image/*" if it is not explicitly specified via options.constraints.mediaTypes
             const constraints = {...options.constraints, mediaTypes: (options.constraints && options.constraints.mediaTypes) || ['image/*']};
+            const {component: AssetUploadScreen} = secondaryEditorsRegistry.get('Neos.Neos/Inspector/Secondary/Editors/AssetUploadScreen');
             this.props.renderSecondaryInspector('IMAGE_UPLOAD_MEDIA', () => <AssetUploadScreen type="images" constraints={constraints} onComplete={this.afterUpload}/>);
         } else {
             this.previewScreen.chooseFromLocalFileSystem();

--- a/packages/neos-ui-editors/src/Editors/Image/index.js
+++ b/packages/neos-ui-editors/src/Editors/Image/index.js
@@ -221,7 +221,7 @@ export default class ImageEditor extends Component {
         if (AssetUploadScreen) {
             // set media type constraint to "image/*" if it is not explicitly specified via options.constraints.mediaTypes
             const constraints = {...options.constraints, mediaTypes: (options.constraints && options.constraints.mediaTypes) || ['image/*']};
-            this.props.renderSecondaryInspector('IMAGE_UPLOAD_MEDIA', () => <MediaUploadScreen type="images" constraints={constraints} onComplete={this.afterUpload}/>);
+            this.props.renderSecondaryInspector('IMAGE_UPLOAD_MEDIA', () => <AssetUploadScreen type="images" constraints={constraints} onComplete={this.afterUpload}/>);
         } else {
             this.previewScreen.chooseFromLocalFileSystem();
             this.setState({isAssetLoading: true});

--- a/packages/neos-ui-editors/src/Editors/Image/index.js
+++ b/packages/neos-ui-editors/src/Editors/Image/index.js
@@ -1,10 +1,12 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {$set, $drop, $get} from 'plow-js';
+import {connect} from 'react-redux';
 import mergeClassNames from 'classnames';
 
 import backend from '@neos-project/neos-ui-backend-connector';
 import {neos} from '@neos-project/neos-ui-decorators';
+import {selectors} from '@neos-project/neos-ui-redux-store';
 
 import {PreviewScreen, Controls, ResizeControls} from './Components/index';
 import {Image, CROP_IMAGE_ADJUSTMENT, RESIZE_IMAGE_ADJUSTMENT} from './Utils/index';
@@ -18,6 +20,10 @@ const DEFAULT_FEATURES = {
     upload: true
 };
 
+@connect(state => ({
+    siteNodePath: state?.cr?.nodes?.siteNode,
+    focusedNodePath: selectors.CR.Nodes.focusedNodePathSelector(state)
+}), null, null, {forwardRef: true})
 @neos(globalRegistry => ({secondaryEditorsRegistry: globalRegistry.get('inspector').get('secondaryEditors')}))
 export default class ImageEditor extends Component {
     state = {
@@ -48,7 +54,10 @@ export default class ImageEditor extends Component {
         // I18N key
         fileChooserLabel: PropTypes.string,
 
-        accept: PropTypes.string
+        accept: PropTypes.string,
+
+        siteNodePath: PropTypes.string.isRequired,
+        focusedNodePath: PropTypes.string.isRequired,
     };
 
     static defaultProps = {
@@ -220,7 +229,13 @@ export default class ImageEditor extends Component {
             // set media type constraint to "image/*" if it is not explicitly specified via options.constraints.mediaTypes
             const constraints = {...options.constraints, mediaTypes: (options.constraints && options.constraints.mediaTypes) || ['image/*']};
             const {component: AssetUploadScreen} = secondaryEditorsRegistry.get('Neos.Neos/Inspector/Secondary/Editors/AssetUploadScreen');
-            this.props.renderSecondaryInspector('IMAGE_UPLOAD_MEDIA', () => <AssetUploadScreen type="images" constraints={constraints} onComplete={this.afterUpload}/>);
+            const additionalData = {
+                propertyName: this.props.identifier,
+                focusedNodePath: this.props.focusedNodePath,
+                siteNodePath: this.props.siteNodePath,
+                metaData: 'Image'
+            };
+            this.props.renderSecondaryInspector('IMAGE_UPLOAD_MEDIA', () => <AssetUploadScreen type="images" constraints={constraints} onComplete={this.afterUpload} additionalData={additionalData}/>);
         } else {
             this.previewScreen.chooseFromLocalFileSystem();
             this.setState({isAssetLoading: true});


### PR DESCRIPTION
**What I did**
I adjusted the image editor to allow a custom upload screen / dialog as an replacement option for the default upload behaviour. 

**How I did it**
I adjusted the `handleChooseFile` function to look for a `MediaUploadScreen` in the secondary editors registry. If a component is found , it is used and renderd as a secondary editor for the upload of a file. If no component is found, the previous behaviour is used for handeling the file upload.

**How to verify it**
For testing this behaviour you need to write a plugin and add a component to be used as `MediaUploadScreen` to the secondary editors registry in your plugin. 
