### PR TITLE
TASK: improve document title node creation handler

### DIFF
--- a/Classes/Domain/Model/Changes/AbstractCreate.php
+++ b/Classes/Domain/Model/Changes/AbstractCreate.php
@@ -101,10 +101,13 @@ abstract class AbstractCreate extends AbstractStructuralChange
         // $name = $this->getName() ?: $this->nodeService->generateUniqueNodeName($parent->findParentNode());
         $nodeName = NodeName::fromString($this->getName() ?: uniqid('node-', false));
 
-        $nodeAggregateId = NodeAggregateId::create(); // generate a new NodeAggregateId
+        // deterministic node id
+        $nodeAggregateId = NodeAggregateId::fromParentNodeAggregateIdAndNodeName(
+            $parentNode->nodeAggregateId,
+            $nodeName
+        );
 
         $contentRepository = $this->contentRepositoryRegistry->get($parentNode->subgraphIdentity->contentRepositoryId);
-        $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($nodeTypeName);
 
         $command = new CreateNodeAggregateWithNode(
             $parentNode->subgraphIdentity->contentStreamId,
@@ -113,8 +116,7 @@ abstract class AbstractCreate extends AbstractStructuralChange
             OriginDimensionSpacePoint::fromDimensionSpacePoint($parentNode->subgraphIdentity->dimensionSpacePoint),
             $parentNode->nodeAggregateId,
             $succeedingSiblingNodeAggregateId,
-            $nodeName,
-            tetheredDescendantNodeAggregateIds: $nodeType->createTetheredDescendantNodeAggregateIds(),
+            $nodeName
         );
 
         $commands = $this->applyNodeCreationHandlers(new NodeCreationCommands($command), $nodeTypeName, $contentRepository);

--- a/Classes/Domain/Model/Changes/AbstractCreate.php
+++ b/Classes/Domain/Model/Changes/AbstractCreate.php
@@ -21,6 +21,7 @@ use Neos\ContentRepository\Core\SharedModel\Exception\NodeNameIsAlreadyOccupied;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\Neos\Ui\Exception\InvalidNodeCreationHandlerException;
+use Neos\Neos\Ui\NodeCreationHandler\NodeCreationCommands;
 use Neos\Neos\Ui\NodeCreationHandler\NodeCreationHandlerInterface;
 
 abstract class AbstractCreate extends AbstractStructuralChange
@@ -102,6 +103,9 @@ abstract class AbstractCreate extends AbstractStructuralChange
 
         $nodeAggregateId = NodeAggregateId::create(); // generate a new NodeAggregateId
 
+        $contentRepository = $this->contentRepositoryRegistry->get($parentNode->subgraphIdentity->contentRepositoryId);
+        $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($nodeTypeName);
+
         $command = new CreateNodeAggregateWithNode(
             $parentNode->subgraphIdentity->contentStreamId,
             $nodeAggregateId,
@@ -109,16 +113,19 @@ abstract class AbstractCreate extends AbstractStructuralChange
             OriginDimensionSpacePoint::fromDimensionSpacePoint($parentNode->subgraphIdentity->dimensionSpacePoint),
             $parentNode->nodeAggregateId,
             $succeedingSiblingNodeAggregateId,
-            $nodeName
+            $nodeName,
+            tetheredDescendantNodeAggregateIds: $nodeType->createTetheredDescendantNodeAggregateIds(),
         );
-        $contentRepository = $this->contentRepositoryRegistry->get($parentNode->subgraphIdentity->contentRepositoryId);
 
-        $command = $this->applyNodeCreationHandlers($command, $nodeTypeName, $contentRepository);
+        $commands = $this->applyNodeCreationHandlers(new NodeCreationCommands($command), $nodeTypeName, $contentRepository);
 
-        $contentRepository->handle($command)->block();
+        foreach ($commands as $command) {
+            $contentRepository->handle($command)->block();
+        }
+
         /** @var Node $newlyCreatedNode */
         $newlyCreatedNode = $this->contentRepositoryRegistry->subgraphForNode($parentNode)
