### PR TITLE
BUGFIX: #3495 dimension selector deactivate search-box

### DIFF
--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelector.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelector.js
@@ -71,7 +71,7 @@ export default class DimensionSelector extends PureComponent {
                 value={activePreset}
                 allowEmpty={false}
                 headerIcon={showDropDownHeaderIcon ? this.props.icon : null}
-                displaySearchBox={sortedPresetOptions.length >= 10}
+                displaySearchBox={false} // TODO reenable `sortedPresetOptions.length >= 10` but see https://github.com/neos/neos-ui/issues/3495
                 searchOptions={searchOptions(this.state.searchTerm, sortedPresetOptions)}
                 onSearchTermChange={this.handleSearchTermChange}
                 noMatchesFoundLabel={i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}


### PR DESCRIPTION

solves as a hotfix #3495

The `SelectBox` component doest seem to work currently when beeing expanded in the upper toolbar.
As it will take some time investigating this, we should disable the optional search feature to make the switcher useable for now at all.

before:


https://github.com/neos/neos-ui/assets/85400359/d072eee4-4799-4c23-b28d-045888f4dc1b


after:

https://github.com/neos/neos-ui/assets/85400359/3f4a2f70-df82-4c16-86ba-0d3fa5cd4105




**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
