### PR TITLE
BUGFIX: Reset focused fusion path to `null` whenever the edit-/preview-mode changes

### DIFF
--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
@@ -2,6 +2,7 @@ import produce from 'immer';
 import {defaultsDeep} from 'lodash';
 import {action as createAction, ActionType} from 'typesafe-actions';
 import {actionTypes as system, InitAction} from '@neos-project/neos-ui-redux-store/src/System';
+import {actionTypes as editPreviewMode, Action as EditPreviewModeAction} from '@neos-project/neos-ui-redux-store/src/UI/EditPreviewMode';
 
 import * as selectors from './selectors';
 import {calculateNewFocusedNodes, getNodeOrThrow} from './helpers';
@@ -391,7 +392,7 @@ const moveNodeInState = (
 //
 // Export the reducer
 //
-export const reducer = (state: State = defaultState, action: InitAction | Action) => produce(state, draft => {
+export const reducer = (state: State = defaultState, action: InitAction | EditPreviewModeAction | Action) => produce(state, draft => {
     switch (action.type) {
         case system.INIT: {
             draft.byContextPath = action.payload.cr.nodes.byContextPath;
@@ -399,6 +400,10 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
             draft.siteNode = action.payload.cr.nodes.siteNode;
             draft.clipboard = action.payload.cr.nodes.clipboard;
             draft.clipboardMode = action.payload.cr.nodes.clipboardMode;
+            break;
+        }
+        case editPreviewMode.SET: {
+            draft.focused.fusionPath = null;
             break;
         }
         case actionTypes.ADD: {


### PR DESCRIPTION
fixes: #3335 

**The Problem**

When focusing a node inside the `<ContentCanvas/>`, the associated `fusionPath` of that content element will be saved to the redux store. When the current edit-/preview-mode is then changed, said `fusionPath` is no longer valid (because the content element will be rendered through an entirely different path).

This confuses the `<InlineUI/>` component. It uses the stored `fusionPath` to locate the DOM node inside the `<ContentCanvas/>` that it attaches itself to. Since the `fusionPath` is invalid after the switch, the DOM node can longer be found and the `<InlineUI/>` becomes invisible.

**The solution**

The code responsible for locating nodes inside the `<ContentCanvas/>` can be found here:
https://github.com/neos/neos-ui/blob/b424a7adb4bb1844063c632b7c1d7e29a37c8bd3/packages/neos-ui-guest-frame/src/dom.js#L73-L77

It anticipates situations in which no `fusionPath` is set (which is the case when selecting a node in the `<ContentTree/>` component for example). Basically, if there's no `fusionPath` it selects the first node that matches the focused `contextPath`, which I found quite acceptable for switching between edit-/preview-modes.

Therefore, I altered the `CR.Nodes` reducer to set the focused `fusionPath` to `null` whenever the `UI.EditPreviewMode.SET` action occurs. With this, the  `<InlineUI/>` component no longer disappears when the edit-/preview-mode is switched.