### PR TITLE
BUGFIX: Properly handle object identity DTOs in select box editor

### DIFF
--- a/packages/neos-ui-editors/src/Editors/SelectBox/createSelectBoxValueStringFromPossiblyStrangeNodePropertyValue.spec.ts
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/createSelectBoxValueStringFromPossiblyStrangeNodePropertyValue.spec.ts
@@ -1,0 +1,24 @@
+import {createSelectBoxValueStringFromPossiblyStrangeNodePropertyValue} from './createSelectBoxValueStringFromPossiblyStrangeNodePropertyValue';
+
+describe('createSelectBoxValueStringFromPossiblyStrangeNodePropertyValue', () => {
+    it('accepts value of type "string" and returns a "string"', () => {
+        const value =
+            createSelectBoxValueStringFromPossiblyStrangeNodePropertyValue(
+                'I am already a valid select box value, believe it or not.'
+            );
+
+        expect(value).toEqual(
+            'I am already a valid select box value, believe it or not.'
+        );
+    });
+
+    it('accepts an object identity DTO and returns a "string"', () => {
+        const value =
+            createSelectBoxValueStringFromPossiblyStrangeNodePropertyValue({
+                __identity: 'de93b358-cb77-422e-b295-2f219bfc4dfb',
+                __type: 'Neos\\Media\\Domain\\Model\\Tag',
+            });
+
+        expect(value).toEqual('de93b358-cb77-422e-b295-2f219bfc4dfb');
+    });
+});

--- a/packages/neos-ui-editors/src/Editors/SelectBox/createSelectBoxValueStringFromPossiblyStrangeNodePropertyValue.ts
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/createSelectBoxValueStringFromPossiblyStrangeNodePropertyValue.ts
@@ -1,0 +1,36 @@
+/**
+ * @TODO I am a cry for help!
+ *
+ * This is an ad-hoc solution to the problem that properties of a PHP class type
+ * (like "Neos\Media\Domain\Model\Tag" for example) may or may not be persisted
+ * as object identity DTOs.
+ *
+ * The function name is intentionally kept vague to allow bugfixes to capture
+ * more, potentially obscure cases in which the persisted property value needs
+ * to be filtered before the select box receives it.
+ *
+ * A proper way to handle this would be to define precisely what kind of values
+ * the select box editor is going to accept and simply reject everything that
+ * violates that definition. Errors would need to be handled in way that
+ * indicates to editors that there's a problem that an integrator needs to fix.
+ * Furthermore the error handling should make it easy for integrators to figure
+ * out what value has been provided to the select box and why it has been
+ * rejected.
+ *
+ * That however would constitute a breaking change and that's how we end up
+ * with with this function.
+ */
+export const createSelectBoxValueStringFromPossiblyStrangeNodePropertyValue = (
+    value: unknown
+) => {
+    if (typeof value === 'object' && value !== null) {
+        if (
+            '__identity' in value &&
+            typeof (value as Record<'__identity', any>).__identity === 'string'
+        ) {
+            return (value as Record<'__identity', string>).__identity;
+        }
+    }
+
+    return value;
+};


### PR DESCRIPTION
fixes: #2553 

**The Problem**

A node property value may be persisted as an object identity DTO:
```json
{
  "__identity": "bef64ff9-4c58-4104-bee6-1395eff1e303",
  "__type": "Vendor\\Package\\Type"
}
```

If this is the case and the property is configured to be edited via select box, the persisted serialized object identity DTO is not recognized by the selectbox.

**Reproduction**

You'll need to prepare the following files:

*[Insert Path To Package]/Configuration/NodeTypes.[Insert Some Content Node Type Name].yaml:*
```yaml
'Vendor.Site:Content.SomeContent':
  # ...
  properties:

    tag:
      type: Neos\Media\Domain\Model\Tag
      defaultValue: null
      ui:
        label: 'Tag'
        reloadIfChanged: true
        inspector:
          group: example
          editorOptions:
            allowEmpty: true

    heckLetsAddABunchOfMoreTags:
      type: array<Neos\Media\Domain\Model\Tag>
      ui:
        label: 'Too many tags 😱'
        inspector:
          group: example
          editorOptions:
            multiple: true
```
☝️ This one's to have an example with two select box editors covering both the single-select and the multi-select case. You may add this to any existing node type or create a new one (can be a document as well).

*[Insert Path To Package]/Configuration/Settings.Neos.Neos.yaml:*
```yaml
Neos:
  Neos:
    userInterface:
      inspector:
        dataTypes:
          Neos\Media\Domain\Model\Tag:
            typeConverter: Neos\Neos\TypeConverter\EntityToIdentityConverter
            editor: Neos.Neos/Inspector/Editors/SelectBoxEditor
            editorOptions:
              dataSourceIdentifier: 'tag-data-source'
          array<Neos\Media\Domain\Model\Tag>:
            typeConverter: Neos\Flow\Property\TypeConverter\TypedArrayConverter
            editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
            editorOptions:
              dataSourceIdentifier: 'tag-data-source'
```
☝️ This one's to achieve default type conversion and editor assignment for `Neos\Media\Domain\Model\Tag` and it's array counterpart. Funny side note: #2553 seems to suggest that this is actually supposed to be the default. During my research I was unable to confirm this, but it would make sense :)

*[Insert Path To Package]/Classes/Application/DataSource/TagDataSource.php:*
```php
<?php

/*
 * This script belongs to the package "Vendor.Site".
 *
 * This package is Open Source Software. For the full copyright and license
 * information, please view the LICENSE file which was distributed with this
 * source code.
 */

declare(strict_types=1);

namespace Vendor\Site\Application\DataSource;

use Neos\Flow\Annotations as Flow;
use Neos\Neos\Service\DataSource\AbstractDataSource;
use Neos\ContentRepository\Domain\Model\NodeInterface;
use Neos\Flow\Persistence\Doctrine\PersistenceManager;
use Neos\Media\Domain\Repository\TagRepository;

#[Flow\Scope("singleton")]
final class TagDataSource extends AbstractDataSource
{
    /**
     * @var string
     */
    static protected $identifier = 'tag-data-source';

    /**
     * @Flow\Inject(lazy=false)
     * @var TagRepository
     */
    protected $tagRepository;

    /**
     * @Flow\Inject(lazy=false)
     * @var PersistenceManager
     */
    protected $persistenceManager;

    /**
     * Get data
     *
     * {@inheritdoc}
     */
    public function getData(NodeInterface $node = NULL, array $arguments = [])
    {
        $tags = $this->tagRepository->findAll();
        $result = [];

        foreach ($tags as $tag) {
            $result[] = [
                'value' => $this->persistenceManager->getIdentifierByObject($tag),
                'icon' => 'tag',
                'label' => $tag->getLabel()
            ];
        }

        return $result;
    }
}

```

☝️ This is the data source that provides our select boxes from above with options straight from the Media package's tag repository. 

For reproduction, just add a node of the type from above and see what happens if you set the select box to a value and then reload.

**The solution**

It's a bit of a lazy solution, but I couldn't think of anything more sophisticated that wouldn't break the select box editor. The gist is: I added a function that pre-processes incoming select box editor values and converts any detected object identity DTO down to it's string-based identity.