### PR TITLE
BUGFIX: Feedbacks have null defaults for optional properties

### DIFF
--- a/Classes/Domain/Model/AbstractChange.php
+++ b/Classes/Domain/Model/AbstractChange.php
@@ -27,7 +27,7 @@ abstract class AbstractChange implements ChangeInterface
 {
     use NodeTypeWithFallbackProvider;
 
-    protected ?Node $subject;
+    protected ?Node $subject = null;
 
     #[Flow\Inject]
     protected ContentRepositoryRegistry $contentRepositoryRegistry;

--- a/Classes/Domain/Model/Changes/AbstractCreate.php
+++ b/Classes/Domain/Model/Changes/AbstractCreate.php
@@ -29,7 +29,7 @@ abstract class AbstractCreate extends AbstractStructuralChange
     /**
      * The type of the node that will be created
      */
-    protected ?NodeTypeName $nodeTypeName;
+    protected ?NodeTypeName $nodeTypeName = null;
 
     /**
      * Incoming data from creationDialog

--- a/Classes/Domain/Model/Changes/CopyInto.php
+++ b/Classes/Domain/Model/Changes/CopyInto.php
@@ -21,7 +21,7 @@ class CopyInto extends AbstractStructuralChange
 {
     protected ?string $parentContextPath;
 
-    protected ?Node $cachedParentNode;
+    protected ?Node $cachedParentNode = null;
 
     public function setParentContextPath(string $parentContextPath): void
     {

--- a/Classes/Domain/Model/Feedback/Operations/ReloadContentOutOfBand.php
+++ b/Classes/Domain/Model/Feedback/Operations/ReloadContentOutOfBand.php
@@ -28,7 +28,7 @@ use Psr\Http\Message\ResponseInterface;
 
 class ReloadContentOutOfBand extends AbstractFeedback
 {
-    protected ?Node $node;
+    protected ?Node $node = null;
 
     protected ?RenderedNodeDomAddress $nodeDomAddress;
 

--- a/Classes/Domain/Model/Feedback/Operations/ReloadDocument.php
+++ b/Classes/Domain/Model/Feedback/Operations/ReloadDocument.php
@@ -23,7 +23,7 @@ use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
 
 class ReloadDocument extends AbstractFeedback
 {
-    protected ?Node $node;
+    protected ?Node $node = null;
 
     #[Flow\Inject]
     protected ContentRepositoryRegistry $contentRepositoryRegistry;

--- a/Classes/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
@@ -23,7 +23,7 @@ use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
 
 class UpdateNodeInfo extends AbstractFeedback
 {
-    protected ?Node $node;
+    protected ?Node $node = null;
 
     /**
      * @Flow\Inject

--- a/Classes/Domain/Model/Feedback/Operations/UpdateWorkspaceInfo.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateWorkspaceInfo.php
@@ -23,7 +23,7 @@ use Neos\Flow\Mvc\Controller\ControllerContext;
 
 class UpdateWorkspaceInfo extends AbstractFeedback
 {
-    protected ?WorkspaceName $workspaceName;
+    protected ?WorkspaceName $workspaceName = null;
 
     /**
      * @Flow\Inject


### PR DESCRIPTION
This is necessary to avoid errors when the property was not initialized before access which happens in the current codebase and should be refactored completely.

Fixes: #3655
