### PR TITLE
BUGFIX: Prevent error on wrong class attribute

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/DeleteNode/index.js
+++ b/packages/neos-ui/src/Containers/Modals/DeleteNode/index.js
@@ -55,7 +55,7 @@ export default class DeleteNodeModal extends PureComponent {
             const nodeType = $get('nodeType', node);
             const nodeTypeLabel = $get('ui.label', nodeTypesRegistry.get(nodeType)) || 'Neos.Neos:Main:node';
             return (
-                <div class={style.modalTitleContainer}>
+                <div className={style.modalTitleContainer}>
                     <Icon icon="exclamation-triangle"/>
                     <span className={style.modalTitle}>
                         <I18n id="Neos.Neos:Main:delete" fallback="Delete"/>


### PR DESCRIPTION
**What I did**

Replaces `class` with `className`