### PR TITLE
BUGFIX: Show full labels in nodetrees if possible

### DIFF
--- a/packages/react-ui-components/src/Tree/node.module.css
+++ b/packages/react-ui-components/src/Tree/node.module.css
@@ -49,7 +49,7 @@
     composes: reset from '../reset.module.css';
     position: relative;
     display: inline-block;
-    min-width: 100%;
+    width: 100%;
     padding: .1em 0;
 
     border-left: 2px solid transparent;
@@ -89,7 +89,7 @@
 }
 
 .header__labelWrapper {
-    max-width: 264px;
+    max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
     display: inline-block;


### PR DESCRIPTION
**What I did**

Previously labels were cut even if there would have been enough space due to the constraint to 264px.
Also since 8.3 the trees can be resized and the labels didn’t adjust to the increased width.

**How I did it**

Now they will use the available width via CSS.

**How to verify it**

Before:

<img width="433" alt="Bildschirmfoto 2023-11-08 um 15 31 58" src="https://github.com/neos/neos-ui/assets/596967/5e025f10-e765-44a7-9575-1a3470494443">
<img width="321" alt="Bildschirmfoto 2023-11-08 um 15 31 51" src="https://github.com/neos/neos-ui/assets/596967/46ca703a-3603-4581-a487-b8ac8e6665e9">

After:

<img width="422" alt="Bildschirmfoto 2023-11-08 um 15 32 17" src="https://github.com/neos/neos-ui/assets/596967/95c5ca2c-beee-4b1d-aed2-9d41e65927ad">
<img width="321" alt="Bildschirmfoto 2023-11-08 um 15 32 10" src="https://github.com/neos/neos-ui/assets/596967/84b0f85c-2a40-4ae0-b73d-b3078524b30a">
