### PR TITLE
Revert "BUGFIX: Make extensibility api compatible with esbuild alias"

### DIFF
--- a/packages/neos-ui-extensibility/extensibilityMap.json
+++ b/packages/neos-ui-extensibility/extensibilityMap.json
@@ -8,7 +8,7 @@
     "classnames": "@neos-project/neos-ui-extensibility/dist/shims/vendor/classnames",
     "react-redux": "@neos-project/neos-ui-extensibility/dist/shims/vendor/react-redux",
     "redux-actions": "@neos-project/neos-ui-extensibility/dist/shims/vendor/redux-actions",
-    "redux-saga/effects": "@neos-project/neos-ui-extensibility/dist/shims/vendor/redux-saga/effects",
+    "redux-saga/effects": "@neos-project/neos-ui-extensibility/dist/shims/vendor/redux-saga-effects",
     "redux-saga": "@neos-project/neos-ui-extensibility/dist/shims/vendor/redux-saga",
     "reselect": "@neos-project/neos-ui-extensibility/dist/shims/vendor/reselect",
     "@friendsofreactjs/react-css-themr": "@neos-project/neos-ui-extensibility/dist/shims/vendor/react-css-themr",

--- a/packages/neos-ui-extensibility/src/shims/vendor/redux-saga-effects/index.js
+++ b/packages/neos-ui-extensibility/src/shims/vendor/redux-saga-effects/index.js
@@ -1,3 +1,3 @@
-import readFromConsumerApi from '../../../../readFromConsumerApi';
+import readFromConsumerApi from '../../../readFromConsumerApi';
 
 module.exports = readFromConsumerApi('vendor')().reduxSagaEffects;


### PR DESCRIPTION
This reverts commit 9c547cc8bb6e79c000bf465ffea7d9ded92601ae.

As it was fixed via: v0.17.11 in esbuild: https://github.com/evanw/esbuild/releases/tag/v0.17.11

see https://github.com/evanw/esbuild/issues/2963
