### PR TITLE
BUGFIX: Position `tableCreationGrid` absolutely

### DIFF
--- a/packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/TableButton.css
+++ b/packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/TableButton.css
@@ -1,4 +1,6 @@
 .tableCreationGrid {
+    position: absolute;
+    z-index: 1;
     background-color: var(--colors-ContrastDarker);
     padding: 10px;
 }


### PR DESCRIPTION
fixes: #3308

The problem described in #3308 (table creation grid does not show up) is probably a regression through https://github.com/neos/neos-ui/pull/3227 (it's hard to tell precisely though).

I decided to target 7.3 however, because the fix for #3308 fixes some other oddities as well, that must have been around forever:

**Before:**

https://user-images.githubusercontent.com/2522299/210530704-be402f11-99bb-41a7-9efb-b561b28ecda1.mp4

This is what happens in 7.3-8.2:

* The `removeFormat` button jumps to the right when the `tableCreationGrid` opens
* When the `tableCreationGrid` is open and the Block Format select box is open as well, the options of the latter would appear detached from the select box

**After:**

https://user-images.githubusercontent.com/2522299/210531101-71479145-88a9-4428-9160-304edc104083.mp4

Now everything stays where it belongs.