### PR TITLE
BUGFIX: Add ellipsis to nodeInfoView content

### DIFF
--- a/packages/neos-ui-views/src/NodeInfoView/style.css
+++ b/packages/neos-ui-views/src/NodeInfoView/style.css
@@ -29,5 +29,8 @@
     &__content {
         font-size: 13px;
         color: var(--colors-ContrastBright);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 }


### PR DESCRIPTION
The NodeTypeName in the info panel was getting cut off, so I implemented a solution to enhance the display. Now, an ellipsis is added to prevent overflow within the container, and the full NodeType name is accessible through a tooltip that appears when hovered over.

Fixes: #3637

<img width="343" alt="Screenshot 2024-01-26 at 12 38 07" src="https://github.com/neos/neos-ui/assets/1014126/e8cd8f51-f6ea-4246-9538-6e2bc8c27a23">
