### PR TITLE
FEATURE: Improve user experience for Dimension Switcher

### DIFF
--- a/Tests/IntegrationTests/Fixtures/1Dimension/switchingDimensions.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/switchingDimensions.e2e.js
@@ -16,7 +16,7 @@ test('Switching dimensions', async t => {
     const otherPageName = 'Untranslated page';
 
     await Page.goToPage(translatedPageName);
-    await DimensionSwitcher.switchLanguageDimension('Latvian');
+    await DimensionSwitcher.switchSingleDimension('Latvian');
     await t.click('#neos-NodeVariantCreationDialog-CreateEmpty');
     await Page.waitForIframeLoading();
     await t
@@ -24,7 +24,7 @@ test('Switching dimensions', async t => {
         .expect(Page.treeNode.withText(otherPageName).exists).notOk('Untranslated node gone from the tree');
 
     subSection('Switch back to original dimension');
-    await DimensionSwitcher.switchLanguageDimension('English (US)');
+    await DimensionSwitcher.switchSingleDimension('English (US)');
     await Page.waitForIframeLoading();
     await t
         .expect(await Page.getReduxState(state => state.cr.contentDimensions.active.language[0])).eql('en_US', 'Dimension back to English')

--- a/Tests/IntegrationTests/pageModel.js
+++ b/Tests/IntegrationTests/pageModel.js
@@ -40,6 +40,12 @@ export class DimensionSwitcher {
             .click(this.dimensionSwitcherFirstDimensionSelector)
             .click(this.dimensionSwitcherFirstDimensionSelectorWithShallowDropDownContents.find('li').withText(name));
     }
+
+    static async switchSingleDimension(name) {
+        await t
+            .click(this.dimensionSwitcher)
+            .click(ReactSelector('DimensionSelectorOption').withProps('option', {label: name}));
+    }
 }
 
 export class PublishDropDown {

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelector.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelector.js
@@ -1,11 +1,9 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import Icon from '@neos-project/react-ui-components/src/Icon/';
 import SelectBox from '@neos-project/react-ui-components/src/SelectBox/';
 import style from './style.module.css';
 import {$get, $transform} from 'plow-js';
 import mapValues from 'lodash.mapvalues';
-import I18n from '@neos-project/neos-ui-i18n';
 import sortBy from 'lodash.sortby';
 import {neos} from '@neos-project/neos-ui-decorators';
 import DimensionSelectorOption from './DimensionSelectorOption';
@@ -25,7 +23,7 @@ export default class DimensionSelector extends PureComponent {
         dimensionName: PropTypes.string.isRequired,
         isLoading: PropTypes.bool,
         onSelect: PropTypes.func.isRequired,
-        showOnlyDimensionDropdown: PropTypes.bool,
+        showDropDownHeaderIcon: PropTypes.bool,
 
         i18nRegistry: PropTypes.object.isRequired
     };
@@ -34,7 +32,7 @@ export default class DimensionSelector extends PureComponent {
         searchTerm: ''
     };
 
-    renderDimensionDropdown = () => {
+    render() {
         const {
             activePreset,
             isLoading,
@@ -42,7 +40,7 @@ export default class DimensionSelector extends PureComponent {
             dimensionName,
             onSelect,
             presets,
-            showOnlyDimensionDropdown
+            showDropDownHeaderIcon
         } = this.props;
 
         const presetOptions = mapValues(
@@ -72,7 +70,7 @@ export default class DimensionSelector extends PureComponent {
                 onValueChange={onPresetSelect}
                 value={activePreset}
                 allowEmpty={false}
-                headerIcon={showOnlyDimensionDropdown ? this.props.icon : null}
+                headerIcon={showDropDownHeaderIcon ? this.props.icon : null}
                 displaySearchBox={sortedPresetOptions.length >= 10}
                 searchOptions={searchOptions(this.state.searchTerm, sortedPresetOptions)}
                 onSearchTermChange={this.handleSearchTermChange}
@@ -83,27 +81,6 @@ export default class DimensionSelector extends PureComponent {
                 className={style.dimensionSwitcherDropDown}
             />
         )
-    }
-
-    render() {
-        const {
-            icon,
-            dimensionLabel,
-            dimensionName,
-            showOnlyDimensionDropdown
-        } = this.props;
-
-        const dimensionDropdown = this.renderDimensionDropdown();
-
-        return showOnlyDimensionDropdown === true ? dimensionDropdown : (
-            <li key={dimensionName} className={style.dimensionCategory}>
-                <div className={style.dimensionLabel}>
-                    <Icon icon={icon} padded="right" className={style.dimensionCategory__icon}/>
-                    <I18n id={dimensionLabel}/>
-                </div>
-                {dimensionDropdown}
-            </li>
-        );
     }
 
     handleSearchTermChange = searchTerm => {

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelector.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelector.js
@@ -1,0 +1,110 @@
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+import Icon from '@neos-project/react-ui-components/src/Icon/';
+import SelectBox from '@neos-project/react-ui-components/src/SelectBox/';
+import style from './style.module.css';
+import {$get, $transform} from 'plow-js';
+import mapValues from 'lodash.mapvalues';
+import I18n from '@neos-project/neos-ui-i18n';
+import sortBy from 'lodash.sortby';
+import {neos} from '@neos-project/neos-ui-decorators';
+import DimensionSelectorOption from './DimensionSelectorOption';
+
+const searchOptions = (searchTerm, processedSelectBoxOptions) =>
+    processedSelectBoxOptions.filter(option => option.label && option.label.toLowerCase().indexOf(searchTerm.toLowerCase()) !== -1);
+
+@neos(globalRegistry => ({
+    i18nRegistry: globalRegistry.get('i18n')
+}))
+export default class DimensionSelector extends PureComponent {
+    static propTypes = {
+        icon: PropTypes.string.isRequired,
+        dimensionLabel: PropTypes.string.isRequired,
+        presets: PropTypes.object.isRequired,
+        activePreset: PropTypes.string.isRequired,
+        dimensionName: PropTypes.string.isRequired,
+        isLoading: PropTypes.bool,
+        onSelect: PropTypes.func.isRequired,
+        showOnlyDimensionDropdown: PropTypes.bool,
+
+        i18nRegistry: PropTypes.object.isRequired
+    };
+
+    state = {
+        searchTerm: ''
+    };
+
+    renderDimensionDropdown = () => {
+        const {
+            activePreset,
+            isLoading,
+            i18nRegistry,
+            dimensionName,
+            onSelect,
+            presets
+        } = this.props;
+
+        const presetOptions = mapValues(
+            presets,
+            (presetConfiguration, presetName) => {
+                return $transform(
+                    {
+                        label: $get('label'),
+                        value: presetName,
+                        disallowed: $get('disallowed')
+                    },
+                    presetConfiguration
+                );
+            }
+        );
+
+        const sortedPresetOptions = sortBy(presetOptions, ['label']);
+
+        const onPresetSelect = presetName => {
+            onSelect(dimensionName, presetName);
+        };
+
+        return (
+            <SelectBox
+                displayLoadingIndicator={isLoading}
+                options={this.state.searchTerm ? searchOptions(this.state.searchTerm, sortedPresetOptions) : sortedPresetOptions}
+                onValueChange={onPresetSelect}
+                value={activePreset}
+                allowEmpty={false}
+                displaySearchBox={sortedPresetOptions.length >= 10}
+                searchOptions={searchOptions(this.state.searchTerm, sortedPresetOptions)}
+                onSearchTermChange={this.handleSearchTermChange}
+                noMatchesFoundLabel={i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}
+                searchBoxLeftToTypeLabel={i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
+                threshold={0}
+                ListPreviewElement={DimensionSelectorOption}
+                className={style.dimensionSwitcherDropDown}
+            />
+        )
+    }
+
+    render() {
+        const {
+            icon,
+            dimensionLabel,
+            dimensionName,
+            showOnlyDimensionDropdown
+        } = this.props;
+
+        const dimensionDropdown = this.renderDimensionDropdown();
+
+        return showOnlyDimensionDropdown === true ? dimensionDropdown : (
+            <li key={dimensionName} className={style.dimensionCategory}>
+                <div className={style.dimensionLabel}>
+                    <Icon icon={icon} padded="right" className={style.dimensionCategory__icon}/>
+                    <I18n id={dimensionLabel}/>
+                </div>
+                {dimensionDropdown}
+            </li>
+        );
+    }
+
+    handleSearchTermChange = searchTerm => {
+        this.setState({searchTerm});
+    }
+}

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelector.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelector.js
@@ -41,7 +41,8 @@ export default class DimensionSelector extends PureComponent {
             i18nRegistry,
             dimensionName,
             onSelect,
-            presets
+            presets,
+            showOnlyDimensionDropdown
         } = this.props;
 
         const presetOptions = mapValues(
@@ -71,7 +72,7 @@ export default class DimensionSelector extends PureComponent {
                 onValueChange={onPresetSelect}
                 value={activePreset}
                 allowEmpty={false}
-                headerIcon={this.props.icon}
+                headerIcon={showOnlyDimensionDropdown ? this.props.icon : null}
                 displaySearchBox={sortedPresetOptions.length >= 10}
                 searchOptions={searchOptions(this.state.searchTerm, sortedPresetOptions)}
                 onSearchTermChange={this.handleSearchTermChange}

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelector.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelector.js
@@ -71,6 +71,7 @@ export default class DimensionSelector extends PureComponent {
                 onValueChange={onPresetSelect}
                 value={activePreset}
                 allowEmpty={false}
+                headerIcon={this.props.icon}
                 displaySearchBox={sortedPresetOptions.length >= 10}
                 searchOptions={searchOptions(this.state.searchTerm, sortedPresetOptions)}
                 onSearchTermChange={this.handleSearchTermChange}

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/index.js
@@ -4,16 +4,14 @@ import {connect} from 'react-redux';
 import Button from '@neos-project/react-ui-components/src/Button/';
 import Icon from '@neos-project/react-ui-components/src/Icon/';
 import DropDown from '@neos-project/react-ui-components/src/DropDown/';
-import SelectBox from '@neos-project/react-ui-components/src/SelectBox/';
 import style from './style.module.css';
 import backend from '@neos-project/neos-ui-backend-connector';
 import {$get, $transform} from 'plow-js';
 import mapValues from 'lodash.mapvalues';
 import {selectors, actions} from '@neos-project/neos-ui-redux-store';
 import I18n from '@neos-project/neos-ui-i18n';
-import sortBy from 'lodash.sortby';
 import {neos} from '@neos-project/neos-ui-decorators';
-import DimensionSelectorOption from './DimensionSelectorOption';
+import DimensionSelector from './DimensionSelector';
 
 // TODO Add title prop to Icon component
 const SelectedPreset = props => {
@@ -31,82 +29,6 @@ SelectedPreset.propTypes = {
     presetLabel: PropTypes.string.isRequired,
     dimensionName: PropTypes.string.isRequired
 };
-
-const searchOptions = (searchTerm, processedSelectBoxOptions) =>
-    processedSelectBoxOptions.filter(option => option.label && option.label.toLowerCase().indexOf(searchTerm.toLowerCase()) !== -1);
-
-@neos(globalRegistry => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}))
-class DimensionSelector extends PureComponent {
-    static propTypes = {
-        icon: PropTypes.string.isRequired,
-        dimensionLabel: PropTypes.string.isRequired,
-        presets: PropTypes.object.isRequired,
-        activePreset: PropTypes.string.isRequired,
-        dimensionName: PropTypes.string.isRequired,
-        isLoading: PropTypes.bool,
-        onSelect: PropTypes.func.isRequired,
-
-        i18nRegistry: PropTypes.object.isRequired
-    };
-
-    state = {
-        searchTerm: ''
-    };
-
-    render() {
-        const {icon, dimensionLabel, presets, dimensionName, activePreset, onSelect, isLoading, i18nRegistry} = this.props;
-
-        const presetOptions = mapValues(
-            presets,
-            (presetConfiguration, presetName) => {
-                return $transform(
-                    {
-                        label: $get('label'),
-                        value: presetName,
-                        disallowed: $get('disallowed')
-                    },
-                    presetConfiguration
-                );
-            }
-        );
-
-        const sortedPresetOptions = sortBy(presetOptions, ['label']);
-
-        const onPresetSelect = presetName => {
-            onSelect(dimensionName, presetName);
-        };
-
-        return (
-            <li key={dimensionName} className={style.dimensionCategory}>
-                <div className={style.dimensionLabel}>
-                    <Icon icon={icon} padded="right" className={style.dimensionCategory__icon}/>
-                    <I18n id={dimensionLabel}/>
-                </div>
-                <SelectBox
-                    displayLoadingIndicator={isLoading}
-                    options={this.state.searchTerm ? searchOptions(this.state.searchTerm, sortedPresetOptions) : sortedPresetOptions}
-                    onValueChange={onPresetSelect}
-                    value={activePreset}
-                    allowEmpty={false}
-                    displaySearchBox={sortedPresetOptions.length >= 10}
-                    searchOptions={searchOptions(this.state.searchTerm, sortedPresetOptions)}
-                    onSearchTermChange={this.handleSearchTermChange}
-                    noMatchesFoundLabel={i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}
-                    searchBoxLeftToTypeLabel={i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
-                    threshold={0}
-                    ListPreviewElement={DimensionSelectorOption}
-                    className={style.dimensionSwitcherDropDown}
-                />
-            </li>
-        );
-    }
-
-    handleSearchTermChange = searchTerm => {
-        this.setState({searchTerm});
-    }
-}
 
 @connect($transform({
     contentDimensions: selectors.CR.ContentDimensions.byName,
@@ -228,74 +150,92 @@ export default class DimensionSwitcher extends PureComponent {
         this.setState({isOpen: false});
     }
 
+    renderSingleDimensionSelector = (dimensionName, contentDimensionsObject) => {
+        const dimensionConfiguration = contentDimensionsObject[dimensionName];
+        const icon = $get('icon', dimensionConfiguration) && $get('icon', dimensionConfiguration);
+        // First look for active preset in transient state, else take it from activePresets prop
+        const activePreset = this.getEffectivePresets(this.state.transientPresets)[dimensionName];
+        return (<DimensionSelector
+                isLoading={this.state.loadingPresets[dimensionName]}
+                key={dimensionName}
+                dimensionName={dimensionName}
+                icon={icon}
+                dimensionLabel={$get('label', dimensionConfiguration)}
+                presets={this.presetsForDimension(dimensionName)}
+                activePreset={activePreset}
+                onSelect={this.handleSelectPreset}
+                showOnlyDimensionDropdown={Object.keys(contentDimensionsObject).length === 1}
+            />
+        );
+    }
+
     render() {
         const {contentDimensions, activePresets, i18nRegistry} = this.props;
         const contentDimensionsObject = contentDimensions;
         const contentDimensionsObjectKeys = Object.keys(contentDimensionsObject);
 
-        return contentDimensionsObjectKeys.length ? (
-            <DropDown.Stateless
-                style="darkest"
-                padded={true}
-                className={style.dropDown}
-                isOpen={this.state.isOpen}
-                onToggle={this.handleToggle}
-                onClose={this.handleClose}
+        if (contentDimensionsObjectKeys.length === 1) {
+            const dimensionName = contentDimensionsObjectKeys[0];
+            return (
+                <div className={style.singleDimensionDropdown}>
+                    {this.renderSingleDimensionSelector(dimensionName, contentDimensionsObject)}
+                </div>
+            )
+        }
+
+        if (contentDimensionsObjectKeys.length > 1) {
+            return (
+                <DropDown.Stateless
+                    style="darkest"
+                    padded={true}
+                    className={style.dropDown}
+                    isOpen={this.state.isOpen}
+                    onToggle={this.handleToggle}
+                    onClose={this.handleClose}
                 >
-                <DropDown.Header
-                    className={style.dropDown__header}
-                >
-                    {contentDimensionsObjectKeys.map(dimensionName => {
-                        const dimensionConfiguration = contentDimensionsObject[dimensionName];
-                        const icon = $get('icon', dimensionConfiguration) && $get('icon', dimensionConfiguration);
-                        return (<SelectedPreset
-                            key={dimensionName}
-                            dimensionName={dimensionName}
-                            icon={icon}
-                            dimensionLabel={i18nRegistry.translate($get('label', dimensionConfiguration))}
-                            presetLabel={i18nRegistry.translate($get([dimensionName, 'label'], activePresets))}
-                            />
-                        );
-                    })}
-                </DropDown.Header>
-                <DropDown.Contents className={style.dropDown__contents}>
-                    {contentDimensionsObjectKeys.map(dimensionName => {
-                        const dimensionConfiguration = contentDimensionsObject[dimensionName];
-                        const icon = $get('icon', dimensionConfiguration) && $get('icon', dimensionConfiguration);
-                        // First look for active preset in transient state, else take it from activePresets prop
-                        const activePreset = this.getEffectivePresets(this.state.transientPresets)[dimensionName];
-                        return (<DimensionSelector
-                            isLoading={this.state.loadingPresets[dimensionName]}
-                            key={dimensionName}
-                            dimensionName={dimensionName}
-                            icon={icon}
-                            dimensionLabel={$get('label', dimensionConfiguration)}
-                            presets={this.presetsForDimension(dimensionName)}
-                            activePreset={activePreset}
-                            onSelect={this.handleSelectPreset}
-                            />
-                        );
-                    })}
-                    {Object.keys(contentDimensions).length > 1 && <div className={style.buttonGroup}>
-                        <Button
-                            id="neos-DimensionSwitcher-Cancel"
-                            onClick={this.handleClose}
-                            style="lighter"
-                            className={style.cancelButton}
+                    <DropDown.Header
+                        className={style.dropDown__header}
+                    >
+                        {contentDimensionsObjectKeys.map(dimensionName => {
+                            const dimensionConfiguration = contentDimensionsObject[dimensionName];
+                            const icon = $get('icon', dimensionConfiguration) && $get('icon', dimensionConfiguration);
+                            return (<SelectedPreset
+                                    key={dimensionName}
+                                    dimensionName={dimensionName}
+                                    icon={icon}
+                                    dimensionLabel={i18nRegistry.translate($get('label', dimensionConfiguration))}
+                                    presetLabel={i18nRegistry.translate($get([dimensionName, 'label'], activePresets))}
+                                />
+                            );
+                        })}
+                    </DropDown.Header>
+                    <DropDown.Contents className={style.dropDown__contents}>
+                        {contentDimensionsObjectKeys.map(dimensionName => {
+                            return this.renderSingleDimensionSelector(dimensionName, contentDimensionsObject)
+                        })}
+                        {Object.keys(contentDimensions).length > 1 && <div className={style.buttonGroup}>
+                            <Button
+                                id="neos-DimensionSwitcher-Cancel"
+                                onClick={this.handleClose}
+                                style="lighter"
+                                className={style.cancelButton}
                             >
-                            <I18n id="Neos.Neos:Main:cancel" fallback="Cancel"/>
-                        </Button>
-                        <Button
-                            id="neos-DimensionSwitcher-Apply"
-                            onClick={this.handleApplyPresets}
-                            style="brand"
+                                <I18n id="Neos.Neos:Main:cancel" fallback="Cancel"/>
+                            </Button>
+                            <Button
+                                id="neos-DimensionSwitcher-Apply"
+                                onClick={this.handleApplyPresets}
+                                style="brand"
                             >
-                            <I18n id="Neos.Neos:Main:apply" fallback="Apply"/>
-                        </Button>
-                    </div>}
-                </DropDown.Contents>
-            </DropDown.Stateless>
-        ) : null;
+                                <I18n id="Neos.Neos:Main:apply" fallback="Apply"/>
+                            </Button>
+                        </div>}
+                    </DropDown.Contents>
+                </DropDown.Stateless>
+            )
+        }
+
+        return null;
     }
 
     presetsForDimension(dimensionName) {

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/index.js
@@ -64,6 +64,11 @@ export default class DimensionSwitcher extends PureComponent {
         loadingPresets: {}
     };
 
+    getDimensionIcon = (dimensionName, contentDimensionsObject) => {
+        const dimensionConfiguration = contentDimensionsObject[dimensionName];
+        return $get('icon', dimensionConfiguration) && $get('icon', dimensionConfiguration);
+    }
+
     //
     // Merge active presets comming from redux with local transientPresets state (i.e. presents selected, but not yet applied)
     //
@@ -152,7 +157,7 @@ export default class DimensionSwitcher extends PureComponent {
 
     renderSingleDimensionSelector = (dimensionName, contentDimensionsObject) => {
         const dimensionConfiguration = contentDimensionsObject[dimensionName];
-        const icon = $get('icon', dimensionConfiguration) && $get('icon', dimensionConfiguration);
+        const icon = this.getDimensionIcon(dimensionName, contentDimensionsObject);
         // First look for active preset in transient state, else take it from activePresets prop
         const activePreset = this.getEffectivePresets(this.state.transientPresets)[dimensionName];
         return (
@@ -177,8 +182,10 @@ export default class DimensionSwitcher extends PureComponent {
 
         if (contentDimensionsObjectKeys.length === 1) {
             const dimensionName = contentDimensionsObjectKeys[0];
+            const icon = this.getDimensionIcon(dimensionName, contentDimensionsObject);
             return (
                 <div className={style.singleDimensionDropdown}>
+                    <Icon icon={icon} padded="right" className={style.singleDimensionDropdown__icon} />
                     {this.renderSingleDimensionSelector(dimensionName, contentDimensionsObject)}
                 </div>
             )
@@ -199,7 +206,7 @@ export default class DimensionSwitcher extends PureComponent {
                     >
                         {contentDimensionsObjectKeys.map(dimensionName => {
                             const dimensionConfiguration = contentDimensionsObject[dimensionName];
-                            const icon = $get('icon', dimensionConfiguration) && $get('icon', dimensionConfiguration);
+                            const icon = this.getDimensionIcon(dimensionName, contentDimensionsObject);
                             return (
                                 <SelectedPreset
                                     key={dimensionName}

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/index.js
@@ -182,10 +182,8 @@ export default class DimensionSwitcher extends PureComponent {
 
         if (contentDimensionsObjectKeys.length === 1) {
             const dimensionName = contentDimensionsObjectKeys[0];
-            const icon = this.getDimensionIcon(dimensionName, contentDimensionsObject);
             return (
                 <div className={style.singleDimensionDropdown}>
-                    <Icon icon={icon} padded="right" className={style.singleDimensionDropdown__icon} />
                     {this.renderSingleDimensionSelector(dimensionName, contentDimensionsObject)}
                 </div>
             )

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/index.js
@@ -66,7 +66,7 @@ export default class DimensionSwitcher extends PureComponent {
 
     getDimensionIcon = (dimensionName, contentDimensionsObject) => {
         const dimensionConfiguration = contentDimensionsObject[dimensionName];
-        return $get('icon', dimensionConfiguration) && $get('icon', dimensionConfiguration);
+        return dimensionConfiguration?.icon || null;
     }
 
     //

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/index.js
@@ -170,7 +170,7 @@ export default class DimensionSwitcher extends PureComponent {
                 presets={this.presetsForDimension(dimensionName)}
                 activePreset={activePreset}
                 onSelect={this.handleSelectPreset}
-                showOnlyDimensionDropdown={Object.keys(contentDimensionsObject).length === 1}
+                showDropDownHeaderIcon={Object.keys(contentDimensionsObject).length === 1}
             />
         );
     }
@@ -218,7 +218,17 @@ export default class DimensionSwitcher extends PureComponent {
                     </DropDown.Header>
                     <DropDown.Contents className={style.dropDown__contents}>
                         {contentDimensionsObjectKeys.map(dimensionName => {
-                            return this.renderSingleDimensionSelector(dimensionName, contentDimensionsObject)
+                            const dimensionConfiguration = contentDimensionsObject[dimensionName];
+                            const icon = this.getDimensionIcon(dimensionName, contentDimensionsObject);
+                            return (
+                                <li key={dimensionName} className={style.dimensionCategory}>
+                                    <div className={style.dimensionLabel}>
+                                        <Icon icon={icon} padded="right" className={style.dimensionCategory__icon}/>
+                                        <I18n id={$get('label', dimensionConfiguration)}/>
+                                    </div>
+                                    {this.renderSingleDimensionSelector(dimensionName, contentDimensionsObject)}
+                                </li>
+                            )
                         })}
                         {Object.keys(contentDimensions).length > 1 && <div className={style.buttonGroup}>
                             <Button

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/index.js
@@ -155,7 +155,8 @@ export default class DimensionSwitcher extends PureComponent {
         const icon = $get('icon', dimensionConfiguration) && $get('icon', dimensionConfiguration);
         // First look for active preset in transient state, else take it from activePresets prop
         const activePreset = this.getEffectivePresets(this.state.transientPresets)[dimensionName];
-        return (<DimensionSelector
+        return (
+            <DimensionSelector
                 isLoading={this.state.loadingPresets[dimensionName]}
                 key={dimensionName}
                 dimensionName={dimensionName}
@@ -199,7 +200,8 @@ export default class DimensionSwitcher extends PureComponent {
                         {contentDimensionsObjectKeys.map(dimensionName => {
                             const dimensionConfiguration = contentDimensionsObject[dimensionName];
                             const icon = $get('icon', dimensionConfiguration) && $get('icon', dimensionConfiguration);
-                            return (<SelectedPreset
+                            return (
+                                <SelectedPreset
                                     key={dimensionName}
                                     dimensionName={dimensionName}
                                     icon={icon}

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/style.module.css
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/style.module.css
@@ -71,15 +71,9 @@
 .singleDimensionDropdown {
     display: flex;
     align-items: center;
-    padding-left: var(--spacing-Half);
 
     .dimensionSwitcherDropDown {
         background: unset;
-        min-width: 200px;
-        padding-left: var(--spacing-GoldenUnit);
+        min-width: fit-content;
     }
-}
-
-.singleDimensionDropdown__icon {
-    margin-right: calc(-1.25 * var(--spacing-GoldenUnit));
 }

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/style.module.css
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/style.module.css
@@ -69,9 +69,17 @@
 }
 
 .singleDimensionDropdown {
+    display: flex;
+    align-items: center;
+    padding-left: var(--spacing-Half);
 
     .dimensionSwitcherDropDown {
         background: unset;
-        min-width: auto;
+        min-width: 200px;
+        padding-left: var(--spacing-GoldenUnit);
     }
+}
+
+.singleDimensionDropdown__icon {
+    margin-right: calc(-1.25 * var(--spacing-GoldenUnit));
 }

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/style.module.css
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/style.module.css
@@ -29,7 +29,7 @@
 }
 
 .dimensionSwitcherDropDown {
-    min-width: 240px;
+    min-width: fit-content;
 }
 
 .dimensionCategory + .dimensionCategory {
@@ -75,5 +75,9 @@
     .dimensionSwitcherDropDown {
         background: unset;
         min-width: fit-content;
+    }
+
+    .dimensionSwitcherDropDown div[role='button'] {
+        padding: 5px 0 5px var(--spacing-Full);
     }
 }

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/style.module.css
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/style.module.css
@@ -2,6 +2,7 @@
     max-width: 320px;
     width: auto;
 }
+
 .dropDown__header {
     background-color: transparent;
 
@@ -9,6 +10,7 @@
         color: var(--colors-PrimaryBlue);
     }
 }
+
 .dropDown__contents {
     width: fit-content;
     min-width: 100%;
@@ -16,9 +18,11 @@
     background-color: var(--colors-ContrastDarker) !important;
     box-shadow: 0 5px 5px rgba(0, 0, 0, .2);
 }
+
 .dropDown__btnIcon {
     margin-right: .5em;
 }
+
 .dimensionCategory {
     background-color: var(--colors-ContrastDarkest);
     padding: var(--spacing-Full);
@@ -49,6 +53,7 @@
 .buttonGroup button {
     flex: 1 0 auto;
 }
+
 @media only screen and (max-width: 1024px) {
     .selectPresetLabel {
         display: none;
@@ -61,4 +66,12 @@
 
 .selectPreset + .selectPreset {
     margin-left: var(--spacing-Half);
+}
+
+.singleDimensionDropdown {
+
+    .dimensionSwitcherDropDown {
+        background: unset;
+        min-width: auto;
+    }
 }

--- a/packages/react-ui-components/src/ListPreviewElement/listPreviewElement.js
+++ b/packages/react-ui-components/src/ListPreviewElement/listPreviewElement.js
@@ -38,7 +38,6 @@ class ListPreviewElement extends PureComponent {
         onClick: PropTypes.func,
         isHighlighted: PropTypes.bool,
         onMouseEnter: PropTypes.func,
-        showIcon: PropTypes.bool,
 
         // ------------------------------
         // Theme & Dependencies
@@ -62,7 +61,6 @@ class ListPreviewElement extends PureComponent {
             onClick,
             isHighlighted,
             onMouseEnter,
-            showIcon,
 
             theme,
             Icon
@@ -84,7 +82,7 @@ class ListPreviewElement extends PureComponent {
                 className={optionClassName}
                 role="button"
                 >
-                {(Boolean(icon) && showIcon) && <div className={theme.listPreviewElement__iconWrapper}><Icon className={theme.listPreviewElement__icon} icon={icon}/></div>}
+                {Boolean(icon) && <div className={theme.listPreviewElement__iconWrapper}><Icon className={theme.listPreviewElement__icon} icon={icon}/></div>}
                 {children}
 
             </div>

--- a/packages/react-ui-components/src/ListPreviewElement/listPreviewElement.js
+++ b/packages/react-ui-components/src/ListPreviewElement/listPreviewElement.js
@@ -38,6 +38,7 @@ class ListPreviewElement extends PureComponent {
         onClick: PropTypes.func,
         isHighlighted: PropTypes.bool,
         onMouseEnter: PropTypes.func,
+        showIcon: PropTypes.bool,
 
         // ------------------------------
         // Theme & Dependencies
@@ -61,6 +62,7 @@ class ListPreviewElement extends PureComponent {
             onClick,
             isHighlighted,
             onMouseEnter,
+            showIcon,
 
             theme,
             Icon
@@ -82,7 +84,7 @@ class ListPreviewElement extends PureComponent {
                 className={optionClassName}
                 role="button"
                 >
-                {Boolean(icon) && <div className={theme.listPreviewElement__iconWrapper}><Icon className={theme.listPreviewElement__icon} icon={icon}/></div>}
+                {(Boolean(icon) && showIcon) && <div className={theme.listPreviewElement__iconWrapper}><Icon className={theme.listPreviewElement__icon} icon={icon}/></div>}
                 {children}
 
             </div>

--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -78,6 +78,11 @@ export default class SelectBox extends PureComponent {
         placeholderIcon: PropTypes.string,
 
         /**
+         * This prop is an icon for the header.
+         */
+        headerIcon: PropTypes.string,
+
+        /**
          * Text for the group label of options without a group
          */
         withoutGroupLabel: PropTypes.string,

--- a/packages/react-ui-components/src/SelectBox_Header/selectBox_Header.js
+++ b/packages/react-ui-components/src/SelectBox_Header/selectBox_Header.js
@@ -17,6 +17,7 @@ class SelectBox_Header extends PureComponent {
         }),
         placeholder: PropTypes.string,
         placeholderIcon: PropTypes.string,
+        headerIcon: PropTypes.string,
         showResetButton: PropTypes.bool.isRequired,
         onReset: PropTypes.func,
         onClick: PropTypes.func,
@@ -68,6 +69,7 @@ class SelectBox_Header extends PureComponent {
             theme,
             placeholder,
             placeholderIcon,
+            headerIcon,
             displayLoadingIndicator,
             Icon,
             ListPreviewElement,
@@ -75,7 +77,7 @@ class SelectBox_Header extends PureComponent {
         } = this.props;
 
         const label = option ? option.label : placeholder;
-        const icon = option && option.icon ? option.icon : placeholderIcon;
+        const icon = option && option.icon ? option.icon : (headerIcon ? headerIcon : placeholderIcon);
         const restProps = omit(this.props, ['showResetButton, IconButton']);
 
         return (
@@ -92,6 +94,7 @@ class SelectBox_Header extends PureComponent {
                             icon={icon}
                             disabled={disabled}
                             onClick={this.handleListPreviewElementClick}
+                            showIcon={true}
                             /> : (
                                 <div className={theme.selectBoxHeader__label}>
                                     {icon &&

--- a/packages/react-ui-components/src/SelectBox_ListPreview/selectBox_ListPreview.js
+++ b/packages/react-ui-components/src/SelectBox_ListPreview/selectBox_ListPreview.js
@@ -38,10 +38,13 @@ class SelectBox_ListPreview extends PureComponent {
             SelectBox_ListPreviewFlat,
             SelectBox_ListPreviewGrouped,
             searchBoxLeftToTypeLabel,
+            onCreateNew,
+            searchTerm,
             theme
         } = this.props;
 
         const ListPreviewComponent = options.some(option => option.group) ? SelectBox_ListPreviewGrouped : SelectBox_ListPreviewFlat;
+        const isCreateNewEnabled = onCreateNew && searchTerm;
 
         // TODO: replace horible self-made I18n replace
         return (
@@ -64,9 +67,11 @@ class SelectBox_ListPreview extends PureComponent {
                             />
                     </div>
                 )}
-                <div className={theme.selectBox__item}>
-                    <SelectBox_CreateNew {...this.props}/>
-                </div>
+                {isCreateNewEnabled && (
+                    <div className={theme.selectBox__item}>
+                        <SelectBox_CreateNew {...this.props}/>
+                    </div>
+                )}
             </Fragment>
         );
     }

--- a/packages/react-ui-components/src/SelectBox_Option_SingleLine/__snapshots__/selectBox_Option_SingleLine.spec.js.snap
+++ b/packages/react-ui-components/src/SelectBox_Option_SingleLine/__snapshots__/selectBox_Option_SingleLine.spec.js.snap
@@ -12,7 +12,6 @@ exports[`<SelectBox_Option_SingleLine/> should render correctly. 1`] = `
       "label": "Bar label",
     }
   }
-  showIcon={false}
   theme={Object {}}
 >
   <span

--- a/packages/react-ui-components/src/SelectBox_Option_SingleLine/__snapshots__/selectBox_Option_SingleLine.spec.js.snap
+++ b/packages/react-ui-components/src/SelectBox_Option_SingleLine/__snapshots__/selectBox_Option_SingleLine.spec.js.snap
@@ -4,6 +4,7 @@ exports[`<SelectBox_Option_SingleLine/> should render correctly. 1`] = `
 <ThemedListPreviewElement
   ListPreviewElement={[Function]}
   className=""
+  icon={null}
   label="Foo label"
   onClick={[MockFunction]}
   option={
@@ -11,6 +12,7 @@ exports[`<SelectBox_Option_SingleLine/> should render correctly. 1`] = `
       "label": "Bar label",
     }
   }
+  showIcon={false}
   theme={Object {}}
 >
   <span

--- a/packages/react-ui-components/src/SelectBox_Option_SingleLine/selectBox_Option_SingleLine.js
+++ b/packages/react-ui-components/src/SelectBox_Option_SingleLine/selectBox_Option_SingleLine.js
@@ -13,13 +13,12 @@ class SelectBox_Option_SingleLine extends PureComponent {
         }).isRequired,
 
         disabled: PropTypes.bool,
-        showIcon: PropTypes.bool,
 
         className: PropTypes.string
     }
 
     render() {
-        const {option, className, disabled, showIcon, icon} = this.props;
+        const {option, className, disabled, icon} = this.props;
 
         const isDisabled = disabled || option.disabled;
 
@@ -27,13 +26,10 @@ class SelectBox_Option_SingleLine extends PureComponent {
             [className]: className
         });
 
-        // We want to show the icon of the option when it is defined
-        // If we have no option icon but showIcon is true, we want to show the icon of the SelectBox
-        // If we have no option icon and showIcon is false, we want to show no icon
-        const visibleIcon = option.icon ? option.icon : (showIcon ? icon : null);
+        const previewElementIcon = option.icon ? option.icon : (icon ? icon : null);
 
         return (
-            <ListPreviewElement {...this.props} icon={visibleIcon} showIcon={showIcon || Boolean(visibleIcon)} disabled={isDisabled} className={finalClassNames}>
+            <ListPreviewElement {...this.props} icon={previewElementIcon} disabled={isDisabled} className={finalClassNames}>
                 <span title={option.label}>{option.label}</span>
             </ListPreviewElement>
         );

--- a/packages/react-ui-components/src/SelectBox_Option_SingleLine/selectBox_Option_SingleLine.js
+++ b/packages/react-ui-components/src/SelectBox_Option_SingleLine/selectBox_Option_SingleLine.js
@@ -13,12 +13,13 @@ class SelectBox_Option_SingleLine extends PureComponent {
         }).isRequired,
 
         disabled: PropTypes.bool,
+        showIcon: PropTypes.bool,
 
         className: PropTypes.string
     }
 
     render() {
-        const {option, className, disabled} = this.props;
+        const {option, className, disabled, showIcon, icon} = this.props;
 
         const isDisabled = disabled || option.disabled;
 
@@ -26,8 +27,13 @@ class SelectBox_Option_SingleLine extends PureComponent {
             [className]: className
         });
 
+        // We want to show the icon of the option when it is defined
+        // If we have no option icon but showIcon is true, we want to show the icon of the SelectBox
+        // If we have no option icon and showIcon is false, we want to show no icon
+        const visibleIcon = option.icon ? option.icon : (showIcon ? icon : null);
+
         return (
-            <ListPreviewElement {...this.props} icon={option.icon} disabled={isDisabled} className={finalClassNames}>
+            <ListPreviewElement {...this.props} icon={visibleIcon} showIcon={showIcon || Boolean(visibleIcon)} disabled={isDisabled} className={finalClassNames}>
                 <span title={option.label}>{option.label}</span>
             </ListPreviewElement>
         );


### PR DESCRIPTION
**What I did**
To improve the UX, we want to have just one layer when we have just one dimension configured.
Currently, the Dimension Selector is inside a dropdown.

**How I did it**
I separated the DimensionSelector into an own component and added a property to render the Selector without the label.
The DimensionSwitcher now renders a single DimensionSelector if we have only one dimension and for multiple Dimensions we use the old way.

**How to verify it**
Test the Backend with one and multiple dimensions.

**Open To-dos**

- [x] Adjust the tests
- [x] Add a Dimension Icon for the single dimension
- [x] little CSS tweaks

Related: #3413