### PR TITLE
DRAFT FEATURE: add information to dimensions menu

### DIFF
--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelector.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelector.js
@@ -2,7 +2,7 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import SelectBox from '@neos-project/react-ui-components/src/SelectBox/';
 import style from './style.module.css';
-import {$get, $transform} from 'plow-js';
+import {$transform} from 'plow-js';
 import mapValues from 'lodash.mapvalues';
 import sortBy from 'lodash.sortby';
 import {neos} from '@neos-project/neos-ui-decorators';
@@ -48,9 +48,11 @@ export default class DimensionSelector extends PureComponent {
             (presetConfiguration, presetName) => {
                 return $transform(
                     {
-                        label: $get('label'),
+                        label: presetConfiguration?.label,
                         value: presetName,
-                        disallowed: $get('disallowed')
+                        disallowed: presetConfiguration?.disallowed,
+                        existing: presetConfiguration?.existing,
+                        url: presetConfiguration?.url
                     },
                     presetConfiguration
                 );

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelectorOption.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelectorOption.js
@@ -1,25 +1,51 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import style from './style.module.css';
-// eslint-disable-next-line camelcase
+import SelectBox_Option_SingleLineLink from '@neos-project/react-ui-components/src/SelectBox_Option_SingleLineLink/index';
 import SelectBox_Option_SingleLine from '@neos-project/react-ui-components/src/SelectBox_Option_SingleLine/index';
+import mergeClassNames from 'classnames';
 
 export default class DimensionSelectorOption extends PureComponent {
     static propTypes = {
         option: PropTypes.shape({
             label: PropTypes.string.isRequired,
-            disallowed: PropTypes.bool
+            disallowed: PropTypes.bool,
+            existing: PropTypes.bool,
+            url: PropTypes.string
         })
     };
 
     render() {
         const {option} = this.props;
 
+        const className = mergeClassNames({
+            [style.lighter]: !option.existing,
+            [style.strikethrough]: option.disallowed
+        });
+
+        if (option.existing) {
+            const linkOptions = {
+                className: style.whiteLink,
+                href: option.url,
+                target: '_blank',
+                rel: 'noopener noreferrer',
+                onClick: (event) => event.preventDefault()
+            }
+
+            return (
+                <SelectBox_Option_SingleLineLink
+                    {...this.props}
+                    className={className}
+                    label={option.label}
+                    linkOptions={linkOptions}
+                />
+            );
+        }
+
         return (
-            // eslint-disable-next-line camelcase
             <SelectBox_Option_SingleLine
                 {...this.props}
-                className={option.disallowed ? style.dimmed : ''}
+                className={className}
                 label={option.label}
             />
         );

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/style.module.css
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/style.module.css
@@ -60,8 +60,16 @@
     }
 }
 
-.dimmed {
-    filter: opacity(50%);
+.strikethrough {
+    text-decoration: line-through;
+}
+
+.lighter {
+    filter: opacity(75%);
+}
+
+.whiteLink {
+    color: white;
 }
 
 .selectPreset + .selectPreset {

--- a/packages/react-ui-components/src/SelectBox_Option_SingleLineLink/index.js
+++ b/packages/react-ui-components/src/SelectBox_Option_SingleLineLink/index.js
@@ -1,0 +1,4 @@
+/* eslint-disable camelcase, react/jsx-pascal-case */
+import SelectBox_Option_SingleLineLink from './selectBox_Option_SingleLineLink';
+
+export default SelectBox_Option_SingleLineLink;

--- a/packages/react-ui-components/src/SelectBox_Option_SingleLineLink/selectBox_Option_SingleLineLink.js
+++ b/packages/react-ui-components/src/SelectBox_Option_SingleLineLink/selectBox_Option_SingleLineLink.js
@@ -1,0 +1,39 @@
+/* eslint-disable camelcase, react/jsx-pascal-case */
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+import ListPreviewElement from '../ListPreviewElement';
+import mergeClassNames from 'classnames';
+
+class SelectBox_Option_SingleLineLink extends PureComponent {
+    static propTypes = {
+        option: PropTypes.shape({
+            label: PropTypes.string.isRequired,
+            icon: PropTypes.string,
+            disabled: PropTypes.bool
+        }).isRequired,
+
+        disabled: PropTypes.bool,
+
+        className: PropTypes.string
+    }
+
+    render() {
+        const {option, className, disabled, icon, linkOptions} = this.props;
+
+        const isDisabled = disabled || option.disabled;
+
+        const finalClassNames = mergeClassNames({
+            [className]: className
+        });
+
+        const previewElementIcon = option.icon ? option.icon : (icon ? icon : null);
+
+        return (
+            <ListPreviewElement {...this.props} icon={previewElementIcon} disabled={isDisabled} className={finalClassNames}>
+                <a {...linkOptions} title={option.label}>{option.label}</a>
+            </ListPreviewElement>
+        );
+    }
+}
+
+export default SelectBox_Option_SingleLineLink;


### PR DESCRIPTION
Related to: https://github.com/neos/neos-ui/issues/3413

What I did
Show in the dimension menu, if a dimension already exists.
Add links to existing dimensions, to be able to open them in new browser tabs.

How I did it
getNodeByContextPath gives us a Node with otherNodeVariants attached.
With this information we can find out, which content dimensions already exist and display it in the menu.

For the URL building, I use the current contextPath and append the respective dimensions.

How to verify it
Look at dimension switcher on pages, where not all dimensions exist.

How it looks
Before:
(grey = disallowed)
![Screenshot 2023-07-27 at 16 25 28](https://user-images.githubusercontent.com/46249106/256568098-1acd5ace-0fb2-455e-8da8-c5f0e044147b.png)

After:
(grey = does not exist, strike-through = disallowed)
![Screenshot 2023-07-27 at 16 22 44](https://user-images.githubusercontent.com/46249106/256568106-f6f93887-da70-4158-bfc7-451d54dddfc9.png)

