### PR TITLE
BUGFIX: Pin acceptance tests to window 10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ test:
 
 ## Executes integration tests on saucelabs.
 test-e2e-saucelabs:
-	bash Tests/IntegrationTests/e2e.sh saucelabs:chrome
+	bash Tests/IntegrationTests/e2e.sh "saucelabs:chrome:Windows 10"
 
 ## Executes integration tests locally.
 test-e2e:


### PR DESCRIPTION
**What I did**
Pinned sauce-labs based acceptance tests to Windows 10.
The reason is that sometimes the platform changed to macOS and for some reason some tests always failed on Mac, but manual test always worked fine. As the most end users use Windows 10 or Windows 11 we stick to that.

**How I did it**
Changed the parameter.

**How to verify it**
Check testing output or watch the videos on sauce-labs