### PR TITLE
BUGFIX: Style scrollbar in inspector dropdowns

### DIFF
--- a/packages/neos-ui/src/Containers/style.module.css
+++ b/packages/neos-ui/src/Containers/style.module.css
@@ -57,22 +57,26 @@
 /* Scrollbar styles for appContainer, its siblings (needed for React portals) and also for contentcanvas' body */
 :global(#appContainer ::-webkit-scrollbar),
 :global(#appContainer ~ * ::-webkit-scrollbar),
+:global(#appContainer ~ *::-webkit-scrollbar),
 :global(body::-webkit-scrollbar) {
     width: 4px;
     height: 4px;
 }
 :global(#appContainer ::-webkit-scrollbar-track),
 :global(#appContainer ~ * ::-webkit-scrollbar-track),
+:global(#appContainer ~ *::-webkit-scrollbar-track),
 :global(body::-webkit-scrollbar-track) {
     background-color: transparent;
 }
 :global(#appContainer ::-webkit-scrollbar-thumb),
 :global(#appContainer ~ * ::-webkit-scrollbar-thumb),
+:global(#appContainer ~ *::-webkit-scrollbar-thumb),
 :global(body::-webkit-scrollbar-thumb) {
     background-color: var(--colors-ContrastBright);
 }
 :global(#appContainer ::-webkit-scrollbar-corner),
 :global(#appContainer ~ * ::-webkit-scrollbar-corner),
+:global(#appContainer ~ *::-webkit-scrollbar-corner),
 :global(body::-webkit-scrollbar-corner) {
     background-color: var(--colors-ContrastDark);
 }


### PR DESCRIPTION
**What I did**

Apply the existing scrollbar styling also to the drop-down rendered via React portals

**How I did it**

The CSS was only applied to children of the portal rendered tag and would not apply if the tag itself was scrollable which is the case for dropdown.

**How to verify it**

Before:

<img width="163" alt="Bildschirmfoto 2023-11-15 um 09 15 25" src="https://github.com/neos/neos-ui/assets/596967/6e877920-be88-4a9c-aebe-28f7aada4fb3">

After:

<img width="322" alt="Bildschirmfoto 2023-11-15 um 09 15 06" src="https://github.com/neos/neos-ui/assets/596967/88dbb890-37b8-43c7-ba1b-b743e4fdd52b">

