### PR TITLE
BUGFIX: Remove needless blur filter on unapplied changes overlay

### DIFF
--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/style.css
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/style.css
@@ -50,7 +50,6 @@
     width: calc(100% - var(--size-SidebarWidth));
     height: 100%;
     z-index: var(--zIndex-UnappliedChangesOverlay-Context);
-    filter: blur(5px);
     &,
     &::after {
         position: fixed;


### PR DESCRIPTION
fixes: #3488 

**The problem**

I've stumbled across an oddity while debugging the unapplied changes overlay. When applying a background color to the container, you'll notice a slight blur at the edge:

![Screenshot_2023-05-12_12-33-21 - needless blur filter](https://github.com/neos/neos-ui/assets/2522299/68d0ec80-e447-4d3c-81e2-ac97025a7f06)

I was thinking that maybe this was an attempt to blur the content canvas when there are unapplied changes, which would look like this:

![Screenshot_2023-05-12_13-35-20 - 3488 maybe](https://github.com/neos/neos-ui/assets/2522299/24e08925-d36c-498a-b673-843d91080fd4)

If so, the attempt has been ineffective.

**The solution**

I've removed the `filter: blur(5px)` statement from the unapplied changes overlay.