### PR TITLE
FEATURE: Allow to translate multiple id's in one field

### DIFF
--- a/packages/neos-ui-i18n/src/registry/I18nRegistry.js
+++ b/packages/neos-ui-i18n/src/registry/I18nRegistry.js
@@ -84,6 +84,30 @@ export default class I18nRegistry extends SynchronousRegistry {
 
     // eslint-disable-next-line max-params
     translate(idOrig, fallbackOrig, params = {}, packageKeyOrig = 'Neos.Neos', sourceNameOrig = 'Main', quantity = 0) {
+        let translation = idOrig;
+
+        const regex = /([a-zA-Z0-9.]+:[a-zA-Z0-9.]+:[a-zA-Z0-9.]+)/g;
+        let m;
+
+        while ((m = regex.exec(idOrig)) !== null) {
+            if (m.index === regex.lastIndex) {
+                regex.lastIndex++;
+            }
+
+            m.forEach((match) => {
+                translation = translation.replace(match, this.translateOne(match, fallbackOrig, params, packageKeyOrig, sourceNameOrig, quantity))
+            });
+        }
+
+        if (translation !== idOrig) {
+            return translation;
+        }
+
+        return this.translateOne(idOrig, fallbackOrig, params, packageKeyOrig, sourceNameOrig, quantity);
+    }
+
+    // eslint-disable-next-line max-params
+    translateOne(idOrig, fallbackOrig, params = {}, packageKeyOrig = 'Neos.Neos', sourceNameOrig = 'Main', quantity = 0) {
         const fallback = fallbackOrig || idOrig;
         const [packageKey, sourceName, id] = getTranslationAddress(idOrig, packageKeyOrig, sourceNameOrig);
         let translation = [packageKey, sourceName, id]

--- a/packages/neos-ui-i18n/src/registry/I18nRegistry.js
+++ b/packages/neos-ui-i18n/src/registry/I18nRegistry.js
@@ -84,6 +84,10 @@ export default class I18nRegistry extends SynchronousRegistry {
 
     // eslint-disable-next-line max-params
     translate(idOrig, fallbackOrig, params = {}, packageKeyOrig = 'Neos.Neos', sourceNameOrig = 'Main', quantity = 0) {
+        if (!idOrig) {
+            idOrig = '';
+        }
+
         let translation = idOrig;
 
         translation = translation.replace(

--- a/packages/neos-ui-i18n/src/registry/I18nRegistry.js
+++ b/packages/neos-ui-i18n/src/registry/I18nRegistry.js
@@ -86,18 +86,10 @@ export default class I18nRegistry extends SynchronousRegistry {
     translate(idOrig, fallbackOrig, params = {}, packageKeyOrig = 'Neos.Neos', sourceNameOrig = 'Main', quantity = 0) {
         let translation = idOrig;
 
-        const regex = /([a-zA-Z0-9.]+:[a-zA-Z0-9.]+:[a-zA-Z0-9.]+)/g;
-        let m;
-
-        while ((m = regex.exec(idOrig)) !== null) {
-            if (m.index === regex.lastIndex) {
-                regex.lastIndex++;
-            }
-
-            m.forEach(match => {
-                translation = translation.replace(match, this.translateOne(match, fallbackOrig, params, packageKeyOrig, sourceNameOrig, quantity))
-            });
-        }
+        translation = translation.replace(
+            /([a-z\d.]+:[a-z\d.]+:[a-z\d.]+)/gi,
+            match => this.translateOne(match, match, params, packageKeyOrig, sourceNameOrig, quantity)
+        );
 
         if (translation !== idOrig) {
             return translation;

--- a/packages/neos-ui-i18n/src/registry/I18nRegistry.js
+++ b/packages/neos-ui-i18n/src/registry/I18nRegistry.js
@@ -94,7 +94,7 @@ export default class I18nRegistry extends SynchronousRegistry {
                 regex.lastIndex++;
             }
 
-            m.forEach((match) => {
+            m.forEach(match => {
                 translation = translation.replace(match, this.translateOne(match, fallbackOrig, params, packageKeyOrig, sourceNameOrig, quantity))
             });
         }

--- a/packages/neos-ui-i18n/src/registry/I18nRegistry.spec.js
+++ b/packages/neos-ui-i18n/src/registry/I18nRegistry.spec.js
@@ -178,3 +178,22 @@ test(`
 
     expect(actual).toBe('Singular Translation');
 });
+
+test(`
+    Host > Containers > I18n: should display two translated strings, if two translations
+    were found via short-string.`, () => {
+    const translations = {
+        'Neos_Neos': { // eslint-disable-line quote-props
+            'Main': { // eslint-disable-line quote-props
+                'someLabel': 'The First Translation', // eslint-disable-line quote-props
+                'anotherLabel': 'The Second Translation', // eslint-disable-line quote-props
+            }
+        }
+    };
+
+    const registry = new I18nRegistry();
+    registry.setTranslations(translations);
+    const actual = registry.translate('Neos.Neos:Main:someLabel And Neos.Neos:Main:anotherLabel');
+
+    expect(actual).toBe('The First Translation And The Second Translation');
+});

--- a/packages/neos-ui-i18n/src/registry/I18nRegistry.spec.js
+++ b/packages/neos-ui-i18n/src/registry/I18nRegistry.spec.js
@@ -186,7 +186,7 @@ test(`
         'Neos_Neos': { // eslint-disable-line quote-props
             'Main': { // eslint-disable-line quote-props
                 'someLabel': 'The First Translation', // eslint-disable-line quote-props
-                'anotherLabel': 'The Second Translation', // eslint-disable-line quote-props
+                'anotherLabel': 'The Second Translation' // eslint-disable-line quote-props
             }
         }
     };


### PR DESCRIPTION
…Neos.Demo:Main:translated.a (Neos.Demo:Main:translated.b)'

**What I did**
Labels can now contain multiple translation id's, not just one.

**How I did it**
If there's a regex match, it will be processed in a loop.
Otherwise it follows the original behaviour.

**How to verify it**
Create a NodeType label like:
```
'Neos.Demo:Document.Homepage':
  ui:
    label: 'Static Neos.Demo:Main:translated.a (Neos.Demo:Main:translated.b)'
```
Add the corresponding translation to "Packages/Sites/Neos.Demo/Resources/Private/Translations/en/Main.xlf":
```
<trans-unit id="translated.a" xml:space="preserve">
    <source>Translated-A</source>
</trans-unit>
<trans-unit id="translated.b" xml:space="preserve">
    <source>Translated-B</source>
</trans-unit>
```
Reload the UI and you will see "Static Translated-A (Translated-B)" as a result.

**Why?**
For time to time we wish to have a more flexible label translation, especially for dynamically generated NodeTypes we see a big  advantage in this enhancement.