### PR TITLE
BUGFIX: Prevent ui help message from overflowing

### DIFF
--- a/packages/react-ui-components/src/Tooltip/style.css
+++ b/packages/react-ui-components/src/Tooltip/style.css
@@ -33,6 +33,7 @@
     background: var(--colors-ContrastDarkest);
     color: white;
     box-shadow: 0px 0px 10px rgba(125, 125, 125, .2);
+    overflow-wrap: break-word;
 }
 
 .tooltip--asError .tooltip--inner {


### PR DESCRIPTION
**What I did**

Prevent long text in ui tooltips from overflowing their container.

**How I did it**

Add CSS rule

**How to verify it**

Before:
<img width="319" alt="Bildschirmfoto 2023-12-01 um 11 23 36" src="https://github.com/neos/neos-ui/assets/596967/6514287d-261e-4d96-a3e8-2b38f00f9da4">

After:
<img width="319" alt="Bildschirmfoto 2023-12-01 um 11 24 50" src="https://github.com/neos/neos-ui/assets/596967/1a981fa6-9652-48a7-8b4c-f6efa9ea5b8e">

