### PR TITLE
BUGFIX: Render RightSideBar components even if the sidebar is hidden

### DIFF
--- a/packages/neos-ui/src/Containers/RightSideBar/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/index.js
@@ -66,7 +66,7 @@ export default class RightSideBar extends PureComponent {
                 aria-hidden={isSideBarHidden ? 'true' : 'false'}
                 >
                 {toggle}
-                {!isSideBarHidden && RightSideBarComponents.map((Item, key) => <Item key={key}/>)}
+                {RightSideBarComponents.map((Item, key) => <Item key={key}/>)}
             </SideBar>
         );
     }


### PR DESCRIPTION
fixes: #1744 

**The problem**

https://github.com/neos/neos-ui/assets/2522299/278ba4b4-931c-41d4-b4e0-7ef1a429818e

In #1744 @maltemuth figured out that the rendering of the `RightSideBarComponents` is prevented in case the side bar is hidden.

Since the `<Tabs/>` component from `@neos-project/react-ui-components` is responsible for tracking the open-tab-state, removing the component from the rendering tree inevitably leads to a reset of that state.

**The solution**

https://github.com/neos/neos-ui/assets/2522299/8038e871-9f08-4cfb-952a-460fb97f4151

I removed the condition, so that the `RightSideBarComponents` are now rendered regardless of the toggle-state of the side bar.

Since this is technically a removal of code that was intended to be a performance optimization, I should probably address the potential performance impact:

I believe the idea was to save on the creation of React elements in case they're not actually visible to the user. While this sounds intuitively plausible, I would theorize that this actually hurts performance. Preventing the React elements from being created will cause ReactDOM to remove the DOM tree represented by those elements. When the side bar becomes visible again, the React elements will again be created, which leads ReactDOM to create an entirely new DOM tree from those elements.

If the creation of the React elements isn't prevented, ReactDOM probably won't do anything at all. It would therefore be a fair assumption that this change will lead to a slight performance improvement :)
