### PR TITLE
TASK: Restrict what is published to npm

### DIFF
--- a/packages/neos-ui-extensibility/package.json
+++ b/packages/neos-ui-extensibility/package.json
@@ -9,6 +9,10 @@
   "publishConfig": {
     "main": "./dist/index.js"
   },
+  "files": [
+    "dist",
+    "extensibilityMap.json"
+  ],
   "scripts": {
     "test": "yarn jest -w 2 --coverage",
     "test:watch": "yarn jest --watch",

--- a/packages/positional-array-sorter/package.json
+++ b/packages/positional-array-sorter/package.json
@@ -9,6 +9,9 @@
   "publishConfig": {
     "main": "./dist/positionalArraySorter.js"
   },
+  "files": [
+    "dist"
+  ],
   "license": "GNU GPLv3",
   "scripts": {
     "test": "yarn jest -w 2 --coverage",


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**Why**

It is a good manner to only publish to NPM the dist files to reduce package size, but also since there is nothing to gain from using the source files over dist.

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
