### PR TITLE
BUGFIX: Run GitHub actions also on PRs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,6 +1,11 @@
 name: Build and test
 
-on: push
+on:
+  workflow_dispatch:
+  push:
+    branches: [ '[0-9]+.[0-9]' ]
+  pull_request:
+    branches: [ '[0-9]+.[0-9]' ]
 
 jobs:
   codestyle:


### PR DESCRIPTION
The new GitHub actions only run on Neos branches and do not work for PRs on forked repositories.

**What I did**
Adjusted the events that trigger the GH actions.

**How I did it**
In the docs we have a bunch of events. We use now PRs, pushes and workflow dispatches (for instance weblate)
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows

**How to verify it**
Check if this PR has unit tests and linting via GH action.
