### PR TITLE
TASK: ignoreNeos8Artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,9 @@ npm-debug.log
 .vscode/
 .idea/
 *.iml
+
+#
+# Artifacts from Neos 8.2 / 8.3
+#
+Resources/Public/Build
+.yarn/install-state.gz


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

previously after building 8.3 and checking 7.3 it would look like 
![image](https://github.com/neos/neos-ui/assets/85400359/093999be-5b4e-4d7f-96ca-ba6706d090c0)


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
