### PR TITLE
BUGFIX: Neos 8.3 plugins dont lower yield in plugins

### DIFF
--- a/packages/neos-ui-extensibility-webpack-adapter/scripts/helpers/webpack.config.js
+++ b/packages/neos-ui-extensibility-webpack-adapter/scripts/helpers/webpack.config.js
@@ -45,7 +45,6 @@ module.exports = function (neosPackageJson) {
                                 require.resolve('babel-plugin-transform-es2015-block-scoping'),
                                 require.resolve('babel-plugin-transform-es2015-typeof-symbol'),
                                 require.resolve('babel-plugin-transform-es2015-modules-commonjs'),
-                                [require.resolve('babel-plugin-transform-regenerator'), {async: false, asyncGenerators: false}]
                             ]
                         }
                     }]


### PR DESCRIPTION
Resolves: #3470

This resolves a regression from the EsBuild change in 8.2 as we removed the polyfills (`polyfill.js`) and thus also the regenerator runtime polyfill (`import 'regenerator-runtime/runtime';`). _We removed the polyfills as we were from then on targeting only modern Browsers (at least ES2020) but i didnt think of the fact that build plugins might transpile down to an older es version and thus require `regeneratorRuntime`._

The problem is obscured because other older Neos Ui Plugins might already ship the global `regeneratorRuntime`  and then other plugins can profit from this invisible dependency and work. But as soon as no other plugin is installed anymore or the settings loading order changes (due to a deployment [on another unix system where settings might be picked up in a different order](https://github.com/neos/neos-development-collection/pull/4394#issuecomment-1629254790)) your plugin might stop working.

Plugins using the modern webpack extensibility (v8.2 or 8.3) should simply at no time build plugins which require the legacy `regeneratorRuntime`. This should be the default - and its currently not.

Removing the `babel-plugin-transform-regenerator` from our webpack config works and doesnt transform the code. `yield` stays a js-generator and will not be rewritten to a state machine which depends on `regeneratorRuntime`.


<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
