### PR TITLE
BUGFIX: `@neos-project/neos-ui-extensibility` declare dependency `@neos-project/build-essentials` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.19.1",
-    "@neos-project/build-essentials": "*",
+    "@neos-project/build-essentials": "workspace:*",
     "@typescript-eslint/eslint-plugin": "^5.44.0",
     "@typescript-eslint/parser": "^5.44.0",
     "check-dependencies": "^1.0.1",

--- a/packages/neos-ui-extensibility/package.json
+++ b/packages/neos-ui-extensibility/package.json
@@ -20,11 +20,11 @@
   },
   "devDependencies": {
     "@neos-project/babel-preset-neos-ui": "workspace:*",
-    "@neos-project/build-essentials": "workspace:*",
     "@neos-project/jest-preset-neos-ui": "workspace:*",
     "typescript": "^4.6.4"
   },
   "dependencies": {
+    "@neos-project/build-essentials": "workspace:*",
     "@neos-project/positional-array-sorter": "workspace:*",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-object-rest-spread": "^6.20.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3551,7 +3551,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@neos-project/build-essentials@*, @neos-project/build-essentials@workspace:*, @neos-project/build-essentials@workspace:packages/build-essentials":
+"@neos-project/build-essentials@workspace:*, @neos-project/build-essentials@workspace:packages/build-essentials":
   version: 0.0.0-use.local
   resolution: "@neos-project/build-essentials@workspace:packages/build-essentials"
   dependencies:
@@ -22839,7 +22839,7 @@ __metadata:
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
     "@babel/eslint-parser": ^7.19.1
-    "@neos-project/build-essentials": "*"
+    "@neos-project/build-essentials": "workspace:*"
     "@typescript-eslint/eslint-plugin": ^5.44.0
     "@typescript-eslint/parser": ^5.44.0
     check-dependencies: ^1.0.1


### PR DESCRIPTION
Fix a regression from #3200 

also in the root we use the correct `"workspace:*"`

currently one needs to include it manually when using the "@neos-project/neos-ui-extensibility"