### PR TITLE
TASK: Refactor Validator translations to Neos.Neos.Ui package

### DIFF
--- a/Resources/Private/Translations/ar/Main.xlf
+++ b/Resources/Private/Translations/ar/Main.xlf
@@ -376,6 +376,90 @@
       <trans-unit id="UI.RightSideBar.tabs.validationErrorTooltip[0]" xml:space="preserve">
                     <source>{tabName} – {amountOfErrors} validation issue</source>
       </trans-unit>
+        <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+            <source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="translated">يجب أن يكون طول هذا النص بين {minimum} و {maximum} حرفاً.</target>
+      </trans-unit>
+       <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+            <source>This field must contain at least {minimum} characters.</source>
+            <target state="translated">هذا المجال يجب ان يحتوى على الاقل {minimum} حروف.</target>
+       </trans-unit>
+        <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+            <source>This text may not exceed {maximum} characters.</source>
+            <target state="translated">النص لايجب ان يتخطى{maximum} حروف.</target>
+      </trans-unit>
+       <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="translated">Only regular characters (a to z, umlauts, ...) and numbers are allowed.</target>
+      </trans-unit>
+       <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve">
+			<source>The given subject was not countable.</source>
+            <target state="needs-translation">The given subject was not countable.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="translated">الاحصاء يجب ان يكون بين{minimum} و {maximum}.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve">
+			<source>The given value was not a valid date.</source>
+            <target state="translated">القيمة المعطاة لم تكن تاريخاً صالحاً.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="translated">التاريخ المعطى يجب ان يكون بين{formatEarliestDate} و {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="needs-translation">The given date must be after {formatEarliestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="needs-translation">The given date must be before {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve">
+			<source>Please specify a valid email address.</source>
+            <target state="translated">الرجاء تحديد عنوان بريد إلكتروني صالح.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve">
+			<source>A valid float number is expected.</source>
+            <target state="needs-translation">A valid float number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve">
+			<source>A valid integer number is expected.</source>
+            <target state="needs-translation">A valid integer number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="translated">يُسمح ببعض الحروف، والأرقام، والفراغات، وعلامات الترقيم.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve">
+			<source>This property is required.</source>
+            <target state="translated">هذه الخاصية مطلوبة.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve">
+			<source>A valid number is expected.</source>
+            <target state="needs-translation">A valid number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="translated">الرجاء إدخل رقم صالح بين {minimum} و{maximum}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="needs-translation">The given subject did not match the pattern ({pattern})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve">
+			<source>A valid string is expected.</source>
+            <target state="needs-translation">A valid string is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="needs-translation">Valid text without any XML tags is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="needs-translation">The given subject is not a valid UUID.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/cs/Main.xlf
+++ b/Resources/Private/Translations/cs/Main.xlf
@@ -379,6 +379,90 @@
       <trans-unit id="inspectorMutlipleContentNodesSelectedTooltip" xml:space="preserve">
                 <source>Select a single document in order to be able to edit its properties</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="needs-translation">The length of this text must be between {minimum} and {maximum} characters.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="needs-translation">This field must contain at least {minimum} characters.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="needs-translation">This text may not exceed {maximum} characters.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="translated">Jsou povoleny pouze znaky a–z a číslice.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve">
+			<source>The given subject was not countable.</source>
+            <target state="needs-translation">The given subject was not countable.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="needs-translation">The count must be between {minimum} and {maximum}.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve">
+			<source>The given value was not a valid date.</source>
+            <target state="needs-translation">The given value was not a valid date.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="needs-translation">The given date must be between {formatEarliestDate} and {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="needs-translation">The given date must be after {formatEarliestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="needs-translation">The given date must be before {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve">
+			<source>Please specify a valid email address.</source>
+            <target state="needs-translation">Please specify a valid email address.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve">
+			<source>A valid float number is expected.</source>
+            <target state="needs-translation">A valid float number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve">
+			<source>A valid integer number is expected.</source>
+            <target state="needs-translation">A valid integer number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="needs-translation">Only letters, numbers, spaces and certain punctuation marks are expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve">
+			<source>This property is required.</source>
+            <target state="needs-translation">This property is required.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve">
+			<source>A valid number is expected.</source>
+            <target state="needs-translation">A valid number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="needs-translation">Please enter a valid number between {minimum} and {maximum}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="needs-translation">The given subject did not match the pattern ({pattern})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve">
+			<source>A valid string is expected.</source>
+            <target state="needs-translation">A valid string is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="needs-translation">Valid text without any XML tags is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="needs-translation">The given subject is not a valid UUID.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/da/Main.xlf
+++ b/Resources/Private/Translations/da/Main.xlf
@@ -427,6 +427,90 @@
                 <source>Preformatted</source>
         <target state="translated">Forformateret</target>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve" approved="no">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="translated">Længden af denne tekst skal være mellem {minimum} og {maximum} tegn.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve" approved="no">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="translated">Dette felt skal indeholde mindst {minimum} tegn.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve" approved="no">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="translated">Denne tekst må ikke overstige {maximum} tegn.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve" approved="yes">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="final">Kun almindelige bogstaver (a-z, æøå) og tal er tilladt.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve" approved="yes">
+			<source>The given subject was not countable.</source>
+            <target state="final">Givet emne var ikke tællelig.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve" approved="no">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="translated">Optællingen skal være mellem {minimum} og {maximum}.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve" approved="yes">
+		    <source>The given value was not a valid date.</source>
+            <target state="final">Den angivne værdi er ikke en gyldig dato.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve" approved="no">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="translated">Den angivne dato skal være mellem {formatEarliestDate} og {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve" approved="no">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="translated">Den angivne dato skal være efter {formatEarliestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve" approved="no">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="translated">Den angivne dato skal være før {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve" approved="yes">
+			<source>Please specify a valid email address.</source>
+            <target state="final">Angiv venligst en gyldig e-mailadresse.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve" approved="yes">
+			<source>A valid float number is expected.</source>
+            <target state="final">Et gyldigt decimaltal forventes.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve" approved="yes">
+			<source>A valid integer number is expected.</source>
+            <target state="final">Et gyldigt heltal forventes.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve" approved="yes">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="final">Kun bogstaver, tal, mellemrum og visse skilletegn forventes.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve" approved="yes">
+			<source>This property is required.</source>
+            <target state="final">Dette felt er påkrævet.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve" approved="yes">
+			<source>A valid number is expected.</source>
+            <target state="final">Et gyldigt tal forventes.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve" approved="no">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="translated">Angiv venligst et gyldigt tal mellem {minimum} og {maximum}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve" approved="no">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="translated">Den givne værdi matcher ikke mønsteret ({pattern})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve" approved="yes">
+			<source>A valid string is expected.</source>
+            <target state="final">En gyldig streng forventes.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve" approved="yes">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="final">Gyldig tekst uden XML-tags er forventet.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve" approved="yes">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="final">Det givne emne er ikke et gyldigt UUID.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -634,6 +634,90 @@
                 <source>Inside</source>
         <target state="translated">Innen</target>
       </trans-unit>
+        <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve" approved="yes">
+				<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="final">Die Länge dieses Textes muss zwischen {minimum} und {maximum} Zeichen sein.</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve" approved="yes">
+				<source>This field must contain at least {minimum} characters.</source>
+            <target state="final">Dieses Feld muss mindestens {minimum} Zeichen enthalten.</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve" approved="yes">
+				<source>This text may not exceed {maximum} characters.</source>
+            <target state="final">Dieser Text darf {maximum} Zeichen nicht überschreiten.</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve" approved="yes">
+				<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="final">Nur Buchstaben (A-Z, Umlaute usw.) und Ziffern sind erlaubt.</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve" approved="yes">
+				<source>The given subject was not countable.</source>
+            <target state="final">Das Objekt ist nicht zählbar.</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve" approved="yes">
+				<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="final">Die Anzahl muss zwischen {minimum} und {maximum} liegen.</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve" approved="yes">
+				<source>The given value was not a valid date.</source>
+            <target state="final">Der angegebene Wert ist kein gültiges Datum.</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve" approved="yes">
+				<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="final">Das angegebene Datum muss zwischen {formatEarliestDate} und {formatLatestDate} liegen</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve" approved="yes">
+				<source>The given date must be after {formatEarliestDate}</source>
+            <target state="final">Das angegebene Datum muss nach {formatEarliestDate} liegen</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve" approved="yes">
+				<source>The given date must be before {formatLatestDate}</source>
+            <target state="final">Das angegebene Datum muss vor {formatLatestDate} liegen</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve" approved="yes">
+				<source>Please specify a valid email address.</source>
+            <target state="final">Bitte geben Sie eine gültige E-Mail-Adresse an.</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve" approved="yes">
+				<source>A valid float number is expected.</source>
+            <target state="final">Eine gültige Dezimalzahl wird erwartet.</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve" approved="yes">
+				<source>A valid integer number is expected.</source>
+            <target state="final">Eine gültige Ganzzahl wird erwartet.</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve" approved="yes">
+				<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="final">Nur Buchstaben, Ziffern, Leerzeichen und bestimmte Satzzeichen sind erlaubt.</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve" approved="yes">
+				<source>This property is required.</source>
+            <target state="final">Diese Eigenschaft ist erforderlich.</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve" approved="yes">
+				<source>A valid number is expected.</source>
+            <target state="final">Eine gültige Zahl wird erwartet.</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve" approved="yes">
+				<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="final">Bitte geben Sie eine gültige Zahl zwischen {minimum} und {maximum} ein.</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve" approved="yes">
+				<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="final">Der angegebene Wert stimmt nicht mit dem Muster ({pattern}) überein</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve" approved="yes">
+				<source>A valid string is expected.</source>
+            <target state="final">Eine gültige Zeichenfolge wird erwartet.</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve" approved="yes">
+				<source>Valid text without any XML tags is expected.</source>
+            <target state="final">Gültiger Text ohne XML-Tags wird erwartet.</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve" approved="yes">
+				<source>The given subject is not a valid UUID.</source>
+            <target state="final">Der Wert ist keine gültige UUID.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/el/Main.xlf
+++ b/Resources/Private/Translations/el/Main.xlf
@@ -376,6 +376,90 @@
       <trans-unit id="deleteXNodes" xml:space="preserve">
                 <source>Delete {amount} nodes</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="needs-translation">The length of this text must be between {minimum} and {maximum} characters.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="needs-translation">This field must contain at least {minimum} characters.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="needs-translation">This text may not exceed {maximum} characters.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="translated">Only regular characters (a to z, umlauts, ...) and numbers are allowed.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve">
+			<source>The given subject was not countable.</source>
+            <target state="needs-translation">The given subject was not countable.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="needs-translation">The count must be between {minimum} and {maximum}.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve">
+			<source>The given value was not a valid date.</source>
+            <target state="needs-translation">The given value was not a valid date.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="needs-translation">The given date must be between {formatEarliestDate} and {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="needs-translation">The given date must be after {formatEarliestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="needs-translation">The given date must be before {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve">
+			<source>Please specify a valid email address.</source>
+            <target state="needs-translation">Please specify a valid email address.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve">
+			<source>A valid float number is expected.</source>
+            <target state="needs-translation">A valid float number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve">
+			<source>A valid integer number is expected.</source>
+            <target state="needs-translation">A valid integer number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="needs-translation">Only letters, numbers, spaces and certain punctuation marks are expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve">
+			<source>This property is required.</source>
+            <target state="needs-translation">This property is required.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve">
+			<source>A valid number is expected.</source>
+            <target state="needs-translation">A valid number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="needs-translation">Please enter a valid number between {minimum} and {maximum}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="needs-translation">The given subject did not match the pattern ({pattern})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve">
+			<source>A valid string is expected.</source>
+            <target state="needs-translation">A valid string is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="needs-translation">Valid text without any XML tags is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="needs-translation">The given subject is not a valid UUID.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -371,6 +371,69 @@
             <trans-unit id="errorBoundary.footer" xml:space="preserve">
                 <source>For more information about the error please refer to the JavaScript console.</source>
             </trans-unit>
+            <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+				<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+			</trans-unit>
+            <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+				<source>This field must contain at least {minimum} characters.</source>
+			</trans-unit>
+            <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+				<source>This text may not exceed {maximum} characters.</source>
+			</trans-unit>
+            <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve">
+				<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+			</trans-unit>
+            <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve">
+				<source>The given subject was not countable.</source>
+			</trans-unit>
+            <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+				<source>The count must be between {minimum} and {maximum}.</source>
+			</trans-unit>
+            <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve">
+				<source>The given value was not a valid date.</source>
+			</trans-unit>
+            <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+				<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+			</trans-unit>
+            <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+				<source>The given date must be after {formatEarliestDate}</source>
+			</trans-unit>
+            <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+				<source>The given date must be before {formatLatestDate}</source>
+			</trans-unit>
+            <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve">
+				<source>Please specify a valid email address.</source>
+			</trans-unit>
+            <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve">
+				<source>A valid float number is expected.</source>
+			</trans-unit>
+            <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve">
+				<source>A valid integer number is expected.</source>
+			</trans-unit>
+            <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve">
+				<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+			</trans-unit>
+            <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve">
+				<source>This property is required.</source>
+			</trans-unit>
+            <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve">
+				<source>A valid number is expected.</source>
+			</trans-unit>
+            <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+				<source>Please enter a valid number between {minimum} and {maximum}</source>
+			</trans-unit>
+            <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+				<source>The given subject did not match the pattern ({pattern})</source>
+			</trans-unit>
+            <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve">
+				<source>A valid string is expected.</source>
+			</trans-unit>
+            <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve">
+				<source>Valid text without any XML tags is expected.</source>
+			</trans-unit>
+            <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve">
+				<source>The given subject is not a valid UUID.</source>
+			</trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Translations/es/Main.xlf
+++ b/Resources/Private/Translations/es/Main.xlf
@@ -534,6 +534,90 @@
                 <source>Format options</source>
         <target state="translated">Opciones del formato</target>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="translated">La longitud de este texto debe ser entre {{minimum}} y {{maximum}} caracteres.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="translated">Este campo debe contener al menos {{minimum}} caracteres.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="translated">Este texto no puede superar {{maximum}} caracteres.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="translated">Sólo están permitidos caracteres alfabéticos (de la a a la z, tildes,...) y números.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve">
+			<source>The given subject was not countable.</source>
+            <target state="translated">El objeto no es contable.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="translated">La cuenta debe estar entre {{minimum}} y {{maximum}}.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve">
+			<source>The given value was not a valid date.</source>
+            <target state="translated">El valor dado no era una fecha válida.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="translated">La fecha debe estar entre {{formatEarliestDate}} y {{formatLatestDate}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="translated">La fecha debe ser posterior a {{formatEarliestDate}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="translated">La fecha debe ser anterior a {{formatLatestDate}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve">
+			<source>Please specify a valid email address.</source>
+            <target state="translated">Especifique una dirección de correo electrónico válida.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve">
+			<source>A valid float number is expected.</source>
+            <target state="translated">Se esperaba un número con decimales válido.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve">
+			<source>A valid integer number is expected.</source>
+            <target state="translated">Se esperaba un número entero válido.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="translated">Sólo son permitidas letras, números, espacios y algunos signos de puntuación.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve">
+			<source>This property is required.</source>
+            <target state="translated">Esta propiedad es necesaria.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve">
+			<source>A valid number is expected.</source>
+            <target state="translated">Se esperaba un número válido.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="translated">Por favor, introduzca un número válido entre {{minimum}} y {{maximum}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="translated">El objeto no coincide con el patrón ({{pattern}})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve">
+			<source>A valid string is expected.</source>
+            <target state="translated">Se esperaba una cadena válida.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="translated">Se esperaba un texto válido sin ninguna etiqueta XML.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="translated">El objeto no es un UUID válido.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/fi/Main.xlf
+++ b/Resources/Private/Translations/fi/Main.xlf
@@ -388,6 +388,90 @@
       <trans-unit id="deleteXNodes" xml:space="preserve">
                 <source>Delete {amount} nodes</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve" approved="yes">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="final">Tekstin pituuden on oltava {{minimum}}-{{maximum}} merkkiä.</target>
+      </trans-unit>
+        <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve" approved="yes">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="final">Kentän vähimmäispituus on {{minimum}} merkkiä.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve" approved="yes">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="final">Tekstin enimmäispituus on {{maximum}} merkkiä.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve" approved="yes">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="final">Ainoastaan kirjaimet ja numerot ovat sallittuja</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve" approved="yes">
+			<source>The given subject was not countable.</source>
+            <target state="final">Kohde ei ole laskettavissa.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve" approved="yes">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="final">Määrän on oltava väliltä {{minimum}}-{{maximum}}.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve" approved="yes">
+			<source>The given value was not a valid date.</source>
+            <target state="final">Arvo ei ole kelvollinen päivämäärä.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve" approved="yes">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="final">Päivämäärän on oltava väliltä {{formatEarliestDate}}-{{formatLatestDate}}</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve" approved="yes">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="final">Päivämäärän on oltava {{formatEarliestDate}} jälkeen</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve" approved="yes">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="final">Päivämäärän on oltava ennen {{formatLatestDate}}</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve" approved="yes">
+			<source>Please specify a valid email address.</source>
+            <target state="final">Anna kelvollinen sähköpostiosoite.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve" approved="yes">
+			<source>A valid float number is expected.</source>
+            <target state="final">Anna kelvollinen liukuluku.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve" approved="yes">
+			<source>A valid integer number is expected.</source>
+            <target state="final">Anna kelvollinen kokonaisluku.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve" approved="yes">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="final">Ainoastaan kirjaimet, numerot, välilyönnit ja tietyt välimerkit ovat sallittuja.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve" approved="yes">
+			<source>This property is required.</source>
+            <target state="final">Pakollinen ominaisuus.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve" approved="yes">
+			<source>A valid number is expected.</source>
+            <target state="final">Kelvollinen numero vaaditaan.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve" approved="yes">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="final">Anna kelvollinen numero väliltä {{minimum}}-{{maximum}}</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve" approved="yes">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="final">Syöte ei vastaa mallia ({pattern})</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve" approved="yes">
+			<source>A valid string is expected.</source>
+            <target state="final">Kelvollinen merkkijono vaaditaan.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve" approved="yes">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="final">Kelvollinen teksti ilman XML-tageja vaaditaan.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve" approved="yes">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="final">Syöte ei ole kelvollinen UUID.</target>
+        </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/fr/Main.xlf
+++ b/Resources/Private/Translations/fr/Main.xlf
@@ -388,6 +388,87 @@
       <trans-unit id="documentsSelected" xml:space="preserve">
                 <source>documents selected</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve" approved="yes">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="final">La longueur de ce texte doit être comprise entre {{minimum}} et {{maximum}} caractères.</target>
+      </trans-unit>
+       <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve" approved="yes">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="final">Ce champ doit contenir au moins {{minimum}} caractères.</target>
+       </trans-unit>
+       <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve" approved="yes">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="final">Ce texte ne doit pas dépasser {{maximum}} caractères.</target>
+       </trans-unit>
+       <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve" approved="yes">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="final">Seuls les caractères a à z et les nombres sont autorisés</target>
+       </trans-unit>
+        <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve" approved="yes">
+			<source>The given subject was not countable.</source>
+            <target state="final">Le sujet donné n'est pas dénombrable.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve" approved="yes">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="final">Le décompte doit être compris entre {{minimum}} et {{maximum}}.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve" approved="yes">
+			<source>The given value was not a valid date.</source>
+            <target state="final">La valeur donnée n'était pas une date valide.</target></trans-unit>
+        <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve" approved="yes">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="final">La date doit être comprise entre le {{formatEarliestDate}} et le {{formatLatestDate}}</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve" approved="yes">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="final">La date donnée doit être après le {{formatEarliestDate}}</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve" approved="yes">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="final">La date donnée doit être avant le {{formatLatestDate}}</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve" approved="yes">
+			<source>Please specify a valid email address.</source>
+            <target state="final">Veuillez entrer une adresse e-mail valide.</target></trans-unit>
+        <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve" approved="yes">
+			<source>A valid float number is expected.</source>
+            <target state="final">Un nombre à virgule flottante valide est attendu.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve" approved="yes">
+			<source>A valid integer number is expected.</source>
+            <target state="final">Un nombre entier valide est attendu.</target></trans-unit>
+        <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve" approved="yes">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="final">Seuls les lettres, les nombres, les espaces et certaines ponctuations sont attentus.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve" approved="yes">
+			<source>This property is required.</source>
+            <target state="final">Cette propriété est obligatoire.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve" approved="yes">
+			<source>A valid number is expected.</source>
+            <target state="final">Un nombre valide est attendu.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve" approved="yes">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="final">Veuillez entrer un nombre valide entre {{minimum}} et {{maximum}}</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve" approved="yes">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="final">Le sujet donné ne correspond pas au modèle ({{pattern}})</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve" approved="yes">
+			<source>A valid string is expected.</source>
+            <target state="final">Une chaîne valide est attendue.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve" approved="yes">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="final">Le texte ne doit pas contenir de balises XML.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve" approved="yes">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="final">Le sujet donné n'est pas un UUID valide.</target>
+        </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/hu/Main.xlf
+++ b/Resources/Private/Translations/hu/Main.xlf
@@ -376,6 +376,90 @@
       <trans-unit id="inspectorMutlipleContentNodesSelectedTooltip" xml:space="preserve">
                 <source>Select a single document in order to be able to edit its properties</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="translated">A szöveg hossza {minimum} és {maximum} karakter között kell legyen.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="translated">Ez a mező legalább {minimum} karakter kell legyen.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="translated">Ez a szöveg maximum {maximum} karakter lehet.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="translated">Csak reguláris karakterek és számok megengedettek.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve">
+			<source>The given subject was not countable.</source>
+            <target state="translated">A megadott objektum nem számolható meg.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="translated">A számnak {minimum} és {maximum} között kell lennie.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve">
+			<source>The given value was not a valid date.</source>
+            <target state="translated">A megadott érték nem érvényes dátum.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="translated">A dátumnak {formatEarliestDate} és {formatLatestDate} között kell lennie</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="translated">A dátumnak {formatEarliestDate} után kell lennie</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="translated">A dátumnak {formatLatestDate} előtt kell lennie</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve">
+			<source>Please specify a valid email address.</source>
+            <target state="translated">Adjon meg egy érvényes e-mail címet.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve">
+			<source>A valid float number is expected.</source>
+            <target state="translated">Egy érvényes lebegőpontos szám szükséges.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve">
+			<source>A valid integer number is expected.</source>
+            <target state="translated">Egy érvényes egész szám szükséges.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="translated">Csak betűk, számok, szóközök és egyes írásjelek érvényesek.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve">
+			<source>This property is required.</source>
+            <target state="translated">Ez a tulajdonság szükséges.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve">
+			<source>A valid number is expected.</source>
+            <target state="translated">Érvényes szám szükséges.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="translated">Adjon meg egy érvényes számot {minimum} és {maximum} között</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="translated">Az megadott tárgy nem található a mintában. {pattern} adott</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve">
+			<source>A valid string is expected.</source>
+            <target state="translated">Érvényes karakterlánc szükséges.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="translated">XML tagok nélküli text szükséges.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="translated">Az adott tárgy nem egy érvényes UUID.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/id/Main.xlf
+++ b/Resources/Private/Translations/id/Main.xlf
@@ -379,6 +379,89 @@
       <trans-unit id="UI.RightSideBar.tabs.validationErrorTooltip[0]" xml:space="preserve">
                     <source>{tabName} – {amountOfErrors} validation issue</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="translated">Panjang teks ini harus antara {minimum} dan {maximum} karakter.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="translated">Bidang ini harus mengandung setidaknya {minimum} karakter.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="translated">Teks ini tidak boleh melebihi {maximum} karakter.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="translated">Hanya karakter biasa (A sampai z, umlauts,...) dan angka yang diperbolehkan.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve">
+			<source>The given subject was not countable.</source>
+            <target state="translated">Subjek tertentu itu tidak dihitung.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="translated">Jumlah harus antara {minimum} dan {maximum}.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve">
+			<source>The given value was not a valid date.</source>
+            <target state="translated">Nilai yang diberikan bukanlah tanggal yang valid.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="translated">Tanggal yang diberikan harus antara {formatEarliestDate} dan {formatLatestDate}</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="translated">Tanggal yang diberikan harus setelah {formatEarliestDate}</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="translated">Tanggal yang diberikan harus sebelum {formatLatestDate}</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve">
+			<source>Please specify a valid email address.</source>
+            <target state="translated">Silakan tentukan alamat email yang valid.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve">
+			<source>A valid float number is expected.</source>
+            <target state="translated">Angka valid yang muncul diharapkan.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve">
+			<source>A valid integer number is expected.</source>
+            <target state="translated">Bilangan bulat yang valid diharapkan.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="translated">Hanya huruf, angka, spasi dan tanda baca tertentu diharapkan.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve">
+			<source>This property is required.</source>
+            <target state="translated">Properti ini diperlukan.</target></trans-unit>
+        <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve">
+			<source>A valid number is expected.</source>
+            <target state="translated">Nomor yang valid diharapkan.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="translated">Masukkan nomor yang valid antara {minimum} dan {maximum}</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="translated">Subjek yang diberikan tidak cocok dengan pola ({pattern})</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve">
+			<source>A valid string is expected.</source>
+            <target state="translated">String yang valid diharapkan.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="translated">Teks yang valid tanpa tag XML diharapkan.</target>
+        </trans-unit>
+        <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="translated">Subjek tertentu bukanlah UUID yang valid.</target>
+        </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/it/Main.xlf
+++ b/Resources/Private/Translations/it/Main.xlf
@@ -376,6 +376,90 @@
       <trans-unit id="syncUriPathSegment" xml:space="preserve">
                 <source>Syncronize with the title property</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="translated">La lunghezza di questo testo deve essere compresa tra {minimum} e {maximum} caratteri.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="translated">Questo campo deve contenere almeno {minimum} caratteri.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="translated">Questo testo non può superare {maximum} caratteri.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="translated">Solo caratteri normali (a-z, dieresi,...) e numeri sono ammessi.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve">
+			<source>The given subject was not countable.</source>
+            <target state="translated">Il soggetto dato non era numerabile.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="translated">Il conto deve essere compreso tra {minimum} e {maximum}.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve">
+			<source>The given value was not a valid date.</source>
+            <target state="translated">Il valore dato non era una data valida.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="translated">La data data deve essere compresa tra {formatEarliestDate} e {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="translated">La data data deve essere successiva a {formatEarliestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="translated">La data data deve essere precedente a {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve">
+			<source>Please specify a valid email address.</source>
+            <target state="translated">Si prega di specificare un indirizzo email valido.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve">
+			<source>A valid float number is expected.</source>
+            <target state="translated">Un numero virtuale valido è previsto.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve">
+			<source>A valid integer number is expected.</source>
+            <target state="translated">Un numero intero valido è previsto.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="translated">Solo lettere, numeri, spazi e certi segni di punteggiatura sono previsti.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve">
+			<source>This property is required.</source>
+            <target state="translated">Questa proprietà è richiesta.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve">
+			<source>A valid number is expected.</source>
+            <target state="translated">Un numero valido è previsto.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="translated">Si prega di inserire un numero valido tra {minimum} e {maximum}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="translated">Il soggetto dato non corrisponde al modello ({pattern})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve">
+			<source>A valid string is expected.</source>
+            <target state="translated">Una stringa valida è prevista.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="translated">Testo valido senza qualsiasi tag XML è previsto.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="translated">Il soggetto dato non è un UUID valido.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/ja/Main.xlf
+++ b/Resources/Private/Translations/ja/Main.xlf
@@ -376,6 +376,90 @@
       <trans-unit id="contentElementsSelected" xml:space="preserve">
                 <source>content elements selected</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="needs-translation">The length of this text must be between {minimum} and {maximum} characters.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="needs-translation">This field must contain at least {minimum} characters.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="needs-translation">This text may not exceed {maximum} characters.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="translated">通常の文字(a〜z、ウムラウト、...) と数字のみが許されます。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve">
+			<source>The given subject was not countable.</source>
+            <target state="translated">与えられたテーマは、可算でした。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="needs-translation">The count must be between {minimum} and {maximum}.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve">
+			<source>The given value was not a valid date.</source>
+            <target state="translated">指定された値は有効な日付ではありませんでした。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="needs-translation">The given date must be between {formatEarliestDate} and {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="needs-translation">The given date must be after {formatEarliestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="needs-translation">The given date must be before {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve">
+			<source>Please specify a valid email address.</source>
+            <target state="translated">有効なメール アドレスを指定してください</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve">
+			<source>A valid float number is expected.</source>
+            <target state="translated">有効な浮動小数点数が期待されます。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve">
+			<source>A valid integer number is expected.</source>
+            <target state="translated">有効な整数が必要です</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="translated">有効な浮動小数点数が期待されます。文字、数字、スペース、およびある特定の句読点だけを期待されています。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve">
+			<source>This property is required.</source>
+            <target state="translated">このプロパティが必要です。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve">
+			<source>A valid number is expected.</source>
+            <target state="translated">有効な番号になっています。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="needs-translation">Please enter a valid number between {minimum} and {maximum}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="needs-translation">The given subject did not match the pattern ({pattern})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve">
+			<source>A valid string is expected.</source>
+            <target state="translated">有効な文字列が期待される。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="needs-translation">Valid text without any XML tags is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="needs-translation">The given subject is not a valid UUID.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/km/Main.xlf
+++ b/Resources/Private/Translations/km/Main.xlf
@@ -388,6 +388,90 @@
       <trans-unit id="rangeEditorCurrentValue" xml:space="preserve">
                 <source>Current value</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve" approved="yes">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="final">ប្រវែងនៃអត្ថបទនេះត្រូវតែនៅចន្លោះ {{អប្បរមា}} និង {{អតិបរមា}} តួអក្សរ។</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve" approved="yes">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="final">ជួរឈរនេះត្រូវតែមានយ៉ាងហោចណាស់ {{អប្បរមា}} តួអក្សរ។</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve" approved="yes">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="final">អត្ថបទនេះមិនអាចលើសពី {{អតិបរមា}} តួអក្សរ។</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve" approved="yes">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="final">បានតែអក្សរឡាតាំង និងលេខតែប៉ុណ្ណោះ</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve" approved="yes">
+			<source>The given subject was not countable.</source>
+            <target state="final">ប្រធានបទមិនត្រូវបានរាប់បញ្ជូល.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve" approved="yes">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="final">ការរាប់ចំនួនត្រូវតែនៅចន្លោះ {{អប្បរមា}} និង {{អតិបរមា}} ។</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve" approved="yes">
+			<source>The given value was not a valid date.</source>
+            <target state="final">តម្លៃដែលឲ្យមិនត្រឹមត្រូវថ្ងៃទេ</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve" approved="yes">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="final">កាលបរិច្ឆេទដែលបានផ្ដល់ឱ្យត្រូវតែនៅចន្លោះ {{formatEarliestDate}} និង {{formatLatestDate}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve" approved="yes">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="final">កាលបរិច្ឆេទដែលបានផ្ដល់ឱ្យត្រូវតែនៅបន្ទាប់ពី {{formatEarliestDate}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve" approved="yes">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="final">កាលបរិច្ឆេទដែលបានផ្ដល់ឱ្យត្រូវតែនៅពីមុខ {{formatEarliestDate}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve" approved="yes">
+			<source>Please specify a valid email address.</source>
+            <target state="final">សូមបញ្ជាក់អាស័យដ្ឋានអ៊ីម៉ែលត្រឹមត្រូវមួយ។</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve" approved="yes">
+			<source>A valid float number is expected.</source>
+            <target state="final">ត្រូវការជាចំនួនទសភាគ</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve" approved="yes">
+			<source>A valid integer number is expected.</source>
+            <target state="final">ត្រូវការជាចំនួនលេខគត់</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve" approved="yes">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="final">ត្រឹមតែអក្សរ, លេខ, ចន្លោះនិងសញ្ញាវណ្ណយុត្តមួយចំនួនត្រូវបានគេរំពឹងទុក។</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve" approved="yes">
+			<source>This property is required.</source>
+            <target state="final">អចលនទ្រព្យនេះត្រូវបានទាមទារ។</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve" approved="yes">
+			<source>A valid number is expected.</source>
+            <target state="final">ត្រូវការជាចំនួនលេខ</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve" approved="yes">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="final">សូមបញ្ចូលលេខដែលត្រឹមត្រូវរវាងចន្លោះ {{អប្បរមា}} និង {{អតិបរមា}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve" approved="yes">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="final">គាត់បានផ្តល់ឱ្យប្រធានបទនោះមិនជាផ្គូផ្គងលំនាំ ({{គំរូ}})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve" approved="yes">
+			<source>A valid string is expected.</source>
+            <target state="final">អក្សរដែលត្រូវរំពឹងថានឹងមានសុពលភាព</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve" approved="yes">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="final">អត្ថបទដែលត្រឹមត្រូវដោយគ្មានស្លាក XML ណាមួយត្រូវបានរំពឹងទុក។</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve" approved="yes">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="final">ការផ្ដល់ឲ្យនូវប្រធានបទគឺមិនមែនជាការ UUID ត្រឹមត្រូវ។</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/lv/Main.xlf
+++ b/Resources/Private/Translations/lv/Main.xlf
@@ -447,6 +447,90 @@
                 <source>Preformatted</source>
         <target state="translated">Iepriekš formatēts</target>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="translated">Šim tekstam jābūt starp {{minimum}} un {{maximum}} rakstzīmēm.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="translated">Šim laukam jāsatur vismaz {{minimum}} rakstzīmes.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="translated">Šis teksts nedrīkst būt garāks par {{maximum}} rakstzīmēm.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve" approved="yes">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="final">Tikai rakstzīmes (līdz z … umlauts) un numuri ir atļauti.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve" approved="yes">
+			<source>The given subject was not countable.</source>
+            <target state="final">Attiecīgais elements nav saskaitāms.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="translated">Skaitam ir jābūt starp {{minimum}} un {{maximum}}.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve" approved="yes">
+			<source>The given value was not a valid date.</source>
+            <target state="final">Noteiktā vērtība nav derīgs datums.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="translated">Dotajam datumam jābūt starp {{formatEarliestDate}} un {{formatLatestDate}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="translated">Dotajam datumam jābūt pēc {{formatEarliestDate}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="translated">Dotajam datumam jābūt pirms {{formatLatestDate}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve" approved="yes">
+			<source>Please specify a valid email address.</source>
+            <target state="final">Lūdzu, norādiet derīgu e-pasta adresi.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve" approved="yes">
+			<source>A valid float number is expected.</source>
+            <target state="final">Tiek gaidīts derīgs mainīgais.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve" approved="yes">
+			<source>A valid integer number is expected.</source>
+            <target state="final">Tiek gaidīts vesels skaitlis.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve" approved="yes">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="final">Ir paredzēts tikai burtiem, cipariem, atstarpēm un dažām interpunkcijas zīmēm.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve" approved="yes">
+			<source>This property is required.</source>
+            <target state="final">Šī vērtība ir nepieciešama.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve" approved="yes">
+			<source>A valid number is expected.</source>
+            <target state="final">Tiek gaidīts derīgs skaitlis.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="translated">Lūdzu, ievadiet derīgu skaitli starp {{minimum}} un {{maximum}}</target>
+      </trans-unit>
+       <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="translated">Attiecīgais lauks neatbilst šablonam ({{pattern}})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve" approved="yes">
+			<source>A valid string is expected.</source>
+            <target state="final">Tiek gaidīts teksts.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve" approved="yes">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="final">Tiek gaidīts derīgs teksts, bez jebkādiem XML tagiem.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve" approved="yes">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="final">Attiecīgajā vērtībā nav derīgs UUID.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/nl/Main.xlf
+++ b/Resources/Private/Translations/nl/Main.xlf
@@ -519,6 +519,90 @@
                 <source>Format options</source>
         <target state="translated">Opmaakopties</target>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="translated">De lengte van deze tekst moet minimaal {minimum} en maximaal {maximum} karakters bevatten.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="translated">Dit veld moet op zijn minst {minimum} karakters bevatten.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="translated">Deze tekst mag niet langer zijn dan {maximum} karakters.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve" approved="no">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="translated">Alleen de karakters a tot en met z en getallen zijn toegestaan.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve" approved="yes">
+			<source>The given subject was not countable.</source>
+            <target state="final">Het gegeven onderwerp is niet telbaar.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="translated">Het resultaat van de optelsom moet minimaal {minimum} zijn en maximaal {maximum}.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve" approved="yes">
+			<source>The given value was not a valid date.</source>
+            <target state="final">De gegeven waarde is geen geldige datum.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="translated">De opgegeven datum moet zich tussen {formatEarliestDate} en {formatLatestDate} bevinden</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="translated">De opgegeven datum moet na {formatEarliestDate} zijn</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="translated">De opgegeven datum moet voor {formatLatestDate} zijn</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve" approved="yes">
+			<source>Please specify a valid email address.</source>
+            <target state="final">Vul een geldig e-mailadres in.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve" approved="yes">
+			<source>A valid float number is expected.</source>
+            <target state="final">Een geldige float waarde wordt verwacht.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve" approved="yes">
+			<source>A valid integer number is expected.</source>
+            <target state="final">Een geldig integer getal wordt verwacht.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve" approved="yes">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="final">Alleen letters, cijfers, spaties en sommige leestekens worden verwacht.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve" approved="yes">
+			<source>This property is required.</source>
+            <target state="final">Dit is een verplicht veld.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve" approved="yes">
+			<source>A valid number is expected.</source>
+            <target state="final">Een geldig nummer wordt verwacht.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="translated">Voer een geldig getal tussen {minimum} en {maximum}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="translated">Het gegeven onderwerp komt niet overeen met het patroon ({pattern})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve" approved="yes">
+			<source>A valid string is expected.</source>
+            <target state="final">Een geldige tekenreeks (string) wordt verwacht.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve" approved="yes">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="final">Geldige tekst zonder XML-tags wordt verwacht.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve" approved="yes">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="final">De opgegeven waarde is geen geldige UUID.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/no/Main.xlf
+++ b/Resources/Private/Translations/no/Main.xlf
@@ -388,6 +388,90 @@
       <trans-unit id="rangeEditorCurrentValue" xml:space="preserve">
                 <source>Current value</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="translated">Lengden på denne teksten må være mellom {{minimum}} og {{maximum}} tegn.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="translated">Dette feltet må inneholde minst {{minimum}} tegn.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="translated">Denne teksten kan ikke være lenger enn {{maximum}} tegn.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="translated">Bare vanlige tegn (a til å, omlyder, m. fl.) og tall er tillatt.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve">
+			<source>The given subject was not countable.</source>
+            <target state="translated">Verdien var ikke tellbar.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="translated">Antallet må være mellom {{minimum}} og {{maximum}}.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve">
+			<source>The given value was not a valid date.</source>
+            <target state="translated">Den gitte verdien var ikke en gyldig dato.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="translated">Den angitte datoen må være mellom {{formatEarliestDate}} og {{formatLatestDate}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="translated">Den angitte datoen må være etter {{formatEarliestDate}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="translated">Den angitte datoen må være før {{formatLatestDate}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve">
+			<source>Please specify a valid email address.</source>
+            <target state="translated">Angi en gyldig epostadresse.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve">
+			<source>A valid float number is expected.</source>
+            <target state="translated">Verdien må være et gyldig desimaltall.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve">
+			<source>A valid integer number is expected.</source>
+            <target state="translated">Verdien må være et gyldig heltall.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="translated">Bare bokstaver, tall, mellomrom og visse tegn kan brukes.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve">
+			<source>This property is required.</source>
+            <target state="translated">Denne verdien er påkrevet.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve">
+			<source>A valid number is expected.</source>
+            <target state="translated">Verdien må være et gyldig tall.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="translated">Angi et tall mellom {{minimum}} og {{maximum}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="translated">Verdien samsvarte ikke med mønsteret ({{pattern}})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve">
+			<source>A valid string is expected.</source>
+            <target state="translated">Verdien må være en tekst.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="translated">Teksten må være uten XML-tagger.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="translated">Verdien er ikke en gyldig UUID.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/pl/Main.xlf
+++ b/Resources/Private/Translations/pl/Main.xlf
@@ -388,6 +388,90 @@
       <trans-unit id="documentsSelected" xml:space="preserve">
                 <source>documents selected</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve" approved="yes">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="final">Długość tego tekstu musi zawierać się między {minimum} i {maximum} znakami.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve" approved="yes">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="final">To pole musi zawierać co najmniej {{minimum}} znaków.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve" approved="yes">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="final">Tekst nie może przekraczać {{maximum}} znaków.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve" approved="yes">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="final">Dozwolone są tylko znaki od a do z i cyfry</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve" approved="yes">
+			<source>The given subject was not countable.</source>
+            <target state="final">Podany element nie jest policzalny.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve" approved="yes">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="final">Wartość licznika musi zawierać się pomiędzy {{minimum}} a {{maximum}}.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve" approved="yes">
+			<source>The given value was not a valid date.</source>
+            <target state="final">Podana wartość nie jest poprawną datą.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve" approved="yes">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="final">Podana data musi zawierać się między {{formatEarliestDate}} i {{formatLatestDate}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve" approved="yes">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="final">Podana data musi być po {{formatEarliestDate}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve" approved="yes">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="final">Podana data musi być przed {{formatLatestDate}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve" approved="yes">
+			<source>Please specify a valid email address.</source>
+            <target state="final">Proszę podać poprawny adres email.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve" approved="yes">
+			<source>A valid float number is expected.</source>
+            <target state="final">Oczekiwana jest poprawna liczba zmiennoprzecinkowa.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve" approved="yes">
+			<source>A valid integer number is expected.</source>
+            <target state="final">Oczekiwana jest poprawna liczba całkowita.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve" approved="yes">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="final">Oczekiwane są tylko litery, cyfry, spacje i wybrane znaki interpunkcyjne.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve" approved="yes">
+			<source>This property is required.</source>
+            <target state="final">Ta właściwość jest wymagana.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve" approved="yes">
+			<source>A valid number is expected.</source>
+            <target state="final">Oczekiwana jest poprawna liczba.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve" approved="yes">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="final">Proszę podać poprawną liczbę pomiędzy {{minimum}} a {{maximum}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve" approved="yes">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="final">Podany ciąg znaków nie odpowiada wzorcowi ({pattern})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve" approved="yes">
+			<source>A valid string is expected.</source>
+            <target state="final">Oczekiwany jest poprawny ciąg znaków.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve" approved="yes">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="final">Oczekiwany jest poprawny tekst bez żadnych znaczników XML.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve" approved="yes">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="final">Podana wartość posiada niepoprawny identyfikator.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/pt/Main.xlf
+++ b/Resources/Private/Translations/pt/Main.xlf
@@ -387,6 +387,90 @@
       <trans-unit id="rangeEditorCurrentValue" xml:space="preserve">
                 <source>Current value</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="translated">O comprimento deste texto deve estar entre {{minimum}} e {{maximum}} caracteres.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="translated">Este campo deve conter pelo menos {{minimum}} caracteres.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="translated">Este texto não pode exceder {{maximum}} caracteres.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="translated">Apenas caracteres regulares (a a z, tremas, ...) e números são permitidos.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve">
+			<source>The given subject was not countable.</source>
+            <target state="translated">O assunto fornecido não é contável.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="translated">A contagem deve estar entre {{minimum}} e {{maximum}}.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve">
+			<source>The given value was not a valid date.</source>
+            <target state="translated">O valor fornecido não é uma data válida.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="translated">A data deve estar entre {{formatEarliestDate}} e {{formatLatestDate}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="translated">A data deve ser depois de {{formatEarliestDate}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="translated">A data deve ser antes de {{formatLatestDate}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve">
+			<source>Please specify a valid email address.</source>
+            <target state="translated">Por favor, especifique um endereço de email válido.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve">
+			<source>A valid float number is expected.</source>
+            <target state="translated">É esperado um número flutuador válido.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve">
+			<source>A valid integer number is expected.</source>
+            <target state="translated">É esperado um número inteiro válido.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="translated">São esperados apenas letras, números, espaços e certas marcas de pontuação.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve">
+			<source>This property is required.</source>
+            <target state="translated">Esta propriedade é necessária.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve">
+			<source>A valid number is expected.</source>
+            <target state="translated">É esperado um número válido.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="translated">Por favor, digite um número válido entre {{minimum}} e {{maximum}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="translated">O determinado assunto não corresponde ao padrão ({{pattern}})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve">
+			<source>A valid string is expected.</source>
+            <target state="translated">Espera-se uma cadeia de caracteres válida</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="translated">Texto válido sem quaisquer tags XML é esperado.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="translated">O determinado assunto não é um válido UUID.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/pt_PT/Main.xlf
+++ b/Resources/Private/Translations/pt_PT/Main.xlf
@@ -388,6 +388,89 @@
       <trans-unit id="UI.RightSideBar.tabs.validationErrorTooltip[0]" xml:space="preserve">
                     <source>{tabName} – {amountOfErrors} validation issue</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="translated">O comprimento deste texto deve estar entre {{minimum}} e {{maximum}} caracteres.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="translated">Este campo deve conter pelo menos {{minimum}} caracteres.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="translated">Este texto não pode exceder {{maximum}} caracteres.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="translated">Somente letras baixas (a a z , tremas, ... ) e números são permitidos.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve">
+			<source>The given subject was not countable.</source>
+            <target state="translated">O assunto fornecido não é contável.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="translated">A contagem deve estar entre {{minimum}} e {{maximum}}.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve">
+			<source>The given value was not a valid date.</source>
+            <target state="translated">O valor fornecido não é uma data válida.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="translated">A data deve estar entre {{formatEarliestDate}} e {{formatLatestDate}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="translated">A data deve ser depois de {{formatEarliestDate}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="translated">A data deve ser antes de {{formatLatestDate}}</target></trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve">
+			<source>Please specify a valid email address.</source>
+            <target state="translated">Por favor, especifique um endereço de email válido.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve">
+			<source>A valid float number is expected.</source>
+            <target state="translated">É esperado um número flutuador válido.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve">
+			<source>A valid integer number is expected.</source>
+            <target state="translated">É esperado um número inteiro válido.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="translated">É esperado apenas letras, números, espaços e certas marcas de pontuação.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve">
+			<source>This property is required.</source>
+            <target state="translated">Esta propriedade é necessária.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve">
+			<source>A valid number is expected.</source>
+            <target state="translated">É esperado um número válido.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="translated">Por favor, digite um número válido entre {{minimum}} e {{maximum}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="translated">O determinado assunto não corresponde ao padrão ({{pattern}})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve">
+			<source>A valid string is expected.</source>
+            <target state="translated">Espera-se caracteres válidos.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="translated">Texto válido sem quaisquer tags XML é esperado.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="translated">O determinado assunto não é um válido UUID.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/ru/Main.xlf
+++ b/Resources/Private/Translations/ru/Main.xlf
@@ -388,6 +388,90 @@
       <trans-unit id="inspectorMutlipleDocumentNodesSelectedTooltip" xml:space="preserve">
                 <source>Select a single content element in order to be able to edit its properties</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve" approved="yes">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="final">Длина этого текста должна быть между {minimum} и {maximum} символами.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve" approved="yes">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="final">Это поле должно содержать по крайней мере {minimum} символов.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve" approved="yes">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="final">Этот текст не может превышать {maximum} символов.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve" approved="yes">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="final">Разрешены только латинские(a до z, умлауты, ...) малые буквы и цифры.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve" approved="yes">
+			<source>The given subject was not countable.</source>
+            <target state="final">Содержимое не является исчислимым.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve" approved="yes">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="final">Количество должно быть между {minimum} и {maximum}.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve" approved="yes">
+			<source>The given value was not a valid date.</source>
+            <target state="final">Данное значение не является допустимой датой.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve" approved="yes">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="final">Данная дата должна быть между {formatEarliestDate} и {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve" approved="yes">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="final">Данная дата должна быть позже чем {formatEarliestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve" approved="yes">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="final">Данная дата должна быть раньше {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve" approved="yes">
+			<source>Please specify a valid email address.</source>
+            <target state="final">Пожалуйста укажите верный адрес электронной почты.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve" approved="yes">
+			<source>A valid float number is expected.</source>
+            <target state="final">Ожидается вещественное число.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve" approved="yes">
+			<source>A valid integer number is expected.</source>
+            <target state="final">Ожидается целое число.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve" approved="yes">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="final">Ожидаются только буквы, цифры, пробелы и определенные знаки пунктуации.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve" approved="yes">
+			<source>This property is required.</source>
+            <target state="final">Это свойство является обязательным.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve" approved="yes">
+			<source>A valid number is expected.</source>
+            <target state="final">Ожидается число.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve" approved="yes">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="final">Пожалуйста, введите число от {minimum} до {maximum}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve" approved="yes">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="final">Данное поле не соответствует шаблону ({pattern})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve" approved="yes">
+			<source>A valid string is expected.</source>
+            <target state="final">Ожидается строковый тип.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve" approved="yes">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="final">Ожидается текст без XML-тэгов.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve" approved="yes">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="final">Значение не является допустимым UUID.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/sr/Main.xlf
+++ b/Resources/Private/Translations/sr/Main.xlf
@@ -376,6 +376,90 @@
       <trans-unit id="rangeEditorCurrentValue" xml:space="preserve">
                 <source>Current value</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="needs-translation">The length of this text must be between {minimum} and {maximum} characters.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="needs-translation">This field must contain at least {minimum} characters.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="needs-translation">This text may not exceed {maximum} characters.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="translated">Only regular characters (a to z, umlauts, ...) and numbers are allowed.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve">
+			<source>The given subject was not countable.</source>
+            <target state="needs-translation">The given subject was not countable.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="needs-translation">The count must be between {minimum} and {maximum}.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve">
+			<source>The given value was not a valid date.</source>
+            <target state="needs-translation">The given value was not a valid date.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="needs-translation">The given date must be between {formatEarliestDate} and {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="needs-translation">The given date must be after {formatEarliestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="needs-translation">The given date must be before {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve">
+			<source>Please specify a valid email address.</source>
+            <target state="needs-translation">Please specify a valid email address.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve">
+			<source>A valid float number is expected.</source>
+            <target state="needs-translation">A valid float number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve">
+			<source>A valid integer number is expected.</source>
+            <target state="needs-translation">A valid integer number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="needs-translation">Only letters, numbers, spaces and certain punctuation marks are expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve">
+			<source>This property is required.</source>
+            <target state="needs-translation">This property is required.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve">
+			<source>A valid number is expected.</source>
+            <target state="needs-translation">A valid number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="needs-translation">Please enter a valid number between {minimum} and {maximum}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="needs-translation">The given subject did not match the pattern ({pattern})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve">
+			<source>A valid string is expected.</source>
+            <target state="needs-translation">A valid string is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="needs-translation">Valid text without any XML tags is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="needs-translation">The given subject is not a valid UUID.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/sv/Main.xlf
+++ b/Resources/Private/Translations/sv/Main.xlf
@@ -376,6 +376,90 @@
       <trans-unit id="changesPublished[1]" xml:space="preserve">
                     <source>Published {0} changes to "{1}".</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="translated">Texten måste vara mellan {minimum} och {maximum} tecken lång.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="translated">Detta fält måste innehålla minst {minimum} tecken.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="translated">Denna text får ej överstiga {maximum} tecken.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="translated">Endast vanliga tecken (a till ö) och siffror är tillåtna.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve">
+			<source>The given subject was not countable.</source>
+            <target state="translated">Det angivna ämnet är inte räkenbart.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="translated">Antalet måste vara mellan {minimum} och {maximum}.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve">
+			<source>The given value was not a valid date.</source>
+            <target state="translated">Det angivna värdet var inte ett giltigt datum.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="translated">Det angivna datumet måste ligga mellan {formatEarliestDate} och {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="translated">Det angivna datumet måste infalla efter {formatEarliestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="translated">Det angivna datumet måste infalla före {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve">
+			<source>Please specify a valid email address.</source>
+            <target state="translated">Vänligen ange en giltig e-postadress.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve">
+			<source>A valid float number is expected.</source>
+            <target state="translated">Ett giltigt decimalt nummer förväntas.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve">
+			<source>A valid integer number is expected.</source>
+            <target state="translated">Ett giltigt heltal förväntas.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="translated">Endast bokstäver, siffror, mellanslag och vissa skiljetecken förväntas.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve">
+			<source>This property is required.</source>
+            <target state="translated">Denna egenskap krävs.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve">
+			<source>A valid number is expected.</source>
+            <target state="translated">Ett giltigt tal förväntas.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="translated">Ange ett giltigt nummer mellan {minimum} och {maximum}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="translated">Det angivna ämnet matchar inte mönstret ({pattern})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve">
+			<source>A valid string is expected.</source>
+            <target state="translated">En giltig sträng förväntas.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="translated">En giltig text utan XML-taggar förväntas.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="translated">Det angivna ämnet är ej en giltig UUID.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/tl/Main.xlf
+++ b/Resources/Private/Translations/tl/Main.xlf
@@ -376,6 +376,90 @@
       <trans-unit id="rangeEditorCurrentValue" xml:space="preserve">
                 <source>Current value</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="needs-translation">The length of this text must be between {minimum} and {maximum} characters.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="needs-translation">This field must contain at least {minimum} characters.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="needs-translation">This text may not exceed {maximum} characters.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="translated">Only regular characters (a to z, umlauts, ...) and numbers are allowed.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve">
+			<source>The given subject was not countable.</source>
+            <target state="needs-translation">The given subject was not countable.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="needs-translation">The count must be between {minimum} and {maximum}.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve">
+			<source>The given value was not a valid date.</source>
+            <target state="needs-translation">The given value was not a valid date.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="translated">Ang binigay na petsa ay dapat sa gitna ng {formatEarliestDate} at {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="translated">Ang binigay na petsa ay dapat sa pagkatapos ng {formatEarliestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="translated">Ang binigay na petsa ay dapat sa bagong {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve">
+			<source>Please specify a valid email address.</source>
+            <target state="needs-translation">Please specify a valid email address.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve">
+			<source>A valid float number is expected.</source>
+            <target state="needs-translation">A valid float number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve">
+			<source>A valid integer number is expected.</source>
+            <target state="needs-translation">A valid integer number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="needs-translation">Only letters, numbers, spaces and certain punctuation marks are expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve">
+			<source>This property is required.</source>
+            <target state="needs-translation">This property is required.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve">
+			<source>A valid number is expected.</source>
+            <target state="needs-translation">A valid number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="needs-translation">Please enter a valid number between {minimum} and {maximum}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+		<source>The given subject did not match the pattern ({pattern})</source>
+        <target state="needs-translation">The given subject did not match the pattern ({pattern})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve">
+			<source>A valid string is expected.</source>
+            <target state="needs-translation">A valid string is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="needs-translation">Valid text without any XML tags is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="needs-translation">The given subject is not a valid UUID.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/tr/Main.xlf
+++ b/Resources/Private/Translations/tr/Main.xlf
@@ -379,6 +379,90 @@
       <trans-unit id="changesPublished[0]" xml:space="preserve">
                     <source>Published {0} change to "{1}".</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="translated">Bu metnin uzunluğu {minimum} ile {maximum} karakter arasında olmalıdır.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="translated">Bu alan en az {minimum} karakter içermeli.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="translated">Bu metin {maximum} karakteri aşamaz.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="translated">Yalnızca İngilizce normal karakterlere (a'dan z'ye, çift noktalı karakterler, ...) ve sayılara izin verilir.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve">
+			<source>The given subject was not countable.</source>
+            <target state="translated">Verilen başlık sayılabilir değildi.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="translated">Sayaç {minimum} ile {maximum} arasında olmalıdır.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve">
+			<source>The given value was not a valid date.</source>
+            <target state="translated">Verilen değer geçerli bir tarih değildi.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="translated">Verilen tarih {formatEarliestDate} ile {formatLatestDate} arasında olmalıdır</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="translated">Verilen tarih, {formatEarliestDate} tarihinden sonra olmalıdır</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="translated">Verilen tarih {formatLatestDate} tarihinden önce olmalıdır</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve">
+			<source>Please specify a valid email address.</source>
+            <target state="translated">Lütfen geçerli bir e-posta adresi belirleyin.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve">
+			<source>A valid float number is expected.</source>
+            <target state="translated">Geçerli bir ondalık sayı bekleniyor.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve">
+			<source>A valid integer number is expected.</source>
+            <target state="translated">Geçerli bir tamsayı bekleniyor.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="translated">Yalnızca harfler, sayılar, boşluklar ve belirli noktalama işaretleri kabul edilir.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve">
+			<source>This property is required.</source>
+            <target state="translated">Bu özellik gereklidir.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve">
+			<source>A valid number is expected.</source>
+            <target state="translated">Geçerli bir sayı bekleniyor.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="translated">Lütfen {minimum} ile {maximum} arasında geçerli bir sayı girin</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="translated">Verilen konu şablon ({pattern}) ile eşleşmedi</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve">
+			<source>A valid string is expected.</source>
+            <target state="translated">Geçerli bir dizi bekleniyor.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="translated">XML etiketleri bulundurmayan, geçerli bir metin bekleniyor.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="translated">Verilen konu geçerli bir UUID değil.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/uk/Main.xlf
+++ b/Resources/Private/Translations/uk/Main.xlf
@@ -379,6 +379,90 @@
       <trans-unit id="rangeEditorCurrentValue" xml:space="preserve">
                 <source>Current value</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="needs-translation">The length of this text must be between {minimum} and {maximum} characters.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="needs-translation">This field must contain at least {minimum} characters.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="needs-translation">This text may not exceed {maximum} characters.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="translated">Only regular characters (a to z, umlauts, ...) and numbers are allowed.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve">
+			<source>The given subject was not countable.</source>
+            <target state="needs-translation">The given subject was not countable.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="needs-translation">The count must be between {minimum} and {maximum}.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve">
+			<source>The given value was not a valid date.</source>
+            <target state="needs-translation">The given value was not a valid date.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="needs-translation">The given date must be between {formatEarliestDate} and {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="needs-translation">The given date must be after {formatEarliestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="needs-translation">The given date must be before {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve">
+			<source>Please specify a valid email address.</source>
+            <target state="needs-translation">Please specify a valid email address.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve">
+			<source>A valid float number is expected.</source>
+            <target state="needs-translation">A valid float number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve">
+			<source>A valid integer number is expected.</source>
+            <target state="needs-translation">A valid integer number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="needs-translation">Only letters, numbers, spaces and certain punctuation marks are expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve">
+			<source>This property is required.</source>
+            <target state="needs-translation">This property is required.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve">
+			<source>A valid number is expected.</source>
+            <target state="needs-translation">A valid number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="needs-translation">Please enter a valid number between {minimum} and {maximum}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="needs-translation">The given subject did not match the pattern ({pattern})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve">
+			<source>A valid string is expected.</source>
+            <target state="needs-translation">A valid string is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="needs-translation">Valid text without any XML tags is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="needs-translation">The given subject is not a valid UUID.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/vi/Main.xlf
+++ b/Resources/Private/Translations/vi/Main.xlf
@@ -376,6 +376,90 @@
       <trans-unit id="rangeEditorCurrentValue" xml:space="preserve">
                 <source>Current value</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="translated">Độ dài của văn bản nên ở khoảng {{minimum}} và {{maximum}} ký tự.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="translated">Trường này phải chứa ít nhất {{minimum}} ký tự.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="translated">Văn bản này không thể vượt quá {{maximum}} ký tự.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="translated">Only regular characters (a to z, umlauts, ...) and numbers are allowed.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve">
+			<source>The given subject was not countable.</source>
+            <target state="needs-translation">The given subject was not countable.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="needs-translation">The count must be between {minimum} and {maximum}.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve">
+			<source>The given value was not a valid date.</source>
+            <target state="needs-translation">The given value was not a valid date.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="needs-translation">The given date must be between {formatEarliestDate} and {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="needs-translation">The given date must be after {formatEarliestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="needs-translation">The given date must be before {formatLatestDate}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve">
+			<source>Please specify a valid email address.</source>
+            <target state="needs-translation">Please specify a valid email address.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve">
+			<source>A valid float number is expected.</source>
+            <target state="needs-translation">A valid float number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve">
+			<source>A valid integer number is expected.</source>
+            <target state="needs-translation">A valid integer number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="needs-translation">Only letters, numbers, spaces and certain punctuation marks are expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve">
+			<source>This property is required.</source>
+            <target state="translated">Thuộc tính này là bắt buộc</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve">
+			<source>A valid number is expected.</source>
+            <target state="needs-translation">A valid number is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="translated">Vui lòng nhập vào số hợp lệ trong khoảng {{minimum}} and {{maximum}}</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="needs-translation">The given subject did not match the pattern ({pattern})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve">
+			<source>A valid string is expected.</source>
+            <target state="needs-translation">A valid string is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="needs-translation">Valid text without any XML tags is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="needs-translation">The given subject is not a valid UUID.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/zh/Main.xlf
+++ b/Resources/Private/Translations/zh/Main.xlf
@@ -388,6 +388,90 @@
       <trans-unit id="rangeEditorMaximum" xml:space="preserve">
                 <source>Maximum</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="translated">此文本的长度必须介于 {{minimum}} 和 {{maximum}} 个字符之间。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="translated">此字段必须包含至少 {{minimum}} 字符。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="translated">此文本可能不超过 {{maximum}} 个字符。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="translated">只允许字母和数字</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve">
+			<source>The given subject was not countable.</source>
+            <target state="translated">给定的主题不是可数的。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="translated">该计数必须 {{minimum}} 和 {{maximum}} 之间。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve">
+			<source>The given value was not a valid date.</source>
+            <target state="translated">给定的值不是有效的日期。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="translated">给定的日期必须介于 {{formatEarliestDate}} 和 {{formatLatestDate}} 之间</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="translated">给定的日期必须在 {{formatEarliestDate}} 后</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="translated">给定的日期必须在 {{formatLatestDate}} 之前</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve">
+			<source>Please specify a valid email address.</source>
+            <target state="translated">请指定一个有效的电子邮件地址。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve">
+			<source>A valid float number is expected.</source>
+            <target state="translated">要求有效的浮点数字</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve">
+			<source>A valid integer number is expected.</source>
+            <target state="translated">要求有效的整数。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="translated">要求只有字母、 数字、 空格和某些标点符号。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve">
+			<source>This property is required.</source>
+            <target state="translated">此属性是必需的。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve">
+			<source>A valid number is expected.</source>
+            <target state="translated">要求一个有效的数字。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="translated">请输入一个有效号码 {{minimum}} 和 {{maximum}} 之间</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="translated">给定的主题不匹配模式 ({{pattern}})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve">
+			<source>A valid string is expected.</source>
+            <target state="translated">要求有效的字符串。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="translated">要求没有任何 XML 标签有效文本。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="translated">给定的标题不是一个有效的 UUID。</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/zh_TW/Main.xlf
+++ b/Resources/Private/Translations/zh_TW/Main.xlf
@@ -376,6 +376,90 @@
       <trans-unit id="rangeEditorCurrentValue" xml:space="preserve">
                 <source>Current value</source>
       </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.outOfBounds" xml:space="preserve">
+			<source>The length of this text must be between {minimum} and {maximum} characters.</source>
+            <target state="translated">此文字長度必須介於 {minimum} 和 {maximum} 個字元。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.smallerThanMinimum" xml:space="preserve">
+			<source>This field must contain at least {minimum} characters.</source>
+            <target state="translated">此欄位必須包含至少 {minimum} 個字元。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringLength.greaterThanMaximum" xml:space="preserve">
+			<source>This text may not exceed {maximum} characters.</source>
+            <target state="translated">此文字可能不超過 {maximum} 個字元。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.alphanumericValidator" xml:space="preserve">
+			<source>Only regular characters (a to z, umlauts, ...) and numbers are allowed.</source>
+            <target state="translated">只允許使用一般字元 (a 至 z, 變音, ...) 和數字。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.notCountable" xml:space="preserve">
+			<source>The given subject was not countable.</source>
+            <target state="translated">給予的主題不可數。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.countValidator.countBetween" xml:space="preserve">
+			<source>The count must be between {minimum} and {maximum}.</source>
+            <target state="translated">計數必須在 {minimum} 和 {maximum} 之間。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.invalidDate" xml:space="preserve">
+			<source>The given value was not a valid date.</source>
+            <target state="translated">給予的值不是有效日期。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBetween" xml:space="preserve">
+			<source>The given date must be between {formatEarliestDate} and {formatLatestDate}</source>
+            <target state="translated">有效日期必須在 {formatEarliestDate} 和 {formatLatestDate} 之間。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeAfter" xml:space="preserve">
+			<source>The given date must be after {formatEarliestDate}</source>
+            <target state="translated">有效日期必須在 {formatEarliestDate} 之後</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.dateTimeRangeValidator.mustBeBefore" xml:space="preserve">
+			<source>The given date must be before {formatLatestDate}</source>
+            <target state="translated">有效日期必須在 {formatLatestDate} 之前</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.emailAddressValidator.invalidEmail" xml:space="preserve">
+			<source>Please specify a valid email address.</source>
+            <target state="translated">請指定一個有效的電子郵件。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.floatValidator.validFloatExpected" xml:space="preserve">
+			<source>A valid float number is expected.</source>
+            <target state="translated">預期為有效的浮點數字。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected" xml:space="preserve">
+			<source>A valid integer number is expected.</source>
+            <target state="translated">預期為有效的整數。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.labelValidator.invalidLabel" xml:space="preserve">
+			<source>Only letters, numbers, spaces and certain punctuation marks are expected.</source>
+            <target state="translated">預期只有文字、數字、空格和部份標點符號。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.notEmptyValidator.isEmpty" xml:space="preserve">
+			<source>This property is required.</source>
+            <target state="translated">此為必要屬性。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.validNumberExpected" xml:space="preserve">
+			<source>A valid number is expected.</source>
+            <target state="translated">預期為有效的數字。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.numberRangeValidator.numberShouldBeInRange" xml:space="preserve">
+			<source>Please enter a valid number between {minimum} and {maximum}</source>
+            <target state="translated">請輸入一個介於 {minimum} 和 {maximum} 之間的有效數字</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.regularExpressionValidator.patternDoesNotMatch" xml:space="preserve">
+			<source>The given subject did not match the pattern ({pattern})</source>
+            <target state="needs-translation">The given subject did not match the pattern ({pattern})</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.stringValidator.stringIsExpected" xml:space="preserve">
+			<source>A valid string is expected.</source>
+            <target state="translated">預期為有效的字串。</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected" xml:space="preserve">
+			<source>Valid text without any XML tags is expected.</source>
+            <target state="needs-translation">Valid text without any XML tags is expected.</target>
+      </trans-unit>
+      <trans-unit id="content.inspector.validators.uuidValidator.invalidUuid" xml:space="preserve">
+			<source>The given subject is not a valid UUID.</source>
+            <target state="needs-translation">The given subject is not a valid UUID.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/packages/neos-ui-validators/src/Alphanumeric/index.tsx
+++ b/packages/neos-ui-validators/src/Alphanumeric/index.tsx
@@ -17,7 +17,7 @@ const Alphanumeric = (value: any, validatorOptions: AlphanumericOptions) => {
         return null;
     }
     const label = validatorOptions?.validationErrorMessage ?? 'content.inspector.validators.alphanumericValidator';
-    return <I18n id={label}/>;
+    return <I18n id={label} packageKey="Neos.Neos.Ui" sourceName="Main" />;
 };
 
 export default Alphanumeric;

--- a/packages/neos-ui-validators/src/Count/index.spec.js
+++ b/packages/neos-ui-validators/src/Count/index.spec.js
@@ -65,10 +65,12 @@ test('[1, 2, 3, 4] should result in an error message for min: 1 max: 3', () => {
     expect(actual).not.toBe(null);
     expect(actual.props).toEqual({
         id: 'content.inspector.validators.countValidator.countBetween',
+        packageKey: 'Neos.Neos.Ui',
         params: {
             minimum: 1,
             maximum: 3
-        }
+        },
+        sourceName: 'Main'
     });
 });
 

--- a/packages/neos-ui-validators/src/Count/index.tsx
+++ b/packages/neos-ui-validators/src/Count/index.tsx
@@ -28,7 +28,7 @@ const Count = (value: any, validatorOptions: CountOptions) => {
     }
 
     if (typeof value !== 'object' || value === null) {
-        return <I18n id="content.inspector.validators.countValidator.notCountable"/>;
+        return <I18n id="content.inspector.validators.countValidator.notCountable" packageKey="Neos.Neos.Ui" sourceName="Main" />;
     }
 
     const {length} = Object.keys(value);
@@ -41,7 +41,7 @@ const Count = (value: any, validatorOptions: CountOptions) => {
 
     if (length < minimum || length > maximum) {
         const label = validatorOptions?.validationErrorMessage ?? 'content.inspector.validators.countValidator.countBetween';
-        return <I18n id={label} params={{minimum, maximum}}/>;
+        return <I18n id={label} params={{minimum, maximum}} packageKey="Neos.Neos.Ui" sourceName="Main" />;
     }
 
     return null;

--- a/packages/neos-ui-validators/src/DateTime/index.tsx
+++ b/packages/neos-ui-validators/src/DateTime/index.tsx
@@ -12,7 +12,7 @@ const DateTime = (value: any, validatorOptions: DateTimeOptions) => {
 
     if (value !== undefined && value !== null && value !== '' && value.length > 0 && (dateRegularExpression.test(value) === false || /Invalid|NaN/.test(new Date(value).toString()))) {
         const label = validatorOptions?.validationErrorMessage ?? 'content.inspector.validators.dateTimeRangeValidator.invalidDate';
-        return <I18n id={label}/>;
+        return <I18n id={label} packageKey="Neos.Neos.Ui" sourceName="Main" />;
     }
     return null;
 };

--- a/packages/neos-ui-validators/src/EmailAddress/index.tsx
+++ b/packages/neos-ui-validators/src/EmailAddress/index.tsx
@@ -12,7 +12,7 @@ const EmailAddress = (value: any, validatorOptions: EmailAddressOptions) => {
         return null;
     }
     const label = validatorOptions?.validationErrorMessage ?? 'content.inspector.validators.emailAddressValidator.invalidEmail';
-    return isEmail.validate(value) ? null : <I18n id={label}/>;
+    return isEmail.validate(value) ? null : <I18n id={label} packageKey="Neos.Neos.Ui" sourceName="Main" />;
 };
 
 export default EmailAddress;

--- a/packages/neos-ui-validators/src/Float/index.tsx
+++ b/packages/neos-ui-validators/src/Float/index.tsx
@@ -10,7 +10,7 @@ const Float = (value: any, validatorOptions: FloatOptions) => {
     const number = parseFloat(value);
     if (value !== null && value !== undefined && value.length !== 0 && ((isNaN(number) || value.toString().match(/^[-+]?[0-9]*\.[0-9]+([eE][-+]?[0-9]+)?$/) === null))) {
         const label = validatorOptions?.validationErrorMessage ?? 'content.inspector.validators.floatValidator.validFloatExpected';
-        return <I18n id={label}/>;
+        return <I18n id={label} packageKey="Neos.Neos.Ui" sourceName="Main" />;
     }
     return null;
 };

--- a/packages/neos-ui-validators/src/Integer/index.tsx
+++ b/packages/neos-ui-validators/src/Integer/index.tsx
@@ -19,7 +19,7 @@ const Integer = (value: any, validatorOptions: IntegerOptions) => {
         // if the value contains other characters than '-' or a digit it's not valid
         !(/^[\d-]+$/.test(value)))) {
         const label = validatorOptions?.validationErrorMessage ?? 'content.inspector.validators.integerValidator.aValidIntegerNumberIsExpected';
-        return <I18n id={label}/>;
+        return <I18n id={label} packageKey="Neos.Neos.Ui" sourceName="Main" />;
     }
     return null;
 };

--- a/packages/neos-ui-validators/src/Label/index.tsx
+++ b/packages/neos-ui-validators/src/Label/index.tsx
@@ -17,7 +17,7 @@ const Label = (value: any, validatorOptions: LabelOptions) => {
         return null;
     }
     const label = validatorOptions?.validationErrorMessage ?? 'content.inspector.validators.labelValidator.invalidLabel';
-    return <I18n id={label}/>;
+    return <I18n id={label} packageKey="Neos.Neos.Ui" sourceName="Main" />;
 };
 
 export default Label;

--- a/packages/neos-ui-validators/src/NotEmpty/index.tsx
+++ b/packages/neos-ui-validators/src/NotEmpty/index.tsx
@@ -10,7 +10,7 @@ interface NotEmptyOptions {
 const NotEmpty = (value: any, validatorOptions: NotEmptyOptions) => {
     if (value === undefined || value === null || value === '' || value.length === 0) {
         const label = validatorOptions?.validationErrorMessage ?? 'content.inspector.validators.notEmptyValidator.isEmpty';
-        return <I18n id={label}/>;
+        return <I18n id={label} packageKey="Neos.Neos.Ui" sourceName="Main" />;
     }
     return null;
 };

--- a/packages/neos-ui-validators/src/NumberRange/index.tsx
+++ b/packages/neos-ui-validators/src/NumberRange/index.tsx
@@ -33,11 +33,11 @@ const NumberRange = (value: any, validatorOptions: NumberRangeOptions) => {
     }
 
     if (value.length > 0 && !Number.isSafeInteger(number)) {
-        return <I18n id="content.inspector.validators.numberRangeValidator.validNumberExpected"/>;
+        return <I18n id="content.inspector.validators.numberRangeValidator.validNumberExpected" packageKey="Neos.Neos.Ui" sourceName="Main" />;
     }
     if (number < minimum || number > maximum) {
         const label = validatorOptions?.validationErrorMessage ?? 'content.inspector.validators.numberRangeValidator.numberShouldBeInRange';
-        return <I18n id={label} params={{minimum, maximum}}/>;
+        return <I18n id={label} params={{minimum, maximum}} packageKey="Neos.Neos.Ui" sourceName="Main" />;
     }
     return null;
 };

--- a/packages/neos-ui-validators/src/RegularExpression/index.tsx
+++ b/packages/neos-ui-validators/src/RegularExpression/index.tsx
@@ -25,7 +25,7 @@ const RegularExpression = (value: any, validatorOptions: RegularExpressionOption
     }
     const pattern = regularExpression.toString();
     const label = validatorOptions?.validationErrorMessage ?? 'content.inspector.validators.regularExpressionValidator.patternDoesNotMatch';
-    return <I18n id={label} params={{pattern}}/>;
+    return <I18n id={label} params={{pattern}} packageKey="Neos.Neos.Ui" sourceName="Main" />;
 };
 
 export default RegularExpression;

--- a/packages/neos-ui-validators/src/String/index.tsx
+++ b/packages/neos-ui-validators/src/String/index.tsx
@@ -10,7 +10,7 @@ interface StringOptions {
 const String = (value: any, validatorOptions: StringOptions) => {
     if (value !== undefined && value !== null && typeof value !== 'string') {
         const label = validatorOptions?.validationErrorMessage ?? 'content.inspector.validators.stringValidator.stringIsExpected';
-        return <I18n id={label}/>;
+        return <I18n id={label} packageKey="Neos.Neos.Ui" sourceName="Main" />;
     }
     return null;
 };

--- a/packages/neos-ui-validators/src/StringLength/index.tsx
+++ b/packages/neos-ui-validators/src/StringLength/index.tsx
@@ -40,12 +40,12 @@ const StringLength = (value: any, validatorOptions: StringLengthOptions) => {
     if (stringLength < minimum || stringLength > maximum) {
         if (minimum > 0 && maximum < 10000) {
             const label = validatorOptions?.validationErrorMessage ?? 'content.inspector.validators.stringLength.outOfBounds';
-            return <I18n id={label} params={{minimum, maximum}}/>;
+            return <I18n id={label} params={{minimum, maximum}} packageKey="Neos.Neos.Ui" sourceName="Main" />;
         }
         if (minimum > 0) {
-            return <I18n id="content.inspector.validators.stringLength.smallerThanMinimum" params={{minimum}}/>;
+            return <I18n id="content.inspector.validators.stringLength.smallerThanMinimum" params={{minimum}} packageKey="Neos.Neos.Ui" sourceName="Main" />;
         }
-        return <I18n id="content.inspector.validators.stringLength.greaterThanMaximum" params={{maximum}}/>;
+        return <I18n id="content.inspector.validators.stringLength.greaterThanMaximum" params={{maximum}} packageKey="Neos.Neos.Ui" sourceName="Main" />;
     }
     return null;
 };

--- a/packages/neos-ui-validators/src/Text/index.tsx
+++ b/packages/neos-ui-validators/src/Text/index.tsx
@@ -11,7 +11,7 @@ interface TextOptions {
 const Text = (value: any, validatorOptions: TextOptions) => {
     if (value !== undefined && value !== null && value !== value.replace(/<\/?([a-z][a-z0-9]*)\b[^>]*>/gi, '')) {
         const label = validatorOptions?.validationErrorMessage ?? 'content.inspector.validators.textValidator.validTextWithoutAnyXMLtagsIsExpected';
-        return <I18n id={label}/>;
+        return <I18n id={label} packageKey="Neos.Neos.Ui" sourceName="Main" />;
     }
     return null;
 };

--- a/packages/neos-ui-validators/src/Uuid/index.tsx
+++ b/packages/neos-ui-validators/src/Uuid/index.tsx
@@ -10,7 +10,7 @@ interface UuidOptions {
 const Uuid = (value: any, validatorOptions: UuidOptions) => {
     if (value !== undefined && value !== null && value.length !== 0 && value.match(/([a-f0-9]){8}-([a-f0-9]){4}-([a-f0-9]){4}-([a-f0-9]){4}-([a-f0-9]){12}/) === null) {
         const label = validatorOptions?.validationErrorMessage ?? 'content.inspector.validators.uuidValidator.invalidUuid';
-        return <I18n id={label}/>;
+        return <I18n id={label} packageKey="Neos.Neos.Ui" sourceName="Main" />;
     }
     return null;
 };


### PR DESCRIPTION
**What I did**

I added the translations of our validators from the Neos.Neos package directly too the Neos.Neos.Ui package.

**How I did it**

Moved the translations over, and adjusted the Validator Components to load the correct translations.

**How to verify it**

Checkout this PR in combination with: https://github.com/neos/neos-development-collection/pull/4493

and add a Validator to your NodeType. You should see, that the translation is still working.