### PR TITLE
BUGFIX: Ensure that `<DropDown/>` closes only after the current call-stack has been processed

### DIFF
--- a/packages/react-ui-components/src/DropDown/wrapper.spec.tsx
+++ b/packages/react-ui-components/src/DropDown/wrapper.spec.tsx
@@ -33,25 +33,28 @@ describe('<DropDownWrapper/>', () => {
         expect(wrapper.state('isOpen')).toBe(false);
     });
 
-    it('should set the "isOpen" state value to opposite when calling the toggle method.', () => {
+    it('should set the "isOpen" state value to opposite when calling the toggle method.', async () => {
         const wrapper = shallow(<DropDownWrapper {...props}/>);
 
         // @ts-ignore
         wrapper.instance().handleToggle();
 
+        await new Promise(resolve => setTimeout(resolve, 0));
         expect(wrapper.state('isOpen')).toBe(true);
 
         // @ts-ignore
         wrapper.instance().handleToggle();
 
+        await new Promise((resolve) => setTimeout(resolve, 0));
         expect(wrapper.state('isOpen')).toBe(false);
     });
-    it('should set the "isOpen" state value to false when calling the close method.', () => {
+    it('should set the "isOpen" state value to false when calling the close method.', async () => {
         const wrapper = shallow(<DropDownWrapper {...props}/>);
 
         // @ts-ignore
         wrapper.instance().handleClose();
 
+        await new Promise((resolve) => setTimeout(resolve, 0));
         expect(wrapper.state('isOpen')).toBe(false);
     });
 });

--- a/packages/react-ui-components/src/DropDown/wrapper.tsx
+++ b/packages/react-ui-components/src/DropDown/wrapper.tsx
@@ -145,6 +145,8 @@ export const StatelessDropDownWrapper = enhanceWithClickOutside(StatelessDropDow
 export class DropDownWrapper extends PureComponent<DropDownWrapperProps, DropDownWrapperState> {
     public static readonly defaultProps = defaultProps;
 
+    private updateIsOpenHandle: null | ReturnType<typeof setTimeout> = null;
+
     constructor(props: DropDownWrapperProps) {
         super(props);
         this.state = {
@@ -152,8 +154,33 @@ export class DropDownWrapper extends PureComponent<DropDownWrapperProps, DropDow
         };
     }
 
+    public componentWillUnmount(): void {
+        if (this.updateIsOpenHandle !== null) {
+            clearTimeout(this.updateIsOpenHandle);
+        }
+    }
+
     public render(): JSX.Element {
         return <StatelessDropDownWrapper {...this.props} isOpen={this.state.isOpen} onToggle={this.handleToggle} onClose={this.handleClose}/>;
+    }
+
+    //
+    // Closing the DropDown removes the DropDown.Contents from the DOM. There may be DOM nodes inside the
+    // DropDown.Contents that still need to receive events before that happens.
+    //
+    // This method makes sure that the DropDown closes only after the current call-stack has been
+    // processed. This prevents behavior like the one described in: https://github.com/neos/neos-ui/issues/3305
+    //
+    private readonly updateIsOpen = (
+        handlerFn: (isOpen: boolean) => boolean
+    ) => {
+        if (this.updateIsOpenHandle !== null) {
+            clearTimeout(this.updateIsOpenHandle);
+        }
+
+        this.updateIsOpenHandle = setTimeout(() => {
+            this.setState((state) => ({ isOpen: handlerFn(state.isOpen) }));
+        }, 0);
     }
 
     private readonly handleToggle = (event: MouseEvent) => {
@@ -161,11 +188,11 @@ export class DropDownWrapper extends PureComponent<DropDownWrapperProps, DropDow
             this.props.onToggle(event);
         }
 
-        this.setState({isOpen: !this.state.isOpen});
+        this.updateIsOpen((isOpen) => !isOpen);
     }
 
     private readonly handleClose = () => {
-        this.setState({isOpen: false});
+        this.updateIsOpen(() => false);
     }
 }
 


### PR DESCRIPTION
fixes: #3305 

**The Problem**

The behavior described in #3305 is a regression through https://github.com/neos/neos-ui/pull/3211. 

#3211 made sure that the `<Label/>` around the auto-publish checkbox is clickable. Normally, one would expect that clicking on the label would trigger a change in the corresponding checkbox input through event delegation.

To illustrate that idea:
```
      (User clicks on <Label/>)
                │
                │ // Click event is being delegated to the corresponding
                │ // <input type="checkbox"> element
                │
                ▼
(<CheckBox/> OnChange event happens)
```

Clicking inside the `<DropDown.Contents/>` also causes the outer `<DropDown/>` to close. Closing the `<DropDown/>` means, that the `<DropDown.Contents/>` are removed from the DOM.

This update mechanism is handled by `React` in a way that is non-deterministic (at least to us it is). This means that sometimes the `<DropDown.Contents/>`  are removed before the Click event from the `<Label/>` component reaches  the corresponding checkbox input:

```
 (User clicks on <Label/>)
            │
            💥 ◀─────── (DropDown.Contents are removed from DOM)
            ┊
            ▼
(<CheckBox/> is gone...)
```

**The Solution**

I lieu of `setImmediate`-support in browsers, I wrapped the toggling mechanism of the `<DropDown/>`-component in a `setTimeout(..., 0)` call.

This makes sure that components inside the `<DropDown.Contents/>` will receive all events that are currently scheduled, before the  `<DropDown.Contents/>` are removed from the DOM.
