### PR TITLE
TASK: consistently use public readonly properties in value objects, instead of getters

### DIFF
--- a/Classes/Domain/Model/Changes/AbstractCreate.php
+++ b/Classes/Domain/Model/Changes/AbstractCreate.php
@@ -136,7 +136,7 @@ abstract class AbstractCreate extends AbstractStructuralChange
         ContentRepository $contentRepository
     ): CreateNodeAggregateWithNode {
         $data = $this->getData() ?: [];
-        $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($nodeTypeName->getValue());
+        $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($nodeTypeName);
         if (!isset($nodeType->getOptions()['nodeCreationHandlers'])
             || !is_array($nodeType->getOptions()['nodeCreationHandlers'])) {
             return $command;

--- a/Classes/Domain/Model/Changes/Create.php
+++ b/Classes/Domain/Model/Changes/Create.php
@@ -35,7 +35,7 @@ class Create extends AbstractCreate
         $subject = $this->getSubject();
         $nodeTypeName = $this->getNodeTypeName();
         $contentRepository = $this->contentRepositoryRegistry->get($subject->subgraphIdentity->contentRepositoryId);
-        $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($nodeTypeName->getValue());
+        $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($nodeTypeName);
 
         return $this->isNodeTypeAllowedAsChildNode($subject, $nodeType);
     }

--- a/Classes/Domain/Model/Changes/CreateAfter.php
+++ b/Classes/Domain/Model/Changes/CreateAfter.php
@@ -33,7 +33,7 @@ class CreateAfter extends AbstractCreate
         $parent = $this->findParentNode($this->subject);
         $nodeTypeName = $this->getNodeTypeName();
         $contentRepository = $this->contentRepositoryRegistry->get($parent->subgraphIdentity->contentRepositoryId);
-        $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($nodeTypeName->getValue());
+        $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($nodeTypeName);
 
         return $this->isNodeTypeAllowedAsChildNode($parent, $nodeType);
     }

--- a/Classes/Domain/Model/Changes/CreateBefore.php
+++ b/Classes/Domain/Model/Changes/CreateBefore.php
@@ -34,7 +34,7 @@ class CreateBefore extends AbstractCreate
         $parent = $this->findParentNode($this->subject);
         $nodeTypeName = $this->getNodeTypeName();
         $contentRepository = $this->contentRepositoryRegistry->get($parent->subgraphIdentity->contentRepositoryId);
-        $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($nodeTypeName->getValue());
+        $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($nodeTypeName);
 
         return $this->isNodeTypeAllowedAsChildNode($parent, $nodeType);
     }

--- a/Classes/NodeCreationHandler/ContentTitleNodeCreationHandler.php
+++ b/Classes/NodeCreationHandler/ContentTitleNodeCreationHandler.php
@@ -42,7 +42,7 @@ class ContentTitleNodeCreationHandler implements NodeCreationHandlerInterface
     public function handle(CreateNodeAggregateWithNode $command, array $data, ContentRepository $contentRepository): CreateNodeAggregateWithNode
     {
         if (
-            !$contentRepository->getNodeTypeManager()->getNodeType($command->nodeTypeName->getValue())
+            !$contentRepository->getNodeTypeManager()->getNodeType($command->nodeTypeName)
                 ->isOfType('Neos.Neos:Content')
         ) {
             return $command;

--- a/Classes/NodeCreationHandler/CreationDialogPropertiesCreationHandler.php
+++ b/Classes/NodeCreationHandler/CreationDialogPropertiesCreationHandler.php
@@ -41,7 +41,7 @@ class CreationDialogPropertiesCreationHandler implements NodeCreationHandlerInte
         $propertyMappingConfiguration->forProperty('*')->allowAllProperties();
         $propertyMappingConfiguration->setTypeConverterOption(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED, true);
 
-        $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($command->nodeTypeName->getValue());
+        $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($command->nodeTypeName);
         $propertyValues = $command->initialPropertyValues;
         foreach ($nodeType->getConfiguration('properties') as $propertyName => $propertyConfiguration) {
             if (

--- a/Classes/NodeCreationHandler/DocumentTitleNodeCreationHandler.php
+++ b/Classes/NodeCreationHandler/DocumentTitleNodeCreationHandler.php
@@ -45,7 +45,7 @@ class DocumentTitleNodeCreationHandler implements NodeCreationHandlerInterface
     public function handle(CreateNodeAggregateWithNode $command, array $data, ContentRepository $contentRepository): CreateNodeAggregateWithNode
     {
         if (
-            !$contentRepository->getNodeTypeManager()->getNodeType($command->nodeTypeName->getValue())
+            !$contentRepository->getNodeTypeManager()->getNodeType($command->nodeTypeName)
                 ->isOfType('Neos.Neos:Document')
         ) {
             return $command;


### PR DESCRIPTION
This is the compatibility change for https://github.com/neos/neos-development-collection/pull/4095
