### PR TITLE
BUGFIX: fix hover on toggle icon not changing color to blue, add hove…

### DIFF
--- a/packages/neos-ui-redux-store/src/UI/ContentTree/index.ts
+++ b/packages/neos-ui-redux-store/src/UI/ContentTree/index.ts
@@ -33,7 +33,7 @@ export enum actionTypes {
     SET_AS_LOADED = '@neos/neos-ui/UI/ContentTree/SET_AS_LOADED',
 }
 
-const toggle = (contextPath: NodeContextPath) => createAction(actionTypes.TOGGLE, contextPath);
+const toggle = (contextPath: NodeContextPath, collapseChildren: boolean, childrenContextPaths: NodeContextPath[], childrenCollapsedByDefault: boolean) => createAction(actionTypes.TOGGLE, {contextPath, collapseChildren, childrenContextPaths, childrenCollapsedByDefault});
 const startLoading = () => createAction(actionTypes.START_LOADING);
 const stopLoading = () => createAction(actionTypes.STOP_LOADING);
 const reloadTree = () => createAction(actionTypes.RELOAD_TREE);
@@ -70,8 +70,16 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
             break;
         }
         case actionTypes.TOGGLE: {
-            const contextPath = action.payload;
-            if (draft.toggled.includes(contextPath)) {
+            const {contextPath, collapseChildren, childrenContextPaths, childrenCollapsedByDefault} = action.payload;
+            if (collapseChildren) {
+                childrenContextPaths.forEach(child => {
+                    if (!childrenCollapsedByDefault && !draft.toggled.includes(child)) {
+                        draft.toggled.push(child);
+                    } else if (childrenCollapsedByDefault && draft.toggled.includes(child)) {
+                        draft.toggled = draft.toggled.filter(i => i !== child);
+                    }
+                })
+            } else if (draft.toggled.includes(contextPath)) {
                 draft.toggled = draft.toggled.filter(i => i !== contextPath);
             } else {
                 draft.toggled.push(contextPath);

--- a/packages/neos-ui-redux-store/src/UI/PageTree/index.ts
+++ b/packages/neos-ui-redux-store/src/UI/PageTree/index.ts
@@ -44,7 +44,7 @@ export enum actionTypes {
 }
 
 const focus = (contextPath: NodeContextPath, _: undefined, selectionMode: SelectionModeTypes = SelectionModeTypes.SINGLE_SELECT) => createAction(actionTypes.FOCUS, {contextPath, selectionMode});
-const toggle = (contextPath: NodeContextPath) => createAction(actionTypes.TOGGLE, {contextPath});
+const toggle = (contextPath: NodeContextPath, collapseChildren: boolean, childrenContextPaths: NodeContextPath[], childrenCollapsedByDefault: boolean) => createAction(actionTypes.TOGGLE, {contextPath, collapseChildren, childrenContextPaths, childrenCollapsedByDefault});
 const invalidate = (contextPath: NodeContextPath) => createAction(actionTypes.INVALIDATE, {contextPath});
 const requestChildren = (contextPath: NodeContextPath, {unCollapse = true, activate = false} = {}) => createAction(actionTypes.REQUEST_CHILDREN, {contextPath, opts: {unCollapse, activate}});
 const setAsLoading = (contextPath: NodeContextPath) => createAction(actionTypes.SET_AS_LOADING, {contextPath});
@@ -96,8 +96,16 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
             break;
         }
         case actionTypes.TOGGLE: {
-            const {contextPath} = action.payload;
-            if (draft.toggled.includes(contextPath)) {
+            const {contextPath, collapseChildren, childrenContextPaths, childrenCollapsedByDefault} = action.payload;
+            if (collapseChildren) {
+                childrenContextPaths.forEach(child => {
+                    if (!childrenCollapsedByDefault && !draft.toggled.includes(child)) {
+                        draft.toggled.push(child);
+                    } else if (childrenCollapsedByDefault && draft.toggled.includes(child)) {
+                        draft.toggled = draft.toggled.filter(i => i !== child);
+                    }
+                })
+            } else if (draft.toggled.includes(contextPath)) {
                 draft.toggled = draft.toggled.filter(i => i !== contextPath);
             } else {
                 draft.toggled.push(contextPath);

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -358,9 +358,23 @@ export default class Node extends PureComponent {
         );
     }
 
-    handleNodeToggle = () => {
-        const {node, onNodeToggle} = this.props;
-        onNodeToggle(node.contextPath);
+    handleNodeToggle = (e) => {
+        const {node, onNodeToggle, childNodes, isContentTreeNode, loadingDepth, rootNode} = this.props;
+        const children = [...childNodes];
+        const childrenLoaded = children[0] !== undefined;
+        const childrenContextPaths = [];
+        let childrenCollapsedByDefault = false;
+
+        if (childrenLoaded) {
+            childrenCollapsedByDefault = loadingDepth === 0 ? false : (node.depth + 1) - rootNode.depth >= loadingDepth;
+            const childrenWithChildren = children.filter((child) => child.children.length > (isContentTreeNode ? 0 : 1));
+
+            childrenWithChildren.forEach(child => {
+                childrenContextPaths.push(child.contextPath);
+            })
+        }
+
+        onNodeToggle(node.contextPath, e.shiftKey, childrenContextPaths, childrenCollapsedByDefault);
     }
 
     handleNodeClick = e => {

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
@@ -39,10 +39,9 @@ export default class NodeTree extends PureComponent {
         currentlyDraggedNodes: []
     };
 
-    handleToggle = contextPath => {
+    handleToggle = (contextPath, collapseChildren, childrenContextPaths, childrenCollapsedByDefault) => {
         const {toggle} = this.props;
-
-        toggle(contextPath);
+        toggle(contextPath, collapseChildren, childrenContextPaths, childrenCollapsedByDefault);
     }
 
     handleFocus = (contextPath, metaKeyPressed, altKeyPressed, shiftKeyPressed) => {

--- a/packages/react-ui-components/src/Tree/node.module.css
+++ b/packages/react-ui-components/src/Tree/node.module.css
@@ -18,7 +18,7 @@
 
     cursor: pointer;
 
-    &:hover {
+    &:hover > svg {
         color: var(--colors-PrimaryBlue);
     }
 }
@@ -43,6 +43,11 @@
     display: inline-block;
     position: absolute;
     text-align: center;
+
+    .header:hover & > svg,
+    .header__data--isActive & > svg {
+        color: var(--colors-PrimaryBlue);
+    }
 }
 
 .header__data {
@@ -100,6 +105,7 @@
     composes: reset from '../reset.module.css';
     margin-left: 2em;
 
+    .header:hover &,
     .header__data--isActive & {
         color: var(--colors-PrimaryBlue);
     }
@@ -119,6 +125,7 @@
 
     [data-is-drag-happening] & {
         visibility: visible;
+        height: 5px;
     }
 }
 .dropTarget--before {


### PR DESCRIPTION
**What I did**

*Problem 1: Hover States*

Looking at the CSS it looks as if the toggle button of a node in the Content and Page NodeTrees is supposed to change their color to blue when hovering over them.

While at it I also replicated the behavior from the top left burger menu. The Label and the icon now appear blue when they are either hovered over or selected (While selected the grey Background is still present).

*Problem 2: Collapsing all children*

Since I am new to Reselect  I wasn't able to create a new selector to get all descendants of a node. Also I didn't want to break anything accidentally. Instead I added the function to optionally collapse the children of a node by shift-clicking the toggle icon of a node.

*Problem 3: Make it easier to drop a node into a dropTarget*

**How I did it**

*Problem 1: Hover States*

* Styles are now applied to the toggle  SVG
* Added a hover state to the nodes

*Problem 2: Collapsing all children*

1. The toggle action now has more arguments
    - ```collapseChildren: boolean``` true if the shift key is pressed on the click event
    - ```childrenContextPaths: NodeContextPath[]``` the context paths of all children of the clicked node 
      - children that cant be toggled are filtered out
      - checks if children are loaded at all
   - ```childrenCollapsedByDefault: boolean```
     - checks if children are collapsedbydefault (unlike a normal node these nodes must be removed from the redux store to be appear collapsed

2. To integrate a simple collapse all button the toggle buttons could be selected and the click events could be fired including the shiftKey event via simple JS. I wonder if a solution like this would be up to the standards? Since the redux actions would be fired, I don't think it would create any unwanted side effects.

*Problem 3: Make it easier to drop a node into a dropTarget*

I added extra height to the dropTarget but only after a node is already being dragged.

**How to verify it**

Before: No hover effects

After:
New Hover Effects and collapsing children nodes in action:

![2023-09-17 01-44-48](https://github.com/neos/neos-ui/assets/56877180/c9927963-4703-410c-bd0c-f6688ef89490)

