### PR TITLE
BUGFIX: Check for unapplied inspector changes before allowing focus change via `<SelectedElement/>`

### DIFF
--- a/packages/neos-ui-redux-store/src/UI/Inspector/index.ts
+++ b/packages/neos-ui-redux-store/src/UI/Inspector/index.ts
@@ -41,6 +41,7 @@ export enum actionTypes {
     DISCARD = '@neos/neos-ui/UI/Inspector/DISCARD',
     ESCAPE = '@neos/neos-ui/UI/Inspector/ESCAPE',
     RESUME = '@neos/neos-ui/UI/Inspector/RESUME',
+    ELEMENT_WAS_SELECTED = '@neos/neos-ui/UI/Inspector/ELEMENT_WAS_SELECTED',
 
     //
     // Actions to control the secondary inspector window
@@ -61,6 +62,10 @@ const apply = () => createAction(actionTypes.APPLY);
 const discard = (focusedNodeContextPath: NodeContextPath) => createAction(actionTypes.DISCARD, {focusedNodeContextPath});
 const escape = () => createAction(actionTypes.ESCAPE);
 const resume = () => createAction(actionTypes.RESUME);
+const selectElement = (selectedElementContextPath: NodeContextPath) =>
+    createAction(actionTypes.ELEMENT_WAS_SELECTED, {
+        selectedElementContextPath,
+    });
 
 const openSecondaryInspector = () => createAction(actionTypes.SECONDARY_OPEN);
 const closeSecondaryInspector = () => createAction(actionTypes.SECONDARY_CLOSE);
@@ -76,9 +81,10 @@ export const actions = {
     discard,
     escape,
     resume,
+    selectElement,
     openSecondaryInspector,
     closeSecondaryInspector,
-    toggleSecondaryInspector
+    toggleSecondaryInspector,
 };
 
 export type Action = ActionType<typeof actions>;

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/SelectedElement/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/SelectedElement/index.js
@@ -23,22 +23,22 @@ import style from './style.css';
         focusedNodeParentLine: selectors.CR.Nodes.focusedNodeParentLineSelector(state)
     };
 }, {
-    focusNode: actions.CR.Nodes.focus
+    selectElement: actions.UI.Inspector.selectElement
 })
 export default class SelectedElement extends PureComponent {
     static propTypes = {
         focusedNode: PropTypes.object.isRequired,
         focusedNodeParentLine: PropTypes.array.isRequired,
 
-        focusNode: PropTypes.func.isRequired,
+        selectElement: PropTypes.func.isRequired,
         nodeTypesRegistry: PropTypes.object.isRequired
     };
 
     handleSelectNode = selectedNodeContextPath => {
-        const {focusNode, focusedNode} = this.props;
+        const {selectElement, focusedNode} = this.props;
 
         if (selectedNodeContextPath && selectedNodeContextPath !== $get('contextPath', focusedNode)) {
-            focusNode(selectedNodeContextPath);
+            selectElement(selectedNodeContextPath);
         }
     };
 

--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -565,8 +565,14 @@ manifest('main', {}, globalRegistry => {
                 nodes
             })
         );
-        store.dispatch(actions.CR.Nodes.focus(contextPath, fusionPath));
-        store.dispatch(actions.UI.ContentCanvas.requestScrollIntoView(true));
+
+        const currentlyFocusedNodeContextPaths =
+            selectors.CR.Nodes.focusedNodePathsSelector(store.getState());
+
+        if (currentlyFocusedNodeContextPaths.includes(contextPath)) {
+            store.dispatch(actions.CR.Nodes.focus(contextPath, fusionPath));
+            store.dispatch(actions.UI.ContentCanvas.requestScrollIntoView(true));
+        }
     });
 
     //


### PR DESCRIPTION
fixes: #3174 

**The problem**

#3174 describes a way to bypass the "Unapplied Changes"-dialog that is supposed to prevent the user from losing pending inspector changes.

The user can focus a different node by using the `<SelectedElement/>` container that is always at the top of the inspector:
![image](https://github.com/neos/neos-ui/assets/2522299/db93bb3b-1624-4f6a-95fb-5043ee94e597)

This works, because the "Unapplied Changes"-dialog is exclusively triggered by an overlay that appears, when there are pending changes, and covers the entire UI (after https://github.com/neos/neos-ui/pull/3491 has been merged that is) except the inspector. Since the `<SelectedElement/>` container is part of the inspector, it is not covered by the overlay and thus allows the user to bypass the "Unapplied Changes"-dialog.

**The solution**

The first part of the solution introduces a new redux action to the inspector state called `ELEMENT_WAS_SELECTED`. *(The naming is up for discussion, since it introduces past-tense as opposed to imperatives - which is more correct but runs counter the established convention. It may or may not be a confusing name anyway though - idk)*

The inspector saga is then used to handle `ELEMENT_WAS_SELECTED` actions so that it first checks if there are pending changes in the inspector, triggers the "Unapplied Changes"-dialog if so, and - depending on the result of the latter - focuses the selected node or leaves the state untouched.

The second part of the solution concerns the handling of the `Neos.Neos.Ui:ReloadContentOutOfBand` server feedback. I noticed that if I selected an element and then clicked on "apply" in the "Unapplied Changes"-dialog, the node I've selected would be focused for a brief moment, after which the UI jumped back to the previously focused node. 

The reason for this was, that the server feedback handler for `Neos.Neos.Ui:ReloadContentOutOfBand` wanted to re-focus the node it just reloaded, without checking whether it was still *supposed* to be focused. I added a check for that, so that no jumping occurs anymore.