### PR TITLE
WIP: BUGFIX: NodeInfoHelper::getBasicNodeInformation handle nodeName == null

### DIFF
--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -24,6 +24,7 @@ use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Neos\FrontendRouting\NodeAddress;
 use Neos\Neos\FrontendRouting\NodeAddressFactory;
 use Neos\Neos\FrontendRouting\NodeUriBuilder;
+use Neos\Neos\Fusion\Helper\NodeHelper;
 use Neos\Neos\TypeConverter\EntityToIdentityConverter;
 use Neos\Neos\Ui\Domain\Service\NodePropertyConverterService;
 use Neos\Neos\Ui\Domain\Service\UserLocaleService;
@@ -237,7 +238,9 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
             'label' => $node->getLabel(),
             'isAutoCreated' => self::isAutoCreated($node, $subgraph),
             // TODO: depth is expensive to calculate; maybe let's get rid of this?
-            'depth' => $subgraph->retrieveNodePath($node->nodeAggregateId)->getDepth(),
+            // currently only used in the ui to calculate if `isNodeCollapsed`
+            // https://github.com/neos/neos-ui/blob/b2222ab1c8c429462cdec9fac2568f47a6eb727e/packages/neos-ui-redux-store/src/CR/Nodes/helpers.ts#L45-L51
+            'depth' => (new NodeHelper())->depth($node),
             'children' => [],
             'parent' => $parentNode ? $nodeAddressFactory->createFromNode($parentNode)->serializeForUri() : null,
             'matchesCurrentDimensions' => $node->subgraphIdentity->dimensionSpacePoint->equals($node->originDimensionSpacePoint),


### PR DESCRIPTION

see https://neos-project.slack.com/archives/C3MCBK6S2/p1685647511878619


> The path "//neosdemo/node-6478f04d86976/main/" is no valid NodePath because it contains a segment "" that is no valid NodeName

tracked the above issue to this call:

https://github.com/neos/neos-ui/blob/4a229485899f035245bac62c8db1152bcb244046/Classes/Fusion/Helper/NodeInfoHelper.php#L240

we want to find out the depth and actually dont care about the nodePath that much.

the problem is:

`$subgraph->retrieveNodePath()`

fails in the dbal adapter, if the path has at least one unamed segment.

https://github.com/neos/neos-development-collection/blob/8d7acb506d87c76b47bf9114dddd696bee15fdab/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php#L253
NodePath::fromPathSegments([null,"neosdemo","node-6478f04d86976","main",null])

(im also wondering why we have the null at the start everytime? Seems odd and also seems to cause the double slash //  at the start of (every?) path.

maybe one should be able to build nodePaths even with null as part to get the depth? Only a toString wouldnt be allowed then?





