### PR TITLE
BUGFIX: Resolve console errors while jests test

### DIFF
--- a/packages/neos-ui-editors/src/_lib/testUtils.js
+++ b/packages/neos-ui-editors/src/_lib/testUtils.js
@@ -38,7 +38,9 @@ export const MockDataSourceDataLoader = {
         return this._currentPromise;
     }
 };
-globalRegistry.set('inspector', new SynchronousRegistry());
+
+const inspector = globalRegistry.set('inspector', new SynchronousMetaRegistry());
+inspector.set('editors', new SynchronousRegistry());
 globalRegistry.set('dataLoaders', new SynchronousRegistry());
 globalRegistry.get('dataLoaders').set('DataSources', MockDataSourceDataLoader);
 

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.spec.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.spec.js
@@ -12,12 +12,14 @@ test(`PropertyGroup > is rendered`, () => {
         {
             id: '1',
             type: 'editor',
+            editor: '',
             label: 'Foo',
             hidden: false
         },
         {
             id: '2',
             type: 'editor',
+            editor: '',
             label: 'Bar',
             hidden: true
         }


### PR DESCRIPTION
When we run our `jest` test we have plenty of console.errors in the output. That is distracting and should not happen.

We want to prevent errors like `Warning: Failed prop type: The prop `editorRegistry` is marked as required in `EditorEnvelope`, but its value is `null`.`

**What I did**
Walked through all packages and searched which packages were effected.

- [x] neos-ui
- [ ] neos-ui-editors
- [ ] neos-ui-sagas
