### PR TITLE
BUGFIX: Disable asset search through asset editor when media browser is disabled

### DIFF
--- a/packages/neos-ui-editors/src/Editors/AssetEditor/index.js
+++ b/packages/neos-ui-editors/src/Editors/AssetEditor/index.js
@@ -238,7 +238,7 @@ export default class AssetEditor extends PureComponent {
             <SelectBox
                 optionValueField="identifier"
                 loadingLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:loading')}
-                displaySearchBox={true}
+                displaySearchBox={this.isFeatureEnabled('mediaBrowser')}
                 ListPreviewElement={AssetOption}
                 placeholder={this.props.i18nRegistry.translate(this.props.placeholder)}
                 options={this.props.value ? this.state.options : this.state.searchOptions}
@@ -265,7 +265,7 @@ export default class AssetEditor extends PureComponent {
                 dndType={dndTypes.MULTISELECT}
                 optionValueField="identifier"
                 loadingLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:loading')}
-                displaySearchBox={true}
+                displaySearchBox={this.isFeatureEnabled('mediaBrowser')}
                 ListPreviewElement={AssetOption}
                 placeholder={this.props.i18nRegistry.translate(this.props.placeholder)}
                 options={this.state.options || []}


### PR DESCRIPTION
fixes: #1571 

**The problem**

As stated in #1571, even if the media browser has been deactivated via feature-toggle in the asset editor configuration, it is still accessible through search-as-you-type, because the search results are sourced from the media module.

I can very well be argued that by configuring `mediaBrowser: false`, the integrator's intent is to restrict the asset editor solely to its upload function. At the moment this intent could be bypassed.

**The solution**

I added code to dynamically disable the asset search in the asset editor depending on the value of the `mediaBrowser` feature toggle. If `mediaBrowser` is set to `false`, search will be disabled as well.

Despite the quick fix, I think we should discuss if we want to consider this the correct way to interpret the feature toggle. (Maybe also use :+1: / :-1:  on this description)
