### PR TITLE
TASK: Improve ckeditor plugin migration to Neos 8.2 and up #3452

### DIFF
--- a/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
@@ -78,7 +78,13 @@ export const createEditor = store => options => {
 
             editor.model.document.on('change', () => handleUserInteractionCallback());
             editor.model.document.on('change:data', debounce(() => onChange(cleanupContentBeforeCommit(editor.getData())), 500, {maxWait: 5000}));
-        }).catch(e => console.error(e));
+        }).catch(e => {
+            if (e instanceof TypeError && e.message.match(/Class constructor .* cannot be invoked without 'new'/)) {
+                console.error("Neos.Ui: Youre probably using a CKeditor plugin which needs to be rebuild.\nsee https://github.com/neos/neos-ui/issues/3287\n\nOriginal Error:\n\n" + e.stack);
+            } else {
+                console.error(e);
+            }
+        });
 };
 
 export const executeCommand = (command, argument, reFocusEditor = true) => {


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->
solves #3452

**What I did**

throw a nicer error:

```
Neos.Ui: Youre probably using a CKeditor plugin which needs to be rebuild.
see https://github.com/neos/neos-ui/issues/3287

Original Error:

TypeError: Class constructor et cannot be invoked without 'new'
    at new CodeFormating (http://127.0.0.1:8081/_Resources/Static/Packages/Neos.Demo/Scripts/CodeTagPlugin/Plugin.js?ee34d796:37088:115)
    at http://127.0.0.1:8081/_Resources/Static/Packages/Neos.Neos.Ui/Build/Host.js?ea7d7a0a:516:151225
    at new Promise (<anonymous>)
    at h (http://127.0.0.1:8081/_Resources/Static/Packages/Neos.Neos.Ui/Build/Host.js?ea7d7a0a:516:150962)
    at f (http://127.0.0.1:8081/_Resources/Static/Packages/Neos.Neos.Ui/Build/Host.js?ea7d7a0a:516:150735)
    at Array.map (<anonymous>)
    at tx.init (http://127.0.0.1:8081/_Resources/Static/Packages/Neos.Neos.Ui/Build/Host.js?ea7d7a0a:516:150595)
    at A5.initPlugins (http://127.0.0.1:8081/_Resources/Static/Packages/Neos.Neos.Ui/Build/Host.js?ea7d7a0a:516:232527)
    at http://127.0.0.1:8081/_Resources/Static/Packages/Neos.Neos.Ui/Build/Host.js?ea7d7a0a:517:6881
    at new Promise (<anonymous>)
```

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