-            ->findChildNodeConnectedThroughEdgeName($parentNode->nodeAggregateId, $nodeName);
+            ->findNodeById($nodeAggregateId);
 
         $this->finish($newlyCreatedNode);
         // NOTE: we need to run "finish" before "addNodeCreatedFeedback"
@@ -131,15 +138,15 @@ abstract class AbstractCreate extends AbstractStructuralChange
      * @throws InvalidNodeCreationHandlerException
      */
     protected function applyNodeCreationHandlers(
-        CreateNodeAggregateWithNode $command,
+        NodeCreationCommands $commands,
         NodeTypeName $nodeTypeName,
         ContentRepository $contentRepository
-    ): CreateNodeAggregateWithNode {
+    ): NodeCreationCommands {
         $data = $this->getData() ?: [];
         $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($nodeTypeName);
         if (!isset($nodeType->getOptions()['nodeCreationHandlers'])
             || !is_array($nodeType->getOptions()['nodeCreationHandlers'])) {
-            return $command;
+            return $commands;
         }
         foreach ($nodeType->getOptions()['nodeCreationHandlers'] as $nodeCreationHandlerConfiguration) {
             $nodeCreationHandler = new $nodeCreationHandlerConfiguration['nodeCreationHandler']();
@@ -150,8 +157,8 @@ abstract class AbstractCreate extends AbstractStructuralChange
                     get_class($nodeCreationHandler)
                 ), 1364759956);
             }
-            $command = $nodeCreationHandler->handle($command, $data, $contentRepository);
+            $commands = $nodeCreationHandler->handle($commands, $data, $contentRepository);
         }
-        return $command;
+        return $commands;
     }
 }

--- a/Classes/NodeCreationHandler/ContentTitleNodeCreationHandler.php
+++ b/Classes/NodeCreationHandler/ContentTitleNodeCreationHandler.php
@@ -12,11 +12,7 @@ namespace Neos\Neos\Ui\NodeCreationHandler;
  */
 
 use Neos\ContentRepository\Core\ContentRepository;
-use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\SharedModel\Exception\NodeTypeNotFoundException;
-use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode;
-use Neos\Flow\Annotations as Flow;
-use Neos\Neos\Service\TransliterationService;
 
 /**
  * Node creation handler that sets the "title" property for new content elements according
@@ -28,31 +24,25 @@ use Neos\Neos\Service\TransliterationService;
 class ContentTitleNodeCreationHandler implements NodeCreationHandlerInterface
 {
     /**
-     * @Flow\Inject
-     * @var TransliterationService
-     */
-    protected $transliterationService;
-
-    /**
      * Set the node title for the newly created Content node
      *
      * @param array<string|int,mixed> $data incoming data from the creationDialog
      * @throws NodeTypeNotFoundException
      */
-    public function handle(CreateNodeAggregateWithNode $command, array $data, ContentRepository $contentRepository): CreateNodeAggregateWithNode
+    public function handle(NodeCreationCommands $commands, array $data, ContentRepository $contentRepository): NodeCreationCommands
     {
         if (
-            !$contentRepository->getNodeTypeManager()->getNodeType($command->nodeTypeName)
+            !$contentRepository->getNodeTypeManager()->getNodeType($commands->initialCreateCommand->nodeTypeName)
                 ->isOfType('Neos.Neos:Content')
         ) {
-            return $command;
+            return $commands;
         }
 
-        $propertyValues = $command->initialPropertyValues;
+        $propertyValues = $commands->initialCreateCommand->initialPropertyValues;
         if (isset($data['title'])) {
             $propertyValues = $propertyValues->withValue('title', $data['title']);
         }
 
-        return $command->withInitialPropertyValues($propertyValues);
+        return $commands->withInitialPropertyValues($propertyValues);
     }
 }

--- a/Classes/NodeCreationHandler/CreationDialogPropertiesCreationHandler.php
+++ b/Classes/NodeCreationHandler/CreationDialogPropertiesCreationHandler.php
@@ -12,8 +12,6 @@ namespace Neos\Neos\Ui\NodeCreationHandler;
  */
 
 use Neos\ContentRepository\Core\ContentRepository;
