### PR TITLE
BUGFIX: Make sure secondary inspector container does not overlap editors in node creation dialog

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/style.css
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/style.css
@@ -19,6 +19,7 @@
     opacity: 0;
     transition: var(--transition-Default) ease width,
         var(--transition-Default) ease opacity;
+    overflow: hidden;
 
     .expanded & {
         width: 100%;


### PR DESCRIPTION
fixes: #3318 

**The Problem**

![neos-ui-issue-3318-before](https://user-images.githubusercontent.com/2522299/210750953-395acdbe-b382-46be-9456-278b31b276bf.png)

This is a regression through https://github.com/neos/neos-ui/pull/2870.

The secondary inspector for the node creation dialog is wrapped in a container that is invisible, but has a padding that overlaps part of the editors.

In cases in which the help message button flows into the next row, the button is entirely covered by that padding and can therefore not be clicked.

**The Solution**

Quite simple: I added `overflow: hidden;` to the surrounding container, so the padding cannot overlap the editors anymore:


https://user-images.githubusercontent.com/2522299/210751594-e94e13e5-26cb-48de-a7f8-e4e7e2195192.mp4

