### PR TITLE
TASK: Adjust to removal of `findChildNodeConnectedThroughEdgeName`

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -175,7 +175,7 @@ class BackendController extends ActionController
         );
         $rootNode = $rootNodeAggregate->getNodeByCoveredDimensionSpacePoint($defaultDimensionSpacePoint);
 
-        $siteNode = $subgraph->findChildNodeConnectedThroughEdgeName(
+        $siteNode = $subgraph->findChildNodeByNodeName(
             $rootNode->nodeAggregateId,
             $siteDetectionResult->siteNodeName->toNodeName()
         );

--- a/Classes/Domain/Model/Changes/CopyAfter.php
+++ b/Classes/Domain/Model/Changes/CopyAfter.php
@@ -14,7 +14,6 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
 
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\NodeDuplication\Command\CopyNodesRecursively;
-use Neos\ContentRepository\Core\Projection\ContentGraph\NodePath;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 
@@ -83,7 +82,7 @@ class CopyAfter extends AbstractStructuralChange
 
             $newlyCreatedNode = $this->contentRepositoryRegistry->subgraphForNode($parentNodeOfPreviousSibling)
                 ->findNodeByPath(
-                    NodePath::fromNodeNames($targetNodeName),
+                    $targetNodeName,
                     $parentNodeOfPreviousSibling->nodeAggregateId
                 );
             $this->finish($newlyCreatedNode);

--- a/Classes/Domain/Model/Changes/CopyAfter.php
+++ b/Classes/Domain/Model/Changes/CopyAfter.php
@@ -81,7 +81,7 @@ class CopyAfter extends AbstractStructuralChange
             $contentRepository->handle($command)->block();
 
             $newlyCreatedNode = $this->contentRepositoryRegistry->subgraphForNode($parentNodeOfPreviousSibling)
-                ->findChildNodeConnectedThroughEdgeName(
+                ->findChildNodeByNodeName(
                     $parentNodeOfPreviousSibling->nodeAggregateId,
                     $targetNodeName
                 );

--- a/Classes/Domain/Model/Changes/CopyAfter.php
+++ b/Classes/Domain/Model/Changes/CopyAfter.php
@@ -14,6 +14,7 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
 
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\NodeDuplication\Command\CopyNodesRecursively;
+use Neos\ContentRepository\Core\Projection\ContentGraph\NodePath;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 
@@ -81,9 +82,9 @@ class CopyAfter extends AbstractStructuralChange
             $contentRepository->handle($command)->block();
 
             $newlyCreatedNode = $this->contentRepositoryRegistry->subgraphForNode($parentNodeOfPreviousSibling)
-                ->findChildNodeByNodeName(
-                    $parentNodeOfPreviousSibling->nodeAggregateId,
-                    $targetNodeName
+                ->findNodeByPath(
+                    NodePath::fromNodeNames($targetNodeName),
+                    $parentNodeOfPreviousSibling->nodeAggregateId
                 );
             $this->finish($newlyCreatedNode);
             // NOTE: we need to run "finish" before "addNodeCreatedFeedback"

--- a/Classes/Domain/Model/Changes/CopyBefore.php
+++ b/Classes/Domain/Model/Changes/CopyBefore.php
@@ -14,6 +14,7 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
 
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\NodeDuplication\Command\CopyNodesRecursively;
+use Neos\ContentRepository\Core\Projection\ContentGraph\NodePath;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 
 class CopyBefore extends AbstractStructuralChange
@@ -74,9 +75,9 @@ class CopyBefore extends AbstractStructuralChange
             $contentRepository->handle($command)->block();
 
             $newlyCreatedNode = $this->contentRepositoryRegistry->subgraphForNode($parentNodeOfSucceedingSibling)
-                ->findChildNodeByNodeName(
-                    $parentNodeOfSucceedingSibling->nodeAggregateId,
-                    $targetNodeName
+                ->findNodeByPath(
+                    NodePath::fromNodeNames($targetNodeName),
+                    $parentNodeOfSucceedingSibling->nodeAggregateId
                 );
             $this->finish($newlyCreatedNode);
             // NOTE: we need to run "finish" before "addNodeCreatedFeedback"

--- a/Classes/Domain/Model/Changes/CopyBefore.php
+++ b/Classes/Domain/Model/Changes/CopyBefore.php
@@ -14,7 +14,6 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
 
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\NodeDuplication\Command\CopyNodesRecursively;
-use Neos\ContentRepository\Core\Projection\ContentGraph\NodePath;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 
 class CopyBefore extends AbstractStructuralChange
@@ -76,7 +75,7 @@ class CopyBefore extends AbstractStructuralChange
 
             $newlyCreatedNode = $this->contentRepositoryRegistry->subgraphForNode($parentNodeOfSucceedingSibling)
                 ->findNodeByPath(
-                    NodePath::fromNodeNames($targetNodeName),
+                    $targetNodeName,
                     $parentNodeOfSucceedingSibling->nodeAggregateId
                 );
             $this->finish($newlyCreatedNode);

--- a/Classes/Domain/Model/Changes/CopyBefore.php
+++ b/Classes/Domain/Model/Changes/CopyBefore.php
@@ -74,7 +74,7 @@ class CopyBefore extends AbstractStructuralChange
             $contentRepository->handle($command)->block();
 
             $newlyCreatedNode = $this->contentRepositoryRegistry->subgraphForNode($parentNodeOfSucceedingSibling)
-                ->findChildNodeConnectedThroughEdgeName(
+                ->findChildNodeByNodeName(
                     $parentNodeOfSucceedingSibling->nodeAggregateId,
                     $targetNodeName
                 );

--- a/Classes/Domain/Model/Changes/CopyInto.php
+++ b/Classes/Domain/Model/Changes/CopyInto.php
@@ -15,6 +15,7 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\NodeDuplication\Command\CopyNodesRecursively;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\ContentRepository\Core\Projection\ContentGraph\NodePath;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 
 class CopyInto extends AbstractStructuralChange
@@ -82,9 +83,9 @@ class CopyInto extends AbstractStructuralChange
             $contentRepository->handle($command)->block();
 
             $newlyCreatedNode = $this->contentRepositoryRegistry->subgraphForNode($parentNode)
-                ->findChildNodeByNodeName(
-                    $parentNode->nodeAggregateId,
-                    $targetNodeName
+                ->findNodeByPath(
+                    NodePath::fromNodeNames($targetNodeName),
+                    $parentNode->nodeAggregateId
                 );
             $this->finish($newlyCreatedNode);
             // NOTE: we need to run "finish" before "addNodeCreatedFeedback"

--- a/Classes/Domain/Model/Changes/CopyInto.php
+++ b/Classes/Domain/Model/Changes/CopyInto.php
@@ -82,7 +82,7 @@ class CopyInto extends AbstractStructuralChange
             $contentRepository->handle($command)->block();
 
             $newlyCreatedNode = $this->contentRepositoryRegistry->subgraphForNode($parentNode)
-                ->findChildNodeConnectedThroughEdgeName(
+                ->findChildNodeByNodeName(
                     $parentNode->nodeAggregateId,
                     $targetNodeName
                 );

--- a/Classes/Domain/Model/Changes/CopyInto.php
+++ b/Classes/Domain/Model/Changes/CopyInto.php
@@ -15,7 +15,6 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\NodeDuplication\Command\CopyNodesRecursively;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
-use Neos\ContentRepository\Core\Projection\ContentGraph\NodePath;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 
 class CopyInto extends AbstractStructuralChange
@@ -84,7 +83,7 @@ class CopyInto extends AbstractStructuralChange
 
             $newlyCreatedNode = $this->contentRepositoryRegistry->subgraphForNode($parentNode)
                 ->findNodeByPath(
-                    NodePath::fromNodeNames($targetNodeName),
+                    $targetNodeName,
                     $parentNode->nodeAggregateId
                 );
             $this->finish($newlyCreatedNode);


### PR DESCRIPTION
Adjustments for https://github.com/neos/neos-development-collection/pull/4755 replacing calls to `findChildNodeConnectedThroughEdgeName(…)` by `findNodeByPath(…)`.