### PR TITLE
BUGFIX: Colocate react-ui-components esm-build declarations and sources

### DIFF
--- a/packages/react-ui-components/package.json
+++ b/packages/react-ui-components/package.json
@@ -26,6 +26,7 @@
     "@neos-project/build-essentials": "7.3.10",
     "@neos-project/debug-reason-for-rendering": "7.3.10",
     "@neos-project/jest-preset-neos-ui": "7.3.10",
+    "@neos-project/utils-helpers": "7.3.10",
     "@storybook/addon-info": "^3.2.16",
     "@storybook/addon-knobs": "3.2.16",
     "@storybook/react": "3.2.16",

--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -5,7 +5,7 @@ import {$get} from 'plow-js';
 import SelectBox_Option_SingleLine from '../SelectBox_Option_SingleLine';
 import mergeClassNames from 'classnames';
 import isEqual from 'lodash.isequal';
-import isNil from '../../../utils-helpers/src/isNil';
+import {isNil} from '@neos-project/utils-helpers';
 
 // TODO: document component usage && check code in detail
 export default class SelectBox extends PureComponent {

--- a/packages/react-ui-components/tsconfig.esm.json
+++ b/packages/react-ui-components/tsconfig.esm.json
@@ -1,6 +1,7 @@
 {
   "exclude": [
     "scripts/",
+    "coverage/",
     "**/*.spec.tsx",
     "**/*.spec.ts",
     "**/*.spec.js",
@@ -8,6 +9,7 @@
   ],
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "lib-esm",
     "module": "esnext",
     "target": "es6",


### PR DESCRIPTION
The relative import in the selectbox component forced typescript to create a different file structure for the source files than for the declaration files causing issues with importing the esm build.

By using the package style import the folder structure is correct again and by defining the rootDir in the tsconfig file an error will be thrown if a relative include outside of the components package is used.

Resolves: #3329
