### PR TITLE
TASK: Analyze bundle size and health `node esbuild.js --production --analyze`

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -7,6 +7,7 @@ const { version } = require('./package.json')
 const isProduction = process.env.NODE_ENV === 'production' || process.argv.includes('--production');
 const isE2ETesting = process.argv.includes('--e2e-testing');
 const isWatch = process.argv.includes('--watch');
+const isAnalyze = process.argv.includes('--analyze');
 
 if (isE2ETesting) {
     console.log('Building for E2E testing');
@@ -26,6 +27,7 @@ const options = {
     color: true,
     bundle: true,
     keepNames: isE2ETesting, // for react magic selectors,
+    metafile: isAnalyze,
     legalComments: "linked",
     loader: {
         '.js': 'tsx',
@@ -96,5 +98,10 @@ const options = {
 if (isWatch) {
     esbuild.context(options).then((ctx) => ctx.watch())
 } else {
-    esbuild.build(options)
+    esbuild.build(options).then(result => {
+        if (isAnalyze) {
+            require("fs").writeFileSync('meta.json', JSON.stringify(result.metafile))
+            console.log("\nUpload './meta.json' to https://esbuild.github.io/analyze/ to analyze the bundle.")
+        }
+    })
 }

--- a/packages/neos-ui-sagas/src/index.js
+++ b/packages/neos-ui-sagas/src/index.js
@@ -1,31 +1,14 @@
-import * as browser from './Browser/index';
-import * as changes from './Changes/index';
-import * as crContentDimensions from './CR/ContentDimensions/index';
-import * as crNodeOperations from './CR/NodeOperations/index';
-import * as crPolicies from './CR/Policies/index';
-import * as publish from './Publish/index';
-import * as serverFeedback from './ServerFeedback/index';
-import * as uiContentCanvas from './UI/ContentCanvas/index';
-import * as uiContentTree from './UI/ContentTree/index';
-import * as uiEditPreviewMode from './UI/EditPreviewMode/index';
-import * as uiInspector from './UI/Inspector/index';
-import * as uiPageTree from './UI/PageTree/index';
-import * as uiHotkeys from './UI/Hotkeys/index';
-import * as impersonate from './UI/Impersonate/index';
-
-module.exports = {
-    browser,
-    changes,
-    crContentDimensions,
-    crNodeOperations,
-    crPolicies,
-    publish,
-    serverFeedback,
-    uiContentCanvas,
-    uiContentTree,
-    uiEditPreviewMode,
-    uiInspector,
-    uiPageTree,
-    uiHotkeys,
-    impersonate
-};
+export * as browser from './Browser/index';
+export * as changes from './Changes/index';
+export * as crContentDimensions from './CR/ContentDimensions/index';
+export * as crNodeOperations from './CR/NodeOperations/index';
+export * as crPolicies from './CR/Policies/index';
+export * as publish from './Publish/index';
+export * as serverFeedback from './ServerFeedback/index';
+export * as uiContentCanvas from './UI/ContentCanvas/index';
+export * as uiContentTree from './UI/ContentTree/index';
+export * as uiEditPreviewMode from './UI/EditPreviewMode/index';
+export * as uiInspector from './UI/Inspector/index';
+export * as uiPageTree from './UI/PageTree/index';
+export * as uiHotkeys from './UI/Hotkeys/index';
+export * as impersonate from './UI/Impersonate/index';


### PR DESCRIPTION
This Pr is made against feature/cssBuildRefactor as the refactoring is much further there


**What I did**
add a new flag "--analyze" as i used this a few times now ;)

**My findings**

![image](https://user-images.githubusercontent.com/85400359/219874231-4dd3e43f-945e-47a5-b558-1803e9e9ce78.png)


It seems esbuild is doing a really great job and there is little to nothing to improve manually ;)

We seem to have some duplicates of super small libs (less than 2kb to 500bytes original size) in the bundle (12 warnings)
Fixing those inconsistencies has actually no real impact so thats fine ^^

I also found out that two bigger libs: "code-mirror@5" and "react-dom@16" are using cjs instead of the better esm standard.
While i was able to tell esbuild to use code-mirrors source files it still includes lots of cjs files which are not present as plain esm. And i also was not really lucky with react-dom: we can only access the transpiled cjs and not the esm source. Both libs now have a more up-to date major version, so an update might help.
But either way, i dont consider these foundings as big problems and im not sure how big the gain would be either way when using pure esm in that case but the future will tell ;)

Yes well hello: Fontawesome costs us 1.2mb ciao

Also suprisingly a super seldom used feature: the inspector views will claim with "rechats" 218kb of total bundle size which is relatively large. Actually the same counts for the above mentioned "code-mirror" editor it does cost 263kb for its relatively small ussage.



