### PR TITLE
BUGFIX: Adjust module path to distribution

### DIFF
--- a/Build/Jenkins/release-neos-ui.sh
+++ b/Build/Jenkins/release-neos-ui.sh
@@ -45,6 +45,7 @@ make install
 
 # build
 make build-production
+make adjust-extensibility
 
 # code quality
 make lint

--- a/Build/Jenkins/update-neos-ui-compiled.sh
+++ b/Build/Jenkins/update-neos-ui-compiled.sh
@@ -36,6 +36,7 @@ export NODE_OPTIONS="--max-old-space-size=4096"
 nvm install && nvm use
 make clean && make setup
 make build-production
+make adjust-extensibility
 
 rm -Rf tmp_compiled_pkg
 git clone git@github.com:neos/neos-ui-compiled.git tmp_compiled_pkg

--- a/Build/adjust-extensibility-package.sh
+++ b/Build/adjust-extensibility-package.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Set the path to the package.json file
+package_json="packages/neos-ui-extensibility/package.json"
+
+# Set the new value for the "module" field
+new_module_value="./dist/index.js"
+
+# Replace module parameter for package.json from src to dist
+if [ -f "$package_json" ]; then
+  jq --arg new_module_value "$new_module_value" '.module = $new_module_value' "$package_json" > "$package_json.tmp" && mv "$package_json.tmp" "$package_json"
+  echo "Updated 'module' field in $package_json"
+else
+  echo "Error: $package_json does not exist"
+fi

--- a/Build/adjust-extensibility-package.sh
+++ b/Build/adjust-extensibility-package.sh
@@ -6,6 +6,20 @@ package_json="packages/neos-ui-extensibility/package.json"
 # Set the new value for the "module" field
 new_module_value="./dist/index.js"
 
+# Check if jq is installed
+if ! command -v jq > /dev/null; then
+  # Install jq using apt-get if running on Ubuntu
+  if [ -f /etc/lsb-release ]; then
+    sudo apt-get install jq
+  # Install jq using brew if running on macOS
+  elif [ -f /usr/local/bin/brew ]; then
+    brew install jq
+  else
+    echo "Error: OS not recognized. Please install jq manually."
+    exit 1
+  fi
+fi
+
 # Replace module parameter for package.json from src to dist
 if [ -f "$package_json" ]; then
   jq --arg new_module_value "$new_module_value" '.module = $new_module_value' "$package_json" > "$package_json.tmp" && mv "$package_json.tmp" "$package_json"

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,10 @@ bump-version: called-with-version
 	./Build/bumpVersion.sh
 	./Build/createVersionFile.sh
 
+adjust-extensibility:
+	./Build/adjust-extensibility-package.sh
+
+
 publish-npm: called-with-version
 	yarn workspaces foreach --no-private npm publish --access public
 

--- a/packages/neos-ui-extensibility/package.json
+++ b/packages/neos-ui-extensibility/package.json
@@ -5,7 +5,7 @@
   "repository": "neos/neos-ui",
   "bugs": "https://github.com/neos/neos-ui/issues",
   "homepage": "https://github.com/neos/neos-ui/blob/master/README.md",
-  "module": "./dist/index.js",
+  "module": "./src/index.ts",
   "scripts": {
     "test": "yarn jest -w 2 --coverage",
     "test:watch": "yarn jest --watch",

--- a/packages/neos-ui-extensibility/package.json
+++ b/packages/neos-ui-extensibility/package.json
@@ -5,7 +5,7 @@
   "repository": "neos/neos-ui",
   "bugs": "https://github.com/neos/neos-ui/issues",
   "homepage": "https://github.com/neos/neos-ui/blob/master/README.md",
-  "module": "./src/index.ts",
+  "module": "./dist/index.js",
   "scripts": {
     "test": "yarn jest -w 2 --coverage",
     "test:watch": "yarn jest --watch",


### PR DESCRIPTION
When the package is "compiled" the build will not handle typescript and expect a JavaScript module. As we create a distribution, we should target the dist folder.
