### PR TITLE
BUGFIX SpeedUp Inspector Title E2E Test

### DIFF
--- a/Tests/IntegrationTests/Fixtures/1Dimension/inspector.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/inspector.e2e.js
@@ -44,7 +44,7 @@ test('Can edit the page title via inspector', async t => {
     await t
         .click(InspectorTitleProperty)
         .typeText(InspectorTitleProperty, '-2')
-        .click(Selector('[name="neos-content-main"]'))
+        .click(Selector('#neos-Inspector'), {offsetX: -400}) // hack to click into the iframe even with overlaying changes div in dom
         .expect(Selector('#neos-UnappliedChangesDialog').exists)
         .ok()
         .click(Selector('#neos-UnappliedChangesDialog-resume'))
@@ -55,7 +55,7 @@ test('Can edit the page title via inspector', async t => {
 
     subSection('Test unapplied changes dialog - discard');
     await t
-        .click(Selector('[name="neos-content-main"]'))
+        .click(Selector('#neos-Inspector'), {offsetX: -400}) // hack to click into the iframe even with overlaying changes div in dom
         .click(Selector('#neos-UnappliedChangesDialog-discard'))
         .expect(InspectorTitleProperty.value)
         .eql('Home-1');
@@ -63,11 +63,11 @@ test('Can edit the page title via inspector', async t => {
     subSection('Test unapplied changes dialog - apply');
     await t
         .typeText(InspectorTitleProperty, '-3')
-        .click(Selector('[name="neos-content-main"]'))
+        .click(Selector('#neos-Inspector'), {offsetX: -400}) // hack to click into the iframe even with overlaying changes div in dom
         .click(Selector('#neos-UnappliedChangesDialog-apply'))
         .expect(InspectorTitleProperty.value)
         .eql('Home-1-3')
-        .click(Selector('[name="neos-content-main"]'))
+        .click(Selector('#neos-Inspector'), {offsetX: -400}) // hack to click into the iframe even with overlaying changes div in dom
         .expect(Selector('#neos-UnappliedChangesDialog').exists)
         .notOk();
 });


### PR DESCRIPTION
Previously do to some automatic magic tescafe would wait before clicking into the iframe because the unappliedChangesOverlay is already in the dom and this warning is shown:

> TestCafe cannot interact with the `<iframe name="neos-content-main">` element because another element obstructs it.
  When something overlaps the action target, TestCafe performs the action with the topmost element at the original target's location.
  The following element with a greater z-order replaced the original action target: `<div class="unappliedChangesOverlay">`.
  Review your code to prevent this behavior.

This waiting results in a super slow down of multiple seconds! To fix this we dont attempt to click directly in the iframe via selector but we use click left to the inspector (via negative offset) that allows to trick tescafe.

Alternative options are possibly to use a ClientFunction, absolute coordinate clicking (doesnt seem possible with testcafe) or adding a timeout `Selector('iframe', {timeout: 200})` to the selector, which would still cause the warning to dispatch though.

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
