### PR TITLE
BUGFIX: Remove initiatingUserId from node commands

### DIFF
--- a/Classes/Domain/Model/AbstractChange.php
+++ b/Classes/Domain/Model/AbstractChange.php
@@ -125,12 +125,4 @@ abstract class AbstractChange implements ChangeInterface
             $this->feedbackCollection->add($nodeCreated);
         }
     }
-
-    final protected function getInitiatingUserIdentifier(): UserId
-    {
-        /** @var User $user */
-        $user = $this->userService->getBackendUser();
-
-        return UserId::fromString($this->persistenceManager->getIdentifierByObject($user));
-    }
 }

--- a/Classes/Domain/Model/Changes/AbstractCreate.php
+++ b/Classes/Domain/Model/Changes/AbstractCreate.php
@@ -13,14 +13,13 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
  */
 
 use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
+use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode;
+use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\ContentRepository\Core\SharedModel\Exception\NodeNameIsAlreadyOccupied;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
-use Neos\ContentRepository\Core\NodeType\NodeTypeName;
-use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode;
-use Neos\ContentRepository\Core\SharedModel\Exception\NodeNameIsAlreadyOccupied;
-use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
-use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Neos\Ui\Exception\InvalidNodeCreationHandlerException;
 use Neos\Neos\Ui\NodeCreationHandler\NodeCreationHandlerInterface;
 

--- a/Classes/Domain/Model/Changes/CopyAfter.php
+++ b/Classes/Domain/Model/Changes/CopyAfter.php
@@ -12,13 +12,10 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
  * source code.
  */
 
-use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
-use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
-use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Core\Feature\NodeDuplication\Command\CopyNodesRecursively;
-use Neos\ContentRepository\Core\Feature\NodeDuplication\NodeDuplicationCommandHandler;
+use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 
 class CopyAfter extends AbstractStructuralChange
 {
@@ -77,7 +74,6 @@ class CopyAfter extends AbstractStructuralChange
                 ),
                 $subject,
                 OriginDimensionSpacePoint::fromDimensionSpacePoint($subject->subgraphIdentity->dimensionSpacePoint),
-                $this->getInitiatingUserIdentifier(),
                 $parentNodeOfPreviousSibling->nodeAggregateId,
                 $succeedingSibling?->nodeAggregateId,
                 $targetNodeName

--- a/Classes/Domain/Model/Changes/MoveAfter.php
+++ b/Classes/Domain/Model/Changes/MoveAfter.php
@@ -78,8 +78,7 @@ class MoveAfter extends AbstractStructuralChange
                 $hasEqualParentNode ? null : $parentNodeOfPreviousSibling->nodeAggregateId,
                 $precedingSibling->nodeAggregateId,
                 $succeedingSibling?->nodeAggregateId,
-                RelationDistributionStrategy::STRATEGY_GATHER_ALL,
-                $this->getInitiatingUserIdentifier()
+                RelationDistributionStrategy::STRATEGY_GATHER_ALL
             );
 
             $contentRepository = $this->contentRepositoryRegistry->get($subject->subgraphIdentity->contentRepositoryId);

--- a/Classes/Domain/Model/Changes/MoveBefore.php
+++ b/Classes/Domain/Model/Changes/MoveBefore.php
@@ -12,7 +12,6 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
  * source code.
  */
 
-use Neos\ContentRepository\Core\Feature\NodeAggregateCommandHandler;
 use Neos\ContentRepository\Core\Feature\NodeMove\Command\MoveNodeAggregate;
 use Neos\ContentRepository\Core\Feature\NodeMove\Dto\RelationDistributionStrategy;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\RemoveNode;
@@ -79,8 +78,7 @@ class MoveBefore extends AbstractStructuralChange
                         : $succeedingSiblingParent->nodeAggregateId,
                     $precedingSibling?->nodeAggregateId,
                     $succeedingSibling->nodeAggregateId,
-                    RelationDistributionStrategy::STRATEGY_GATHER_ALL,
-                    $this->getInitiatingUserIdentifier()
+                    RelationDistributionStrategy::STRATEGY_GATHER_ALL
                 )
             )->block();
 

--- a/Classes/Domain/Model/Changes/MoveInto.php
+++ b/Classes/Domain/Model/Changes/MoveInto.php
@@ -87,8 +87,7 @@ class MoveInto extends AbstractStructuralChange
                     $hasEqualParentNode ? null : $parentNode->nodeAggregateId,
                     null,
                     null,
-                    RelationDistributionStrategy::STRATEGY_GATHER_ALL,
-                    $this->getInitiatingUserIdentifier()
+                    RelationDistributionStrategy::STRATEGY_GATHER_ALL
                 )
             )->block();
 

--- a/Classes/Domain/Model/Changes/Property.php
+++ b/Classes/Domain/Model/Changes/Property.php
@@ -13,23 +13,22 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
  */
 
 use Neos\ContentRepository\Core\DimensionSpace\Exception\DimensionSpacePointNotFound;
-use Neos\ContentRepository\Core\SharedModel\Exception\ContentStreamDoesNotExistYet;
-use Neos\ContentRepository\Core\SharedModel\Exception\NodeAggregatesTypeIsAmbiguous;
-use Neos\ContentRepository\Core\Feature\NodeReferencing\Dto\NodeReferencesToWrite;
-use Neos\ContentRepository\Core\SharedModel\Node\NodeVariantSelectionStrategy;
-use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
+use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\NodeDisabling\Command\DisableNodeAggregate;
 use Neos\ContentRepository\Core\Feature\NodeDisabling\Command\EnableNodeAggregate;
 use Neos\ContentRepository\Core\Feature\NodeModification\Command\SetNodeProperties;
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
 use Neos\ContentRepository\Core\Feature\NodeReferencing\Command\SetNodeReferences;
