### PR TITLE
BUGFIX: flowQueryAction (js endpoint for `q()`) handle non-existing nodes gracefully

### DIFF
--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -533,13 +533,13 @@ class BackendServiceController extends ActionController
         $result = [];
         switch ($finisher['type']) {
             case 'get':
-                $result = $nodeInfoHelper->renderNodes($flowQuery->get(), $this->getControllerContext());
+                $result = $nodeInfoHelper->renderNodes(array_filter($flowQuery->get()), $this->getControllerContext());
                 break;
             case 'getForTree':
-                $result = $nodeInfoHelper->renderNodes($flowQuery->get(), $this->getControllerContext(), true);
+                $result = $nodeInfoHelper->renderNodes(array_filter($flowQuery->get()), $this->getControllerContext(), true);
                 break;
             case 'getForTreeWithParents':
-                $result = $nodeInfoHelper->renderNodesWithParents($flowQuery->get(), $this->getControllerContext());
+                $result = $nodeInfoHelper->renderNodesWithParents(array_filter($flowQuery->get()), $this->getControllerContext());
                 break;
         }
 


### PR DESCRIPTION

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

if a plugin uses the flowquery backend api via
```ts
import backend from '@neos-project/neos-ui-backend-connector';

const {q} = backend.get();

q([siteNodeContextPath]).find("#123").getForTree()
```

but if the node-identifier `123` doesnt exist the NodeInfoHelper (`getForTree`) will fail.

![image](https://user-images.githubusercontent.com/85400359/225865618-2d8320bb-7f4b-4d9f-ac72-457415d82eb7.png)


**What I did**

we filter empty items out of the result of the flowquery, and only then pass it to the NodeInfoHelper, which will result in a nice empty json response.

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
