### PR TITLE
BUGFIX: Distribute height between inspector tabs header and content dynamically

### DIFF
--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/style.css
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/style.css
@@ -1,4 +1,6 @@
 .inspector {
+    display: flex;
+    flex-direction: column;
     height: 100%;
     width: 100%;
     overflow: hidden;
@@ -24,6 +26,9 @@
     }
 }
 .tabs {
+    display: flex;
+    flex-direction: column;
+    height: calc(100% - 101px); /* Accounting for <SelectedElement/> */
     margin-left: var(--spacing-Quarter);
     border-left: 1px solid var(--colors-ContrastDark);
     background: var(--colors-ContrastDarker);

--- a/packages/react-ui-components/src/Tabs/style.css
+++ b/packages/react-ui-components/src/Tabs/style.css
@@ -5,7 +5,6 @@
 
 .tabs__content {
     composes: reset from './../reset.css';
-    height: calc(100% - 141px);
     overflow-y: auto;
 }
 


### PR DESCRIPTION
fixes: #2683 

**The Problem**

The `<Inspector/>`-styles allocate height between the tabs header and the tabs content based on the assumption that there's only one tab header row. As soon as the tabs header breaks into a second row, the tabs content underflows the action buttons at the bottom of the `<Inspector/>` component.

**The Solution**

I've adjusted the `<Inspector/>`-styles using `display: flex` to distribute the height between the tabs header and the tabs content dynamically. This way, all of the tabs contents remain reachable, even if the tabs header breaks into a third row:

[Peek 2023-01-18 16-15 - Inspector spacing.webm](https://user-images.githubusercontent.com/2522299/213212353-8881b671-fb3e-4bc8-900f-80057fe75cea.webm)
