### PR TITLE
BUGFIX: Make sure that validation errors show up after clicking "Create New" in node creation dialog

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
@@ -140,7 +140,7 @@ export default class NodeCreationDialog extends PureComponent {
         const validationErrors = this.getValidationErrorsForTransientValues(transient);
 
         if (validationErrors) {
-            this.setState({validationErrors});
+            this.setState({validationErrors, isDirty: true});
         } else {
             const {apply} = this.props;
             apply(transient);


### PR DESCRIPTION
fixes: #3319

Turns out this could be achieved by simply setting the creation dialog's `isDirty` state to `true` when validation errors occur during `handleApply`.

On a side note, this made me wonder why there is an `isDirty` state for the creation dialog in the first place. It makes sense that the editor fields only show validation errors once they've been touched, but that is their concern. When "Create New" was clicked, all validation errors should show in any case.