### PR TITLE
BUGFIX: 3223 ck plugin `editor.neos` not initialized

### DIFF
--- a/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
@@ -43,6 +43,16 @@ export const createEditor = store => async options => {
         propertyDomNode
     });
 
+    class NeosEditor extends DecoupledEditor {
+        constructor(...args) {
+            super(...args);
+            // We attach all options for this editor to the editor DOM node, so it would be easier to access them from CKE plugins
+            // this has to be done after / in the constructor as `create` is async and plugins accessing .neos have to account for this
+            // https://github.com/neos/neos-ui/issues/3223
+            this.neos = options;
+        }
+    }
+
     return DecoupledEditor
         .create(propertyDomNode, ckEditorConfig)
         .then(editor => {
@@ -58,9 +68,6 @@ export const createEditor = store => async options => {
                 store.dispatch(actions.UI.ContentCanvas.toggleLinkEditor());
                 cancel();
             });
-
-            // We attach all options for this editor to the editor DOM node, so it would be easier to access them from CKE plugins
-            editor.neos = options;
 
             editor.model.document.on('change', () => handleUserInteractionCallback());
             editor.model.document.on('change:data', debounce(() => onChange(cleanupContentBeforeCommit(editor.getData())), 500, {maxWait: 5000}));

--- a/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
@@ -53,7 +53,7 @@ export const createEditor = store => async options => {
         }
     }
 
-    return DecoupledEditor
+    return NeosEditor
         .create(propertyDomNode, ckEditorConfig)
         .then(editor => {
             editor.ui.focusTracker.on('change:isFocused', event => {


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

resolves: #3223

**What I did**

**How I did it**

**How to verify it**

insert into a ckeditor plugin inside `init`
`console.log(this.editor.neos)`

and check it outputs the object
<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
