### PR TITLE
BUGFIX: Ensure that the link editor "anchor" field never receives `undefined`

### DIFF
--- a/packages/neos-ui-editors/src/Library/LinkInputOptions.js
+++ b/packages/neos-ui-editors/src/Library/LinkInputOptions.js
@@ -31,7 +31,7 @@ const LinkInputOptions = ({
                     <div>
                         <TextInput
                             id="__neos__linkEditor--anchor"
-                            value={anchorValue}
+                            value={anchorValue ?? ''}
                             placeholder={i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__anchorPlaceholder', 'Enter anchor name')}
                             onChange={value => {
                                 onLinkChange(value ? `${baseValue}#${value}` : baseValue);


### PR DESCRIPTION
...as an input value.

fixes: #3317

**The Problem**

Given the following code:

```typescript
<input value={someValue} />
```

When `someValue` is `undefined`, React is unable to ascertain that the intention is to bind the input value to the variable `someValue`. Instead, this looks to React as if the `value` attribute hasn't been set in the first place (which in React-speak is called "uncontrolled").

If `someValue` changes to a string on a subsequent update, it looks to React as if the input is now suddenly supposed to be bound to the variable (which in React-speak is called "controlled").

(see also: https://reactjs.org/docs/forms.html#controlled-components)

This is what happened to the "anchor" field of the `LinkInputOptions` component. Its initial value is calculated here:
https://github.com/neos/neos-ui/blob/46b29e10aac859a598951b0d8045501c6a64a6e3/packages/neos-ui-editors/src/Library/LinkInputOptions.js#L22

Obviously, `anchorValue` ends up being `undefined` if `linkValue` does not contain the character "#".

**The solution**

I added a fallback to an empty string via nullish-coalescing operator where `anchorValue` is applied to its corresponding `TextInput`, so the `TextInput` never receives `undefined`.