### PR TITLE
BUGFIX: Image cropper has incorrect height with 150% zoom

### DIFF
--- a/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/index.js
+++ b/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/index.js
@@ -86,7 +86,9 @@ export default class ImageCropper extends PureComponent {
     componentDidMount() {
         //
         // Calculate and set maximum height for the cropped image
-        const secondaryEditorHeight = window.innerHeight - 41 - 41;
+        // The upper toolbars (the publish tool bar and ckeditor bar) are each 41px
+        const upperToolbarHeights = 41 + 41;
+        const secondaryEditorHeight = window.innerHeight - upperToolbarHeights;
         const toolbarStyles = getComputedStyle(this.toolbarNode);
         const toolbarFullHeight = parseInt(toolbarStyles.height, 10) + parseInt(toolbarStyles['margin-top'], 10) + parseInt(toolbarStyles['margin-bottom'], 10);
         const spacing = 32;

--- a/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/index.js
+++ b/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/index.js
@@ -86,11 +86,12 @@ export default class ImageCropper extends PureComponent {
     componentDidMount() {
         //
         // Calculate and set maximum height for the cropped image
-        const containerHeight = this.containerNode.parentElement.clientHeight;
+        const secondaryEditorHeight = window.innerHeight - 41 - 41;
         const toolbarStyles = getComputedStyle(this.toolbarNode);
         const toolbarFullHeight = parseInt(toolbarStyles.height, 10) + parseInt(toolbarStyles['margin-top'], 10) + parseInt(toolbarStyles['margin-bottom'], 10);
         const spacing = 32;
-        const height = (containerHeight - toolbarFullHeight - spacing) + 'px';
+        const height = (secondaryEditorHeight - toolbarFullHeight - spacing) + 'px';
+
         const imageNode = this.containerNode.querySelector('.ReactCrop__image');
         const imageCopyNode = this.containerNode.querySelector('.ReactCrop__image-copy');
         imageNode.style.maxHeight = height;


### PR DESCRIPTION
The `containerHeight` should be (on my pc) `532px` but instead is higher with `617px` as the `ReactCrop` component will already be rendered and falsifies the result (stretches the inner height). To get the correct height of an empty SecondaryEditor, we either need to calculate `100vh - 41px - 41px` (the size of the upper toolbars)

An alternative approach would be, to `display: none` everything in the secondary editor (especially the `ReactCrop` component) to be able to calculate the correct height without any inner influence, and later show the inner contents again.

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

actual:

<img width="1716" alt="image" src="https://github.com/neos/neos-ui/assets/85400359/e8938339-ff4e-4571-8532-93dcd67b7413">

expected:

<img width="1727" alt="image" src="https://github.com/neos/neos-ui/assets/85400359/c016996b-cdca-4b01-93b6-d8d9a99b7295">



**What I did**

**How I did it**

**How to verify it**

Set your resolution (on windows in the settings to 150%)

or on mac, just use the browser zoom to get to 150%


<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
