### PR TITLE
BUGFIX: Change context from pull_request to  pull_request_target

### DIFF
--- a/.github/workflows/add-pr-labels.yml
+++ b/.github/workflows/add-pr-labels.yml
@@ -1,7 +1,7 @@
 name: Add Labels to Pull Request
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize, edited]
 
 jobs:

--- a/.github/workflows/add-pr-labels.yml
+++ b/.github/workflows/add-pr-labels.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+          repository: ${{ github.head_repository.full_name }}
       - name: Maybe remove base branch label
         if: github.event.action == 'edited' && github.event.changes.base.ref.from != ''
         uses: actions-ecosystem/action-remove-labels@v1


### PR DESCRIPTION
GitHub Actions typically run in the context of the repository where they are defined, so by default they won't have access to forks of the repository.

To enable your GitHub Action to work for PRs based on a fork, you can use the pull_request_target event instead of the pull_request event. The pull_request_target event is triggered whenever a pull request is opened, edited, or synchronized on a forked repository, and it provides a head_repository context that you can use to access the forked repository.
