### PR TITLE
BUGFIX: Adds group for dimension configuration

### DIFF
--- a/Classes/Fusion/Helper/ContentDimensionsHelper.php
+++ b/Classes/Fusion/Helper/ContentDimensionsHelper.php
@@ -56,7 +56,8 @@ class ContentDimensionsHelper implements ProtectedContextAwareInterface
                 $result[$dimension->id->value]['presets'][$value->value] = [
                     // TODO: name, uriSegment!
                     'values' => [$value->value],
-                    'label' => $value->getConfigurationValue('label')
+                    'label' => $value->getConfigurationValue('label'),
+                    'group' => $value->getConfigurationValue('group'),
                 ];
             }
         }

--- a/Tests/IntegrationTests/TestDistribution/DistributionPackages/Neos.Test.OneDimension/Configuration/Settings.yaml
+++ b/Tests/IntegrationTests/TestDistribution/DistributionPackages/Neos.Test.OneDimension/Configuration/Settings.yaml
@@ -9,19 +9,26 @@ Neos:
             values:
               'en_US':
                 label: English (US)
+                group: NON-EU
                 specializations:
                   'en_UK':
+                    group: NON-EU
                     label: English (UK)
               'de':
                 label: German
+                group: EU
                 specializations:
                   'nl':
+                    group: EU
                     label: Dutch
               'fr':
+                group: EU
                 label: French
               'da':
+                group: EU
                 label: Danish
               'lv':
+                group: EU
                 label: Latvian
   Neos:
     sites:


### PR DESCRIPTION
In version 8.4 of the neos-ui we added the group property for dimensions, that is, for grouping dimensions visually. Therefore, we need the configuration information in the UI.

The original change: https://github.com/neos/neos-ui/pull/3670