### PR TITLE
!!! TASK: Remove legacy editor name support

### DIFF
--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -53,9 +53,7 @@ export default class EditorEnvelope extends PureComponent {
 
     getEditorDefinition() {
         const {editor, editorRegistry} = this.props;
-        // Support legacy editor definitions
-        const editorName = editor.replace('Content/Inspector/Editors', 'Neos.Neos/Inspector/Editors');
-        return editorRegistry.get(editorName);
+        return editorRegistry.get(editor);
     }
 
     isInvalid() {

--- a/packages/neos-ui-views/src/ViewEnvelope/index.js
+++ b/packages/neos-ui-views/src/ViewEnvelope/index.js
@@ -25,9 +25,7 @@ export default class ViewEnvelope extends PureComponent {
 
     getViewDefinition() {
         const {view, viewRegistry} = this.props;
-        // Support legacy view definitions
-        const viewName = view.replace('Content/Inspector/Views', 'Neos.Neos/Inspector/Views');
-        return viewRegistry.get(viewName);
+        return viewRegistry.get(view);
     }
 
     renderViewComponent() {


### PR DESCRIPTION
This is breaking as old style editor paths will not be mapped anymore and would stop working with this change.

These were deprecated since Neos 4.3.