### PR TITLE
BUGFIX: Respect also min value in width of input field on RangeEditor

### DIFF
--- a/packages/neos-ui-editors/src/Editors/Range/index.js
+++ b/packages/neos-ui-editors/src/Editors/Range/index.js
@@ -64,6 +64,7 @@ class RangeEditor extends PureComponent {
         const options = {...this.constructor.defaultProps.options, ...this.props.options};
         const {value, highlight} = this.props;
         const valueAsString = value === 0 ? '0' : (value || '');
+        const styleWidth = Math.max(options.min.toString().length, options.max.toString().length) + 'ch'
 
         return (
             <div
@@ -94,7 +95,7 @@ class RangeEditor extends PureComponent {
                             onKeyPress={this.onKeyPress}
                             onChange={this.handleChange}
                             value={valueAsString}
-                            style={ {width: `${options.max.toString().length}ch`} }
+                            style={ {width: styleWidth} }
                             disabled={options.disabled}
                         />
                         {options.unit}

--- a/packages/neos-ui-editors/src/Editors/Range/index.js
+++ b/packages/neos-ui-editors/src/Editors/Range/index.js
@@ -64,7 +64,7 @@ class RangeEditor extends PureComponent {
         const options = {...this.constructor.defaultProps.options, ...this.props.options};
         const {value, highlight} = this.props;
         const valueAsString = value === 0 ? '0' : (value || '');
-        const styleWidth = Math.max(options.min.toString().length, options.max.toString().length) + 'ch'
+        const styleWidth = Math.max(options.min.toString().length, options.max.toString().length) + 'ch';
 
         return (
             <div


### PR DESCRIPTION
Closes #3648

## Before

<img width="436" alt="image" src="https://github.com/neos/neos-ui/assets/4510166/70eba58a-f211-4b78-a4d3-6bd3c4b716cf">

## After

<img width="427" alt="image" src="https://github.com/neos/neos-ui/assets/4510166/a63dc11d-ffe0-47c9-9eea-2f8db9b0134d">
