### PR TITLE
BUGFIX: Sort nodeCreationHandlers

### DIFF
--- a/Classes/Domain/Model/Changes/AbstractCreate.php
+++ b/Classes/Domain/Model/Changes/AbstractCreate.php
@@ -19,6 +19,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
 use Neos\Neos\Ui\Exception\InvalidNodeCreationHandlerException;
 use Neos\Neos\Ui\NodeCreationHandler\NodeCreationHandlerInterface;
+use Neos\Utility\PositionalArraySorter;
 
 abstract class AbstractCreate extends AbstractStructuralChange
 {
@@ -175,7 +176,7 @@ abstract class AbstractCreate extends AbstractStructuralChange
         if (isset($nodeType->getOptions()['nodeCreationHandlers'])) {
             $nodeCreationHandlers = $nodeType->getOptions()['nodeCreationHandlers'];
             if (is_array($nodeCreationHandlers)) {
-                foreach ($nodeCreationHandlers as $nodeCreationHandlerConfiguration) {
+                foreach ((new PositionalArraySorter($nodeCreationHandlers))->toArray() as $nodeCreationHandlerConfiguration) {
                     $nodeCreationHandler = new $nodeCreationHandlerConfiguration['nodeCreationHandler']();
                     if (!$nodeCreationHandler instanceof NodeCreationHandlerInterface) {
                         throw new InvalidNodeCreationHandlerException(sprintf('Expected NodeCreationHandlerInterface but got "%s"', get_class($nodeCreationHandler)), 1364759956);


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

will make ordering issues like this fixable https://github.com/Flowpack/Flowpack.NodeTemplates/issues/45

_it doesnt make sense to not allow sorting for any extensibility point._

**What I did**

Add `position` option to `nodeCreationHandlers` configuration.

```yaml
'Neos.Neos:Document':
   options:
     nodeCreationHandlers:
       # after the default Neos.Neos.Ui documentTitleNodeCreationHandler
       templatingDocumentTitle:
         position: end
         nodeCreationHandler: 'Flowpack\NodeTemplates\NodeCreationHandler\TemplatingDocumentTitleNodeCreationHandler'
```

**How I did it**

Use neos' positional array sorting

**How to verify it**

A processor at the end should be able to override node properties set by previous processors.

Example:

build a handler that sets the title property (configure it without position) and then create a new page (with title set in the creation dialog)

the title of your processor will be ignored, because the neos ui takes the title from the creation dialog,

then set the position to "end", now your processor is taken.

```php
MyHander implements NodeCreationHandlerInterface
{
  public function handle(NodeInterface $node, array $data)
  {
     $node->setProperty('title', 'huhu');
  }
}
```

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
