### PR TITLE
TASK: Avoid heavily use of controller context and make `Neos.Ui.NodeInfo` internal

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -198,7 +198,7 @@ class BackendController extends ActionController
                 ),
             'frontendConfiguration' =>
                 $this->frontendConfigurationProvider->getFrontendConfiguration(
-                    controllerContext: $this->controllerContext,
+                    actionRequest: $this->request,
                 ),
             'nodeTypes' =>
                 $this->nodeTypeGroupsAndRolesProvider->getNodeTypes(),
@@ -208,7 +208,7 @@ class BackendController extends ActionController
                 ),
             'initialState' =>
                 $this->initialStateProvider->getInitialState(
-                    controllerContext: $this->controllerContext,
+                    actionRequest: $this->request,
                     contentRepositoryId: $siteDetectionResult->contentRepositoryId,
                     documentNode: $node,
                     site: $siteNode,

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -204,7 +204,7 @@ class BackendController extends ActionController
                 $this->nodeTypeGroupsAndRolesProvider->getNodeTypes(),
             'menu' =>
                 $this->menuProvider->getMenu(
-                    controllerContext: $this->controllerContext,
+                    actionRequest: $this->request,
                 ),
             'initialState' =>
                 $this->initialStateProvider->getInitialState(

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -590,15 +590,15 @@ class BackendServiceController extends ActionController
         $nodeInfoHelper = new NodeInfoHelper();
         $type = $finisher['type'] ?? null;
         $result = match ($type) {
-            'get' => $nodeInfoHelper->renderNodes(array_filter($flowQuery->get()), $this->getControllerContext()),
+            'get' => $nodeInfoHelper->renderNodes(array_filter($flowQuery->get()), $this->request),
             'getForTree' => $nodeInfoHelper->renderNodes(
                 array_filter($flowQuery->get()),
-                $this->getControllerContext(),
+                $this->request,
                 true
             ),
             'getForTreeWithParents' => $nodeInfoHelper->renderNodesWithParents(
                 array_filter($flowQuery->get()),
-                $this->getControllerContext()
+                $this->request
             ),
             default => []
         };

--- a/Classes/Domain/InitialData/FrontendConfigurationProviderInterface.php
+++ b/Classes/Domain/InitialData/FrontendConfigurationProviderInterface.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace Neos\Neos\Ui\Domain\InitialData;
 
-use Neos\Flow\Mvc\Controller\ControllerContext;
+use Neos\Flow\Mvc\ActionRequest;
 
 /**
  * Reads and preprocesses the `Neos.Neos.Ui.frontendConfiguration` settings
@@ -27,6 +27,6 @@ interface FrontendConfigurationProviderInterface
 {
     /** @return array<mixed> */
     public function getFrontendConfiguration(
-        ControllerContext $controllerContext
+        ActionRequest $actionRequest
     ): array;
 }

--- a/Classes/Domain/InitialData/InitialStateProviderInterface.php
+++ b/Classes/Domain/InitialData/InitialStateProviderInterface.php
@@ -16,7 +16,7 @@ namespace Neos\Neos\Ui\Domain\InitialData;
 
 use Neos\ContentRepository\Core\Factory\ContentRepositoryId;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
-use Neos\Flow\Mvc\Controller\ControllerContext;
+use Neos\Flow\Mvc\ActionRequest;
 use Neos\Neos\Domain\Model\User;
 
 /**
@@ -29,7 +29,7 @@ interface InitialStateProviderInterface
 {
     /** @return array<mixed> */
     public function getInitialState(
-        ControllerContext $controllerContext,
+        ActionRequest $actionRequest,
         ContentRepositoryId $contentRepositoryId,
         ?Node $documentNode,
         ?Node $site,

--- a/Classes/Domain/InitialData/MenuProviderInterface.php
+++ b/Classes/Domain/InitialData/MenuProviderInterface.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace Neos\Neos\Ui\Domain\InitialData;
 
-use Neos\Flow\Mvc\Controller\ControllerContext;
+use Neos\Flow\Mvc\ActionRequest;
 
 /**
  * Retrieves all data needed to render the main burger menu located in the
@@ -27,5 +27,5 @@ interface MenuProviderInterface
     /**
      * @return array<int,array{label:string,icon:string,uri:string,target:string,children:array<int,array{icon:string,label:string,uri:string,position?:string,isActive:bool,target:string,skipI18n:bool}>}>
      */
-    public function getMenu(ControllerContext $controllerContext): array;
+    public function getMenu(ActionRequest $actionRequest): array;
 }

--- a/Classes/Domain/Model/Feedback/Operations/ReloadDocument.php
+++ b/Classes/Domain/Model/Feedback/Operations/ReloadDocument.php
@@ -80,7 +80,7 @@ class ReloadDocument extends AbstractFeedback
 
         if ($documentNode) {
             return [
-                'uri' => $nodeInfoHelper->previewUri($documentNode, $controllerContext)
+                'uri' => $nodeInfoHelper->previewUri($documentNode, $controllerContext->getRequest())
             ];
         }
 

--- a/Classes/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
@@ -13,6 +13,7 @@ namespace Neos\Neos\Ui\Domain\Model\Feedback\Operations;
 
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Flow\Mvc\ActionRequest;
 use Neos\Neos\FrontendRouting\NodeAddressFactory;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
@@ -106,7 +107,7 @@ class UpdateNodeInfo extends AbstractFeedback
     {
         return $this->node
             ? [
-                'byContextPath' => $this->serializeNodeRecursively($this->node, $controllerContext)
+                'byContextPath' => $this->serializeNodeRecursively($this->node, $controllerContext->getRequest())
             ]
             : [];
     }
@@ -116,7 +117,7 @@ class UpdateNodeInfo extends AbstractFeedback
      *
      * @return array<string,?array<string,mixed>>
      */
-    private function serializeNodeRecursively(Node $node, ControllerContext $controllerContext): array
+    private function serializeNodeRecursively(Node $node, ActionRequest $actionRequest): array
     {
         $contentRepository = $this->contentRepositoryRegistry->get($node->subgraphIdentity->contentRepositoryId);
         $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
@@ -125,14 +126,14 @@ class UpdateNodeInfo extends AbstractFeedback
             $nodeAddressFactory->createFromNode($node)->serializeForUri()
             => $this->nodeInfoHelper->renderNodeWithPropertiesAndChildrenInformation(
                 $node,
-                $controllerContext
+                $actionRequest
             )
         ];
 
         if ($this->isRecursive === true) {
             $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
             foreach ($subgraph->findChildNodes($node->nodeAggregateId, FindChildNodesFilter::create()) as $childNode) {
-                $result = array_merge($result, $this->serializeNodeRecursively($childNode, $controllerContext));
+                $result = array_merge($result, $this->serializeNodeRecursively($childNode, $actionRequest));
             }
         }
 

--- a/Classes/Domain/Model/Feedback/Operations/UpdateNodePreviewUrl.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateNodePreviewUrl.php
@@ -106,7 +106,7 @@ class UpdateNodePreviewUrl extends AbstractFeedback
             $nodeInfoHelper = new NodeInfoHelper();
             $contentRepository = $this->contentRepositoryRegistry->get($this->node->subgraphIdentity->contentRepositoryId);
             $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
-            $newPreviewUrl = $nodeInfoHelper->createRedirectToNode($this->node, $controllerContext);
+            $newPreviewUrl = $nodeInfoHelper->createRedirectToNode($this->node, $controllerContext->getRequest());
             $contextPath = $nodeAddressFactory->createFromNode($this->node)->serializeForUri();
         }
         return [

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -31,6 +31,7 @@ use Neos\Neos\Ui\Domain\Service\UserLocaleService;
 use Neos\Neos\Utility\NodeTypeWithFallbackProvider;
 
 /**
+ * @internal
  * @Flow\Scope("singleton")
  * @todo EEL helpers are still to be declared as internal
  */

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -20,7 +20,6 @@ use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\ActionRequest;
-use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Neos\FrontendRouting\NodeAddress;
@@ -414,13 +413,6 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
                 $this->ignoredNodeTypeRole
             )
         );
