### PR TITLE
BUGFIX: Sync frame component location after in-frame navigation happened

### DIFF
--- a/packages/react-ui-components/src/Frame/frame.tsx
+++ b/packages/react-ui-components/src/Frame/frame.tsx
@@ -132,10 +132,25 @@ export default class Frame extends PureComponent<FrameProps> {
             transitioning: false
         });
 
-        const {onLoad} = this.props;
+        if (this.ref) {
+            const {onLoad} = this.props;
 
-        if (typeof onLoad === 'function' && this.ref) {
-            onLoad(e);
+            if (typeof onLoad === 'function') {
+                onLoad(e);
+            }
+
+            // Sync with iframe window location, in case the latest navigation
+            // happened in-frame (e.g. via click on link)
+            try {
+                const win = this.ref.contentWindow;
+                if (win && win.location.href !== this.state.location) {
+                    this.setState({
+                        location: win.location.href
+                    });
+                }
+            } catch {
+                // This almost definitely means we've lost access to the iframe
+            }
         }
     }
 


### PR DESCRIPTION
fixes: #2954 

**The problem**

The `<Frame/>`-component tracks its own window location through its internal `location` state. Whenever it receives a new `src` prop, it checks against its `location` state to decide whether or not it needs to actually change its window location.

This tracking mechanism covers every navigation event triggered by the document tree or dimension selector, but it misses all navigation events that happen inside the frame (e.g. through click on a link). This leads to strange behavior (as described in #2954) when an in-frame navigation happens and afterwards you try to navigate back to the document that the `<Frame/>`-component happens to have stored as its latest internal `location` state.

***NOTE:** #2954 mentions that this behavior occurs only if the navigated-to documents are hidden (via `baseNodeType` in node tree preset setting) in the document tree. I found that this actually happens regardless of those documents being hidden in the document tree.*

**The solution**

A adjusted the `onLoad`-handler of our `<Frame/>`-component, so that it stores the latest window location inside the internal `location` state. This way the internal state tracks in-frame navigation events as well.