### PR TITLE
BUGFIX: Apply multiple properties from inspector

### DIFF
--- a/Classes/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
@@ -113,7 +113,7 @@ class UpdateNodeInfo extends AbstractFeedback
      *
      * @return array<string,?array<string,mixed>>
      */
-    public function serializeNodeRecursively(Node $node, ControllerContext $controllerContext): array
+    private function serializeNodeRecursively(Node $node, ControllerContext $controllerContext): array
     {
         $contentRepository = $this->contentRepositoryRegistry->get($node->subgraphIdentity->contentRepositoryId);
         $nodeAddressFactory = NodeAddressFactory::create($contentRepository);

--- a/Classes/Domain/Model/FeedbackCollection.php
+++ b/Classes/Domain/Model/FeedbackCollection.php
@@ -48,8 +48,9 @@ class FeedbackCollection implements \JsonSerializable
      */
     public function add(FeedbackInterface $feedback)
     {
-        foreach ($this->feedbacks as $value) {
-            if ($value->isSimilarTo($feedback)) {
+        foreach ($this->feedbacks as $i => $value) {
+            if ($feedback->isSimilarTo($value)) {
+                $this->feedbacks[$i] = $feedback;
                 return;
             }
         }


### PR DESCRIPTION
Resolves #4656 

This inverts the `UpdateNodeInfo` feedback by applying the respective last similar feedback instead of the first, since nodes don't update their internal state any more.

**How to verify it**

Change two inspector properties at the same time