### PR TITLE
BUGFIX: Prevent error when initialising a node that is not in the store yet

### DIFF
--- a/packages/neos-ui-guest-frame/src/initializeContentDomNode.js
+++ b/packages/neos-ui-guest-frame/src/initializeContentDomNode.js
@@ -12,6 +12,13 @@ import style from './style.css';
 
 export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry, nodes}) => contentDomNode => {
     const contextPath = contentDomNode.getAttribute('data-__neos-node-contextpath');
+
+    if (!nodes[contextPath]) {
+        // Node is not available in the store yet, so we can't initialize any interaction
+        console.warn(`Node with context path "${contextPath}" is not available in the store yet.`);
+        return;
+    }
+
     const isHidden = $get([contextPath, 'properties', '_hidden'], nodes);
     const hasChildren = Boolean($count([contextPath, 'children'], nodes));
     const isInlineEditable = nodeTypesRegistry.isInlineEditable($get([contextPath, 'nodeType'], nodes));

--- a/packages/neos-ui-guest-frame/src/initializePropertyDomNode.js
+++ b/packages/neos-ui-guest-frame/src/initializePropertyDomNode.js
@@ -14,6 +14,13 @@ export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry,
     const initializedInlineEditorApis = guestFrameWindow['@Neos.Neos.Ui:InitializedInlineEditors'];
     const propertyName = propertyDomNode.getAttribute('data-__neos-property');
     const contextPath = closestContextPathInGuestFrame(propertyDomNode);
+
+    if (!nodes[contextPath]) {
+        // Node is not available in the store, so we can't initialize the inline editor
+        console.warn(`Node with context path "${contextPath}" is not available in the store yet.`);
+        return;
+    }
+
     const nodeTypeName = $get([contextPath, 'nodeType'], nodes);
     const nodeType = nodeTypesRegistry.get(nodeTypeName);
     const isInlineEditable = (


### PR DESCRIPTION
This can happen when a node is added via content references, as the backend doesn’t have any nodedata yet for the nodes that are rendered in the guest frame.

Resolves: #3574
