### PR TITLE
BUGFIX: CreationDialog hideable elements

### DIFF
--- a/packages/neos-ts-interfaces/src/index.ts
+++ b/packages/neos-ts-interfaces/src/index.ts
@@ -192,6 +192,7 @@ export interface NodeType {
                 [propName: string]: {
                     type?: string;
                     ui?: {
+                        hidden?: boolean|string;
                         label?: string;
                         editor?: string;
                         editorOptions?: {

--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
@@ -282,7 +282,8 @@ export default class NodeCreationDialog extends PureComponent {
         return Object.keys(configuration.elements).reduce(
             (result, elementName, index) => {
                 const element = configuration.elements[elementName];
-                if (element) {
+                const isHidden = $get('ui.hidden', element);
+                if (element && !isHidden) {
                     result.push(
                         this.renderElement(elementName, element, index === 0)
                     );


### PR DESCRIPTION
closes partially (the ui part) #3483 

optional neos part for support of `showInCreationDialog`: https://github.com/neos/neos-development-collection/pull/4297

introduces logic to evaluate

```yaml
ui:
  creationDialog:
    elements:
      hiddenProperty:
        type: string
        ui:
          hidden: true
```

clientEval is working out of the box, since the configuration has been evaluated with `preprocessNodeConfiguration`

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->



https://github.com/neos/neos-ui/assets/85400359/d4635886-072d-4115-938e-e23c83428d20


**What I did**

**How I did it**

**How to verify it**

test it with this (or your own) nodeType.

Note that creationDialog items that are generated from properties via `showInCreationDialog` will not yet have the hidden property copied, for this a fix in neos/neos has to be done (https://github.com/neos/neos-development-collection/pull/4297)

```yaml
'My.Test:NodeType':
  superTypes:
    'Neos.Neos:Content': true
  ui:
    creationDialog:
      elements:
        bool:
          type: boolean
          ui:
            label: "Enable Text Field"
        text:
          type: string
          ui:
            label: "Select this"
            hidden: "ClientEval:!node.properties.bool"
            editor: Neos.Neos/Inspector/Editors/SelectBoxEditor
            editorOptions:
              values:
                13:
                  label: "13"
                42:
                  label: "42"
        otherField:
          type: string
          ui:
            label: "Other Field"
            hidden: "ClientEval:node.properties.text !== '13'"
            editor: Neos.Neos/Inspector/Editors/TextFieldEditor
```

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
