### PR TITLE
BUGFIX: Consider content role of reference node while calculating enabled state of add button

### DIFF
--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/AddNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/AddNode/index.js
@@ -15,8 +15,13 @@ import {neos} from '@neos-project/neos-ui-decorators';
 
     return state => {
         const focusedNodeContextPath = selectors.CR.Nodes.focusedNodePathSelector(state);
+        const getNodeByContextPathSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector(focusedNodeContextPath);
+        const focusedNode = getNodeByContextPathSelector(state);
+
+        const role = focusedNode ? (nodeTypesRegistry.hasRole(focusedNode.nodeType, 'document') ? 'document' : 'content') : null;
         const isAllowedToAddChildOrSiblingNodes = isAllowedToAddChildOrSiblingNodesSelector(state, {
-            reference: focusedNodeContextPath
+            reference: focusedNodeContextPath,
+            role
         });
 
         return {

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/index.js
@@ -311,8 +311,10 @@ const makeMapStateToProps = isDocument => (state, {nodeTypesRegistry}) => {
 
         const isHidden = $get('properties._hidden', focusedNode);
 
+        const role = focusedNode ? (nodeTypesRegistry.hasRole(focusedNode.nodeType, 'document') ? 'document' : 'content') : null;
         const isAllowedToAddChildOrSiblingNodes = isAllowedToAddChildOrSiblingNodesSelector(state, {
-            reference: focusedNodeContextPath
+            reference: focusedNodeContextPath,
+            role
         });
         const isHiddenContentTree = $get('ui.leftSideBar.contentTree.isHidden', state);
 


### PR DESCRIPTION
fixes: #2929 

**The problem**

We have three toolbars through which a node can be created: The document tree toolbar, the content tree toolbar and the inline UI toolbar. When using the "add node" button on the latter two, the selection of node types is being calculated in a slightly different way than in the document tree toolbar.

The problem is that an editor would expect the content tree toolbar and the inline UI toolbar to exclusively deal with *contents* on the currently active document. The content repository however knows no difference between *content* nodes and *document* nodes. So in theory, when I select a content collection, the node type selection dialog should offer me all kinds of document nodes as possible siblings.

This is why we entered the concept of node type roles. A given node type can either have the role "document" or the role "content". When the editor hits the "add node" button on the content tree toolbar or the inline UI toolbar, the list of node types in the resulting node type selection dialog will be stripped down to only include node types with the role "content".

This distinction is missing from the algorithm that calculates the enabled state of the respective "add node" button, which results in possible scenarios in which the "add node" button can be clicked, but the resulting node type selection dialog is empty. (as described in #2929)

**The solution**

I added the appropriate node type role for the reference node to the respective `isAllowedToAddChildOrSiblingNodesSelector` calls in both the content tree toolbar and the inline UI toolbar containers.