### PR TITLE
BUGFIX: wrong hover color for DateInput component

### DIFF
--- a/packages/react-ui-components/src/DateInput/style.css
+++ b/packages/react-ui-components/src/DateInput/style.css
@@ -271,7 +271,7 @@
         }
         td.rdtMonth:hover,
         td.rdtYear:hover {
-            background: #eee;
+            background: var(--colors-PrimaryBlue);
         }
 
         .rdtCounters {


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

When using the `DateTime` editor and hovering over the years, it has the wrong `:hover` color wich makes it unreadable.

### Before:

![SCR-20230223-lfl](https://user-images.githubusercontent.com/39345336/220987427-20d1bef9-deb0-4cfd-a43b-e2338770a767.png)

## After

![SCR-20230223-pyl](https://user-images.githubusercontent.com/39345336/220987452-ab347a37-4051-462c-9b7c-7ca68a691075.png)

**How I did it**
Adjusted the `style.css` for the `DateInput` component.

**How to verify it**
Create a NodeType with the `DateTime` editor, and hover over the Years.

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
