### PR TITLE
BUGFIX: Properly pause mousetrap during inline editing

### DIFF
--- a/packages/neos-ui-sagas/src/UI/Hotkeys/index.js
+++ b/packages/neos-ui-sagas/src/UI/Hotkeys/index.js
@@ -37,7 +37,7 @@ export function * handleHotkeys({globalRegistry, store}) {
 
         // Pause mousetrap during inline editing
         if (action.type === actionTypes.UI.ContentCanvas.SET_CURRENTLY_EDITED_PROPERTY_NAME) {
-            mousetrapPaused = action.payload.propertyName !== '';
+            mousetrapPaused = action.payload !== '';
         }
     }
 }


### PR DESCRIPTION
fixes: #3099 

**The problem**

We have a `Hotkeys` saga that initializes a `Mousetrap` (see: https://www.npmjs.com/package/mousetrap). The saga does so once for the host frame. For the guest frame it then initializes a separate `Mousetrap` every time, a document has been loaded.

In theory this should ensure that keyboard shortcuts work both in the host and in the guest frame. There's one specific scenario though in which we do not want keyboard shortcuts to work at all and that is: inline editing (basically, because typing something into CKEditor would otherwise trigger all kinds of unintended actions).

This is why the `Hotkeys` saga tracks a `mousetrapPaused` flag. The idea is to pause the mousetrap every time the content canvas signals that there's inline editing going on:

https://github.com/neos/neos-ui/blob/ef72c79b8cbc94cdaf58a3941953aedae8ea8f7c/packages/neos-ui-sagas/src/UI/Hotkeys/index.js#L39-L41

#3099 describes that the hot keys do not work inside the guest frame at all. I found that this is due to `mousetrapPaused` always being `true`.

Looking at the declaration of the action creator for `SET_CURRENTLY_EDITED_PROPERTY_NAME`:

https://github.com/neos/neos-ui/blob/ef72c79b8cbc94cdaf58a3941953aedae8ea8f7c/packages/neos-ui-redux-store/src/UI/ContentCanvas/index.ts#L59

I could see that the payload for `SET_CURRENTLY_EDITED_PROPERTY_NAME` is not an object with a key `propertyName`, but a string that represents just the property name. So, the condition `action.payload.propertyName !== ''` is always true, because `action.payload.propertyName` is always `undefined`.

**The solution**

I changed the condition for `mousetrapPaused` to

```js
mousetrapPaused = action.payload !== '';
```

to match the intended semantics with the action creator definition for `SET_CURRENTLY_EDITED_PROPERTY_NAME`. Now keyboard shortcuts work as intended in the guest frame, but are ignored if there's inline editing going on.