### PR TITLE
BUGFIX: Stop click event propagation on selected element in select box header

### DIFF
--- a/packages/neos-ui-editors/src/Editors/AssetEditor/index.js
+++ b/packages/neos-ui-editors/src/Editors/AssetEditor/index.js
@@ -243,6 +243,7 @@ export default class AssetEditor extends PureComponent {
                 placeholder={this.props.i18nRegistry.translate(this.props.placeholder)}
                 options={this.props.value ? this.state.options : this.state.searchOptions}
                 value={this.getValue()}
+                onHeaderClick={() => { /* prevent toggling of select box dropdown */ }}
                 onValueChange={this.handleValueChange}
                 displayLoadingIndicator={this.state.isLoading}
                 showDropDownToggle={false}

--- a/packages/neos-ui-editors/src/Editors/Reference/index.js
+++ b/packages/neos-ui-editors/src/Editors/Reference/index.js
@@ -48,6 +48,7 @@ export default class ReferenceEditor extends PureComponent {
             options={sanitizeOptions(options)}
             value={value}
             onValueChange={this.handleValueChange}
+            onHeaderClick={() => { /* prevent toggling of select box dropdown */ }}
             loadingLabel={i18nRegistry.translate('Neos.Neos:Main:loading')}
             displayLoadingIndicator={displayLoadingIndicator}
             showDropDownToggle={false}

--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -59,6 +59,11 @@ export default class SelectBox extends PureComponent {
          */
         onValueChange: PropTypes.func.isRequired,
 
+        /**
+         * This prop gets called when the select box header element gets clicked.
+         */
+        onHeaderClick: PropTypes.func,
+
         // ------------------------------
         // Visual customization of the Select Box
         // ------------------------------
@@ -248,7 +253,8 @@ export default class SelectBox extends PureComponent {
             disabled,
 
             SelectBox_HeaderWithSearchInput,
-            SelectBox_Header
+            SelectBox_Header,
+            onHeaderClick
         } = this.props;
         const searchTerm = this.getSearchTerm();
         const optionValueAccessor = this.getOptionValueAccessor();
@@ -283,6 +289,7 @@ export default class SelectBox extends PureComponent {
                 option={selectedOption}
                 showResetButton={showResetButton}
                 onReset={this.handleDeleteClick}
+                onClick={onHeaderClick}
                 />
         );
     }

--- a/packages/react-ui-components/src/SelectBox_Header/selectBox_Header.js
+++ b/packages/react-ui-components/src/SelectBox_Header/selectBox_Header.js
@@ -19,6 +19,7 @@ class SelectBox_Header extends PureComponent {
         placeholderIcon: PropTypes.string,
         showResetButton: PropTypes.bool.isRequired,
         onReset: PropTypes.func,
+        onClick: PropTypes.func,
         displayLoadingIndicator: PropTypes.bool,
         disabled: PropTypes.bool,
 
@@ -33,6 +34,15 @@ class SelectBox_Header extends PureComponent {
         Icon: PropTypes.any.isRequired,
         IconButton: PropTypes.any.isRequired,
         ListPreviewElement: PropTypes.any.isRequired
+    }
+
+    handleListPreviewElementClick = e => {
+        const {onClick} = this.props;
+
+        if (onClick) {
+            e.stopPropagation();
+            onClick();
+        }
     }
 
     resetButton = () => {
@@ -81,6 +91,7 @@ class SelectBox_Header extends PureComponent {
                             label={label}
                             icon={icon}
                             disabled={disabled}
+                            onClick={this.handleListPreviewElementClick}
                             /> : (
                                 <div className={theme.selectBoxHeader__label}>
                                     {icon &&


### PR DESCRIPTION
fixes: #3057 

**The Problem**

Hard to pin down, but I'll try: The issue described in #3057 relates to the `AssetEditor` which uses the `<SelectBox/>` component for input. The `<SelectBox/>`  component uses the `<DropDown/>` component for rendering. The `<DropDown/>` component understands a click on its header as a request to toggle its `expanded` state. When `expanded === true`, the `<SelectBox/>`  changes its header into a search input, so the user can search through the available select options.

Now, the `AssetEditor` kind of misuses the `<SelectBox/>` for its purpose. It narrows the available select options to the currently selected asset, so the `<SelectBox/>` displays the latter properly. This however means that the behavior described above leads to a search input, but only one available select option: the currently selected one. (Side note: On input, the search is still being performed, the `<SelectBox/>` simply does not show the resulting options)

**The Solution**

I've tried to correct the behavior of the `AssetEditor`, so that it shows the search results, but with no luck.

So, I ended up implementing the suggestion from #3057. Through `stopPropagation`, a click on the currently selected option won't toggle the underlying `<DropDown/>` component any longer.
