### PR TITLE
BUGFIX: Fix handling of 'now' in DateTime Editor

### DIFF
--- a/packages/neos-ui-editors/src/Editors/DateTime/helpers.spec.ts
+++ b/packages/neos-ui-editors/src/Editors/DateTime/helpers.spec.ts
@@ -1,0 +1,27 @@
+import {tryDateFrom} from './helpers';
+
+describe('tryDateFrom', () => {
+    test('from empty string', () => {
+        expect(tryDateFrom('')).toBe(undefined);
+    });
+
+    test('from undefined', () => {
+        expect(tryDateFrom(undefined)).toBe(undefined);
+    });
+
+    test('from null', () => {
+        expect(tryDateFrom(null)).toBe(undefined);
+    });
+
+    test('from date string', () => {
+        expect(tryDateFrom('2023-02-23T00:00:00+00:00')).toBeInstanceOf(Date);
+    });
+
+    test('from string "now"', () => {
+        expect(tryDateFrom('now')?.valueOf()).not.toBeNaN();
+    });
+
+    test('from Date', () => {
+        expect(tryDateFrom(new Date())).toBeInstanceOf(Date);
+    });
+});

--- a/packages/neos-ui-editors/src/Editors/DateTime/helpers.ts
+++ b/packages/neos-ui-editors/src/Editors/DateTime/helpers.ts
@@ -3,7 +3,9 @@
 // See: https://neos.readthedocs.io/en/stable/References/PropertyEditorReference.html#property-type-datetime-datetimeeditor-date-time-selection-editor
 //
 // ToDo: Move into re-usable fn - Maybe into `util-helpers`?
-export default function (format) {
+import moment from 'moment';
+
+export default function (format: string): string {
     const formatMap = {
         d: 'DD',
         D: 'ddd',
@@ -33,6 +35,7 @@ export default function (format) {
     };
     return format.replace(
         /[dDjlNwWFmMnoYyaAgGhHisOPU]/g,
+        // @ts-ignore
         phpStr => formatMap[phpStr]
     );
 }
@@ -40,9 +43,21 @@ export default function (format) {
 //
 // Check if given format has a date formatting
 //
-export const hasDateFormat = format => /[yYFmMntdDjlNSw]/.test(format);
+export const hasDateFormat = (format: string) => /[yYFmMntdDjlNSw]/.test(format);
 
 //
 // Check if given format has a time formatting
 //
-export const hasTimeFormat = format => /[gGhHis]/.test(format);
+export const hasTimeFormat = (format: string) => /[gGhHis]/.test(format);
+
+export const tryDateFrom = (value: string | Date | undefined | null) => {
+    if (value === 'now') {
+        return new Date();
+    }
+
+    if (typeof value === 'string' && value.length) {
+        return moment(value).toDate();
+    }
+
+    return value || undefined;
+};

--- a/packages/neos-ui-editors/src/Editors/DateTime/index.js
+++ b/packages/neos-ui-editors/src/Editors/DateTime/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import DateInput from '@neos-project/react-ui-components/src/DateInput/';
 import moment from 'moment';
 import {neos} from '@neos-project/neos-ui-decorators';
-import convertPhpDateFormatToMoment, {hasDateFormat, hasTimeFormat} from './helpers';
+import convertPhpDateFormatToMoment, {hasDateFormat, hasTimeFormat, tryDateFrom} from './helpers';
 import {connect} from 'react-redux';
 import {$transform, $get} from 'plow-js';
 
@@ -39,7 +39,7 @@ class DateTime extends PureComponent {
             i18nRegistry,
             interfaceLanguage
         } = this.props;
-        const mappedValue = (typeof value === 'string' && value.length) ? moment(value).toDate() : (value || undefined);
+        const mappedValue = tryDateFrom(value);
 
         const onChange = date => {
             commit(date ? moment(date).format('YYYY-MM-DDTHH:mm:ssZ') : '');


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**
fixes #3391 

**How I did it**
Enabled DateTimeEditor to handle 'now' string.
Built tests for that 🚀 

**How to verify it**
See instructions in #3391.

Run tests.
<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
![Screenshot 2023-02-23 at 11 38 00 AM](https://user-images.githubusercontent.com/1615332/220883696-35bf0624-dba2-4f92-a3b4-daba3e213628.png)