-use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
-use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
@@ -35,14 +33,14 @@ class CreationDialogPropertiesCreationHandler implements NodeCreationHandlerInte
     /**
      * @param array<string|int,mixed> $data
      */
-    public function handle(CreateNodeAggregateWithNode $command, array $data, ContentRepository $contentRepository): CreateNodeAggregateWithNode
+    public function handle(NodeCreationCommands $commands, array $data, ContentRepository $contentRepository): NodeCreationCommands
     {
         $propertyMappingConfiguration = $this->propertyMapper->buildPropertyMappingConfiguration();
         $propertyMappingConfiguration->forProperty('*')->allowAllProperties();
         $propertyMappingConfiguration->setTypeConverterOption(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED, true);
 
-        $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($command->nodeTypeName);
-        $propertyValues = $command->initialPropertyValues;
+        $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($commands->initialCreateCommand->nodeTypeName);
+        $propertyValues = $commands->initialCreateCommand->initialPropertyValues;
         foreach ($nodeType->getConfiguration('properties') as $propertyName => $propertyConfiguration) {
             if (
                 !isset($propertyConfiguration['ui']['showInCreationDialog'])
@@ -62,6 +60,6 @@ class CreationDialogPropertiesCreationHandler implements NodeCreationHandlerInte
             $propertyValues = $propertyValues->withValue($propertyName, $propertyValue);
         }
 
-        return $command->withInitialPropertyValues($propertyValues);
+        return $commands->withInitialPropertyValues($propertyValues);
     }
 }

--- a/Classes/NodeCreationHandler/DocumentTitleNodeCreationHandler.php
+++ b/Classes/NodeCreationHandler/DocumentTitleNodeCreationHandler.php
@@ -11,13 +11,11 @@ namespace Neos\Neos\Ui\NodeCreationHandler;
  * source code.
  */
 
-use Neos\ContentRepository\Core\ContentRepository;
-use Neos\Flow\Annotations as Flow;
 use Behat\Transliterator\Transliterator;
+use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Dimension\ContentDimensionId;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
-use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode;
-use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
+use Neos\Flow\Annotations as Flow;
 use Neos\Flow\I18n\Exception\InvalidLocaleIdentifierException;
 use Neos\Flow\I18n\Locale;
 use Neos\Neos\Service\TransliterationService;
@@ -42,15 +40,16 @@ class DocumentTitleNodeCreationHandler implements NodeCreationHandlerInterface
     /**
      * @param array<string|int,mixed> $data
      */
