### PR TITLE
FEATURE: Allow grouping in DimensionSwitcher

### DIFF
--- a/Tests/IntegrationTests/Fixtures/1Dimension/SitePackage/Configuration/Settings.yaml
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/SitePackage/Configuration/Settings.yaml
@@ -12,35 +12,42 @@ Neos:
             values:
               - en_US
             uriSegment: en
+            group: NON-EU
           en_UK:
             label: 'English (UK)'
             values:
               - en_UK
               - en_US
             uriSegment: uk
+            group: NON-EU
           de:
             label: German
             values:
               - de
             uriSegment: de
+            group: EU
           fr:
             label: French
             values:
               - fr
             uriSegment: fr
+            group: EU
           nl:
             label: Dutch
             values:
               - nl
               - de
             uriSegment: nl
+            group: EU
           da:
             label: Danish
             values:
               - da
             uriSegment: da
+            group: EU
           lv:
             label: Latvian
             values:
               - lv
             uriSegment: lv
+            group: EU

--- a/Tests/IntegrationTests/Fixtures/1Dimension/switchingDimensions.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/switchingDimensions.e2e.js
@@ -3,6 +3,7 @@ import {
     Page,
     DimensionSwitcher
 } from './../../pageModel';
+import {Selector} from 'testcafe';
 
 /* global fixture:true */
 
@@ -29,4 +30,10 @@ test('Switching dimensions', async t => {
     await t
         .expect(await Page.getReduxState(state => state.cr.contentDimensions.active.language[0])).eql('en_US', 'Dimension back to English')
         .expect(Page.treeNode.withText(otherPageName).exists).ok('Untranslated node back in the tree');
+});
+
+test('Grouping of dimensions', async t => {
+    await t
+        .click(DimensionSwitcher.dimensionSwitcher)
+        .expect(Selector('div[class*="selectBox__groupHeader"]').withExactText('EU').exists).ok('Languages group exists');
 });

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelector.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelector.js
@@ -54,7 +54,7 @@ export default class DimensionSelector extends PureComponent {
             }
         );
 
-        const sortedPresetOptions = sortBy(presetOptions, ['label']);
+        const sortedPresetOptions = sortBy(presetOptions, ['group', 'label']);
 
         const onPresetSelect = presetName => {
             onSelect(dimensionName, presetName);

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelector.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelector.js
@@ -2,7 +2,6 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import SelectBox from '@neos-project/react-ui-components/src/SelectBox/';
 import style from './style.module.css';
-import {$get, $transform} from 'plow-js';
 import mapValues from 'lodash.mapvalues';
 import sortBy from 'lodash.sortby';
 import {neos} from '@neos-project/neos-ui-decorators';
@@ -46,14 +45,12 @@ export default class DimensionSelector extends PureComponent {
         const presetOptions = mapValues(
             presets,
             (presetConfiguration, presetName) => {
-                return $transform(
-                    {
-                        label: $get('label'),
-                        value: presetName,
-                        disallowed: $get('disallowed')
-                    },
-                    presetConfiguration
-                );
+                return {
+                    label: presetConfiguration?.label,
+                    value: presetName,
+                    disallowed: presetConfiguration?.disallowed,
+                    group: presetConfiguration?.group
+                };
             }
         );
 


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**
If (and only if) a `Neos.ContentRepository.contentDimensions.[...].presets` preset contains a `group` then the `DimensionSwitcher` dropdown is grouped.

Example:
```yaml
Neos:
  ContentRepository:
    contentDimensions:
      language:
        label: 'Language'
        icon: icon-language
        default: en_UK
        defaultPreset: en_UK
        presets:
          en_UK:
            label: 'English (UK)'
            values:
              - en_UK
            uriSegment: uk
            group: NON-EU
          de:
            label: German
            values:
              - de
            uriSegment: de
            group: EU
```

**How I did it**
I additionally map the `group` field when transforming language presets to select box options.

**How to verify it**
Wrote a test for it.

Add groups to language presets and open the DimensionSwitcher.

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
![Screenshot 2023-12-05 at 1 29 04 PM](https://github.com/neos/neos-ui/assets/1615332/d7c57978-1081-4dc4-8c0f-0f565d066bb0)
