### PR TITLE
BUGFIX Prevent prop `preventClosing` being passed to dom

### DIFF
--- a/packages/react-ui-components/src/Dialog/dialog.tsx
+++ b/packages/react-ui-components/src/Dialog/dialog.tsx
@@ -190,6 +190,7 @@ class DialogWithOverlay extends PureComponent<DialogProps> {
             actions,
             theme,
             type,
+            preventClosing,
             onRequestClose,
             ...rest
         } = this.props;


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

Fixes #3586

This is very likely a regression through https://github.com/neos/neos-ui/pull/3579, where the `preventClosing` prop was introduced. We seem to have missed that it is forwarded down to some DOM element.

**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
