### PR TITLE
TASK: Remove `CACHE_VERSION` and invalidate cache after each run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,34 +3,34 @@ version: 2.0
 aliases:
   - &workspace_root ~/neos-ui-workspace
   - &store_yarn_package_cache
-    key: yarn-cache-v{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
+    key: yarn-cache-v{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "yarn.lock" }}
     paths:
       - ~/.cache/yarn
 
   - &restore_yarn_package_cache
     keys:
-      - yarn-cache-v{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
+      - yarn-cache-v{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "yarn.lock" }}
 
   - &store_app_cache
-    key: full-app-cache-v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}-{{ checksum "Tests/IntegrationTests/TestDistribution/Configuration/Settings.yaml" }}
+    key: full-app-cache-v{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ arch }}-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}-{{ checksum "Tests/IntegrationTests/TestDistribution/Configuration/Settings.yaml" }}
     paths:
       - /home/circleci/app
 
   - &restore_app_cache
     keys:
-      - full-app-cache-v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}-{{ checksum "Tests/IntegrationTests/TestDistribution/Configuration/Settings.yaml" }}
-      - full-app-cache-v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}-
-      - full-app-cache-v{{ .Environment.CACHE_VERSION }}-{{ arch }}-
+      - full-app-cache-v{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ arch }}-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}-{{ checksum "Tests/IntegrationTests/TestDistribution/Configuration/Settings.yaml" }}
+      - full-app-cache-v{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ arch }}-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}-
+      - full-app-cache-v{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ arch }}-
 
   - &save_composer_cache
-    key: composer-cache-v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}
+    key: composer-cache-v{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ arch }}-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}
     paths:
       - /home/circleci/composer/cache-dir
 
   - &restore_composer_cache
     keys:
-      - composer-cache-v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}
-      - composer-cache-v{{ .Environment.CACHE_VERSION }}-{{ arch }}-
+      - composer-cache-v{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ arch }}-{{ checksum "Tests/IntegrationTests/TestDistribution/composer.json" }}
+      - composer-cache-v{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ arch }}-
 
   - &attach_workspace
     at: *workspace_root

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
       - run: rm -rf /home/circleci/app/Packages/Application/Neos.Neos.Ui
       - run: cd /home/circleci/app/Packages/Application && mv ~/neos-ui-workspace Neos.Neos.Ui
       - run: |
-          cd /home/circleci/app/Packages/Application/Neos.Neos.Ui/Tests/Unit
+          cd /home/circleci/app/Packages/Application/Neos.Neos.Ui
           ../../../bin/phpstan analyse
 
 workflows:

--- a/README.md
+++ b/README.md
@@ -191,18 +191,6 @@ To speed up the e2e-test workflow/feedback loop you can start the system under t
 * Observe Flow exceptions and logs in build artifacts.
 * You can trigger a SSH enabled build via the CircleCI interface and then login.
 
-###### Just the end to end tests fail
-
-It can happen that end to end tests fail caused by cached sources. So if you change PHP code for instance and don't adjust the composer.json it can happen that your new code change is not used because it is not part of the cache. In this case we need to flush the CircleCI caches manualy.
-
-We have introduced an environment variable called CACHE_VERSION. We need to change the variable to to new timestamp for instance to invalidate the caches.
-
-1. go to https://app.circleci.com/settings/project/github/neos/neos-ui and login
-2. open the project settings and choose `Environment Variables`
-3. Delete the `CACHE_VERSION` and create a new one with the value of the current timestamp
-
-Retrigger the build and it should work.
-
 #### Releasing
 
 You only need to trigger the jenkins release with the version you want to release.


### PR DESCRIPTION
Lately we have a lot of depending pull requests - changes here and in Neos - that results in the ci failing and me having to adjust the `CACHE_VERSION` continuously (which will then still fail for another feature pr)

The `CACHE_VERSION` was introduced via https://github.com/neos/neos-ui/pull/2883 as previously the cache could only be invalidated by changing the `composer.json`

Eventually we should refactor our ci completely and only cache what is safely cacheable. This change effectively disables the cache. (We need the cache though for subsequent jobs)

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
