### PR TITLE
9.0: Use site detection result instead of the default site in hostframe

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -177,7 +177,7 @@ class BackendController extends ActionController
 
         $siteNode = $subgraph->findChildNodeConnectedThroughEdgeName(
             $rootNode->nodeAggregateId,
-            $this->siteRepository->findDefault()->getNodeName()->toNodeName()
+            $siteDetectionResult->siteNodeName->toNodeName()
         );
 
         if (!$nodeAddress) {


### PR DESCRIPTION
In a 9.0 multisite installation, the hostframe always initialized the default site

**What I did**
**How I did it**
I replaced the default site with the site detection result

**How to verify it**
Have a Neos9 multisite installation and call any homepage but the default one