### PR TITLE
WIP: BUGFIX: Show if selectbox options mismatch with current value

### DIFF
--- a/packages/react-ui-components/src/MultiSelectBox_ListPreviewSortable/multiSelectBox_ListPreviewSortable.js
+++ b/packages/react-ui-components/src/MultiSelectBox_ListPreviewSortable/multiSelectBox_ListPreviewSortable.js
@@ -30,6 +30,7 @@ export default class MultiSelectBox_ListPreviewSortable extends PureComponent {
         ).isRequired,
         values: PropTypes.arrayOf(PropTypes.string),
         onValuesChange: PropTypes.func.isRequired,
+        displayLoadingIndicator: PropTypes.bool,
         ListPreviewElement: PropTypes.any.isRequired,
 
         // API with MultiSelectBox
@@ -59,8 +60,13 @@ export default class MultiSelectBox_ListPreviewSortable extends PureComponent {
     render() {
         const {
             options,
-            optionValueAccessor
+            optionValueAccessor,
+            displayLoadingIndicator
         } = this.props;
+
+        if (displayLoadingIndicator) {
+            return '';
+        }
 
         const {draggableValues} = this.state;
 

--- a/packages/react-ui-components/src/MultiSelectBox_ListPreviewSortable/multiSelectBox_ListPreviewSortable.js
+++ b/packages/react-ui-components/src/MultiSelectBox_ListPreviewSortable/multiSelectBox_ListPreviewSortable.js
@@ -66,8 +66,11 @@ export default class MultiSelectBox_ListPreviewSortable extends PureComponent {
 
         // Sorted options by draggable value ordering
         const draggableOptions = draggableValues.map(value =>
-            options.find(option => optionValueAccessor(option) === value)
-        ).filter(Boolean);
+            options.find(option => optionValueAccessor(option) === value) || {
+                label: `Invalid: "${value}"`,
+                icon: 'exclamation-triangle'
+            }
+        );
 
         return draggableOptions.map(this.renderOption);
     }

--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -284,7 +284,7 @@ export default class SelectBox extends PureComponent {
         }
 
         const mismatchOfValueInOptions = !valueIsEmpty && !selectedOption;
-        const showResetButton = (allowEmpty && !displayLoadingIndicator && !valueIsEmpty) || mismatchOfValueInOptions;
+        const showResetButton = (allowEmpty && !valueIsEmpty) || mismatchOfValueInOptions;
 
         return (
             <SelectBox_Header
@@ -295,7 +295,7 @@ export default class SelectBox extends PureComponent {
                         icon: 'exclamation-triangle'
                     } : selectedOption
                 }
-                showResetButton={showResetButton}
+                showResetButton={!displayLoadingIndicator && showResetButton}
                 onReset={this.handleDeleteClick}
                 onClick={onHeaderClick}
                 />

--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -289,12 +289,10 @@ export default class SelectBox extends PureComponent {
         return (
             <SelectBox_Header
                 {...this.props}
-                option={mismatchOfValueInOptions
-                    ? {
-                        label: `Invalid: "${value}"`,
-                        icon: 'exclamation-triangle'
-                    } : selectedOption
-                }
+                option={mismatchOfValueInOptions ? {
+                    label: `Invalid: "${value}"`,
+                    icon: 'exclamation-triangle'
+                } : selectedOption}
                 showResetButton={!displayLoadingIndicator && showResetButton}
                 onReset={this.handleDeleteClick}
                 onClick={onHeaderClick}

--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -5,7 +5,6 @@ import {$get} from 'plow-js';
 import SelectBox_Option_SingleLine from '../SelectBox_Option_SingleLine';
 import mergeClassNames from 'classnames';
 import isEqual from 'lodash.isequal';
-import {isNil} from '@neos-project/utils-helpers';
 
 // TODO: document component usage && check code in detail
 export default class SelectBox extends PureComponent {
@@ -262,10 +261,13 @@ export default class SelectBox extends PureComponent {
         // Compare selected value less strictly: allow loose comparision and deep equality of objects
         const selectedOption = options.find(option => optionValueAccessor(option) == value || isEqual(optionValueAccessor(option), value)); // eslint-disable-line eqeqeq
 
+        // check for null or undefined
+        /* eslint-disable no-eq-null, eqeqeq */
+        const valueIsEmpty = value == null || value === '';
+
         if (
             displaySearchBox && (
-                isNil(value) ||
-                value === '' ||
+                valueIsEmpty ||
                 this.state.isExpanded ||
                 plainInputMode
             )
@@ -281,12 +283,18 @@ export default class SelectBox extends PureComponent {
             );
         }
 
-        const showResetButton = Boolean(allowEmpty && !displayLoadingIndicator && value);
+        const mismatchOfValueInOptions = !valueIsEmpty && !selectedOption;
+        const showResetButton = (allowEmpty && !displayLoadingIndicator && !valueIsEmpty) || mismatchOfValueInOptions;
 
         return (
             <SelectBox_Header
                 {...this.props}
-                option={selectedOption}
+                option={mismatchOfValueInOptions
+                    ? {
+                        label: `Invalid: "${value}"`,
+                        icon: 'exclamation-triangle'
+                    } : selectedOption
+                }
                 showResetButton={showResetButton}
                 onReset={this.handleDeleteClick}
                 onClick={onHeaderClick}


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

solves: #3520

**What I did**


For the first and second case (mentioned in #3520)  i could imagine adding a warning icon, a proper label and additionally allow to reset the value like:

![image](https://github.com/neos/neos-ui/assets/85400359/6b3f5f8c-6d3a-4342-b040-f3ffd07d5e69)


And for the multi select box it could look like:


https://github.com/neos/neos-ui/assets/85400359/55a92ddc-a591-4fe0-9ee4-39712b2e6098


For a (slow) datasource it looks like:

https://github.com/neos/neos-ui/assets/85400359/890717cc-986e-42c4-a1e4-d74202fd6b2f

multiple: true

https://github.com/neos/neos-ui/assets/85400359/ef8c27a1-1693-481a-8b28-a7f1623165ac



**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->


TODO:
- [ ] ~translations~ Nope: to low level and this is just a bug fix. Wed need to refactor a lot. https://github.com/neos/neos-ui/pull/3526#issuecomment-1629025114
- [x] backport to 7.3
- [x] discuss icon choice
- [x] discuss if my "simple" approach is enough or if the selectbox should highlight it differently -> yes stay simple for this bugfix
- [ ] ~color icon and string red or orange~ Nope: this is just a bug fix. Wed need to refactor a lot. https://github.com/neos/neos-ui/pull/3526#issuecomment-1629025114
- [ ] move this logic out of selectbox into usage