### PR TITLE
FEATURE: Add inspector default group

### DIFF
--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.ts
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.ts
@@ -202,7 +202,14 @@ export default class NodeTypesRegistry extends SynchronousRegistry<NodeType> {
                 }).map(group => ({
                     ...group,
                     items: positionalArraySorter([
-                        ...properties.filter(p => $get(['ui', 'inspector', 'group'], p) === group.id)
+                        ...properties.filter(p => {
+                            const isMatch = p?.ui?.inspector?.group === group.id;
+                            const useDefaultGroup = !p?.ui?.inspector?.group
+                                && group.id === 'default'
+                                && p?.ui?.inspector?.editor;
+
+                            return isMatch || useDefaultGroup;
+                        })
                                 .map(property => ({
                                     type: 'editor',
                                     id: $get(['id'], property),


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

<img width="317" alt="Bildschirm­foto 2023-03-10 um 22 30 15" src="https://user-images.githubusercontent.com/85400359/224432291-de748166-2687-4864-b4a7-c8e5d828abe7.png">

Neos part: https://github.com/neos/neos-development-collection/pull/4068

Resolves: https://github.com/neos/neos-development-collection/issues/4060

**What I did**
Use the same code like for the default tabs, but also check if an editor is set as always properties will be shown which dont have an editor configured

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