+use Neos\ContentRepository\Core\Feature\NodeReferencing\Dto\NodeReferencesToWrite;
 use Neos\ContentRepository\Core\Feature\NodeTypeChange\Command\ChangeNodeAggregateType;
 use Neos\ContentRepository\Core\Feature\NodeTypeChange\Dto\NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy;
 use Neos\ContentRepository\Core\Feature\NodeVariation\Command\CreateNodeVariant;
-use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
-use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
-use Neos\ContentRepository\Core\SharedModel\Node\PropertyName;
-use Neos\ContentRepository\Core\SharedModel\Node\ReferenceName;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\SharedModel\Exception\ContentStreamDoesNotExistYet;
+use Neos\ContentRepository\Core\SharedModel\Exception\NodeAggregatesTypeIsAmbiguous;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeVariantSelectionStrategy;
+use Neos\ContentRepository\Core\SharedModel\Node\ReferenceName;
 use Neos\Flow\Annotations as Flow;
 use Neos\Neos\Ui\Domain\Model\AbstractChange;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\ReloadContentOutOfBand;
@@ -149,7 +148,6 @@ class Property extends AbstractChange
             $contentRepository = $this->contentRepositoryRegistry->get($subject->subgraphIdentity->contentRepositoryId);
 
             $propertyType = $subject->nodeType->getPropertyType($propertyName);
-            $userIdentifier = $this->getInitiatingUserIdentifier();
 
             // Use extra commands for reference handling
             if ($propertyType === 'reference' || $propertyType === 'references') {
@@ -177,8 +175,7 @@ class Property extends AbstractChange
                         $subject->nodeAggregateId,
                         $subject->originDimensionSpacePoint,
                         ReferenceName::fromString($propertyName),
-                        NodeReferencesToWrite::fromNodeAggregateIds(NodeAggregateIds::fromArray($destinationNodeAggregateIdentifiers)),
-                        $this->getInitiatingUserIdentifier()
+                        NodeReferencesToWrite::fromNodeAggregateIds(NodeAggregateIds::fromArray($destinationNodeAggregateIdentifiers))
                     )
                 );
             } else {
@@ -199,8 +196,7 @@ class Property extends AbstractChange
                                 $subject->subgraphIdentity->contentStreamId,
                                 $subject->nodeAggregateId,
                                 $subject->originDimensionSpacePoint,
-                                $originDimensionSpacePoint,
-                                $this->getInitiatingUserIdentifier()
+                                $originDimensionSpacePoint
                             )
                         )->block();
                     }
@@ -213,8 +209,7 @@ class Property extends AbstractChange
                                 [
                                     $propertyName => $value
                                 ]
-                            ),
-                            $this->getInitiatingUserIdentifier()
+                            )
                         )
                     );
                 } else {
@@ -225,8 +220,7 @@ class Property extends AbstractChange
                                 $subject->subgraphIdentity->contentStreamId,
                                 $subject->nodeAggregateId,
                                 NodeTypeName::fromString($value),
-                                NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::STRATEGY_DELETE,
-                                $userIdentifier
+                                NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::STRATEGY_DELETE
                             )
                         );
                     } elseif ($propertyName === '_hidden') {
@@ -236,8 +230,7 @@ class Property extends AbstractChange
                                     $subject->subgraphIdentity->contentStreamId,
                                     $subject->nodeAggregateId,
                                     $subject->originDimensionSpacePoint->toDimensionSpacePoint(),
-                                    NodeVariantSelectionStrategy::STRATEGY_ALL_SPECIALIZATIONS,
-                                    $userIdentifier
+                                    NodeVariantSelectionStrategy::STRATEGY_ALL_SPECIALIZATIONS
                                 )
                             );
                         } else {
@@ -247,8 +240,7 @@ class Property extends AbstractChange
                                     $subject->subgraphIdentity->contentStreamId,
                                     $subject->nodeAggregateId,
                                     $subject->originDimensionSpacePoint->toDimensionSpacePoint(),
-                                    NodeVariantSelectionStrategy::STRATEGY_ALL_SPECIALIZATIONS,
-                                    $userIdentifier
+                                    NodeVariantSelectionStrategy::STRATEGY_ALL_SPECIALIZATIONS
                                 )
                             );
                         }

--- a/Classes/Domain/Model/Changes/Remove.php
+++ b/Classes/Domain/Model/Changes/Remove.php
@@ -64,7 +64,7 @@ class Remove extends AbstractChange
                 );
             }
 
-            // we have to schedule an the update workspace info before we actually delete the node;
+            // we have to schedule and the update workspace info before we actually delete the node;
             // otherwise we cannot find the parent nodes anymore.
             $this->updateWorkspaceInfo();
 
@@ -74,7 +74,6 @@ class Remove extends AbstractChange
                 $subject->nodeAggregateId,
                 $subject->subgraphIdentity->dimensionSpacePoint,
                 NodeVariantSelectionStrategy::STRATEGY_ALL_SPECIALIZATIONS,
-                $this->getInitiatingUserIdentifier(),
                 $closestDocumentParentNode?->nodeAggregateId
             );
 


### PR DESCRIPTION
- checked for all usages of `getInitiatingUserIdentifier` to remove the initiatingUserId from node commands
- removed function `getInitiatingUserIdentifier` because it is not needed anymore
- removed unused imported classes in touched files

Relates: neos/neos-development-collection@4c9dd087324317c8b2823b2ee4a658b23d638892
Relates: #3349 
