### PR TITLE
TASK: cleanup node service

### DIFF
--- a/Classes/ContentRepository/Service/NeosUiNodeService.php
+++ b/Classes/ContentRepository/Service/NeosUiNodeService.php
@@ -21,22 +21,20 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Neos\Utility\NodeTypeWithFallbackProvider;
 
 /**
+ * @internal
  * @Flow\Scope("singleton")
  */
-class NodeService
+class NeosUiNodeService
 {
     use NodeTypeWithFallbackProvider;
 
     #[Flow\Inject]
     protected ContentRepositoryRegistry $contentRepositoryRegistry;
 
-    /**
-     * Converts a given context path to a node object
-     */
-    public function getNodeFromContextPath(string $contextPath, ContentRepositoryId $contentRepositoryId): ?Node
+    public function findNodeBySerializedNodeAddress(string $serializedNodeAddress, ContentRepositoryId $contentRepositoryId): ?Node
     {
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
-        $nodeAddress = NodeAddressFactory::create($contentRepository)->createFromUriString($contextPath);
+        $nodeAddress = NodeAddressFactory::create($contentRepository)->createFromUriString($serializedNodeAddress);
 
         $subgraph = $contentRepository->getContentGraph()->getSubgraph(
             $nodeAddress->contentStreamId,

--- a/Classes/ContentRepository/Service/NodeService.php
+++ b/Classes/ContentRepository/Service/NodeService.php
@@ -31,38 +31,6 @@ class NodeService
     protected ContentRepositoryRegistry $contentRepositoryRegistry;
 
     /**
-     * Helper method to retrieve the closest document for a node
-     */
-    public function getClosestDocument(Node $node): ?Node
-    {
-        if ($this->getNodeType($node)->isOfType('Neos.Neos:Document')) {
-            return $node;
-        }
-
-        $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
-
-        while ($node instanceof Node) {
-            if ($this->getNodeType($node)->isOfType('Neos.Neos:Document')) {
-                return $node;
-            }
-            $node = $subgraph->findParentNode($node->nodeAggregateId);
-        }
-
-        return null;
-    }
-
-    /**
-     * Helper method to check if a given node is a document node.
-     *
-     * @param  Node $node The node to check
-     * @return boolean             A boolean which indicates if the given node is a document node.
-     */
-    public function isDocument(Node $node): bool
-    {
-        return ($this->getClosestDocument($node) === $node);
-    }
-
-    /**
      * Converts a given context path to a node object
      */
     public function getNodeFromContextPath(string $contextPath, ContentRepositoryId $contentRepositoryId): ?Node

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -37,7 +37,7 @@ use Neos\Neos\FrontendRouting\NodeAddress;
 use Neos\Neos\FrontendRouting\NodeAddressFactory;
 use Neos\Neos\FrontendRouting\SiteDetection\SiteDetectionResult;
 use Neos\Neos\Service\UserService;
-use Neos\Neos\Ui\ContentRepository\Service\NodeService;
+use Neos\Neos\Ui\ContentRepository\Service\NeosUiNodeService;
 use Neos\Neos\Ui\ContentRepository\Service\WorkspaceService;
 use Neos\Neos\Ui\Domain\Model\ChangeCollection;
 use Neos\Neos\Ui\Domain\Model\Feedback\Messages\Error;
@@ -88,7 +88,7 @@ class BackendServiceController extends ActionController
 
     /**
      * @Flow\Inject
-     * @var NodeService
+     * @var NeosUiNodeService
      */
     protected $nodeService;
 
@@ -590,7 +590,7 @@ class BackendServiceController extends ActionController
         /** @var array<int,mixed> $payload */
         $payload = $createContext['payload'] ?? [];
         $flowQuery = new FlowQuery(array_map(
-            fn ($envelope) => $this->nodeService->getNodeFromContextPath($envelope['$node'], $contentRepositoryId),
+            fn ($envelope) => $this->nodeService->findNodeBySerializedNodeAddress($envelope['$node'], $contentRepositoryId),
             $payload
         ));
 

--- a/Classes/Domain/Model/AbstractChange.php
+++ b/Classes/Domain/Model/AbstractChange.php
@@ -11,10 +11,12 @@ namespace Neos\Neos\Ui\Domain\Model;
  * source code.
  */
 
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindClosestNodeFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Neos\Domain\Service\NodeTypeNameFactory;
 use Neos\Neos\Service\UserService;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\NodeCreated;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\ReloadDocument;
@@ -64,7 +66,8 @@ abstract class AbstractChange implements ChangeInterface
     protected function updateWorkspaceInfo(): void
     {
         if (!is_null($this->subject)) {
-            $documentNode = $this->findClosestDocumentNode($this->subject);
+            $subgraph = $this->contentRepositoryRegistry->subgraphForNode($this->subject);
+            $documentNode = $subgraph->findClosestNode($this->subject->nodeAggregateId, FindClosestNodeFilter::create(nodeTypeConstraints: NodeTypeNameFactory::NAME_DOCUMENT));
             if (!is_null($documentNode)) {
                 $contentRepository = $this->contentRepositoryRegistry->get($this->subject->subgraphIdentity->contentRepositoryId);
                 $workspace = $contentRepository->getWorkspaceFinder()->findOneByCurrentContentStreamId(
@@ -76,18 +79,6 @@ abstract class AbstractChange implements ChangeInterface
                 }
             }
         }
-    }
-
-    final protected function findClosestDocumentNode(Node $node): ?Node
-    {
-        while ($node instanceof Node) {
-            if ($this->getNodeType($node)->isOfType('Neos.Neos:Document')) {
-                return $node;
-            }
-            $node = $this->findParentNode($node);
-        }
-
-        return null;
     }
 
     protected function findParentNode(Node $node): ?Node

--- a/Classes/Domain/Model/Changes/AbstractStructuralChange.php
+++ b/Classes/Domain/Model/Changes/AbstractStructuralChange.php
@@ -20,7 +20,7 @@ use Neos\Neos\FrontendRouting\NodeAddressFactory;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Nodes;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
-use Neos\Neos\Ui\ContentRepository\Service\NodeService;
+use Neos\Neos\Ui\ContentRepository\Service\NeosUiNodeService;
 use Neos\Neos\Ui\Domain\Model\AbstractChange;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\ReloadDocument;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\RenderContentOutOfBand;
@@ -50,7 +50,7 @@ abstract class AbstractStructuralChange extends AbstractChange
 
     /**
      * @Flow\Inject
-     * @var NodeService
+     * @var NeosUiNodeService
      */
     protected $nodeService;
 
@@ -111,7 +111,7 @@ abstract class AbstractStructuralChange extends AbstractChange
         }
 
         if ($this->cachedSiblingNode === null) {
-            $this->cachedSiblingNode = $this->nodeService->getNodeFromContextPath(
+            $this->cachedSiblingNode = $this->nodeService->findNodeBySerializedNodeAddress(
                 $this->siblingDomAddress->getContextPath(),
                 $this->getSubject()->subgraphIdentity->contentRepositoryId
             );

--- a/Classes/Domain/Model/Changes/CopyInto.php
+++ b/Classes/Domain/Model/Changes/CopyInto.php
@@ -32,7 +32,7 @@ class CopyInto extends AbstractStructuralChange
     {
         if (!isset($this->cachedParentNode)) {
             $this->cachedParentNode = $this->parentContextPath
-                ? $this->nodeService->getNodeFromContextPath($this->parentContextPath, $this->getSubject()->subgraphIdentity->contentRepositoryId)
+                ? $this->nodeService->findNodeBySerializedNodeAddress($this->parentContextPath, $this->getSubject()->subgraphIdentity->contentRepositoryId)
                 : null;
         }
 

--- a/Classes/Domain/Model/Changes/MoveInto.php
+++ b/Classes/Domain/Model/Changes/MoveInto.php
@@ -33,7 +33,7 @@ class MoveInto extends AbstractStructuralChange
             return null;
         }
 
-        return $this->nodeService->getNodeFromContextPath(
+        return $this->nodeService->findNodeBySerializedNodeAddress(
             $this->parentContextPath,
             $this->getSubject()->subgraphIdentity->contentRepositoryId
         );

--- a/Classes/Domain/Model/Changes/Remove.php
+++ b/Classes/Domain/Model/Changes/Remove.php
@@ -13,11 +13,13 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
  */
 
 use Neos\ContentRepository\Core\DimensionSpace\Exception\DimensionSpacePointNotFound;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindClosestNodeFilter;
 use Neos\ContentRepository\Core\SharedModel\Exception\ContentStreamDoesNotExistYet;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeVariantSelectionStrategy;
 use Neos\ContentRepository\Core\Feature\NodeRemoval\Command\RemoveNodeAggregate;
 use Neos\ContentRepository\Core\SharedModel\Exception\NodeAggregatesTypeIsAmbiguous;
 use Neos\Flow\Annotations as Flow;
+use Neos\Neos\Domain\Service\NodeTypeNameFactory;
 use Neos\Neos\Fusion\Cache\ContentCacheFlusher;
 use Neos\Neos\Ui\Domain\Model\AbstractChange;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\RemoveNode;
@@ -68,7 +70,8 @@ class Remove extends AbstractChange
             // otherwise we cannot find the parent nodes anymore.
             $this->updateWorkspaceInfo();
 
-            $closestDocumentParentNode = $this->findClosestDocumentNode($subject);
+            $subgraph = $this->contentRepositoryRegistry->subgraphForNode($this->subject);
+            $closestDocumentParentNode = $subgraph->findClosestNode($this->subject->nodeAggregateId, FindClosestNodeFilter::create(nodeTypeConstraints: NodeTypeNameFactory::NAME_DOCUMENT));
             $command = RemoveNodeAggregate::create(
                 $subject->subgraphIdentity->contentStreamId,
                 $subject->nodeAggregateId,

--- a/Classes/Domain/Service/NodeTreeBuilder.php
+++ b/Classes/Domain/Service/NodeTreeBuilder.php
@@ -17,7 +17,7 @@ use Neos\ContentRepository\Core\Factory\ContentRepositoryId;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Neos\Service\LinkingService;
-use Neos\Neos\Ui\ContentRepository\Service\NodeService;
+use Neos\Neos\Ui\ContentRepository\Service\NeosUiNodeService;
 
 class NodeTreeBuilder
 {
@@ -58,7 +58,7 @@ class NodeTreeBuilder
 
     /**
      * @Flow\Inject
-     * @var NodeService
+     * @var NeosUiNodeService
      */
     protected $nodeService;
 

--- a/Classes/TypeConverter/ChangeCollectionConverter.php
+++ b/Classes/TypeConverter/ChangeCollectionConverter.php
@@ -20,7 +20,7 @@ use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
 use Neos\Flow\Property\TypeConverter\AbstractTypeConverter;
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Neos\Ui\ContentRepository\Service\NodeService;
+use Neos\Neos\Ui\ContentRepository\Service\NeosUiNodeService;
 use Neos\Neos\Ui\Domain\Model\ChangeCollection;
 use Neos\Neos\Ui\Domain\Model\ChangeInterface;
 use Neos\Neos\Ui\Domain\Model\Changes\Property;
@@ -76,7 +76,7 @@ class ChangeCollectionConverter
 
     /**
      * @Flow\Inject
-     * @var NodeService
+     * @var NeosUiNodeService
      */
     protected $nodeService;
 
@@ -141,7 +141,7 @@ class ChangeCollectionConverter
 
 
         $subjectContextPath = $changeData['subject'];
-        $subject = $this->nodeService->getNodeFromContextPath($subjectContextPath, $contentRepositoryId);
+        $subject = $this->nodeService->findNodeBySerializedNodeAddress($subjectContextPath, $contentRepositoryId);
         if (is_null($subject)) {
             throw new \RuntimeException('Could not find node for subject "' . $subjectContextPath . '"', 1645657340);
         }
@@ -150,7 +150,7 @@ class ChangeCollectionConverter
 
         if (isset($changeData['reference']) && method_exists($changeClassInstance, 'setReference')) {
             $referenceContextPath = $changeData['reference'];
-            $reference = $this->nodeService->getNodeFromContextPath($referenceContextPath, $contentRepositoryId);
+            $reference = $this->nodeService->findNodeBySerializedNodeAddress($referenceContextPath, $contentRepositoryId);
             $changeClassInstance->setReference($reference);
         }
 


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

i leveraged 
```
$this->contentRepositoryRegistry->subgraphForNode($node)
            ->findClosestNode($node->nodeAggregateId, FindClosestNodeFilter::create(nodeTypeConstraints: NodeTypeNameFactory::NAME_DOCUMENT));
```

over manually iterating over the parents. Helper methods were inlined in the few places used.
The "NodeService" was renamed to something which seems more internal and should not be used from outside ;)


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->


requires https://github.com/neos/neos-development-collection/pull/4601 to be merged first.