### PR TITLE
TASK: remove `Neos.Ui.NodeInfo.inBackend` in favour of `Neos.Node.inBackend`

### DIFF
--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -527,13 +527,6 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
         return $nodeAddressFactory->createFromNode($node)->serializeForUri();
     }
 
-    public function inBackend(Node $node): bool
-    {
-        $contentRepository = $this->contentRepositoryRegistry->get($node->subgraphIdentity->contentRepositoryId);
-        $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
-        return !$nodeAddressFactory->createFromNode($node)->isInLiveWorkspace();
-    }
-
     /**
      * @param string $methodName
      * @return boolean

--- a/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -19,9 +19,7 @@ prototype(Neos.Neos:Page) {
 
             @process.json = ${Json.stringify(value)}
             @process.wrapInJsObject = ${'<script>window[\'@Neos.Neos.Ui:DocumentInformation\']=' + value + '</script>'}
-            @if {
-                inBackend = ${Neos.Ui.NodeInfo.inBackend(documentNode)}
-            }
+            @if.inBackend = ${Neos.Node.inBackend(documentNode)}
 
             // We need to ensure the JS backend information is always up to date, especially
             // when child nodes change. Otherwise errors like the following might happen:
@@ -37,11 +35,11 @@ prototype(Neos.Neos:Page) {
                 entryIdentifier {
                     jsBackendInfo = 'javascriptBackendInformation'
                     documentNode = ${Neos.Caching.entryIdentifierForNode(documentNode)}
-                    inBackend = ${Neos.Ui.NodeInfo.inBackend(documentNode)}
+                    inBackend = ${Neos.Node.inBackend(documentNode)}
                 }
                 entryTags {
                     1 = ${Neos.Caching.nodeTag(documentNode)}
-                    2 = ${documentNode.context.inBackend ? Neos.Caching.descendantOfTag(documentNode) : null}
+                    2 = ${Neos.Node.inBackend(documentNode) ? Neos.Caching.descendantOfTag(documentNode) : null}
                 }
             }
         }
@@ -53,20 +51,18 @@ prototype(Neos.Neos:Page) {
             compiledResourcePackage = ${Neos.Ui.StaticResources.compiledResourcePackage()}
 
             sectionName = 'guestFrameApplication'
-            @if {
-                inBackend = ${Neos.Ui.NodeInfo.inBackend(documentNode)}
-            }
+            @if.inBackend = ${Neos.Node.inBackend(documentNode)}
         }
     }
 
     neosBackendContainer = '<div id="neos-backend-container"></div>'
     neosBackendContainer.@position = 'before closingBodyTag'
-    neosBackendContainer.@if.inBackend = ${Neos.Ui.NodeInfo.inBackend(documentNode)}
+    neosBackendContainer.@if.inBackend = ${Neos.Node.inBackend(documentNode)}
 
     neosBackendNotification = Neos.Fusion:Template {
         @position = 'before closingBodyTag'
         templatePath = 'resource://Neos.Neos.Ui/Private/Templates/Backend/GuestNotificationScript.html'
-        @if.inBackend = ${Neos.Ui.NodeInfo.inBackend(documentNode)}
+        @if.inBackend = ${Neos.Node.inBackend(documentNode)}
     }
 
     @exceptionHandler = 'Neos\\Neos\\Ui\\Fusion\\ExceptionHandler\\PageExceptionHandler'

--- a/Resources/Private/Fusion/Prototypes/Shortcut.fusion
+++ b/Resources/Private/Fusion/Prototypes/Shortcut.fusion
@@ -9,8 +9,7 @@ prototype(Neos.Neos:Page) {
             }
 
             @if {
-                # TODO: inBackend helper should be moved OUT of Neos.Ui, as it is public API
-                inBackend = ${Neos.Ui.NodeInfo.inBackend(documentNode)}
+                inBackend = ${Neos.Node.inBackend(documentNode)}
                 isShortcut = ${q(node).is('[instanceof Neos.Neos:Shortcut]')}
             }
         }


### PR DESCRIPTION
- Replace all usages of `Neos.Ui.NodeInfo.inBackend`
- Replace usage of `documentNode.context.inBackend`

Relates: neos/neos-development-collection#4074
