### PR TITLE
BUGFIX: `Cannot read properties of null (reading 'parent')`

### DIFF
--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -37,7 +37,7 @@ import style from './style.css';
         const shouldShowUnappliedChangesOverlay = isDirty && !shouldPromptToHandleUnappliedChanges;
         const shouldShowSecondaryInspector = selectors.UI.Inspector.shouldShowSecondaryInspector(state);
         const focusedNode = selectors.CR.Nodes.focusedSelector(state);
-        const parentNode = selectors.CR.Nodes.nodeByContextPath(state)(focusedNode.parent);
+        const parentNode = focusedNode ? selectors.CR.Nodes.nodeByContextPath(state)(focusedNode.parent) : null;
 
         return {
             focusedNode,


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

solves rare blackscreen in the neos ui:

> Sorry, but the Neos UI could not recover from this error.
> Please reload the application, or contact your system administrator with the given details.
> Name: TypeError
> Message: Cannot read properties of null (reading 'parent')


**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
