### PR TITLE
BUGFIX: Make long nodetype names readable in the node infoview

### DIFF
--- a/packages/neos-ui-views/src/NodeInfoView/index.js
+++ b/packages/neos-ui-views/src/NodeInfoView/index.js
@@ -36,6 +36,8 @@ export default class NodeInfoView extends PureComponent {
         };
 
         const nodeType = $get('nodeType', node);
+        // Insert soft hyphens after dots and colon to make the node type more readable
+        const hyphenatedNodeTypeName = nodeType.replace(/([.:])/g, '$1\u00AD');
 
         return (
             <ul className={style.nodeInfoView}>
@@ -61,7 +63,7 @@ export default class NodeInfoView extends PureComponent {
                 </li>
                 <li className={style.nodeInfoView__item} title={nodeType}>
                     <div className={style.nodeInfoView__title}>{i18nRegistry.translate('type', 'Type', {}, 'Neos.Neos')}</div>
-                    <NodeInfoViewContent>{nodeType}</NodeInfoViewContent>
+                    <NodeInfoViewContent>{hyphenatedNodeTypeName}</NodeInfoViewContent>
                 </li>
             </ul>
         );

--- a/packages/neos-ui-views/src/NodeInfoView/style.module.css
+++ b/packages/neos-ui-views/src/NodeInfoView/style.module.css
@@ -30,4 +30,6 @@
 .nodeInfoView__content {
     font-size: 13px;
     color: var(--colors-ContrastBright);
+    hyphenate-character: '';
+    word-wrap: break-word;
 }


### PR DESCRIPTION
**What I did**

Prevent nodetype name from overflowing the node info view.

**How I did it**

Insert soft hyphens after dots and colons in the nodetype name for the NodeInfoView.
And force word break via CSS and hide browser hyphen character.

**How to verify it**

Before:

<img width="321" alt="Bildschirmfoto 2023-11-08 um 14 33 54" src="https://github.com/neos/neos-ui/assets/596967/b45c9715-67e0-4c91-a8a9-3f53148b1a24">

After:

<img width="327" alt="Bildschirmfoto 2023-11-08 um 14 33 30" src="https://github.com/neos/neos-ui/assets/596967/c602fb00-4cd9-49b3-8471-713b599b7c13">

