### PR TITLE
TASK: Remove target branch in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    target-branch: "7.3"
     open-pull-requests-limit: 0
     labels:
       - "security"


### PR DESCRIPTION
We get non security pull requests from Dependabot and that in the wrong branch. After a chat with a GitHub product manager, the issue seems to be that the open-pull-requests-limit config does not work with target branch together.

So, we remove that now and hope that the docs and the pm are right, and we just get security PRs.

https://twitter.com/jhutchings0/status/1625254020188340224
