### PR TITLE
BUGFIX: Remove initiatingUserId from createNode command

### DIFF
--- a/Classes/Domain/Model/Changes/AbstractCreate.php
+++ b/Classes/Domain/Model/Changes/AbstractCreate.php
@@ -108,7 +108,6 @@ abstract class AbstractCreate extends AbstractStructuralChange
             $nodeAggregateIdentifier,
             $nodeTypeName,
             OriginDimensionSpacePoint::fromDimensionSpacePoint($parentNode->subgraphIdentity->dimensionSpacePoint),
-            $this->getInitiatingUserIdentifier(),
             $parentNode->nodeAggregateId,
             $succeedingSiblingNodeAggregateIdentifier,
             $nodeName


### PR DESCRIPTION
If you add a content element to the page the following exception is thrown:

```
Exception in line 107 of 
  Packages/Application/Neos.Neos.Ui/Classes/Domain/Model/Changes/AbstractCreate.php: 
  Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode::__construct(): 
  Argument #5 ($parentNodeAggregateId) must be of type Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId, 
  Neos\ContentRepository\Core\SharedModel\User\UserId given
```

See: https://neos-project.slack.com/archives/C3MCBK6S2/p1674926113660949 

**How to verify it**

Try to add a document or content node in a Neos 9 installation.

Relates: neos/neos-development-collection@4c9dd087324317c8b2823b2ee4a658b23d638892
