### PR TITLE
BUGFIX: Prevent overlaying of upper toolbars in RichTextEditor

### DIFF
--- a/packages/neos-ui-editors/src/SecondaryEditors/CKEditorWrap/index.css
+++ b/packages/neos-ui-editors/src/SecondaryEditors/CKEditorWrap/index.css
@@ -14,4 +14,5 @@
     flex-grow: 1;
     outline: 0;
     padding: 15px;
+    overflow: scroll;
 }


### PR DESCRIPTION
The `RichTextEditor`, utilizing the `CKEditor` component, experienced an issue where the wrapping component failed to scroll appropriately with increased content, causing it to grow and overlay the upper toolbar. This commit addresses the problem, ensuring proper container resizing and preventing toolbar overlay.

Fixes: #3664

https://github.com/neos/neos-ui/assets/1014126/9d394351-3a94-4098-8c23-8f4b3989ec0a

