### PR TITLE
BUGFIX: Fix accessing nodeAggregateId during content reload

### DIFF
--- a/Classes/Domain/Model/Feedback/Operations/ReloadContentOutOfBand.php
+++ b/Classes/Domain/Model/Feedback/Operations/ReloadContentOutOfBand.php
@@ -76,7 +76,7 @@ class ReloadContentOutOfBand extends AbstractFeedback
 
     public function getDescription(): string
     {
-        return sprintf('Rendering of node "%s" required.', $this->node?->nodeAggregateId ?: '');
+        return sprintf('Rendering of node "%s" required.', $this->node?->nodeAggregateId->value);
     }
 
     /**


### PR DESCRIPTION
**How to verify it**

Change a property which has the setting `reloadIfChanged: true`. You will get the flash message "Object of class Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId could not be converted to string".