### PR TITLE
BUGFIX: Reset/Clear `<SelectNodeType/>`-dialog on apply

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
@@ -115,10 +115,8 @@ export default class SelectNodeType extends PureComponent {
 
     handleCancel = () => {
         const {cancel} = this.props;
-        this.setState({
-            filterSearchTerm: ''
-        });
-        this.handleCloseHelpMessage();
+
+        this.handleClose();
         cancel();
     }
 
@@ -126,8 +124,20 @@ export default class SelectNodeType extends PureComponent {
         const {apply} = this.props;
         const {insertMode} = this.state;
 
+        this.handleClose();
         apply(insertMode, nodeType);
     };
+
+    handleClose = () => {
+        this.handleClearFilterSearchTerm();
+        this.handleCloseHelpMessage();
+    }
+
+    handleClearFilterSearchTerm = () => {
+        this.setState({
+            filterSearchTerm: ''
+        });
+    }
 
     handleCloseHelpMessage = () => {
         this.setState({


### PR DESCRIPTION
fixes: #3034 

**The Problem**

The `<SelectNodeType/>`-dialog uses internal state to manage the filter search term (and toggling of the help message display for node types, which the aforementioned issue does not cover).

When the user presses `cancel`, said state gets cleared, so the dialog is in its initial state the next time it gets opened. 

When the user presses `apply`, the state remains untouched, so when the dialog gets opened again, the filter search term and a possibly open help message are still there.

This can be confusing, especially if the dialog gets opened in a different context, in which both items would lead to different results. 

For example, if the user tries to insert a document after just having inserted a content element (with a ndoe type filter search term applied), the `<SelectNodeType/>`-dialog may indicate that there's no document node type available (due to the still applied search term):
![image](https://user-images.githubusercontent.com/2522299/214822736-f313629d-3fe4-406e-b6c0-ea85ed56a352.png)

Likewise, the dialog may show a help message for a node type that isn't actually available:
![image](https://user-images.githubusercontent.com/2522299/214822570-4a1d37f3-d26b-425c-bd17-8f31d9376c8c.png)


**The Solution**

I ensured that both, the `cancel` and `apply` action lead to the same cleanup routine for the dialog (which means, both filter search term and active help message are being reset).

This solution has a couple of drawbacks however:

- When inserting lots of content nodes of the same type in sequence, some users may actually prefer the current behavior
- If there's a node creation dialog involved, clicking on `back` would appear to reset the  `<SelectNodeType/>`-dialog, which might be confusing to some