### PR TITLE
BUGFIX: Fix dimension dropdown on browser zoom

### DIFF
--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/style.module.css
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/style.module.css
@@ -71,6 +71,7 @@
 .singleDimensionDropdown {
     display: flex;
     align-items: center;
+    align-self: start;
 
     .dimensionSwitcherDropDown {
         background: unset;


### PR DESCRIPTION
resolves #3639 

**What I did**
I had a look at why the language dropdown disappears when the browser is zoomed out. 

**How I did it**
The SelectBox is loading DropDown.Contents with scrollable="true" which triggers a check if the element is out of bound. 
The check for const elementBoundingBox = el.getBoundingClientRect(); is returning -0.05 for top when I zoom out 80% and thus is "out of bounds" of the viewport. There is apparently some css that makes the dimensions dropdown slightly higher than the right topbar. 
I could not find a good reason why the Element is out of bounds by 0.05, perhaps there is a better solution? 
To resolve the issue, I placed the dimensions menu at the top of the bar, thus it cannot go over the top of the bar. 

**How to verify it**
When zooming out, the dimensions menu is visible again: 
![Bildschirmfoto 2024-01-22 um 14 23 53](https://github.com/neos/neos-ui/assets/91674611/ad59c425-5fb8-4e9e-a9aa-5956793e3eeb)
Before that, Menu was not opening: 
![Bildschirmfoto 2024-01-22 um 14 25 31](https://github.com/neos/neos-ui/assets/91674611/6ab640be-21de-4b05-a343-295ac0c42e37)

Also, I checked on desktop without browser zoom and there was no visible change in styling with the additional CSS