### PR TITLE
TASK: PHP 8.1 deprecations compatibility

### DIFF
--- a/Classes/Domain/Model/FeedbackCollection.php
+++ b/Classes/Domain/Model/FeedbackCollection.php
@@ -62,6 +62,7 @@ class FeedbackCollection implements \JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $feedbacks = [];

--- a/Classes/Domain/Model/RenderedNodeDomAddress.php
+++ b/Classes/Domain/Model/RenderedNodeDomAddress.php
@@ -97,6 +97,7 @@ class RenderedNodeDomAddress implements \JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [


### PR DESCRIPTION
This fixes deprecation warnings. We cannot specify the return types, as Neos 7.3 needs to be compatible with PHP 7.4. As of Neos 8.0 the proper types are added.

**What I did**

**How I did it**

**How to verify it**

Run this on PHP 8.1, no more deprecation warnings should appear (`PHP Deprecated:  Return type of Neos\Neos\Ui\Domain\Model\RenderedNodeDomAddress::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in …`)