### PR TITLE
TASK: abstractCreate Make NodeName Obsolet

### DIFF
--- a/Classes/Domain/Model/Changes/AbstractCreate.php
+++ b/Classes/Domain/Model/Changes/AbstractCreate.php
@@ -118,7 +118,7 @@ abstract class AbstractCreate extends AbstractStructuralChange
         $contentRepository->handle($command)->block();
         /** @var Node $newlyCreatedNode */
         $newlyCreatedNode = $this->contentRepositoryRegistry->subgraphForNode($parentNode)
-            ->findChildNodeConnectedThroughEdgeName($parentNode->nodeAggregateId, $nodeName);
+            ->findNodeById($nodeAggregateId);
 
         $this->finish($newlyCreatedNode);
         // NOTE: we need to run "finish" before "addNodeCreatedFeedback"


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


we should discuss, if we need to set a nodeName at all, as it would resolve todo:

```php
        // TODO: the $name=... line should be as expressed below
        // $name = $this->getName() ?: $this->nodeService->generateUniqueNodeName($parent->findParentNode());
        $nodeName = NodeName::fromString($this->getName() ?: uniqid('node-', false));
```

@nezaniel what do you say? I could not find a similar functionality to `generateUniqueNodeName` in the ESCR. Also when looking at the soft constraint in the NodeCreationCommandHandler one can see that it is not that super simple to find out if a nodeName has already been occupied, so we might as well dont introduce this again?

I have the feeling we really need to discuss nodeNames, currently people mostly use it for small unique identifiers on the same page. Like for building up html ids to link to. In case the nodeName would be null it would be unexpected.

**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
