### PR TITLE
BUGFIX: Hide inline toolbar if current editPreviewMode is not an edit mode

### DIFF
--- a/packages/neos-ui/src/Containers/ContentCanvas/index.js
+++ b/packages/neos-ui/src/Containers/ContentCanvas/index.js
@@ -87,6 +87,10 @@ export default class ContentCanvas extends PureComponent {
         });
         const InlineUI = guestFrameRegistry.get('InlineUIComponent');
         const currentEditPreviewModeConfiguration = editPreviewModes[currentEditPreviewMode] || editPreviewModes[Object.keys(editPreviewModes)[0]];
+        const shouldShowInlineUi =
+            typeof currentEditPreviewModeConfiguration === 'object' &&
+            currentEditPreviewModeConfiguration.isEditingMode &&
+            Boolean(InlineUI);
 
         const width = $get('width', currentEditPreviewModeConfiguration);
         const height = $get('height', currentEditPreviewModeConfiguration);
@@ -133,7 +137,7 @@ export default class ContentCanvas extends PureComponent {
                         role="region"
                         aria-live="assertive"
                         >
-                        {InlineUI && <InlineUI/>}
+                        {shouldShowInlineUi && <InlineUI/>}
                     </Frame>)}
                 </div>
             </div>


### PR DESCRIPTION
fixes: #3144 

**The Problem**

The `<ContentCanvas/>` did not distinguish between edit- and preview-modes when rendering the `<InlineUI/>` component.

This lead to the `<InlineUI/>`  still being present, even though a preview-mode (like "desktop") had been selected.

**The Solution**

I added a condition to the `render` method of the `<ContentCanvas/>` component. If the currently selected `editPreviewMode` is not an edit-mode, the `<InlineUI/>` component will not be rendered any longer.