-    }
-
-    public function nodeAddress(Node $node): NodeAddress
-    {
-        $contentRepository = $this->contentRepositoryRegistry->get($node->subgraphIdentity->contentRepositoryId);
-        $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
-        return $nodeAddressFactory->createFromNode($node);
     }
 
     public function serializedNodeAddress(Node $node): string

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -436,6 +436,13 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
      */
     public function allowsCallOfMethod($methodName)
     {
-        return true;
+        // to control what is used in eel we maintain this list.
+        return in_array($methodName, [
+            'serializedNodeAddress',
+            'createRedirectToNode',
+            'renderNodeWithPropertiesAndChildrenInformation',
+            'defaultNodesForBackend',
+            'uri'
+        ], true);
     }
 }

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -349,40 +349,6 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
     }
 
     /**
-     * @param Node $documentNode
-     * @param ControllerContext $controllerContext
-     * @return array<string,mixed>>
-     */
-    public function renderDocumentNodeAndChildContent(
-        Node $documentNode,
-        ControllerContext $controllerContext
-    ): array {
-        return $this->renderNodeAndChildContent($documentNode, $controllerContext);
-    }
-
-    /**
-     * @return array<string,mixed>>
-     */
-    protected function renderNodeAndChildContent(Node $node, ControllerContext $controllerContext): array
-    {
-        $reducer = function ($nodes, $node) use ($controllerContext) {
-            return array_merge($nodes, $this->renderNodeAndChildContent($node, $controllerContext));
-        };
-
-        $contentRepository = $this->contentRepositoryRegistry->get($node->subgraphIdentity->contentRepositoryId);
-        $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
-
-        return array_reduce(
-            iterator_to_array($this->getChildNodes($node, $this->buildContentChildNodeFilterString())),
-            $reducer,
-            [
-                $nodeAddressFactory->createFromNode($node)->serializeForUri()
-                => $this->renderNodeWithPropertiesAndChildrenInformation($node, $controllerContext)
-            ]
-        );
-    }
-
-    /**
      * @return array<string,array<string,mixed>|null>
      */
     public function defaultNodesForBackend(

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -80,30 +80,6 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
 
     /**
      * @return ?array<string,mixed>
-     * @deprecated See methods with specific names for different behaviors
-     */
-    public function renderNode(
-        Node $node,
-        ControllerContext $controllerContext = null,
-        bool $omitMostPropertiesForTreeState = false,
-        string $nodeTypeFilterOverride = null
-    ):?array {
-        return ($omitMostPropertiesForTreeState
-            ? $this->renderNodeWithMinimalPropertiesAndChildrenInformation(
-                $node,
-                $controllerContext?->getRequest(),
-                $nodeTypeFilterOverride
-            )
-            : $this->renderNodeWithPropertiesAndChildrenInformation(
-                $node,
-                $controllerContext?->getRequest(),
-                $nodeTypeFilterOverride
-            )
-        );
-    }
-
-    /**
-     * @return ?array<string,mixed>
      */
     public function renderNodeWithMinimalPropertiesAndChildrenInformation(
         Node $node,

--- a/Classes/Fusion/RenderConfigurationImplementation.php
+++ b/Classes/Fusion/RenderConfigurationImplementation.php
@@ -13,6 +13,7 @@ namespace Neos\Neos\Ui\Fusion;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Exception;
+use Neos\Flow\Mvc\ActionRequest;
 use Neos\Fusion\FusionObjects\AbstractFusionObject;
 use Neos\Neos\Ui\Domain\Service\ConfigurationRenderingService;
 
@@ -59,7 +60,11 @@ class RenderConfigurationImplementation extends AbstractFusionObject
     {
         $context = $this->getContext();
         $pathToRender = $this->getPath();
-        $context['controllerContext'] = $this->getruntime()->getControllerContext();
+        $actionRequest = $this->getRuntime()->fusionGlobals->get('request');
+        if (!$actionRequest instanceof ActionRequest) {
+            throw new Exception('The request is expected to be an ActionRequest.', 1706639436);
+        }
+        $context['request'] = $actionRequest;
 
         if (!isset($this->settings[$pathToRender])) {
             throw new Exception('The path "Neos.Neos.Ui.' . $pathToRender . '" was not found in the settings.', 1458814468);

--- a/Classes/Infrastructure/Configuration/FrontendConfigurationProvider.php
+++ b/Classes/Infrastructure/Configuration/FrontendConfigurationProvider.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 namespace Neos\Neos\Ui\Infrastructure\Configuration;
 
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Mvc\Controller\ControllerContext;
+use Neos\Flow\Mvc\ActionRequest;
 use Neos\Neos\Ui\Domain\InitialData\FrontendConfigurationProviderInterface;
 use Neos\Neos\Ui\Domain\Service\ConfigurationRenderingService;
 
@@ -33,11 +33,11 @@ final class FrontendConfigurationProvider implements FrontendConfigurationProvid
     protected array $frontendConfigurationBeforeProcessing;
 
     public function getFrontendConfiguration(
-        ControllerContext $controllerContext
+        ActionRequest $actionRequest
     ): array {
         return $this->configurationRenderingService->computeConfiguration(
             $this->frontendConfigurationBeforeProcessing,
-            ['controllerContext' => $controllerContext]
+            ['request' => $actionRequest]
         );
     }
 }

--- a/Classes/Infrastructure/Configuration/InitialStateProvider.php
+++ b/Classes/Infrastructure/Configuration/InitialStateProvider.php
@@ -17,7 +17,7 @@ namespace Neos\Neos\Ui\Infrastructure\Configuration;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryId;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Mvc\Controller\ControllerContext;
+use Neos\Flow\Mvc\ActionRequest;
 use Neos\Neos\Domain\Model\User;
 use Neos\Neos\Ui\Domain\InitialData\InitialStateProviderInterface;
 use Neos\Neos\Ui\Domain\Service\ConfigurationRenderingService;
@@ -40,7 +40,7 @@ final class InitialStateProvider implements InitialStateProviderInterface
     protected array $initialStateBeforeProcessing;
 
     public function getInitialState(
-        ControllerContext $controllerContext,
+        ActionRequest $actionRequest,
         ContentRepositoryId $contentRepositoryId,
         ?Node $documentNode,
         ?Node $site,
@@ -49,7 +49,7 @@ final class InitialStateProvider implements InitialStateProviderInterface
         return $this->configurationRenderingService->computeConfiguration(
             $this->initialStateBeforeProcessing,
             [
-                'controllerContext' => $controllerContext,
+                'request' => $actionRequest,
                 'contentRepositoryId' => $contentRepositoryId,
                 'documentNode' => $documentNode,
                 'site' => $site,

--- a/Classes/Infrastructure/Neos/MenuProvider.php
+++ b/Classes/Infrastructure/Neos/MenuProvider.php
@@ -15,7 +15,11 @@ declare(strict_types=1);
 namespace Neos\Neos\Ui\Infrastructure\Neos;
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Mvc\ActionResponse;
+use Neos\Flow\Mvc\Controller\Arguments;
 use Neos\Flow\Mvc\Controller\ControllerContext;
+use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\Neos\Controller\Backend\MenuHelper;
 use Neos\Neos\Ui\Domain\InitialData\MenuProviderInterface;
 use Neos\Utility\PositionalArraySorter;
@@ -29,8 +33,17 @@ final class MenuProvider implements MenuProviderInterface
     #[Flow\Inject]
     protected MenuHelper $menuHelper;
 
-    public function getMenu(ControllerContext $controllerContext): array
+    public function getMenu(ActionRequest $actionRequest): array
     {
+        $uriBuilder = new UriBuilder();
+        $uriBuilder->setRequest($actionRequest);
+        $controllerContext = new ControllerContext(
+            $actionRequest,
+            new ActionResponse(),
+            new Arguments(),
+            $uriBuilder
+        );
+
         $modulesForMenu = $this->menuHelper->buildModuleList($controllerContext);
 
         $result = [];

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -109,11 +109,11 @@ Neos:
         metaData:
           documentNode: '${Neos.Ui.NodeInfo.serializedNodeAddress(documentNode)}'
           siteNode: '${Neos.Ui.NodeInfo.serializedNodeAddress(site)}'
-          previewUrl: '${Neos.Ui.NodeInfo.createRedirectToNode(documentNode, controllerContext)}'
+          previewUrl: '${Neos.Ui.NodeInfo.createRedirectToNode(documentNode, controllerContext.request)}'
           contentDimensions:
             active: '${Neos.Ui.ContentDimensions.dimensionSpacePointArray(documentNode.subgraphIdentity.dimensionSpacePoint)}'
             allowedPresets: '${Neos.Ui.Api.emptyArrayToObject(Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.subgraphIdentity.dimensionSpacePoint, documentNode.subgraphIdentity.contentRepositoryId))}'
-          documentNodeSerialization: '${Neos.Ui.NodeInfo.renderNodeWithPropertiesAndChildrenInformation(documentNode, controllerContext)}'
+          documentNodeSerialization: '${Neos.Ui.NodeInfo.renderNodeWithPropertiesAndChildrenInformation(documentNode, controllerContext.request)}'
       initialState:
         changes:
           pending: {  }
@@ -121,7 +121,7 @@ Neos:
           failed: {  }
         cr:
           nodes:
-            byContextPath: '${Neos.Ui.NodeInfo.defaultNodesForBackend(site, documentNode, controllerContext)}'
+            byContextPath: '${Neos.Ui.NodeInfo.defaultNodesForBackend(site, documentNode, controllerContext.request)}'
             siteNode: '${Neos.Ui.NodeInfo.serializedNodeAddress(site)}'
             documentNode: '${Neos.Ui.NodeInfo.serializedNodeAddress(documentNode)}'
             clipboard: '${clipboardNodes || []}'
@@ -134,7 +134,7 @@ Neos:
             personalWorkspace: '${Neos.Ui.Workspace.getPersonalWorkspace(contentRepositoryId)}'
         ui:
           contentCanvas:
-            src: '${Neos.Ui.NodeInfo.uri(documentNode, controllerContext)}'
+            src: '${Neos.Ui.NodeInfo.uri(documentNode, controllerContext.request)}'
             backgroundColor: '${Configuration.setting(''Neos.Neos.Ui.contentCanvas.backgroundColor'')}'
           debugMode: false
           editPreviewMode: '${q(user).property("preferences.preferences")["contentEditing.editPreviewMode"] || Configuration.setting(''Neos.Neos.userInterface.defaultEditPreviewMode'')}'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -109,11 +109,11 @@ Neos:
         metaData:
           documentNode: '${Neos.Ui.NodeInfo.serializedNodeAddress(documentNode)}'
           siteNode: '${Neos.Ui.NodeInfo.serializedNodeAddress(site)}'
-          previewUrl: '${Neos.Ui.NodeInfo.createRedirectToNode(documentNode, controllerContext.request)}'
+          previewUrl: '${Neos.Ui.NodeInfo.createRedirectToNode(documentNode, request)}'
           contentDimensions:
             active: '${Neos.Ui.ContentDimensions.dimensionSpacePointArray(documentNode.subgraphIdentity.dimensionSpacePoint)}'
             allowedPresets: '${Neos.Ui.Api.emptyArrayToObject(Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.subgraphIdentity.dimensionSpacePoint, documentNode.subgraphIdentity.contentRepositoryId))}'
-          documentNodeSerialization: '${Neos.Ui.NodeInfo.renderNodeWithPropertiesAndChildrenInformation(documentNode, controllerContext.request)}'
+          documentNodeSerialization: '${Neos.Ui.NodeInfo.renderNodeWithPropertiesAndChildrenInformation(documentNode, request)}'
       initialState:
         changes:
           pending: {  }
@@ -121,7 +121,7 @@ Neos:
           failed: {  }
         cr:
           nodes:
-            byContextPath: '${Neos.Ui.NodeInfo.defaultNodesForBackend(site, documentNode, controllerContext.request)}'
+            byContextPath: '${Neos.Ui.NodeInfo.defaultNodesForBackend(site, documentNode, request)}'
             siteNode: '${Neos.Ui.NodeInfo.serializedNodeAddress(site)}'
             documentNode: '${Neos.Ui.NodeInfo.serializedNodeAddress(documentNode)}'
             clipboard: '${clipboardNodes || []}'
@@ -134,7 +134,7 @@ Neos:
             personalWorkspace: '${Neos.Ui.Workspace.getPersonalWorkspace(contentRepositoryId)}'
         ui:
           contentCanvas:
-            src: '${Neos.Ui.NodeInfo.uri(documentNode, controllerContext.request)}'
+            src: '${Neos.Ui.NodeInfo.uri(documentNode, request)}'
             backgroundColor: '${Configuration.setting(''Neos.Neos.Ui.contentCanvas.backgroundColor'')}'
           debugMode: false
           editPreviewMode: '${q(user).property("preferences.preferences")["contentEditing.editPreviewMode"] || Configuration.setting(''Neos.Neos.userInterface.defaultEditPreviewMode'')}'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -208,4 +208,3 @@ Neos:
       Neos.Ui.Workspace: Neos\Neos\Ui\Fusion\Helper\WorkspaceHelper
       Neos.Ui.StaticResources: Neos\Neos\Ui\Fusion\Helper\StaticResourcesHelper
       Neos.Ui.PositionalArraySorter: Neos\Neos\Ui\Fusion\Helper\PositionalArraySorterHelper
-      Neos.Ui.NodeInfo: Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper


### PR DESCRIPTION
_If_ for some reason `Neos.Ui.NodeInfo` was used in consumer fusion land it must be migrated.
For migration please copy the parts of the `NodeInfo` helper to your own helper.
Note that the helper is sorely an internal detail of the user interface.

**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
