### PR TITLE
BUGFIX: 3594 reduce deprecation logs

### DIFF
--- a/packages/neos-ui/src/deprecated-plow.js
+++ b/packages/neos-ui/src/deprecated-plow.js
@@ -1,10 +1,27 @@
 /* eslint-disable */ // IDGAF
 import * as plowOriginal from 'plow-js';
 
+const MAX_WARNINGS = 20;
+
+let warningCount = 0;
+
+let isDev = undefined;
+
 function augmentAndDeprecatedFunction(functionName, functionImplementation) {
     return function() {
-        if (window?.neos?.systemEnv?.startsWith('Development')) {
-            console.warn(`Plow.js "${functionName}" is deprecated! See: https://github.com/neos/neos-ui/issues/3425`);
+        if (isDev === undefined && window?.neos?.systemEnv) {
+            // if we are called before `window.neos` is set, we are in super early boot stage - in the manifest of a plugin
+            isDev = window.neos.systemEnv.startsWith('Development');
+        }
+        if (isDev) {
+            if (warningCount < MAX_WARNINGS) {
+                ++warningCount;
+                console.error(`Warning: Plow.js "${functionName}" is deprecated! See: https://github.com/neos/neos-ui/issues/3425`);
+            }
+            if (warningCount === MAX_WARNINGS) {
+                ++warningCount;
+                console.error(`Warning: Further Plow.js deprecations will be ignored.`)
+            }
         }
         return functionImplementation.apply(this, arguments);
     };


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

Closes #3594

**What I did**

Reduce maximal logs to 20. (This will most likely then only warn about the first loaded plugin instead all affected plugins, but its hard to determine the plugin who called)

Also console.warn was replaced with error to have also stack straces in safari and firefox:

(you can expand the arrow)

<img width="850" alt="image" src="https://github.com/neos/neos-ui/assets/85400359/dce4ff1a-e905-4df3-abbf-a86bc444f8cd">



**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