-    public function handle(CreateNodeAggregateWithNode $command, array $data, ContentRepository $contentRepository): CreateNodeAggregateWithNode
+    public function handle(NodeCreationCommands $commands, array $data, ContentRepository $contentRepository): NodeCreationCommands
     {
+        $initialCommand = $commands->initialCreateCommand;
         if (
-            !$contentRepository->getNodeTypeManager()->getNodeType($command->nodeTypeName)
+            !$contentRepository->getNodeTypeManager()->getNodeType($initialCommand->nodeTypeName)
                 ->isOfType('Neos.Neos:Document')
         ) {
-            return $command;
+            return $commands;
         }
-        $propertyValues = $command->initialPropertyValues;
+        $propertyValues = $initialCommand->initialPropertyValues;
         if (isset($data['title'])) {
             $propertyValues = $propertyValues->withValue('title', $data['title']);
         }
@@ -59,14 +58,14 @@ class DocumentTitleNodeCreationHandler implements NodeCreationHandlerInterface
         $uriPathSegment = $data['title'];
 
         // otherwise, we fall back to the node name
-        if ($uriPathSegment === null && $command->nodeName !== null) {
-            $uriPathSegment = $command->nodeName->value;
+        if ($uriPathSegment === null && $initialCommand->nodeName !== null) {
+            $uriPathSegment = $initialCommand->nodeName->value;
         }
 
         // if not empty, we transliterate the uriPathSegment according to the language of the new node
         if ($uriPathSegment !== null && $uriPathSegment !== '') {
             $uriPathSegment = $this->transliterateText(
-                $command->originDimensionSpacePoint->toDimensionSpacePoint(),
+                $initialCommand->originDimensionSpacePoint->toDimensionSpacePoint(),
                 $uriPathSegment
             );
         } else {
@@ -76,7 +75,7 @@ class DocumentTitleNodeCreationHandler implements NodeCreationHandlerInterface
         $uriPathSegment = Transliterator::urlize($uriPathSegment);
         $propertyValues = $propertyValues->withValue('uriPathSegment', $uriPathSegment);
 
-        return $command->withInitialPropertyValues($propertyValues);
+        return $commands->withInitialPropertyValues($propertyValues);
     }
 
     private function transliterateText(DimensionSpacePoint $dimensionSpacePoint, string $text): string

--- a/Classes/NodeCreationHandler/NodeCreationCommands.php
+++ b/Classes/NodeCreationHandler/NodeCreationCommands.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Neos\Ui\NodeCreationHandler;
+
+use Neos\ContentRepository\Core\CommandHandler\CommandInterface;
+use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode;
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
+
+class NodeCreationCommands implements \IteratorAggregate
+{
+    /** @var array<int|string, CommandInterface> */
+    public readonly array $additionalCommands;
+
+    /**
+     * @interal to guarantee that the initial create command is mostly preserved as intended.
+     * You should use {@see self::withInitialPropertyValues()} and {@see self::withAdditionalCommands()} instead.
+     */
+    public function __construct(
+        /**
+         * The original node creation command.
+         * It is only allowed to mutate the properties via {@see self::withInitialPropertyValues()}
+         */
+        public readonly CreateNodeAggregateWithNode $initialCreateCommand,
+        /**
+         * Add a list of commands that are executed after the initial created command was run.
+         * This allows you to create child-nodes and other operations.
+         */
+        CommandInterface ...$additionalCommands
+    ) {
+        $this->additionalCommands = $additionalCommands;
+    }
+
+    /**
+     * Augment the initial {@see CreateNodeAggregateWithNode} command with altered properties.
+     */
+    public function withInitialPropertyValues(PropertyValuesToWrite $newInitialPropertyValues): self
+    {
+        return new self(
+            $this->initialCreateCommand->withInitialPropertyValues($newInitialPropertyValues),
+            ...$this->additionalCommands
+        );
+    }
+
+    public function withAdditionalCommands(CommandInterface ...$additionalCommands): self
+    {
+        return new self($this->initialCreateCommand, ...$this->additionalCommands, ...$additionalCommands);
+    }
+
+    /**
+     * @return \Traversable<int, CommandInterface>
+     */
+    public function getIterator(): \Traversable
+    {
+        yield $this->initialCreateCommand;
+        yield from $this->additionalCommands;
+    }
+}

--- a/Classes/NodeCreationHandler/NodeCreationCommands.php
+++ b/Classes/NodeCreationHandler/NodeCreationCommands.php
@@ -5,7 +5,11 @@ namespace Neos\Neos\Ui\NodeCreationHandler;
 
 use Neos\ContentRepository\Core\CommandHandler\CommandInterface;
 use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode;
+use Neos\ContentRepository\Core\Feature\NodeDisabling\Command\DisableNodeAggregate;
+use Neos\ContentRepository\Core\Feature\NodeDisabling\Command\EnableNodeAggregate;
+use Neos\ContentRepository\Core\Feature\NodeModification\Command\SetNodeProperties;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
+use Neos\ContentRepository\Core\Feature\NodeReferencing\Command\SetNodeReferences;
 
 class NodeCreationCommands implements \IteratorAggregate
 {
@@ -13,7 +17,7 @@ class NodeCreationCommands implements \IteratorAggregate
     public readonly array $additionalCommands;
 
     /**
-     * @interal to guarantee that the initial create command is mostly preserved as intended.
+     * @internal to guarantee that the initial create command is mostly preserved as intended.
      * You should use {@see self::withInitialPropertyValues()} and {@see self::withAdditionalCommands()} instead.
      */
     public function __construct(
@@ -26,7 +30,7 @@ class NodeCreationCommands implements \IteratorAggregate
          * Add a list of commands that are executed after the initial created command was run.
          * This allows you to create child-nodes and other operations.
          */
-        CommandInterface ...$additionalCommands
+        CreateNodeAggregateWithNode|SetNodeProperties|DisableNodeAggregate|EnableNodeAggregate|SetNodeReferences ...$additionalCommands
     ) {
         $this->additionalCommands = $additionalCommands;
     }

--- a/Classes/NodeCreationHandler/NodeCreationHandlerInterface.php
+++ b/Classes/NodeCreationHandler/NodeCreationHandlerInterface.php
@@ -12,7 +12,6 @@ namespace Neos\Neos\Ui\NodeCreationHandler;
  */
 
 use Neos\ContentRepository\Core\ContentRepository;
-use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode;
 
 /**
  * Contract for Node Creation handler that allow to hook into the process just before a node is being added
@@ -23,9 +22,9 @@ interface NodeCreationHandlerInterface
     /**
      * Do something with the newly created node
      *
-     * @param CreateNodeAggregateWithNode $command The original node creation command
+     * @param NodeCreationCommands $commands original node creation command
      * @param array<string|int,mixed> $data incoming data from the creationDialog
-     * @return CreateNodeAggregateWithNode the original command or a new creation command with altered properties
+     * @return NodeCreationCommands the original command (or with altered properties) with additional commands
      */
-    public function handle(CreateNodeAggregateWithNode $command, array $data, ContentRepository $contentRepository): CreateNodeAggregateWithNode;
+    public function handle(NodeCreationCommands $commands, array $data, ContentRepository $contentRepository): NodeCreationCommands;
 }

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Classes/NodeCreationHandler/ImagePropertyNodeCreationHandler.php
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Classes/NodeCreationHandler/ImagePropertyNodeCreationHandler.php
@@ -12,11 +12,11 @@ namespace Neos\TestNodeTypes\NodeCreationHandler;
  */
 
 use Neos\ContentRepository\Core\ContentRepository;
-use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
 use Neos\Media\Domain\Model\ImageInterface;
+use Neos\Neos\Ui\NodeCreationHandler\NodeCreationCommands;
 use Neos\Neos\Ui\NodeCreationHandler\NodeCreationHandlerInterface;
 
 class ImagePropertyNodeCreationHandler implements NodeCreationHandlerInterface
@@ -27,17 +27,17 @@ class ImagePropertyNodeCreationHandler implements NodeCreationHandlerInterface
      */
     protected $propertyMapper;
 
-    public function handle(CreateNodeAggregateWithNode $command, array $data, ContentRepository $contentRepository): CreateNodeAggregateWithNode
+    public function handle(NodeCreationCommands $commands, array $data, ContentRepository $contentRepository): NodeCreationCommands
     {
         if (!isset($data['image'])) {
-            return $command;
+            return $commands;
         }
         $propertyMappingConfiguration = $this->propertyMapper->buildPropertyMappingConfiguration();
         $propertyMappingConfiguration->forProperty('*')->allowAllProperties();
         $propertyMappingConfiguration->setTypeConverterOption(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED, true);
         $image = $this->propertyMapper->convert($data['image'], ImageInterface::class, $propertyMappingConfiguration);
 
-        $propertyValues = $command->initialPropertyValues->withValue('image', $image);
-        return $command->withInitialPropertyValues($propertyValues);
+        $propertyValues = $commands->initialCreateCommand->initialPropertyValues->withValue('image', $image);
+        return $commands->withInitialPropertyValues($propertyValues);
     }
 }


### PR DESCRIPTION
depends on:

https://github.com/neos/neos-development-collection/pull/4324

in Neos 8.3, we could use the `NodeUriPathSegmentGenerator::generateUriPathSegment`  but now we dont have actually the node at hand.

Previously `generateUriPathSegment` was partially inlined but by creating the lower level helper `generateUriPathSegmentFromTextForDimension` we can use it again.