### PR TITLE
BUGFIX: Fixes sidebar resizer on Chrome

### DIFF
--- a/packages/neos-ui/src/Containers/LeftSideBar/style.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/style.css
@@ -44,6 +44,7 @@
     margin-right: var(--spacing-Quarter);
     resize: vertical;
     overflow-y: auto;
+    z-index: 1;
 }
 .leftSideBar__top--isFullHeight {
     flex: 1;


### PR DESCRIPTION
closed: #3508 

**What I did**
I added a Z-index for the top Sidebar, this will make the resize handler show below the Creation dialog.

Since the Feature was introduced in 8.2, I used that as the base branch. If I should use another branch, I can do a new PR 

**How to verify it**

Before: 
![Bildschirmfoto 2023-05-31 um 10 55 30](https://github.com/neos/neos-ui/assets/91674611/85728057-3803-4a0f-91d3-b943926de89a)

After:
![Bildschirmfoto 2023-05-31 um 10 52 29](https://github.com/neos/neos-ui/assets/91674611/beac17ea-ef02-4b5c-bd79-ca177207a133)
