### PR TITLE
BUGFIX: Add dirty-state highlighting to RangeEditor

### DIFF
--- a/packages/neos-ui-editors/src/Editors/Range/index.js
+++ b/packages/neos-ui-editors/src/Editors/Range/index.js
@@ -77,7 +77,7 @@ class RangeEditor extends PureComponent {
                     min={options.min}
                     max={options.max}
                     step={options.step}
-                    value={value}
+                    value={value || ''}
                     className="slider"
                     onChange={this.handleChange}
                     disabled={options.disabled}
@@ -92,7 +92,7 @@ class RangeEditor extends PureComponent {
                             type="text"
                             onKeyPress={this.onKeyPress}
                             onChange={this.handleChange}
-                            value={value}
+                            value={value || ''}
                             style={ {width: `${options.max.toString().length}ch`} }
                             disabled={options.disabled}
                         />

--- a/packages/neos-ui-editors/src/Editors/Range/index.js
+++ b/packages/neos-ui-editors/src/Editors/Range/index.js
@@ -1,5 +1,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 import {neos} from '@neos-project/neos-ui-decorators';
 import style from './style.css';
 
@@ -21,7 +22,8 @@ class RangeEditor extends PureComponent {
             minLabel: PropTypes.string,
             maxLabel: PropTypes.string,
             disabled: PropTypes.bool
-        })
+        }),
+        highlight: PropTypes.bool
     };
 
     static defaultProps = {
@@ -60,10 +62,16 @@ class RangeEditor extends PureComponent {
 
     render() {
         const options = {...this.constructor.defaultProps.options, ...this.props.options};
-        const {value} = this.props;
+        const {value, highlight} = this.props;
 
         return (
-            <div className={style.rangeEditor + (options.disabled ? ' ' + style.rangeEditorDisabled : '')}>
+            <div
+                className={cx(
+                    style.rangeEditor,
+                    options.disabled && style.rangeEditorDisabled,
+                    highlight && style.rangeEditorHighlight,
+                )}
+            >
                 <input
                     type="range"
                     min={options.min}

--- a/packages/neos-ui-editors/src/Editors/Range/style.css
+++ b/packages/neos-ui-editors/src/Editors/Range/style.css
@@ -7,6 +7,10 @@
     width: 100%;
     border-radius: 2px;
 }
+.rangeEditor.rangeEditorHighlight input[type='range'] {
+    box-shadow: 0 0 0 2px var(--colors-Warn);
+    border-radius: 2px;
+}
 
 .rangeEditor input[type='range']::-webkit-slider-thumb {
     appearance: none;


### PR DESCRIPTION
fixes: #3499, #3500

**The problem**

#3499 describes that the `RangeEditor` is lacking dirty-state highlighting. The reason is that the highlighting-style is usually forwarded through the `<EditorEnvelope/>`-component, which in the case of the `RangeEditor` isn't happening.

#3500 describes that hitting "Discard" at the bottom of the Inspector does not reset the inputs of the `RangeEditor`. There are two inputs, one with `type="range"` and another one with `type="text"` that is rendered at the bottom and reflects the same (numerical) value. 

Both inputs receive the value without fallback. When the edited property is empty, they receive `null` which confuses React and leads to the following console warning:

![image](https://github.com/neos/neos-ui/assets/2522299/6090d6fd-1ef1-4672-81d3-67acf45323c1)
> Warning: `value` prop on `input` should not be null. Consider using an empty string to clear the component or `undefined` for uncontrolled components.

When the value is edited any non-null value is reflected through the inputs. On "Discard" however, the value is reset to `null`, which React then ignores.

**The solution**

For #3499 I added a simple highlight-style:
![image](https://github.com/neos/neos-ui/assets/2522299/181349f0-adc7-4289-b97a-995da24b076e)

For #3500 I added fallbacks to empty string for the value assignments on the inputs (`value={value || ''}`), which leads React to correctly treat them as controlled inputs.