### PR TITLE
BUGFIX: Use better fallback mechanism for input value of RangeEditor

### DIFF
--- a/packages/neos-ui-editors/src/Editors/Range/index.js
+++ b/packages/neos-ui-editors/src/Editors/Range/index.js
@@ -63,6 +63,7 @@ class RangeEditor extends PureComponent {
     render() {
         const options = {...this.constructor.defaultProps.options, ...this.props.options};
         const {value, highlight} = this.props;
+        const valueAsString = value === 0 ? '0' : (value || '');
 
         return (
             <div
@@ -77,7 +78,7 @@ class RangeEditor extends PureComponent {
                     min={options.min}
                     max={options.max}
                     step={options.step}
-                    value={value || ''}
+                    value={valueAsString}
                     className="slider"
                     onChange={this.handleChange}
                     disabled={options.disabled}
@@ -92,7 +93,7 @@ class RangeEditor extends PureComponent {
                             type="text"
                             onKeyPress={this.onKeyPress}
                             onChange={this.handleChange}
-                            value={value || ''}
+                            value={valueAsString}
                             style={ {width: `${options.max.toString().length}ch`} }
                             disabled={options.disabled}
                         />


### PR DESCRIPTION
fixes: #3563 

**The problem**

The range editor used a fallback to ensure that its input receives a string value. This was implemented as an OR-based fallback, e.g.:
```js
value={value || ''}
```

Unfortunately, this has lead to `0` being treated as an empty string, which was not intended.

This is a regression through https://github.com/neos/neos-ui/pull/3504.

**The solution**

I have replaced the fallback mechanism to handle the value `0` explicitly:
```js
value={value === 0 ? '0' : (value || '')}
```

