### PR TITLE
Add try-catch in publishAction of BackendServiceController.php to...

### DIFF
--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -432,7 +432,7 @@ class BackendServiceController extends ActionController
 
         /** @var array<int,NodeAddress> $nodeAddresses */
         $nodeAddresses = array_map(
-            fn(string $serializedNodeAddress) => $nodeAddressFactory->createFromUriString($serializedNodeAddress),
+            fn (string $serializedNodeAddress) => $nodeAddressFactory->createFromUriString($serializedNodeAddress),
             $nodes
         );
         $this->clipboard->copyNodes($nodeAddresses);
@@ -464,7 +464,7 @@ class BackendServiceController extends ActionController
 
         /** @var array<int,\Neos\Neos\FrontendRouting\NodeAddress> $nodeAddresses */
         $nodeAddresses = array_map(
-            fn(string $serializedNodeAddress) => $nodeAddressFactory->createFromUriString($serializedNodeAddress),
+            fn (string $serializedNodeAddress) => $nodeAddressFactory->createFromUriString($serializedNodeAddress),
             $nodes
         );
 
@@ -590,7 +590,7 @@ class BackendServiceController extends ActionController
         /** @var array<int,mixed> $payload */
         $payload = $createContext['payload'] ?? [];
         $flowQuery = new FlowQuery(array_map(
-            fn($envelope) => $this->nodeService->getNodeFromContextPath($envelope['$node'], $contentRepositoryId),
+            fn ($envelope) => $this->nodeService->getNodeFromContextPath($envelope['$node'], $contentRepositoryId),
             $payload
         ));
 

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -242,7 +242,10 @@ class BackendServiceController extends ActionController
                     )
                 )->block();
             } catch (NodeAggregateCurrentlyDoesNotExist $e) {
-                throw new NodeAggregateCurrentlyDoesNotExist('Node could not be published, probably because of a missing parentNode. Please check that the parentNode has been published.', 1682762156);
+                throw new NodeAggregateCurrentlyDoesNotExist(
+                    'Node could not be published, probably because of a missing parentNode. Please check that the parentNode has been published.',
+                    1682762156
+                );
             }
 
             $success = new Success();


### PR DESCRIPTION
...improve error message and make it understandle for editors.

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

**Issue description**
When you create a new page node and then create a second page as a childNode and then try to publish it without having published the parentNode first, you encounter an error. The node can't be published, because it is missing the node aggregate of the parentNode.

**What I did**
Since this behaviour is correct, but the error message is rather cryptic, I improved the error handling.

**How I did it**
I added a try catch block to the publishAction in the BackendServiceController and gave it a new error message with a hint that the parentNode might not have been published.

**How to verify it**
Create a page without publishing it. Created a nested page and publish that. You will encounter a error message saying "Node could not be published, probably because of a missing parentNode. Please check that the parentNode has been published."
<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
