### PR TITLE
TASK: Allow node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "vfile-message": "^2.0.2"
   },
   "engines": {
-    "node": "~14"
+    "node": "~14 || ~16"
   },
   "devDependencies": {
     "@neos-project/brand": "^1.1.0",


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

resolves: #3566


**What I did**

formally allow node 16 in older branches, otherwise i always get

> error @: The engine "node" is incompatible with this module. Expected version "~14". Got "16.16.0"
> error Found incompatible module.

but the build and linting works perfectly on 16 (ive used it since ever with node 16 :joy: i dont have 14 installed on my system ^^) 

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
