### PR TITLE
FEATURE: Apply link input value immediately after search term was cleared

### DIFF
--- a/packages/neos-ui-editors/src/Library/LinkInput.js
+++ b/packages/neos-ui-editors/src/Library/LinkInput.js
@@ -190,6 +190,12 @@ export default class LinkInput extends PureComponent {
                     }
                 });
         } else {
+            if (this.state.searchTerm) {
+                // The search term has been emptied. To avoid confusion, the emptied
+                // search term gets immediately applied.
+                this.props.onLinkChange(searchTerm);
+            }
+
             this.setState({
                 isLoading: false
             });
@@ -263,7 +269,7 @@ export default class LinkInput extends PureComponent {
     handleManualSetLink = () => {
         this.props.onLinkChange(this.state.searchTerm);
         this.setState({
-            isEditMode: false
+            isEditMode: !this.state.searchTerm
         });
     }
 


### PR DESCRIPTION
solves: #3311

When the search term gets cleared, the change is registered immediately:

[Peek 2023-01-10 16-45 - Link Editor after.webm](https://user-images.githubusercontent.com/2522299/211600025-44ea4d19-680f-485f-af17-da4319f0c7a8.webm)
