### PR TITLE
BUGFIX: 3531 Prevent closing of node creation dialog

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
@@ -307,7 +307,7 @@ export default class NodeCreationDialog extends PureComponent {
                 actions={[this.renderBackAction(), this.renderSaveAction()]}
                 title={this.renderTitle()}
                 onRequestClose={this.handleCancel}
-                preventClosing={true}
+                preventClosing={this.state.isDirty}
                 type="success"
                 isOpen
                 style={this.state.secondaryInspectorComponent ? 'jumbo' : 'wide'}

--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
@@ -307,6 +307,7 @@ export default class NodeCreationDialog extends PureComponent {
                 actions={[this.renderBackAction(), this.renderSaveAction()]}
                 title={this.renderTitle()}
                 onRequestClose={this.handleCancel}
+                preventClosing={true}
                 type="success"
                 isOpen
                 style={this.state.secondaryInspectorComponent ? 'jumbo' : 'wide'}

--- a/packages/react-ui-components/src/Dialog/DialogManager.spec.ts
+++ b/packages/react-ui-components/src/Dialog/DialogManager.spec.ts
@@ -24,9 +24,9 @@ describe('DialogManager', () => {
                 removeEventListener: jest.fn(),
             };
             const dialogManager = new DialogManager({ eventRoot });
-            const dialog1: Dialog = { close: jest.fn() };
-            const dialog2: Dialog = { close: jest.fn() };
-            const dialog3: Dialog = { close: jest.fn() };
+            const dialog1: Dialog = { close: jest.fn().mockReturnValue(true) };
+            const dialog2: Dialog = { close: jest.fn().mockReturnValue(true) };
+            const dialog3: Dialog = { close: jest.fn().mockReturnValue(true) };
 
             dialogManager.register(dialog1);
             dialogManager.register(dialog2);
@@ -41,9 +41,9 @@ describe('DialogManager', () => {
                 removeEventListener: jest.fn(),
             };
             const dialogManager = new DialogManager({ eventRoot });
-            const dialog1: Dialog = { close: jest.fn() };
-            const dialog2: Dialog = { close: jest.fn() };
-            const dialog3: Dialog = { close: jest.fn() };
+            const dialog1: Dialog = { close: jest.fn().mockReturnValue(true) };
+            const dialog2: Dialog = { close: jest.fn().mockReturnValue(true) };
+            const dialog3: Dialog = { close: jest.fn().mockReturnValue(true) };
 
             // Register dialogs
             dialogManager.register(dialog1);
@@ -113,9 +113,9 @@ describe('DialogManager', () => {
                 removeEventListener: jest.fn(),
             };
             const dialogManager = new DialogManager({ eventRoot });
-            const dialog1: Dialog = { close: jest.fn() };
-            const dialog2: Dialog = { close: jest.fn() };
-            const dialog3: Dialog = { close: jest.fn() };
+            const dialog1: Dialog = { close: jest.fn().mockReturnValue(true) };
+            const dialog2: Dialog = { close: jest.fn().mockReturnValue(true) };
+            const dialog3: Dialog = { close: jest.fn().mockReturnValue(true) };
 
             dialogManager.register(dialog1);
             dialogManager.register(dialog2);
@@ -148,9 +148,9 @@ describe('DialogManager', () => {
                 removeEventListener: jest.fn(),
             };
             const dialogManager = new DialogManager({ eventRoot });
-            const dialog1: Dialog = { close: jest.fn() };
-            const dialog2: Dialog = { close: jest.fn() };
-            const dialog3: Dialog = { close: jest.fn() };
+            const dialog1: Dialog = { close: jest.fn().mockReturnValue(true) };
+            const dialog2: Dialog = { close: jest.fn().mockReturnValue(true) };
+            const dialog3: Dialog = { close: jest.fn().mockReturnValue(true) };
 
             dialogManager.register(dialog1);
             dialogManager.register(dialog2);
@@ -173,14 +173,44 @@ describe('DialogManager', () => {
             expect(eventRoot.removeEventListener).toBeCalledTimes(1);
         });
 
+        it('but `dialog.close` prevents a close by returning `false`', () => {
+            const eventRoot: EventRoot = {
+                addEventListener: jest.fn(),
+                removeEventListener: jest.fn(),
+            };
+            const dialogManager = new DialogManager({ eventRoot });
+
+            const closeMock = jest.fn();
+
+            const dialog1: Dialog = { close: closeMock };
+
+            // prevent close
+            closeMock.mockReturnValue(false);
+
+            dialogManager.register(dialog1);
+
+            dialogManager.closeLatest();
+            expect(dialog1.close).toHaveBeenCalledTimes(1);
+
+            expect(eventRoot.removeEventListener).not.toBeCalled();
+
+            closeMock.mockReturnValue(true);
+
+            // allow close
+            dialogManager.closeLatest();
+            expect(dialog1.close).toHaveBeenCalledTimes(2);
+
+            expect(eventRoot.removeEventListener).toBeCalledTimes(1);
+        });
+
         it('closes a registered dialog only once, even if has been registered twice - in which case it uses order of first registration', () => {
             const eventRoot: EventRoot = {
                 addEventListener: jest.fn(),
                 removeEventListener: jest.fn(),
             };
             const dialogManager = new DialogManager({ eventRoot });
-            const dialog1: Dialog = { close: jest.fn() };
-            const dialog2: Dialog = { close: jest.fn() };
+            const dialog1: Dialog = { close: jest.fn().mockReturnValue(true) };
+            const dialog2: Dialog = { close: jest.fn().mockReturnValue(true) };
 
             dialogManager.register(dialog1);
             dialogManager.register(dialog2);
@@ -203,9 +233,9 @@ describe('DialogManager', () => {
                 removeEventListener: jest.fn(),
             };
             const dialogManager = new DialogManager({ eventRoot });
-            const dialog1: Dialog = { close: jest.fn() };
-            const dialog2: Dialog = { close: jest.fn() };
-            const dialog3: Dialog = { close: jest.fn() };
+            const dialog1: Dialog = { close: jest.fn().mockReturnValue(true) };
+            const dialog2: Dialog = { close: jest.fn().mockReturnValue(true) };
+            const dialog3: Dialog = { close: jest.fn().mockReturnValue(true) };
 
             dialogManager.register(dialog1);
             dialogManager.register(dialog2);
@@ -228,7 +258,7 @@ describe('DialogManager', () => {
                 removeEventListener: jest.fn(),
             };
             const dialogManager = new DialogManager({ eventRoot });
-            const dialog: Dialog = { close: jest.fn() };
+            const dialog: Dialog = { close: jest.fn().mockReturnValue(true) };
 
             dialogManager.register(dialog);
             dialogManager.forget(dialog);

--- a/packages/react-ui-components/src/Dialog/DialogManager.ts
+++ b/packages/react-ui-components/src/Dialog/DialogManager.ts
@@ -4,7 +4,7 @@ export interface EventRoot {
 }
 
 export interface Dialog {
-    close: () => void;
+    close: () => boolean;
 }
 
 export class DialogManager {
@@ -36,8 +36,11 @@ export class DialogManager {
     public closeLatest(): void {
         const dialog = this.dialogs.pop();
         if (dialog) {
-            dialog.close();
-            this.removeHandleKeydownEventListenerIfNecessary();
+            if (dialog.close()) {
+                this.removeHandleKeydownEventListenerIfNecessary();
+            } else {
+                this.dialogs.push(dialog);
+            }
         }
     }
 

--- a/packages/react-ui-components/src/Dialog/__snapshots__/dialog.spec.tsx.snap
+++ b/packages/react-ui-components/src/Dialog/__snapshots__/dialog.spec.tsx.snap
@@ -47,39 +47,39 @@ exports[`<Dialog/> Portal should render correctly. 1`] = `
     role="dialog"
     tabIndex={0}
   >
-    <DialogWithoutOverlay
-      actions={
-        Array [
-          "Foo 1",
-          "Foo 2",
-        ]
-      }
-      autoFocus={true}
-      isOpen={true}
-      onRequestClose={[Function]}
-      style="wide"
-      theme={
-        Object {
-          "dialog": "dialogClassName",
-          "dialog--error": "errorClassName",
-          "dialog--jumbo": "jumboClassName",
-          "dialog--narrow": "narrowClassName",
-          "dialog--success": "successClassName",
-          "dialog--warn": "warnClassName",
-          "dialog--wide": "wideClassName",
-          "dialog__actions": "actionsClassName",
-          "dialog__body": "bodyClassName",
-          "dialog__closeBtn": "closeBtnClassName",
-          "dialog__contents": "contentsClassName",
-          "dialog__contentsPosition": "contentsPositionClassName",
-          "dialog__title": "titleClassName",
-        }
-      }
-      title="Foo title"
-      type="error"
+    <div
+      className="contentsPositionClassName"
+      tabIndex={0}
     >
-      Foo children
-    </DialogWithoutOverlay>
+      <div
+        className="contentsClassName"
+      >
+        <div
+          className="titleClassName"
+        >
+          Foo title
+        </div>
+        <div
+          className="bodyClassName errorClassName dialog__body"
+        >
+          Foo children
+        </div>
+        <div
+          className="actionsClassName"
+        >
+          <span
+            key="0/.0"
+          >
+            Foo 1
+          </span>
+          <span
+            key="1/.1"
+          >
+            Foo 2
+          </span>
+        </div>
+      </div>
+    </div>
   </section>
 </Portal>
 `;

--- a/packages/react-ui-components/src/Dialog/dialog.spec.tsx
+++ b/packages/react-ui-components/src/Dialog/dialog.spec.tsx
@@ -27,6 +27,7 @@ describe('<Dialog/>', () => {
             'dialog__contents': 'contentsClassName',
             'dialog__contentsPosition': 'contentsPositionClassName',
             'dialog__title': 'titleClassName',
+            'dialog--effect__shake': 'effectShakeClassName'
         },
         title: 'Foo title',
     };

--- a/packages/react-ui-components/src/Dialog/dialog.spec.tsx
+++ b/packages/react-ui-components/src/Dialog/dialog.spec.tsx
@@ -2,7 +2,7 @@ import {shallow} from 'enzyme';
 import toJson from 'enzyme-to-json';
 import React from 'react';
 
-import DialogWithOverlay, {DialogProps, DialogWithoutOverlay} from './dialog';
+import DialogWithOverlay, {DialogProps} from './dialog';
 
 describe('<Dialog/>', () => {
     const props: DialogProps = {
@@ -38,7 +38,9 @@ describe('<Dialog/>', () => {
     });
 
     it('Content should render correctly.', () => {
-        const wrapper = shallow(<DialogWithoutOverlay {...props}/>);
+        const component = new DialogWithOverlay(props);
+
+        const wrapper = shallow(component.renderDialogWithoutOverlay());
 
         expect(toJson(wrapper)).toMatchSnapshot();
     });
@@ -65,7 +67,9 @@ describe('<Dialog/>', () => {
     });
 
     it('should render the actions if passed.', () => {
-        const wrapper = shallow(<DialogWithoutOverlay {...props}/>);
+        const component = new DialogWithOverlay(props);
+
+        const wrapper = shallow(component.renderDialogWithoutOverlay());
 
         expect(wrapper.html().includes('Foo 1')).toBeTruthy();
         expect(wrapper.html().includes('Foo 2')).toBeTruthy();

--- a/packages/react-ui-components/src/Dialog/dialog.tsx
+++ b/packages/react-ui-components/src/Dialog/dialog.tsx
@@ -129,7 +129,7 @@ class DialogWithOverlay extends PureComponent<DialogProps> {
 
         const finalClassNameBody = mergeClassNames(
             theme.dialog__body,
-            {
+            this.state.isShaking ? theme['dialog--warn'] : {
                 [theme['dialog--success']]: type === 'success',
                 [theme['dialog--warn']]: type === 'warn',
                 [theme['dialog--error']]: type === 'error',
@@ -201,7 +201,7 @@ class DialogWithOverlay extends PureComponent<DialogProps> {
                 [theme['dialog--jumbo']]: style === 'jumbo',
                 [theme['dialog--narrow']]: style === 'narrow',
             },
-            {
+            this.state.isShaking ? theme['dialog--warn'] : {
                 [theme['dialog--success']]: type === 'success',
                 [theme['dialog--warn']]: type === 'warn',
                 [theme['dialog--error']]: type === 'error',

--- a/packages/react-ui-components/src/Dialog/dialog.tsx
+++ b/packages/react-ui-components/src/Dialog/dialog.tsx
@@ -83,7 +83,7 @@ const dialogManager = new DialogManager({
     eventRoot: document
 });
 
-export class DialogWithoutOverlay extends PureComponent<DialogProps> {
+class DialogWithOverlay extends PureComponent<DialogProps> {
     // tslint:disable-next-line:readonly-keyword
     private ref?: HTMLDivElement;
 
@@ -91,7 +91,7 @@ export class DialogWithoutOverlay extends PureComponent<DialogProps> {
         close: this.props.onRequestClose,
     };
 
-    public render(): JSX.Element {
+    public renderDialogWithoutOverlay(): JSX.Element {
         const { title, children, actions, theme, type } = this.props;
 
         const finalClassNameBody = mergeClassNames(
@@ -143,10 +143,7 @@ export class DialogWithoutOverlay extends PureComponent<DialogProps> {
     public readonly componentWillUnmount = (): void => {
         dialogManager.forget(this.dialog);
     }
-}
 
-// tslint:disable-next-line:max-classes-per-file
-class DialogWithOverlay extends PureComponent<DialogProps> {
     public render(): JSX.Element | null {
         const {
             className,
@@ -188,7 +185,7 @@ class DialogWithOverlay extends PureComponent<DialogProps> {
                 tabIndex={0}
                 onClick={this.handleOverlayClick}
             >
-                <DialogWithoutOverlay {...this.props} />
+                {this.renderDialogWithoutOverlay()}
             </section>,
             document.body
         );

--- a/packages/react-ui-components/src/Dialog/style.css
+++ b/packages/react-ui-components/src/Dialog/style.css
@@ -102,3 +102,33 @@
     height: 100%;
     width: 100%;
 }
+
+.dialog--effect__shake {
+    animation: shake .82s cubic-bezier(.36, .07, .19, .97) both;
+    transform: translate3d(0, 0, 0);
+    backface-visibility: hidden;
+    perspective: 1000px;
+}
+@keyframes shake {
+
+    10%,
+    90% {
+        transform: translate3d(-1px, 0, 0);
+    }
+
+    20%,
+    80% {
+        transform: translate3d(2px, 0, 0);
+    }
+
+    30%,
+    50%,
+    70% {
+        transform: translate3d(-4px, 0, 0);
+    }
+
+    40%,
+    60% {
+        transform: translate3d(4px, 0, 0);
+    }
+}


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

resolves: #3531

(alternative fix than https://github.com/neos/neos-ui/pull/3573)

and show shaking animation like in the neos login via DialogWithOverlay.preventClosing

we currently always prevent any accidental closing independent of pending changes

https://github.com/neos/neos-ui/assets/85400359/b81ce4a8-8f12-4465-8573-3077212654f5

(And yes escape is covered / prevented as well)

thanks @grebaldi for the help ;) ❤️ 

**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
