### PR TITLE
TASK: More isolated e2e tests (on their own page)

### DIFF
--- a/Tests/IntegrationTests/SharedNodeTypesPackage/NodeTypes/Content/Headline.yaml
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/NodeTypes/Content/Headline.yaml
@@ -11,18 +11,13 @@
   properties:
     title:
       type: string
-      defaultValue: '<h1>Enter headline here</h1>'
+      defaultValue: 'Enter headline here'
       ui:
         inlineEditable: true
         inline:
           editorOptions:
-            placeholder: '<h2>Enter headline here...</h2>'
+            placeholder: 'Enter headline here...'
             formatting:
-              h1: true
-              h2: true
-              h3: true
-              h4: true
-              h5: true
               a: true
       validation:
         'Neos.Neos/Validation/NotEmptyValidator': []

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Resources/Private/Fusion/Content/Headline/Headline.fusion
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Resources/Private/Fusion/Content/Headline/Headline.fusion
@@ -4,6 +4,6 @@ prototype(Neos.TestNodeTypes:Content.Headline) < prototype(Neos.Neos:ContentComp
     }
 
     renderer = afx`
-        <div class="test-headline">{props.title}</div>
+        <h1 class="test-headline">{props.title}</h1>
     `
 }

--- a/Tests/IntegrationTests/utils.js
+++ b/Tests/IntegrationTests/utils.js
@@ -32,8 +32,12 @@ export async function checkPropTypes() {
 }
 
 export async function beforeEach(t) {
+    await createBeforeEach({ pageTitle: 'Home' })(t)
+}
+
+export const createBeforeEach = ({ pageTitle }) => async function beforeEach(t) {
     await t.useRole(adminUser);
     await waitForReact(30000);
     await PublishDropDown.discardAll();
-    await Page.goToPage('Home');
+    await Page.goToPage(pageTitle);
 }


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

resolves: #3542

I tried to start with my proposed changes. For now i want to run the `createNewNodes.e2e.js` on their own site. But for some reason i can't create new nodes via the inline ui if there is no existing node in the content collection. (At least thats the difference between when the test is run on the home page. And removing the existing node on the homepage yields the same error)

So i tried to debug this test `yarn run testcafe chrome Tests/IntegrationTests/Fixtures -T 'Can create content node from inside InlineUI' --debug-on-fail`

It testcafe just says `1) Uncaught object "[object Object]" was thrown. Throw Error instead.`. I could narrow it down via a try catch to the following lines. And after refining i found out that the line `click(Selector('.neos-contentcollection'))` was failing.

https://github.com/neos/neos-ui/blob/7ea5dd72e8c621c830e72ce1432663854fc92f67/Tests/IntegrationTests/Fixtures/1Dimension/createNewNodes.e2e.js#L159-L169

After putting it in a try catch, it logged 

```js
{
  callsite: CallsiteRecord {
    filename: 'Neos.Neos.Ui/Tests/IntegrationTests/Fixtures/1Dimension/createNewNodes.e2e.js',
    lineNum: 166,
    callsiteFrameIdx: 5,
    stackFrames: [
      [Object],    [Object],
      [Object],    [Object],
      [Object],    [Object],
      CallSite {}, [Object],
      [Object],    [Object]
    ],
    isV8Frames: true
  }
}
```

which is indeed not an error but a normal object ...

if i dont wrap it in a try catch, testcafe will just fail:

![image](https://github.com/neos/neos-ui/assets/85400359/2984a603-0e90-4980-97cd-77a9b33be75a)

And without the try catch testcafe doesnt find the inline add node button ...

The tests `Check the nodetype help in create dialog` and `Check that nodetype without help has no help button` should currently fail due to the same behaviour ...