### PR TITLE
BUGFIX: Hide in-between drop targets in tree component unless there's a drag operation happening

### DIFF
--- a/packages/react-ui-components/src/Tree/node.css
+++ b/packages/react-ui-components/src/Tree/node.css
@@ -115,6 +115,11 @@
     right: 0;
     padding-left: 15px;
     height: 2px;
+    visibility: hidden;
+
+    [data-is-drag-happening] & {
+        visibility: visible;
+    }
 }
 .dropTarget--before {
     top: -5px;

--- a/packages/react-ui-components/src/Tree/reactDndScrollzoneFork.js
+++ b/packages/react-ui-components/src/Tree/reactDndScrollzoneFork.js
@@ -164,9 +164,17 @@ export default function createScrollingComponent(WrappedComponent) {
 
             if (!this.dragging && isDragging) {
                 this.dragging = true;
+
+                if (this.wrappedInstance) {
+                    this.wrappedInstance.setAttribute('data-is-drag-happening', 'true');
+                }
             } else if (this.dragging && !isDragging) {
                 this.dragging = false;
                 this.stopScrolling();
+
+                if (this.wrappedInstance) {
+                    this.wrappedInstance.removeAttribute('data-is-drag-happening');
+                }
             }
         }
 


### PR DESCRIPTION
fixes: #2740 

**The problem**

Each node in the tree component is accompanied by up to 2 additional dom nodes that act as a drop target, so that nodes can be moved alongside other nodes.

These additional dom nodes overlay the tree nodes by a slight margin, so that the tree node is not entirely clickable.

**The solution**

I followed @Sebobo's suggestion from #2740:
> @dimaip can we somehow detect if a drag is going on, and if not hide all those drop targets?
We really don't need them if nothing is dragged.

<s>I did that by utilizing the decorator API of `react-dnd`, asking the `DropTargetMonitor` for the current item type via `getItemType()`, which as per documentation returns `null` if there's no drag operation going on (see: https://react-dnd.github.io/react-dnd/docs/api/drop-target-monitor).</s>

**EDIT:** Following @Sebobo's hint regarding performance, I changed the mechanism for drag recognition. It is now done on tree-level by adding a `[data-is-drag-happening]` data-attribute on the outer-most DOM node. (This is a bit hacky, because I'm circumventing React's state management - this is done to prevent re-rendering)

@dimaip noted that
> we should make sure that it doesn't start jumping on drag start

I did so by managing the visibility of the in-between drop targets via `visibility: hidden` so that any space they might occupy will be reserved regardless of whether they're visible or not.

**EDIT:** Plus, again following @Sebobo's hint regarding performance, the visibility is now managed via CSS only.