### PR TITLE
BUGFIX: Lazy-Load focused node, if it's not fully loaded yet

### DIFF
--- a/packages/neos-ui-sagas/src/UI/Inspector/index.js
+++ b/packages/neos-ui-sagas/src/UI/Inspector/index.js
@@ -5,6 +5,8 @@ import {findNodeInGuestFrame} from '@neos-project/neos-ui-guest-frame/src/dom';
 
 import {actionTypes, actions, selectors} from '@neos-project/neos-ui-redux-store';
 
+import backend from '@neos-project/neos-ui-backend-connector';
+
 import {applySaveHooksForTransientValue} from '../../Changes/saveHooks';
 
 const getFocusedNode = selectors.CR.Nodes.focusedSelector;
@@ -38,6 +40,18 @@ export function * inspectorSaga({globalRegistry}) {
             //
             if (nextAction.type === actionTypes.CR.Nodes.FOCUS) {
                 yield put(actions.UI.Inspector.closeSecondaryInspector());
+
+                const focusedNode = yield select(getFocusedNode);
+                if (!$get('isFullyLoaded', focusedNode)) {
+                    const {q} = backend.get();
+                    const [fullyLoadedFocusedNode] = yield q(focusedNode).get();
+
+                    if (fullyLoadedFocusedNode) {
+                        yield put(actions.CR.Nodes.merge({
+                            [fullyLoadedFocusedNode.contextPath]: fullyLoadedFocusedNode
+                        }));
+                    }
+                }
                 break;
             }
 


### PR DESCRIPTION
fixes: #3219 

**The Problem**

CR Node representations in the central Redux store have a flag `isFullyLoaded` that indicates whether the node has been loaded with all of its meta data. If the node has only been loaded for being displayed in the document- or content-tree, this flag is absent, otherwise it is set to `true`.

The intention behind flag this was to lazy-load the remaining metadata should it become relevant in a specific interaction context. Apparently though, this mechanism has never been implemented.

**The Solution**

I adjusted the Inspector-saga to perform the aforementioned lazy-load. This fixes #3219, but adds a `plow-js` call, which needs to be kept in mind for #3306.