### PR TITLE
BUGFIX: `<Tabs>` add `onActiveTabChange` and use `activeTab` on initial render

### DIFF
--- a/packages/react-ui-components/src/Tabs/panel.tsx
+++ b/packages/react-ui-components/src/Tabs/panel.tsx
@@ -24,6 +24,11 @@ export interface PanelProps {
      * An optional css theme to be injected.
      */
     readonly theme?: PanelTheme;
+
+    /**
+     * An optional string id used by `<Tabs />` for communicating the "activeTab" instead of using the index.
+     */
+    readonly id?: string;
 }
 
 export default class Panel extends PureComponent<PanelProps> {

--- a/packages/react-ui-components/src/Tabs/tabs.spec.tsx
+++ b/packages/react-ui-components/src/Tabs/tabs.spec.tsx
@@ -51,9 +51,9 @@ describe('<Tabs/>', () => {
 
         const tabMenuItems = wrapper.find(TabMenuItem);
 
-        const buttonOfFirstTabMenuItem = tabMenuItems.at(2).find("button").at(0);
+        const buttonOfFirstTabMenuItem = tabMenuItems.at(2).find('button').at(0);
 
-        buttonOfFirstTabMenuItem.simulate("click");
+        buttonOfFirstTabMenuItem.simulate('click');
 
         expect(wrapper.state('activeTab')).toBe(2);
     });
@@ -71,9 +71,9 @@ describe('<Tabs/>', () => {
 
         const tabMenuItems = wrapper.find(TabMenuItem);
 
-        const buttonOfFirstTabMenuItem = tabMenuItems.at(2).find("button").at(0);
+        const buttonOfFirstTabMenuItem = tabMenuItems.at(2).find('button').at(0);
 
-        buttonOfFirstTabMenuItem.simulate("click");
+        buttonOfFirstTabMenuItem.simulate('click');
 
         expect(onActiveTabChange).toHaveBeenCalledTimes(1);
         expect(onActiveTabChange).toBeCalledWith(2);

--- a/packages/react-ui-components/src/Tabs/tabs.spec.tsx
+++ b/packages/react-ui-components/src/Tabs/tabs.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
 import toJson from 'enzyme-to-json';
 import Tabs, {TabMenuItem, TabsProps, tabsDefaultProps} from './tabs';
 import {PanelProps} from './panel';
@@ -27,6 +27,57 @@ describe('<Tabs/>', () => {
         },
         children: [<div key={'foo'}>'Foo children'</div>]
     };
+
+    it('should use the activeTab prop when initializing.', () => {
+        const wrapper = shallow(
+            <Tabs {...props} activeTab={2}>
+                <Tabs.Panel {...panelProps} title="foo 1" icon="level-up">Foo 1</Tabs.Panel>
+                <Tabs.Panel {...panelProps} title="foo 2" icon="level-down">Foo 2</Tabs.Panel>
+                <Tabs.Panel {...panelProps} title="foo 3" icon="mobile">Foo 3</Tabs.Panel>
+            </Tabs>
+        );
+
+        expect(wrapper.state('activeTab')).toBe(2);
+    });
+
+    it('should update the state when a tab menu item is clicked.', () => {
+        const wrapper = mount(
+            <Tabs {...props}>
+                <Tabs.Panel {...panelProps} title="foo 1" icon="level-up">Foo 1</Tabs.Panel>
+                <Tabs.Panel {...panelProps} title="foo 2" icon="level-down">Foo 2</Tabs.Panel>
+                <Tabs.Panel {...panelProps} title="foo 3" icon="mobile">Foo 3</Tabs.Panel>
+            </Tabs>
+        );
+
+        const tabMenuItems = wrapper.find(TabMenuItem);
+
+        const buttonOfFirstTabMenuItem = tabMenuItems.at(2).find("button").at(0);
+
+        buttonOfFirstTabMenuItem.simulate("click");
+
+        expect(wrapper.state('activeTab')).toBe(2);
+    });
+
+    it('should trigger the hook, when a tab menu item is clicked.', () => {
+        const onActiveTabChange = jest.fn();
+
+        const wrapper = mount(
+            <Tabs {...props} onActiveTabChange={onActiveTabChange}>
+                <Tabs.Panel {...panelProps} title="foo 1" icon="level-up">Foo 1</Tabs.Panel>
+                <Tabs.Panel {...panelProps} title="foo 2" icon="level-down">Foo 2</Tabs.Panel>
+                <Tabs.Panel {...panelProps} title="foo 3" icon="mobile">Foo 3</Tabs.Panel>
+            </Tabs>
+        );
+
+        const tabMenuItems = wrapper.find(TabMenuItem);
+
+        const buttonOfFirstTabMenuItem = tabMenuItems.at(2).find("button").at(0);
+
+        buttonOfFirstTabMenuItem.simulate("click");
+
+        expect(onActiveTabChange).toHaveBeenCalledTimes(1);
+        expect(onActiveTabChange).toBeCalledWith(2);
+    });
 
     it('should render correctly.', () => {
         const wrapper = shallow(

--- a/packages/react-ui-components/src/Tabs/tabs.spec.tsx
+++ b/packages/react-ui-components/src/Tabs/tabs.spec.tsx
@@ -79,6 +79,39 @@ describe('<Tabs/>', () => {
         expect(onActiveTabChange).toBeCalledWith(2);
     });
 
+    it('activeTab as string: should use the activeTab prop when initializing.', () => {
+        const wrapper = shallow(
+            <Tabs {...props} activeTab="zwei">
+                <Tabs.Panel {...panelProps} id="eins" title="foo 1" icon="level-up">Foo 1</Tabs.Panel>
+                <Tabs.Panel {...panelProps} id="zwei" title="foo 2" icon="level-down">Foo 2</Tabs.Panel>
+                <Tabs.Panel {...panelProps} id="drei" title="foo 3" icon="mobile">Foo 3</Tabs.Panel>
+            </Tabs>
+        );
+        expect(wrapper.state('activeTab')).toBe('zwei');
+    });
+
+    it('activeTab as string: should update the state & trigger the hook when a tab menu item is clicked.', () => {
+        const onActiveTabChange = jest.fn();
+
+        const wrapper = mount(
+            <Tabs {...props} onActiveTabChange={onActiveTabChange}>
+                <Tabs.Panel {...panelProps} id="eins" title="foo 1" icon="level-up">Foo 1</Tabs.Panel>
+                <Tabs.Panel {...panelProps} id="zwei" title="foo 2" icon="level-down">Foo 2</Tabs.Panel>
+                <Tabs.Panel {...panelProps} id="drei" title="foo 3" icon="mobile">Foo 3</Tabs.Panel>
+            </Tabs>
+        );
+
+        const tabMenuItems = wrapper.find(TabMenuItem);
+
+        const buttonOfFirstTabMenuItem = tabMenuItems.at(2).find('button').at(0);
+
+        buttonOfFirstTabMenuItem.simulate('click');
+
+        expect(wrapper.state('activeTab')).toBe('drei');
+        expect(onActiveTabChange).toHaveBeenCalledTimes(1);
+        expect(onActiveTabChange).toBeCalledWith('drei');
+    });
+
     it('should render correctly.', () => {
         const wrapper = shallow(
             <Tabs {...props}>

--- a/packages/react-ui-components/src/Tabs/tabs.tsx
+++ b/packages/react-ui-components/src/Tabs/tabs.tsx
@@ -56,11 +56,8 @@ export default class Tabs extends PureComponent<TabsProps> {
     public static defaultProps = tabsDefaultProps;
 
     private updateActiveTab(activeTab: string | number): void {
-        if (this.props.onActiveTabChange) {
-            this.props.onActiveTabChange(activeTab);
-        }
-        this.setState({
-            activeTab
+        this.setState({ activeTab }, () => {
+            this.props.onActiveTabChange?.(activeTab);
         });
     }
 

--- a/packages/react-ui-components/src/Tabs/tabs.tsx
+++ b/packages/react-ui-components/src/Tabs/tabs.tsx
@@ -55,7 +55,7 @@ export default class Tabs extends PureComponent<TabsProps> {
 
     public static defaultProps = tabsDefaultProps;
 
-    private updateActiveTab(activeTab: string | number) {
+    private updateActiveTab(activeTab: string | number): void {
         if (this.props.onActiveTabChange) {
             this.props.onActiveTabChange(activeTab);
         }

--- a/packages/react-ui-components/src/Tabs/tabs.tsx
+++ b/packages/react-ui-components/src/Tabs/tabs.tsx
@@ -12,6 +12,11 @@ export interface TabsProps {
     readonly activeTab?: string | number;
 
     /**
+     * Callback when the active tab id changes.
+     */
+    readonly onActiveTabChange?: (activeTab: string | number) => void;
+
+    /**
      * An optional className to render on the wrapping div.
      */
     readonly className?: string;
@@ -45,19 +50,26 @@ interface TabsState {
 export default class Tabs extends PureComponent<TabsProps> {
     public static Panel = Panel;
     public state: TabsState = {
-        activeTab: 0,
+        activeTab: this.props.activeTab ?? 0
     };
 
     public static defaultProps = tabsDefaultProps;
+
+    private updateActiveTab(activeTab: string | number) {
+        if (this.props.onActiveTabChange) {
+            this.props.onActiveTabChange(activeTab);
+        }
+        this.setState({
+            activeTab
+        });
+    }
 
     public UNSAFE_componentWillReceiveProps(newProps: TabsProps): void {
         const newactiveTab = newProps.activeTab;
         const {activeTab} = this.state;
 
         if (newactiveTab && newactiveTab !== activeTab) {
-            this.setState({
-                activeTab: newactiveTab
-            });
+            this.updateActiveTab(newactiveTab);
         }
     }
 
@@ -104,7 +116,7 @@ export default class Tabs extends PureComponent<TabsProps> {
     }
 
     public handleTabNavItemClick = (id: string | number) => {
-        this.setState({activeTab: id});
+        this.updateActiveTab(id);
     }
 
     public renderPanels(): JSX.Element {


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

My usecase is to use the `<Tabs>` component and save the currently selected item to the localstorage to restore the previously used state when the site is opened again.

The problem is currently its not possible to know the currently selected tab.
Thats why i introduced `onActiveTabChange`.
I also thought about adding an option to completely handle the state outside, but this would not make sense for this component. So thats why i keep it as a simple prop.

When experimenting, i also noticed that the `activeTab` prop will have no effect unless the above component is rerendered (which triggers `UNSAFE_componentWillReceiveProps`)


**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
