### PR TITLE
BUGFIX: Resolve issue with custom data source displaying additional l…

### DIFF
--- a/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/style.css
+++ b/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/style.css
@@ -1,6 +1,23 @@
 .multiLineWithThumbnail__item {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: -var(--spacing-Half);
+    align-items: start;
     box-sizing: content-box;
     background-color: var(--colors-ContrastDarkest);
+}
+
+.multiLineWithThumbnail__item span {
+    grid-column: 2;
+    grid-row: 1;
+
+    &.multiLineWithThumbnail__secondaryLabel {
+        grid-row: 2;
+    }
+
+    &.multiLineWithThumbnail__tertiaryLabel {
+        grid-row: 3;
+    }
 }
 
 .multiLineWithThumbnail__item--multiLine {
@@ -26,6 +43,8 @@
 .multiLineWithThumbnail__image {
     width: calc(1.33 * (var(--spacing-GoldenUnit) + var(--spacing-Full)));
     height: calc(var(--spacing-GoldenUnit) + var(--spacing-Full));
+    grid-column: 1;
+    grid-row: 1 / 4;
     object-fit: contain;
     background-color: #fff;
     background-size: 10px 10px;

--- a/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/style.css
+++ b/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/style.css
@@ -1,7 +1,7 @@
 .multiLineWithThumbnail__item {
     display: grid;
     grid-template-columns: auto 1fr;
-    gap: -var(--spacing-Half);
+    column-gap: var(--spacing-Half);
     align-items: start;
     box-sizing: content-box;
     background-color: var(--colors-ContrastDarkest);
@@ -10,6 +10,9 @@
 .multiLineWithThumbnail__item span {
     grid-column: 2;
     grid-row: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 
     &.multiLineWithThumbnail__secondaryLabel {
         grid-row: 2;
@@ -50,12 +53,10 @@
     background-size: 10px 10px;
     background-position: 0 0, 25px 25px;
     background-image: linear-gradient(45deg, #cccccc 25%, transparent 25%, transparent 75%, #cccccc 75%, #cccccc), linear-gradient(45deg, #cccccc 25%, transparent 25%, transparent 75%, #cccccc 75%, #cccccc);
-    margin-right: .75em;
     display: inline-block;
     vertical-align: middle;
-    margin-left: -var(--spacing-Full);
-    margin-top: -var(--spacing-Half);
-    margin-bottom: -var(--spacing-Half);
+    margin-left: -var(--spacing-Half);
+    align-self: center;
 }
 
 .multiLineWithThumbnail__item:hover .multiLineWithThumbnail__secondaryLabel,


### PR DESCRIPTION
Previously, there was an issue with the custom data source where the secondary label, utilized with label and preview, was not being displayed correctly. This commit addresses the problem, ensuring proper alignment and display of the secondary label in conjunction with the label and preview elements. The implementation includes the use of a CSS grid layout to achieve consistent and accurate rendering of the custom data source information.

Fixes: #3675

**Before:**
<img width="397" alt="Screenshot 2024-01-26 at 13 28 55" src="https://github.com/neos/neos-ui/assets/1014126/595550e1-6652-4b48-8930-b4a6ba217637">

**After with preview:**
<img width="335" alt="Screenshot 2024-01-26 at 14 13 09" src="https://github.com/neos/neos-ui/assets/1014126/bf0c6560-0d9e-499f-86c8-97e35cc6fb45">

**After without preview and 3rd label:**
<img width="325" alt="Screenshot 2024-01-26 at 14 17 11" src="https://github.com/neos/neos-ui/assets/1014126/5d24238e-c30a-40a6-99e0-be8aed50fb28">
