### PR TITLE
BUGFIX: Update `formattingUnderCursor` when CKEditor focus changes

### DIFF
--- a/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
@@ -64,6 +64,7 @@ export const createEditor = store => options => {
                 if (event.source.isFocused) {
                     currentEditor = editor;
                     editorConfig.setCurrentlyEditedPropertyName(propertyName);
+                    handleUserInteractionCallback();
                 }
             });
 


### PR DESCRIPTION
refs: #3224 

**The Problem**

[Peek 2023-01-05 14-00 - #3224.webm](https://user-images.githubusercontent.com/2522299/210801247-f63437d3-8172-41f6-ba8b-0128b1875229.webm)

While investigating #3224, I noticed that the `EditorToolbar` sometimes receives the wrong `formattingUnderCursor` when another node is being selected. In fact, in those cases, the `EditorToolbar` received the `formattingUnderCursor` corresponding to the previous selection.

By debugging the events triggered by CKEditor I was able to find out that in those cases a `change:isFocused` event got triggered, but no `change` event, which would have updated the `formattingUnderCursor`.

**The Solution**

This PR makes sure that `formattingUnderCursor` is properly updated when `change:isFocused` occurs through CKEditor. It does so by calling the `handleUserInteractionCallback` that is also called when the `change` event occurs.

Though I was unable to reproduce the original problem described in #3224, it would be very well explicable, if that problem was solved by this measure as well. It would be helpful, if someone who is able to reproduce the issue could verify this :)