### PR TITLE
TASK: #3097 allow module script plugins

### DIFF
--- a/Classes/Domain/Service/StyleAndJavascriptInclusionService.php
+++ b/Classes/Domain/Service/StyleAndJavascriptInclusionService.php
@@ -61,15 +61,15 @@ class StyleAndJavascriptInclusionService
 
     public function getHeadScripts()
     {
-        return $this->build($this->javascriptResources, function ($uri, $defer) {
-            return '<script src="' . $uri . '" ' . $defer . '></script>';
+        return $this->build($this->javascriptResources, function ($uri, $additionalAttributes) {
+            return '<script src="' . $uri . '" ' . $additionalAttributes . '></script>';
         });
     }
 
     public function getHeadStylesheets()
     {
-        return $this->build($this->stylesheetResources, function ($uri, $defer) {
-            return '<link rel="stylesheet" href="' . $uri . '" ' . $defer . '/>';
+        return $this->build($this->stylesheetResources, function ($uri, $additionalAttributes) {
+            return '<link rel="stylesheet" href="' . $uri . '" ' . $additionalAttributes . '/>';
         });
     }
 
@@ -97,10 +97,28 @@ class StyleAndJavascriptInclusionService
                 $resourceExpression = $this->resourceManager->getPublicPackageResourceUriByPath($resourceExpression);
             }
             $finalUri = $hash ? $resourceExpression . '?' . $hash : $resourceExpression;
-            $defer = key_exists('defer', $element) && $element['defer'] ? 'defer ' : '';
-            $result .= $builderForLine($finalUri, $defer);
+            $additionalAttributes = array_merge(
+                // legacy first level 'defer' attribute
+                isset($element['defer']) ? ['defer' => $element['defer']] : [],
+                $element['attributes'] ?? []
+            );
+            $result .= $builderForLine($finalUri, $this->htmlAttributesArrayToString($additionalAttributes));
         }
-
         return $result;
+    }
+
+    /**
+     * @todo use helper like https://github.com/mficzel/neos-development-collection/blob/75e1feaed2e290b1d2ee3e500b82da42c3460aba/Neos.Fusion/Classes/Service/RenderAttributesTrait.php#L19 once its api
+     *
+     * @param array<string,string|bool> $attributes
+     */
+    private function htmlAttributesArrayToString(array $attributes): string
+    {
+        return join(' ', array_filter(array_map(function($key, $value) {
+            if (is_bool($value)) {
+               return $value ? htmlspecialchars($key) : null;
+            }
+            return htmlspecialchars($key) . '="' . htmlspecialchars($value) . '"';
+        }, array_keys($attributes), $attributes)));
     }
 }


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

**What I did**
solves #3097

Allows ES-Module Plugins to be loaded in the Neos.Ui, by allowing `<src type="module" />`

inlines the package: https://github.com/mhsdesign/MhsDesign.ProposalNeosUiEsmPluginLoader

for fully compatibility with type=esm plugins build via our new esbuild extension point

Usage:

`Neos.Neos.Ui.resources.javascript` and `stylesheets`
can make use of the proposed `attributes` array.

```yaml
Neos:
  Neos:
    Ui:
      resources:
        javascript:
          'My.Cool:Plugin':
            resource: 'resource://My.Cool/Public/NeosUserInterface/Plugin.js'
            # legacy first level attribute 'defer'
            # defer: true

            # NEW Attributes!
            attributes:
              type: "module"
              defer: true
              any: "thing"

        stylesheets:
          'My.Cool:Plugin':
            # NEW Attributes!
            attributes:
              any: "thing"
```

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
