### PR TITLE
BUGFIX: Perform additional search for links that look like externals or emails

### DIFF
--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -128,6 +128,10 @@
                 <source>Format as email?</source>
         <target xml:lang="de">Formatieren als E-Mail?</target>
       </trans-unit>
+      <trans-unit id="ckeditor__toolbar__link__formatOptions" xml:space="preserve" approved="yes">
+                <source>Format options</source>
+        <target xml:lang="de">Formatierungsoptionen</target>
+      </trans-unit>
       <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
                 <source>Ordered list</source>
         <target xml:lang="de" state="translated">Geordnete Liste</target>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -107,6 +107,9 @@
             <trans-unit id="ckeditor__toolbar__link__formatAsEmail" xml:space="preserve">
                 <source>Format as email?</source>
             </trans-unit>
+            <trans-unit id="ckeditor__toolbar__link__formatOptions" xml:space="preserve">
+                <source>Format options</source>
+            </trans-unit>
             <trans-unit id="ckeditor__toolbar__ordered-list" xml:space="preserve">
                 <source>Ordered list</source>
             </trans-unit>

--- a/packages/neos-ui-editors/src/Library/LinkInput.js
+++ b/packages/neos-ui-editors/src/Library/LinkInput.js
@@ -150,41 +150,41 @@ export default class LinkInput extends PureComponent {
     handleSearchTermChange = searchTerm => {
         this.setState({searchTerm});
 
-        if (looksLikeExternalLink(searchTerm)) {
-            this.setState({
-                isLoading: false,
-                searchOptions: [{
-                    label: this.props.i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__formatAsHttp', 'Format as https link?'),
-                    loaderUri: `https://${searchTerm}`
-                }]
-            });
-        } else if (isEmail(searchTerm)) {
-            this.setState({
-                isLoading: false,
-                searchOptions: [{
-                    label: this.props.i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__formatAsEmail', 'Format as email?'),
-                    loaderUri: `mailto:${searchTerm}`
-                }]
-            });
-        } else if (isUriOrInternalLink(searchTerm)) {
+        if (isUriOrInternalLink(searchTerm)) {
             this.setState({
                 isLoading: false,
                 searchOptions: []
             });
         } else if (searchTerm) {
-            this.setState({isLoading: true, searchOptions: []});
             // We store the searchTerm at the moment lookup was triggered, and only update the options if the search term hasn't changed
             const searchTermWhenLookupWasTriggered = searchTerm;
+            const groupedSearchOptions = [];
+
+            if (looksLikeExternalLink(searchTermWhenLookupWasTriggered)) {
+                groupedSearchOptions.push({
+                    label: this.props.i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__formatAsHttp', 'Format as https link?'),
+                    loaderUri: `https://${searchTermWhenLookupWasTriggered}`
+                });
+            } else if (isEmail(searchTermWhenLookupWasTriggered)) {
+                groupedSearchOptions.push({
+                    label: this.props.i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__formatAsEmail', 'Format as email?'),
+                    loaderUri: `mailto:${searchTermWhenLookupWasTriggered}`
+                });
+            }
+
+            this.setState({isLoading: true, searchOptions: groupedSearchOptions});
+
             this.props.linkLookupDataLoader.search(this.getDataLoaderOptions(), searchTerm)
                 .then(searchOptions => {
                     if (searchTermWhenLookupWasTriggered === this.state.searchTerm) {
-                        const groupedSearchOption = searchOptions.map(searchOption => {
+                        searchOptions.forEach(searchOption => {
                             searchOption.group = 'assetSourceLabel' in searchOption ? searchOption.assetSourceLabel : this.props.i18nRegistry.translate('Neos.Neos:Main:document');
-                            return searchOption;
+                            groupedSearchOptions.push(searchOption);
                         });
+
                         this.setState({
                             isLoading: false,
-                            searchOptions: groupedSearchOption
+                            searchOptions: [...groupedSearchOptions]
                         });
                     }
                 });

--- a/packages/neos-ui-editors/src/Library/LinkInput.js
+++ b/packages/neos-ui-editors/src/Library/LinkInput.js
@@ -162,11 +162,13 @@ export default class LinkInput extends PureComponent {
 
             if (looksLikeExternalLink(searchTermWhenLookupWasTriggered)) {
                 groupedSearchOptions.push({
+                    group: this.props.i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__formatOptions', 'Format options'),
                     label: this.props.i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__formatAsHttp', 'Format as https link?'),
                     loaderUri: `https://${searchTermWhenLookupWasTriggered}`
                 });
             } else if (isEmail(searchTermWhenLookupWasTriggered)) {
                 groupedSearchOptions.push({
+                    group: this.props.i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__formatOptions', 'Format options'),
                     label: this.props.i18nRegistry.translate('Neos.Neos.Ui:Main:ckeditor__toolbar__link__formatAsEmail', 'Format as email?'),
                     loaderUri: `mailto:${searchTermWhenLookupWasTriggered}`
                 });


### PR DESCRIPTION
fixes: #3016 

|before|after|
|-|-|
|![Screenshot_2023-05-11_16-44-44 3016 - before](https://github.com/neos/neos-ui/assets/2522299/54d0af89-c71a-4eac-ae3b-0bb7a8b48561)|![Screenshot_2023-05-12_12-22-58 3016 - after 2](https://github.com/neos/neos-ui/assets/2522299/f1041e4e-6ff0-4a24-be99-399fde4c98c9) |

**The problem**

The link input will recognize certain strings as E-Mail addresses or probable external links (with very broad coverage there). If it does so, it won't perform a search on nodes or assets but will immediately show a suggestion like "Format as external link?".

It is however quite possible that the user is actually searching for a document or asset that is titled after an E-mail address or anything that may look like a domain. #3016 mentions an example of a document with an SKU as a title that was recognized as an external link and thus could not be found by the link input.

**The solution**

@RobReckham suggested in #3016 to adjust how `looksLikeExternalLink` recognizes external links. I figured however that it may be too difficult to find an actually satisfactory regex that would cover all possible scenarios properly.

So, I decided to go a different route and leave the algorithm as it is. Instead, the link input now performs the search for nodes and assets even if the input looks like an E-Mail address or external link. The actions "Format as external link?" or "Format as e-mail?" are still being displayed if `looksLikeExternalLink` recognizes the input as such, but they're now entirely optional.