### PR TITLE
BUGFIX: Ensure that only numerical property values are converted to integer

### DIFF
--- a/Classes/Domain/Service/NodePropertyConversionService.php
+++ b/Classes/Domain/Service/NodePropertyConversionService.php
@@ -155,11 +155,15 @@ class NodePropertyConversionService
      * Convert raw value to integer
      *
      * @param mixed $rawValue
-     * @return integer
+     * @return null|integer
      */
     protected function convertInteger($rawValue)
     {
-        return (int)$rawValue;
+        if (is_numeric($rawValue)) {
+            return (int) $rawValue;
+        }
+
+        return null;
     }
 
     /**

--- a/packages/neos-ui-editors/src/Editors/TextArea/index.js
+++ b/packages/neos-ui-editors/src/Editors/TextArea/index.js
@@ -34,7 +34,7 @@ export default class TextAreaEditor extends PureComponent {
 
         return (<TextArea
             id={id}
-            value={value}
+            value={value === null ? '' : value}
             className={className}
             onChange={commit}
             disabled={finalOptions.disabled}

--- a/packages/neos-ui-editors/src/Editors/TextField/index.js
+++ b/packages/neos-ui-editors/src/Editors/TextField/index.js
@@ -41,7 +41,7 @@ export default class TextField extends PureComponent {
             className={className}
             id={id}
             autoFocus={finalOptions.autoFocus}
-            value={value}
+            value={value === null ? '' : value}
             onChange={commit}
             placeholder={placeholder}
             onKeyPress={onKeyPress}


### PR DESCRIPTION
fixes: #3158, #3157 

**The problem**

The UI's `NodePropertyConversionService` over-generalizes when converting incoming values to integer. It just casts any incoming `string` to `int` via `(int) $someValue`.

Now, PHP throws no error if the value we're casting to `int` actually cannot be meaningfully converted. So, pretty much anything it cannot make sense of ends up being `0`:

```
php > echo (int) "foo";
0
```

**The solution**

I adjusted the method `convertInteger` of `NodePropertyConversionService` to only convert strings to integers that pass PHP's `is_numerical` check.

In case the string doesn't pass, `convertInteger` now defaults to `null`.

Because of this, I needed to adjust the `TextFieldEditor` component, so that it now handles the occurrence of `null`-values correctly.

As a result, if I enter a non-numerical string into a text field for a property of type `integer`, the property will receive `null` as a value. The same thing happens, if I enter an empty string.
