### PR TITLE
BUGFIX: Show resize icon on safari for document tree

### DIFF
--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/style.module.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/style.module.css
@@ -3,7 +3,6 @@
     /* Node Tree is expected to be rendered inside a display: flex container - and it will take up all remaining space */
     flex: 1 0 0px;
     transition: var(--transition-Slow) ease height, overflow-y var(--transition-Slow);
-    background: var(--colors-ContrastDarker);
     border-bottom: 1px solid var(--colors-ContrastDark);
     border-right: 1px solid var(--colors-ContrastDark);
 }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/style.module.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/style.module.css
@@ -1,5 +1,4 @@
 .pageTree {
-    overflow-y: auto;
     /* Node Tree is expected to be rendered inside a display: flex container - and it will take up all remaining space */
     flex: 1 0 0px;
     transition: var(--transition-Slow) ease height, overflow-y var(--transition-Slow);

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/style.module.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/style.module.css
@@ -19,3 +19,6 @@
     float: left;
     width: var(--spacing-GoldenUnit);
 }
+.header {
+    background: var(--colors-ContrastDarkest);
+}

--- a/packages/neos-ui/src/Containers/LeftSideBar/style.module.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/style.module.css
@@ -45,6 +45,7 @@
     resize: vertical;
     overflow-y: auto;
     z-index: 1;
+    background: var(--colors-ContrastDarker);
 }
 .leftSideBar__top--isFullHeight {
     flex: 1;
@@ -57,6 +58,7 @@
     flex-direction: column;
     min-height: 40px;
     margin-right: var(--spacing-Quarter);
+    background: var(--colors-ContrastDarker);
 }
 
 .leftSideBar__bottom--isCollapsed {


### PR DESCRIPTION
**What I did**

Both resize icons for the left sidebar are now visible (functionality was always there only invisible)

Resolves: #3556

**How I did it**

Removed the background color from the tree component itself and instead set the background colours of the parent component that define the resize option.

**How to verify it**

Check in all browsers whether the resize icons all properly show up.