### PR TITLE
9.0: BUGFIX: fix converting `reference` or `references` properties in `NodePropertyConverterService`

### DIFF
--- a/Classes/Domain/Service/NodePropertyConverterService.php
+++ b/Classes/Domain/Service/NodePropertyConverterService.php
@@ -17,6 +17,8 @@ namespace Neos\Neos\Ui\Domain\Service;
 use Neos\ContentRepository\Core\NodeType\NodeType;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindReferencesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Reference;
+use Neos\ContentRepository\Core\Projection\ContentGraph\References;
 use Neos\ContentRepository\Core\Projection\NodeHiddenState\NodeHiddenStateFinder;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
@@ -174,14 +176,13 @@ class NodePropertyConverterService
     }
 
     /**
-     * @param iterable<int,Node> $nodes
      * @return array<int,string>
      */
-    private function toNodeIdentifierStrings(iterable $nodes): array
+    private function toNodeIdentifierStrings(References $references): array
     {
         $identifiers = [];
-        foreach ($nodes as $node) {
-            $identifiers[] = (string)$node->nodeAggregateId;
+        foreach ($references as $reference) {
+            $identifiers[] = (string)$reference->node->nodeAggregateId;
         }
         return $identifiers;
     }


### PR DESCRIPTION
**Review instructions**

⚠️ Can't be tested without neos/neos-development-collection#4120.

Steps to Reproduce:
1. Define NodeType with property of type `reference` or `references` (restirct `nodeTypes` e.g. to `Neos.Neos:Document`) 
2. Search for a page in your installation
3. Select a node

Before bugfix: Throws error `Undefined property: Neos\ContentRepository\Core\Projection\ContentGraph\Reference::$nodeAggregateId in NodePropertyConverterService`

After bugfix: Will show list of selected references in inspector.