### PR TITLE
Update Main.xlf: Add 'add' to the translation of the ui

### DIFF
--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -11,6 +11,9 @@
             <trans-unit id="copy__from__to--description" xml:space="preserve">
                 <source>Please select the position at which you want {source} inserted relative to {target}.</source>
             </trans-unit>
+            <trans-unit id="add" xml:space="preserve">
+                <source>Add</source>
+            </trans-unit>
             <trans-unit id="insert" xml:space="preserve">
                 <source>Insert</source>
             </trans-unit>


### PR DESCRIPTION
I added a language label for Neos.Neos.Ui:Main:add that is called in the host.js: n.translate(“Neos.Neos.Ui:Main:add”,“Add”) and always uses its fallback value.
Therefore it isn't translatable.
