### PR TITLE
BUGFIX: Ensure that UI renders updated content after node type change

### DIFF
--- a/Classes/Domain/Model/Changes/Property.php
+++ b/Classes/Domain/Model/Changes/Property.php
@@ -223,6 +223,11 @@ class Property extends AbstractChange
 
             $this->updateWorkspaceInfo();
 
+            // This might be needed to update node label and other things that we can calculate only on the server
+            $updateNodeInfo = new UpdateNodeInfo();
+            $updateNodeInfo->setNode($node);
+            $this->feedbackCollection->add($updateNodeInfo);
+
             $reloadIfChangedConfigurationPath = sprintf('properties.%s.ui.reloadIfChanged', $propertyName);
             if (!$this->getIsInline() && $node->getNodeType()->getConfiguration($reloadIfChangedConfigurationPath)) {
                 if ($this->getNodeDomAddress() && $this->getNodeDomAddress()->getFusionPath()
@@ -273,11 +278,6 @@ class Property extends AbstractChange
             if (!$this->getIsInline() && $node->getNodeType()->getConfiguration($reloadPageIfChangedConfigurationPath)) {
                 $this->reloadDocument($node);
             }
-
-            // This might be needed to update node label and other things that we can calculate only on the server
-            $updateNodeInfo = new UpdateNodeInfo();
-            $updateNodeInfo->setNode($node);
-            $this->feedbackCollection->add($updateNodeInfo);
         }
     }
 

--- a/Classes/Domain/Model/RenderedNodeDomAddress.php
+++ b/Classes/Domain/Model/RenderedNodeDomAddress.php
@@ -84,7 +84,7 @@ class RenderedNodeDomAddress implements \JsonSerializable
     {
         $fusionPathForContentRendering = $this->getFusionPath();
         $fusionPathForContentRendering = preg_replace(
-            '/(\/itemRenderer<Neos\.Neos:ContentCase>)\/default<Neos\.Fusion:Matcher>\/element(<[^>]+>)$/',
+            '/(\/itemRenderer<Neos\.Neos:ContentCase>)\/([^<>\/]+)<Neos\.Fusion:Matcher>\/element(<[^>]+>)$/',
             '$1',
             $fusionPathForContentRendering
         );

--- a/Tests/Unit/Domain/Model/RenderedNodeDomAddressTest.php
+++ b/Tests/Unit/Domain/Model/RenderedNodeDomAddressTest.php
@@ -53,6 +53,10 @@ final class RenderedNodeDomAddressTest extends UnitTestCase
             '(Full) Content Element via second-level ContentCase' => [
                 'root<Neos.Fusion:Case>/documentType<Neos.Fusion:Matcher>/element<Vendor.Site:Document.HomePage>/renderer<Vendor.Site:Document.Base>/body<Vendor.Site:Component.Template.Page>/content<Neos.Neos:ContentCollection>/content<Neos.Neos:ContentCollectionRenderer>/itemRenderer<Neos.Neos:ContentCase>/default<Neos.Fusion:Matcher>/element<Vendor.Site:Content.2767.Reproduction.TwoColumn>/column0<Neos.Neos:ContentCollection>/content<Neos.Neos:ContentCollectionRenderer>/itemRenderer<Neos.Neos:ContentCase>/default<Neos.Fusion:Matcher>/element<Vendor.Site:Content.2767.Reproduction.TwoColumn>',
                 'root<Neos.Fusion:Case>/documentType<Neos.Fusion:Matcher>/element<Vendor.Site:Document.HomePage>/renderer<Vendor.Site:Document.Base>/body<Vendor.Site:Component.Template.Page>/content<Neos.Neos:ContentCollection>/content<Neos.Neos:ContentCollectionRenderer>/itemRenderer<Neos.Neos:ContentCase>/default<Neos.Fusion:Matcher>/element<Vendor.Site:Content.2767.Reproduction.TwoColumn>/column0<Neos.Neos:ContentCollection>/content<Neos.Neos:ContentCollectionRenderer>/itemRenderer<Neos.Neos:ContentCase>'
+            ],
+            '(Full) Content Element via other than "default"-branch' => [
+                'root<Neos.Fusion:Case>/documentType<Neos.Fusion:Matcher>/element<Vendor.Site:Document.HomePage>/renderer<Vendor.Site:Document.Base>/body<Vendor.Site:Component.Template.Page>/content<Neos.Neos:ContentCollection>/content<Neos.Neos:ContentCollectionRenderer>/itemRenderer<Neos.Neos:ContentCase>/content<Neos.Fusion:Matcher>/element<Vendor.Site:Content.H2>',
+                'root<Neos.Fusion:Case>/documentType<Neos.Fusion:Matcher>/element<Vendor.Site:Document.HomePage>/renderer<Vendor.Site:Document.Base>/body<Vendor.Site:Component.Template.Page>/content<Neos.Neos:ContentCollection>/content<Neos.Neos:ContentCollectionRenderer>/itemRenderer<Neos.Neos:ContentCase>'
             ]
         ];
     }


### PR DESCRIPTION
fixes: #1910 

**The problem**

#1910 should have been fixed by #2892. However, I was able to find some edge-cases:

1. When a content element is rendered trough a `Neos.Neos:ContentCase`-case that is not the `default`-case, but still redirects to a fusion prototype that depends on the node type name, the wrong content element will be rendered when the node type changes.
2. Even when the correct content shows up, CKEditor placeholders may still reflect the old node type, because they are populated from stale node type configuration.

**The solution**

To fix 1) I made the regular expression in `RenderedNodeDomAddress` that captures the fusion path of the closest `Neos.Neos:ContentCase` a bit more lenient on the case-part. This covers more cases (sorry for the inflationary and ambiguous  use of the word "case" here - but I don't know what to do about it :D), but will only serve as a temporary solution. OutOfBand-Rendering requires more love in general.

To fix 2) I made sure that the `UpdateNodeInfo` feedback is delivered before the `ReloadContentOutOfBand` feedback, so that the feedback handler for the latter will operate on the updated node type.