### PR TITLE
TASK: Handling extensibility module path

### DIFF
--- a/Build/Jenkins/release-neos-ui.sh
+++ b/Build/Jenkins/release-neos-ui.sh
@@ -45,7 +45,7 @@ make install
 
 # build
 make build-production
-make adjust-extensibility
+make adjust-extensibility target-path="./dist/index.js"
 
 # code quality
 make lint
@@ -54,6 +54,9 @@ make test
 # publishing
 VERSION=$VERSION make bump-version
 VERSION=$VERSION NPM_TOKEN=$NPM_TOKEN make publish-npm
+
+# Change extensibility module target path back to src
+make adjust-extensibility target-path="./src/index.ts"
 
 # add changes to git and push
 git add .

--- a/Build/Jenkins/update-neos-ui-compiled.sh
+++ b/Build/Jenkins/update-neos-ui-compiled.sh
@@ -36,7 +36,6 @@ export NODE_OPTIONS="--max-old-space-size=4096"
 nvm install && nvm use
 make clean && make setup
 make build-production
-make adjust-extensibility
 
 rm -Rf tmp_compiled_pkg
 git clone git@github.com:neos/neos-ui-compiled.git tmp_compiled_pkg

--- a/Build/adjust-extensibility-package.sh
+++ b/Build/adjust-extensibility-package.sh
@@ -4,7 +4,14 @@
 package_json="packages/neos-ui-extensibility/package.json"
 
 # Set the new value for the "module" field
-new_module_value="./dist/index.js"
+if [ $# -eq 0 ]; then
+  # Print an error message if no argument was provided
+  echo "Error: No value provided for 'module path'"
+  exit 1
+else
+  # Set the new value for the "module" field
+  new_module_value=$1
+fi
 
 # Check if jq is installed
 if ! command -v jq > /dev/null; then

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ bump-version: called-with-version
 	./Build/createVersionFile.sh
 
 adjust-extensibility:
-	./Build/adjust-extensibility-package.sh
+	./Build/adjust-extensibility-package.sh $(target-path)
 
 
 publish-npm: called-with-version

--- a/packages/neos-ui-extensibility/package.json
+++ b/packages/neos-ui-extensibility/package.json
@@ -5,7 +5,7 @@
   "repository": "neos/neos-ui",
   "bugs": "https://github.com/neos/neos-ui/issues",
   "homepage": "https://github.com/neos/neos-ui/blob/master/README.md",
-  "module": "./dist/index.js",
+  "module": "./src/index.ts",
   "scripts": {
     "test": "yarn jest -w 2 --coverage",
     "test:watch": "yarn jest --watch",


### PR DESCRIPTION
The extensibility module path need only be changed to the dist folder for the NPM packages. The regular code base need to target the src folder. So, we now have the adjust-extensibility command with a parameter, and we switch the module path before the NPM Release and switch back to src before the git commit.
