### PR TITLE
TASK: Add moment locales to have a localized DatePicker

### DIFF
--- a/packages/react-ui-components/src/DateInput/dateInput.tsx
+++ b/packages/react-ui-components/src/DateInput/dateInput.tsx
@@ -10,6 +10,8 @@ import {PickDefaultProps} from '../../types';
 import Button from '../Button';
 import Icon from '../Icon';
 
+// WHY: Because momentJs locales are not bundled automatically, we have to explicitly add them.
+import 'moment/locale/de';
 
 export interface DateInputProps {
     /**


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**
A customer notized that the DatePicker Editor is not localized (anymore?).
So I added the missing moment locales.

**How I did it**
Our current DatePicker is localized via `moment` locales, so I had to import them.
This sadly adds ~200kb to the bundle.

We could also only import specific locales (e.g. `de`, etc.) to keep the bundle size impact smaller.

**How to verify it**
Change language in user setting and open the DatePicker Editor in the Neos Inspector.
<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
