### PR TITLE
BUGFIX: fix bug with pixelSnapping on certain aspectRatios and image dimensions

### DIFF
--- a/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/index.js
+++ b/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/index.js
@@ -159,8 +159,14 @@ export default class ImageCropper extends PureComponent {
             const normalizedAspectRatioHeight = currentAspectRatioStrategy.height / aspectRatioGcd;
 
             // pixel perfect calculations
-            const naturalCropWidth = Math.floor(imageWidth * (cropArea.width / 100) / normalizedAspectRatioWidth) * normalizedAspectRatioWidth;
-            const naturalCropHeight = naturalCropWidth / normalizedAspectRatioWidth * normalizedAspectRatioHeight;
+            let naturalCropWidth = Math.floor(imageWidth * (cropArea.width / 100) / normalizedAspectRatioWidth) * normalizedAspectRatioWidth;
+            let naturalCropHeight = naturalCropWidth / normalizedAspectRatioWidth * normalizedAspectRatioHeight;
+
+            while (naturalCropHeight > imageHeight) {
+                // can't crop area larger than image itself, so keep subtracting normalized aspect ratio values until area is valid
+                naturalCropHeight -= normalizedAspectRatioHeight;
+                naturalCropWidth -= normalizedAspectRatioWidth;
+            }
 
             // modify cropArea with pixel snapping values
             cropArea.width = (naturalCropWidth / imageWidth) * 100;


### PR DESCRIPTION
With 8.2 the pixelSnapping feature got introduced https://github.com/neos/neos-ui/pull/3065. We started using it in all our installations and I noticed a rare bug happening with specific combinations of image sizes and aspect ratio. 

Since only `cropArea.width` is used for calculating the dimensions, it might happen that the resulting `naturalCropHeight` was bigger than the image itself, leading to errors when trying to save the image. I think it happened due to rounding in react-crop component.

The solution is made this way to keep ensuring correct aspect ratio values, incrementally subtracting the normalized aspect ratio values until the area is valid.