### PR TITLE
BUGFIX: Enforce closing dialog

### DIFF
--- a/packages/react-ui-components/src/Dialog/DialogManager.ts
+++ b/packages/react-ui-components/src/Dialog/DialogManager.ts
@@ -4,7 +4,7 @@ export interface EventRoot {
 }
 
 export interface Dialog {
-    close: () => boolean;
+    close: (force?: boolean) => boolean;
 }
 
 export class DialogManager {
@@ -29,14 +29,14 @@ export class DialogManager {
 
     public readonly handleKeydown = (event: KeyboardEvent): void => {
         if (event.key === 'Escape') {
-            this.closeLatest();
+            this.closeLatest(true);
         }
     }
 
-    public closeLatest(): void {
+    public closeLatest(force: boolean = false): void {
         const dialog = this.dialogs.pop();
         if (dialog) {
-            if (dialog.close()) {
+            if (dialog.close(force)) {
                 this.removeHandleKeydownEventListenerIfNecessary();
             } else {
                 this.dialogs.push(dialog);

--- a/packages/react-ui-components/src/Dialog/dialog.tsx
+++ b/packages/react-ui-components/src/Dialog/dialog.tsx
@@ -94,8 +94,8 @@ class DialogWithOverlay extends PureComponent<DialogProps> {
     private ref?: HTMLDivElement;
 
     private dialog: Dialog = {
-        close: () => {
-            if (this.props.preventClosing) {
+        close: (force: boolean = false) => {
+            if (!force && this.props.preventClosing) {
                 this.startShaking();
                 return false;
             }
@@ -232,7 +232,7 @@ class DialogWithOverlay extends PureComponent<DialogProps> {
 
     private readonly handleOverlayClick = (ev: React.MouseEvent) => {
         if (ev.target === ev.currentTarget) {
-            this.dialog.close();
+            this.dialog.close(true);
         }
     }
 }


### PR DESCRIPTION
Resolve creation dialog closure issue with property validation errors by introducing a 'force' parameter. The 'close' function now accepts an optional 'force' parameter, defaulting to false, allowing the dialog to be closed even when validation errors occur.

Fixes: #3679

**What I did**
Added a force parameter to the close function of the dialog that is false by default and optional, to be not too breaky.
So we can change the behavior for the KeyboardEvent or click outside.

**How to verify it**
Create a page, for instance in the Neos.Demo and don't enter a title and click create. So you will get a validation error, before the adjustment you cannot close the dialog with ESC or click outside the dialog.
With the PR it will work!
