### PR TITLE
BUGFIX: Adjust width of dropdown content

### DIFF
--- a/Tests/IntegrationTests/Fixtures/1Dimension/selectBoxes.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/selectBoxes.e2e.js
@@ -34,7 +34,7 @@ test('SelectBox opens above in creation dialog if there\'s not enough space belo
         .lt(await ReactSelector('NodeCreationDialog SelectBox').getBoundingClientRectProperty('top'));
     await t
         .expect(await ReactSelector('NodeCreationDialog SelectBox ShallowDropDownContents').getStyleProperty('display'))
-        .eql('block');
+        .eql('flex');
 
     subSection('SelectBox contents disappear when SelectBox is scrolled out of sight.');
     await t.hover(Selector('#neos-NodeCreationDialog [for="__neos__editor__property---title--creation-dialog"]'));

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/UserDropDown/style.css
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/UserDropDown/style.css
@@ -6,6 +6,7 @@
 .dropDown {
     position: static;
     display: block;
+    overflow-x: auto;
 }
 .dropDown__btn {
     position: relative;
@@ -29,6 +30,7 @@
 .dropDown__contents {
     position: absolute;
     min-width: 160px;
+    width: max-content;
     right: 0px;
     left: auto;
     padding: 2px !important;

--- a/packages/react-ui-components/src/DropDown/style.css
+++ b/packages/react-ui-components/src/DropDown/style.css
@@ -63,7 +63,8 @@
     overflow-y: auto;
 }
 .dropDown__contents--isOpen {
-    display: block;
+    display: flex;
+    flex-direction: column;
 }
 .dropDown--darker {
     > .dropDown__btn--open {


### PR DESCRIPTION
The content of the user dropdown was limited in the width, and therefore it could happen that the space for the labels was not enough. Now the contents section can get bigger than the trigger button.

This was also an issue in 7.3 and not an issue related to the impersonation feature.
In the past, we fixed that only for the 8.1 and newer.

Thanks to @dlubitz for the report!

Fixes: #3235