### PR TITLE
TASK: Declare public api in php classes

### DIFF
--- a/Classes/ContentRepository/Service/WorkspaceService.php
+++ b/Classes/ContentRepository/Service/WorkspaceService.php
@@ -30,6 +30,7 @@ use Neos\Neos\Ui\Domain\Model\Feedback\Operations\RemoveNode;
 use Neos\Neos\Utility\NodeTypeWithFallbackProvider;
 
 /**
+ * @internal
  * @Flow\Scope("singleton")
  */
 class WorkspaceService

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -35,6 +35,9 @@ use Neos\Neos\Ui\Domain\InitialData\NodeTypeGroupsAndRolesProviderInterface;
 use Neos\Neos\Ui\Domain\InitialData\RoutesProviderInterface;
 use Neos\Neos\Ui\Presentation\ApplicationView;
 
+/**
+ * @internal
+ */
 class BackendController extends ActionController
 {
     /**

--- a/Classes/Controller/BackendControllerInternals.php
+++ b/Classes/Controller/BackendControllerInternals.php
@@ -20,6 +20,7 @@ use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceInterface;
 
 /**
  * @deprecated really un-nice :D
+ * @internal
  */
 class BackendControllerInternals implements ContentRepositoryServiceInterface
 {

--- a/Classes/Controller/BackendControllerInternalsFactory.php
+++ b/Classes/Controller/BackendControllerInternalsFactory.php
@@ -20,6 +20,7 @@ use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceFactoryInterface
 /**
  * @deprecated
  * @implements ContentRepositoryServiceFactoryInterface<BackendControllerInternals>
+ * @internal
  */
 class BackendControllerInternalsFactory implements ContentRepositoryServiceFactoryInterface
 {

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -55,6 +55,9 @@ use Neos\Neos\Ui\Service\PublishingService;
 use Neos\Neos\Ui\TypeConverter\ChangeCollectionConverter;
 use Neos\Neos\Utility\NodeUriPathSegmentGenerator;
 
+/**
+ * @internal
+ */
 class BackendServiceController extends ActionController
 {
     use TranslationTrait;

--- a/Classes/Controller/TranslationTrait.php
+++ b/Classes/Controller/TranslationTrait.php
@@ -19,6 +19,7 @@ use Neos\Flow\I18n\Translator;
 
 /**
  * A trait to do easy backend module translations
+ * @internal
  */
 trait TranslationTrait
 {

--- a/Classes/Domain/Model/AbstractChange.php
+++ b/Classes/Domain/Model/AbstractChange.php
@@ -23,6 +23,9 @@ use Neos\Neos\Ui\Domain\Model\Feedback\Operations\ReloadDocument;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateWorkspaceInfo;
 use Neos\Neos\Utility\NodeTypeWithFallbackProvider;
 
+/**
+ * @internal
+ */
 abstract class AbstractChange implements ChangeInterface
 {
     use NodeTypeWithFallbackProvider;

--- a/Classes/Domain/Model/AbstractFeedback.php
+++ b/Classes/Domain/Model/AbstractFeedback.php
@@ -14,6 +14,9 @@ namespace Neos\Neos\Ui\Domain\Model;
 
 use Neos\Flow\Mvc\Controller\ControllerContext;
 
+/**
+ * @internal
+ */
 abstract class AbstractFeedback implements FeedbackInterface
 {
     /** @return array<string, mixed> */

--- a/Classes/Domain/Model/ChangeCollection.php
+++ b/Classes/Domain/Model/ChangeCollection.php
@@ -13,6 +13,7 @@ namespace Neos\Neos\Ui\Domain\Model;
 
 /**
  * A collection of changes
+ * @internal
  */
 class ChangeCollection
 {

--- a/Classes/Domain/Model/ChangeInterface.php
+++ b/Classes/Domain/Model/ChangeInterface.php
@@ -17,6 +17,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 
 /**
  * An interface to describe a change
+ * @internal
  */
 interface ChangeInterface
 {

--- a/Classes/Domain/Model/Changes/AbstractCreate.php
+++ b/Classes/Domain/Model/Changes/AbstractCreate.php
@@ -24,6 +24,11 @@ use Neos\Neos\Ui\Exception\InvalidNodeCreationHandlerException;
 use Neos\Neos\Ui\NodeCreationHandler\NodeCreationHandlerInterface;
 use Neos\Utility\PositionalArraySorter;
 
+/**
+ * @internal These objects internally reflect possible operations made by the Neos.Ui.
+ *           They are sorely an implementation detail. You should not use them!
+ *           Please look into the php command API of the Neos CR instead.
+ */
 abstract class AbstractCreate extends AbstractStructuralChange
 {
     /**

--- a/Classes/Domain/Model/Changes/AbstractStructuralChange.php
+++ b/Classes/Domain/Model/Changes/AbstractStructuralChange.php
@@ -30,6 +30,9 @@ use Neos\Neos\Utility\NodeTypeWithFallbackProvider;
 
 /**
  * A change that performs structural actions like moving or creating nodes
+ * @internal These objects internally reflect possible operations made by the Neos.Ui.
+ *           They are sorely an implementation detail. You should not use them!
+ *           Please look into the php command API of the Neos CR instead.
  */
 abstract class AbstractStructuralChange extends AbstractChange
 {

--- a/Classes/Domain/Model/Changes/CopyAfter.php
+++ b/Classes/Domain/Model/Changes/CopyAfter.php
@@ -17,6 +17,11 @@ use Neos\ContentRepository\Core\Feature\NodeDuplication\Command\CopyNodesRecursi
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 
+/**
+ * @internal These objects internally reflect possible operations made by the Neos.Ui.
+ *           They are sorely an implementation detail. You should not use them!
+ *           Please look into the php command API of the Neos CR instead.
+ */
 class CopyAfter extends AbstractStructuralChange
 {
     /**

--- a/Classes/Domain/Model/Changes/CopyBefore.php
+++ b/Classes/Domain/Model/Changes/CopyBefore.php
@@ -16,6 +16,11 @@ use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\NodeDuplication\Command\CopyNodesRecursively;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 
+/**
+ * @internal These objects internally reflect possible operations made by the Neos.Ui.
+ *           They are sorely an implementation detail. You should not use them!
+ *           Please look into the php command API of the Neos CR instead.
+ */
 class CopyBefore extends AbstractStructuralChange
 {
     /**

--- a/Classes/Domain/Model/Changes/CopyInto.php
+++ b/Classes/Domain/Model/Changes/CopyInto.php
@@ -17,6 +17,11 @@ use Neos\ContentRepository\Core\Feature\NodeDuplication\Command\CopyNodesRecursi
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 
+/**
+ * @internal These objects internally reflect possible operations made by the Neos.Ui.
+ *           They are sorely an implementation detail. You should not use them!
+ *           Please look into the php command API of the Neos CR instead.
+ */
 class CopyInto extends AbstractStructuralChange
 {
     protected ?string $parentContextPath;

--- a/Classes/Domain/Model/Changes/Create.php
+++ b/Classes/Domain/Model/Changes/Create.php
@@ -12,6 +12,11 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
  * source code.
  */
 
+/**
+ * @internal These objects internally reflect possible operations made by the Neos.Ui.
+ *           They are sorely an implementation detail. You should not use them!
+ *           Please look into the php command API of the Neos CR instead.
+ */
 class Create extends AbstractCreate
 {
     public function setParentContextPath(string $parentContextPath): void

--- a/Classes/Domain/Model/Changes/CreateAfter.php
+++ b/Classes/Domain/Model/Changes/CreateAfter.php
@@ -12,6 +12,11 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
  * source code.
  */
 
+/**
+ * @internal These objects internally reflect possible operations made by the Neos.Ui.
+ *           They are sorely an implementation detail. You should not use them!
+ *           Please look into the php command API of the Neos CR instead.
+ */
 class CreateAfter extends AbstractCreate
 {
     /**

--- a/Classes/Domain/Model/Changes/CreateBefore.php
+++ b/Classes/Domain/Model/Changes/CreateBefore.php
@@ -12,7 +12,11 @@ namespace Neos\Neos\Ui\Domain\Model\Changes;
  * source code.
  */
 
-
+/**
+ * @internal These objects internally reflect possible operations made by the Neos.Ui.
+ *           They are sorely an implementation detail. You should not use them!
+ *           Please look into the php command API of the Neos CR instead.
+ */
 class CreateBefore extends AbstractCreate
 {
     /**

--- a/Classes/Domain/Model/Changes/MoveAfter.php
+++ b/Classes/Domain/Model/Changes/MoveAfter.php
@@ -18,6 +18,11 @@ use Neos\ContentRepository\Core\Feature\NodeMove\Dto\RelationDistributionStrateg
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\RemoveNode;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
 
+/**
+ * @internal These objects internally reflect possible operations made by the Neos.Ui.
+ *           They are sorely an implementation detail. You should not use them!
+ *           Please look into the php command API of the Neos CR instead.
+ */
 class MoveAfter extends AbstractStructuralChange
 {
     /**

--- a/Classes/Domain/Model/Changes/MoveBefore.php
+++ b/Classes/Domain/Model/Changes/MoveBefore.php
@@ -17,6 +17,11 @@ use Neos\ContentRepository\Core\Feature\NodeMove\Dto\RelationDistributionStrateg
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\RemoveNode;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
 
+/**
+ * @internal These objects internally reflect possible operations made by the Neos.Ui.
+ *           They are sorely an implementation detail. You should not use them!
+ *           Please look into the php command API of the Neos CR instead.
+ */
 class MoveBefore extends AbstractStructuralChange
 {
     /**

--- a/Classes/Domain/Model/Changes/MoveInto.php
+++ b/Classes/Domain/Model/Changes/MoveInto.php
@@ -18,6 +18,11 @@ use Neos\ContentRepository\Core\Feature\NodeMove\Dto\RelationDistributionStrateg
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\RemoveNode;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
 
+/**
+ * @internal These objects internally reflect possible operations made by the Neos.Ui.
+ *           They are sorely an implementation detail. You should not use them!
+ *           Please look into the php command API of the Neos CR instead.
+ */
 class MoveInto extends AbstractStructuralChange
 {
     protected ?string $parentContextPath;

--- a/Classes/Domain/Model/Changes/Property.php
+++ b/Classes/Domain/Model/Changes/Property.php
@@ -43,6 +43,9 @@ use Neos\Neos\Utility\NodeTypeWithFallbackProvider;
 
 /**
  * Changes a property on a node
+ * @internal These objects internally reflect possible operations made by the Neos.Ui.
+ *           They are sorely an implementation detail. You should not use them!
+ *           Please look into the php command API of the Neos CR instead.
  */
 class Property extends AbstractChange
 {

--- a/Classes/Domain/Model/Changes/Remove.php
+++ b/Classes/Domain/Model/Changes/Remove.php
@@ -27,6 +27,9 @@ use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
 
 /**
  * Removes a node
+ * @internal These objects internally reflect possible operations made by the Neos.Ui.
+ *           They are sorely an implementation detail. You should not use them!
+ *           Please look into the php command API of the Neos CR instead.
  */
 class Remove extends AbstractChange
 {

--- a/Classes/Domain/Model/Feedback/AbstractMessageFeedback.php
+++ b/Classes/Domain/Model/Feedback/AbstractMessageFeedback.php
@@ -15,6 +15,9 @@ use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
 
+/**
+ * @internal
+ */
 abstract class AbstractMessageFeedback extends AbstractFeedback
 {
     /**

--- a/Classes/Domain/Model/Feedback/Messages/Error.php
+++ b/Classes/Domain/Model/Feedback/Messages/Error.php
@@ -13,6 +13,9 @@ namespace Neos\Neos\Ui\Domain\Model\Feedback\Messages;
 
 use Neos\Neos\Ui\Domain\Model\Feedback\AbstractMessageFeedback;
 
+/**
+ * @internal
+ */
 class Error extends AbstractMessageFeedback
 {
     /**

--- a/Classes/Domain/Model/Feedback/Messages/Info.php
+++ b/Classes/Domain/Model/Feedback/Messages/Info.php
@@ -13,6 +13,9 @@ namespace Neos\Neos\Ui\Domain\Model\Feedback\Messages;
 
 use Neos\Neos\Ui\Domain\Model\Feedback\AbstractMessageFeedback;
 
+/**
+ * @internal
+ */
 class Info extends AbstractMessageFeedback
 {
     /**

--- a/Classes/Domain/Model/Feedback/Messages/Success.php
+++ b/Classes/Domain/Model/Feedback/Messages/Success.php
@@ -13,6 +13,9 @@ namespace Neos\Neos\Ui\Domain\Model\Feedback\Messages;
 
 use Neos\Neos\Ui\Domain\Model\Feedback\AbstractMessageFeedback;
 
+/**
+ * @internal
+ */
 class Success extends AbstractMessageFeedback
 {
     /**

--- a/Classes/Domain/Model/Feedback/Operations/NodeCreated.php
+++ b/Classes/Domain/Model/Feedback/Operations/NodeCreated.php
@@ -21,6 +21,9 @@ use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
 use Neos\Neos\Utility\NodeTypeWithFallbackProvider;
 
+/**
+ * @internal
+ */
 class NodeCreated extends AbstractFeedback
 {
     use NodeTypeWithFallbackProvider;

--- a/Classes/Domain/Model/Feedback/Operations/Redirect.php
+++ b/Classes/Domain/Model/Feedback/Operations/Redirect.php
@@ -10,6 +10,9 @@ use Neos\Neos\Service\LinkingService;
 use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
 
+/**
+ * @internal
+ */
 class Redirect extends AbstractFeedback
 {
     /**

--- a/Classes/Domain/Model/Feedback/Operations/ReloadContentOutOfBand.php
+++ b/Classes/Domain/Model/Feedback/Operations/ReloadContentOutOfBand.php
@@ -26,6 +26,9 @@ use Neos\Neos\Ui\Domain\Model\RenderedNodeDomAddress;
 use Neos\Neos\Ui\View\OutOfBandRenderingViewFactory;
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * @internal
+ */
 class ReloadContentOutOfBand extends AbstractFeedback
 {
     protected ?Node $node = null;

--- a/Classes/Domain/Model/Feedback/Operations/ReloadDocument.php
+++ b/Classes/Domain/Model/Feedback/Operations/ReloadDocument.php
@@ -21,6 +21,9 @@ use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
 use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
 
+/**
+ * @internal
+ */
 class ReloadDocument extends AbstractFeedback
 {
     protected ?Node $node = null;

--- a/Classes/Domain/Model/Feedback/Operations/RemoveNode.php
+++ b/Classes/Domain/Model/Feedback/Operations/RemoveNode.php
@@ -20,6 +20,9 @@ use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
 
+/**
+ * @internal
+ */
 class RemoveNode extends AbstractFeedback
 {
     protected Node $node;

--- a/Classes/Domain/Model/Feedback/Operations/RenderContentOutOfBand.php
+++ b/Classes/Domain/Model/Feedback/Operations/RenderContentOutOfBand.php
@@ -29,6 +29,9 @@ use Neos\Neos\Ui\Domain\Model\RenderedNodeDomAddress;
 use Neos\Neos\Ui\View\OutOfBandRenderingViewFactory;
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * @internal
+ */
 class RenderContentOutOfBand extends AbstractFeedback
 {
     protected ?Node $node = null;

--- a/Classes/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
@@ -21,6 +21,9 @@ use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
 use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
 
+/**
+ * @internal
+ */
 class UpdateNodeInfo extends AbstractFeedback
 {
     protected ?Node $node = null;

--- a/Classes/Domain/Model/Feedback/Operations/UpdateNodePath.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateNodePath.php
@@ -15,6 +15,9 @@ use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
 
+/**
+ * @internal
+ */
 class UpdateNodePath extends AbstractFeedback
 {
     /**

--- a/Classes/Domain/Model/Feedback/Operations/UpdateNodePreviewUrl.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateNodePreviewUrl.php
@@ -20,6 +20,9 @@ use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
 use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
 
+/**
+ * @internal
+ */
 class UpdateNodePreviewUrl extends AbstractFeedback
 {
     /**

--- a/Classes/Domain/Model/Feedback/Operations/UpdateWorkspaceInfo.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateWorkspaceInfo.php
@@ -21,6 +21,9 @@ use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 
+/**
+ * @internal
+ */
 class UpdateWorkspaceInfo extends AbstractFeedback
 {
     protected ?WorkspaceName $workspaceName = null;

--- a/Classes/Domain/Model/FeedbackCollection.php
+++ b/Classes/Domain/Model/FeedbackCollection.php
@@ -16,6 +16,7 @@ use Neos\Flow\Mvc\Controller\ControllerContext;
 
 /**
  * @Flow\Scope("singleton")
+ * @internal
  */
 class FeedbackCollection implements \JsonSerializable
 {

--- a/Classes/Domain/Model/FeedbackInterface.php
+++ b/Classes/Domain/Model/FeedbackInterface.php
@@ -13,6 +13,9 @@ namespace Neos\Neos\Ui\Domain\Model;
 
 use Neos\Flow\Mvc\Controller\ControllerContext;
 
+/**
+ * @internal
+ */
 interface FeedbackInterface
 {
     /**

--- a/Classes/Domain/Model/ReferencingChangeInterface.php
+++ b/Classes/Domain/Model/ReferencingChangeInterface.php
@@ -15,6 +15,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 
 /**
  * A change that needs to reference another node
+ * @internal
  */
 interface ReferencingChangeInterface extends ChangeInterface
 {

--- a/Classes/Domain/Model/RenderedNodeDomAddress.php
+++ b/Classes/Domain/Model/RenderedNodeDomAddress.php
@@ -13,6 +13,7 @@ namespace Neos\Neos\Ui\Domain\Model;
 
 /**
  * Data to address rendered nodes within the DOM
+ * @internal
  */
 class RenderedNodeDomAddress implements \JsonSerializable
 {

--- a/Classes/Domain/Service/ConfigurationRenderingService.php
+++ b/Classes/Domain/Service/ConfigurationRenderingService.php
@@ -17,6 +17,7 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * @Flow\Scope("singleton")
+ * @internal
  */
 class ConfigurationRenderingService
 {

--- a/Classes/Domain/Service/NodePropertyConversionService.php
+++ b/Classes/Domain/Service/NodePropertyConversionService.php
@@ -22,6 +22,7 @@ use Neos\Utility\TypeHandling;
 
 /**
  * @Flow\Scope("singleton")
+ * @internal
  */
 class NodePropertyConversionService
 {

--- a/Classes/Domain/Service/NodePropertyConverterService.php
+++ b/Classes/Domain/Service/NodePropertyConverterService.php
@@ -41,6 +41,7 @@ use Psr\Log\LoggerInterface;
  * instead of the objects.
  *
  * @Flow\Scope("singleton")
+ * @internal
  */
 class NodePropertyConverterService
 {

--- a/Classes/Domain/Service/StyleAndJavascriptInclusionService.php
+++ b/Classes/Domain/Service/StyleAndJavascriptInclusionService.php
@@ -19,6 +19,7 @@ use Neos\Utility\PositionalArraySorter;
 
 /**
  * @Flow\Scope("singleton")
+ * @internal
  */
 class StyleAndJavascriptInclusionService
 {

--- a/Classes/Domain/Service/UserLocaleService.php
+++ b/Classes/Domain/Service/UserLocaleService.php
@@ -16,6 +16,9 @@ use Neos\Flow\I18n\Locale;
 use Neos\Flow\I18n\Service as I18nService;
 use Neos\Neos\Domain\Service\UserService;
 
+/**
+ * @internal
+ */
 class UserLocaleService
 {
     /**

--- a/Classes/Exception/InvalidNodeCreationHandlerException.php
+++ b/Classes/Exception/InvalidNodeCreationHandlerException.php
@@ -13,6 +13,7 @@ namespace Neos\Neos\Ui\Exception;
 
 /**
  * InvalidNodeCreationHandlerException exception
+ * @internal
  */
 class InvalidNodeCreationHandlerException extends \Exception
 {

--- a/Classes/FlowQueryOperations/NeosUiDefaultNodesOperation.php
+++ b/Classes/FlowQueryOperations/NeosUiDefaultNodesOperation.php
@@ -22,6 +22,9 @@ use Neos\Eel\FlowQuery\Operations\AbstractOperation;
 use Neos\Neos\FrontendRouting\NodeAddressFactory;
 use Neos\Flow\Annotations as Flow;
 
+/**
+ * @internal
+ */
 class NeosUiDefaultNodesOperation extends AbstractOperation
 {
     /**

--- a/Classes/FlowQueryOperations/NeosUiFilteredChildrenOperation.php
+++ b/Classes/FlowQueryOperations/NeosUiFilteredChildrenOperation.php
@@ -24,6 +24,7 @@ use Neos\Flow\Annotations as Flow;
  * "children" operation working on ContentRepository nodes. It iterates over all
  * context elements and returns all child nodes or only those matching
  * the filter expression specified as optional argument.
+ * @internal
  */
 class NeosUiFilteredChildrenOperation extends AbstractOperation
 {

--- a/Classes/FlowQueryOperations/SearchOperation.php
+++ b/Classes/FlowQueryOperations/SearchOperation.php
@@ -26,6 +26,7 @@ use Neos\Flow\Annotations as Flow;
  * Custom search operation using the Content Graph fulltext search
  *
  * Original implementation: \Neos\Neos\Ui\FlowQueryOperations\SearchOperation
+ * @internal
  */
 class SearchOperation extends AbstractOperation
 {

--- a/Classes/Fusion/ExceptionHandler/PageExceptionHandler.php
+++ b/Classes/Fusion/ExceptionHandler/PageExceptionHandler.php
@@ -27,6 +27,7 @@ use Psr\Http\Message\StreamFactoryInterface;
  *
  * FIXME: When the old UI is removed this handler needs to be untangled from the PageHandler as the parent functionality is no longer needed.
  * FIXME: We should adapt rendering to requested "format" at some point
+ * @internal
  */
 class PageExceptionHandler extends AbstractRenderingExceptionHandler
 {

--- a/Classes/Fusion/Helper/ApiHelper.php
+++ b/Classes/Fusion/Helper/ApiHelper.php
@@ -14,7 +14,7 @@ namespace Neos\Neos\Ui\Fusion\Helper;
 use Neos\Eel\ProtectedContextAwareInterface;
 
 /**
- * @internal
+ * @todo EEL helpers are still to be declared as internal
  */
 class ApiHelper implements ProtectedContextAwareInterface
 {

--- a/Classes/Fusion/Helper/ApiHelper.php
+++ b/Classes/Fusion/Helper/ApiHelper.php
@@ -13,6 +13,9 @@ namespace Neos\Neos\Ui\Fusion\Helper;
 
 use Neos\Eel\ProtectedContextAwareInterface;
 
+/**
+ * @internal
+ */
 class ApiHelper implements ProtectedContextAwareInterface
 {
     /**

--- a/Classes/Fusion/Helper/ContentDimensionsHelper.php
+++ b/Classes/Fusion/Helper/ContentDimensionsHelper.php
@@ -22,7 +22,7 @@ use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
 
 /**
- * @internal
+ * @todo EEL helpers are still to be declared as internal
  */
 class ContentDimensionsHelper implements ProtectedContextAwareInterface
 {

--- a/Classes/Fusion/Helper/ContentDimensionsHelper.php
+++ b/Classes/Fusion/Helper/ContentDimensionsHelper.php
@@ -21,6 +21,9 @@ use Neos\ContentRepository\Core\Factory\ContentRepositoryId;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
 
+/**
+ * @internal
+ */
 class ContentDimensionsHelper implements ProtectedContextAwareInterface
 {
     /**

--- a/Classes/Fusion/Helper/ContentDimensionsHelperInternals.php
+++ b/Classes/Fusion/Helper/ContentDimensionsHelperInternals.php
@@ -17,7 +17,7 @@ use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceInterface;
 
 /**
  * @deprecated ugly - we want to get rid of this by adding dimension infos in the Subgraph
- * @internal
+ * @todo EEL helpers are still to be declared as internal
  */
 class ContentDimensionsHelperInternals implements ContentRepositoryServiceInterface
 {

--- a/Classes/Fusion/Helper/ContentDimensionsHelperInternals.php
+++ b/Classes/Fusion/Helper/ContentDimensionsHelperInternals.php
@@ -17,6 +17,7 @@ use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceInterface;
 
 /**
  * @deprecated ugly - we want to get rid of this by adding dimension infos in the Subgraph
+ * @internal
  */
 class ContentDimensionsHelperInternals implements ContentRepositoryServiceInterface
 {

--- a/Classes/Fusion/Helper/ContentDimensionsHelperInternalsFactory.php
+++ b/Classes/Fusion/Helper/ContentDimensionsHelperInternalsFactory.php
@@ -19,7 +19,7 @@ use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceInterface;
 /**
  * @deprecated ugly - we want to get rid of this by adding dimension infos in the Subgraph
  * @implements ContentRepositoryServiceFactoryInterface<ContentDimensionsHelperInternals>
- * @internal
+ * @todo EEL helpers are still to be declared as internal
  */
 class ContentDimensionsHelperInternalsFactory implements ContentRepositoryServiceFactoryInterface
 {

--- a/Classes/Fusion/Helper/ContentDimensionsHelperInternalsFactory.php
+++ b/Classes/Fusion/Helper/ContentDimensionsHelperInternalsFactory.php
@@ -19,6 +19,7 @@ use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceInterface;
 /**
  * @deprecated ugly - we want to get rid of this by adding dimension infos in the Subgraph
  * @implements ContentRepositoryServiceFactoryInterface<ContentDimensionsHelperInternals>
+ * @internal
  */
 class ContentDimensionsHelperInternalsFactory implements ContentRepositoryServiceFactoryInterface
 {

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -31,7 +31,7 @@ use Neos\Neos\Utility\NodeTypeWithFallbackProvider;
 
 /**
  * @Flow\Scope("singleton")
- * @internal
+ * @todo EEL helpers are still to be declared as internal
  */
 class NodeInfoHelper implements ProtectedContextAwareInterface
 {

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -31,6 +31,7 @@ use Neos\Neos\Utility\NodeTypeWithFallbackProvider;
 
 /**
  * @Flow\Scope("singleton")
+ * @internal
  */
 class NodeInfoHelper implements ProtectedContextAwareInterface
 {

--- a/Classes/Fusion/Helper/PositionalArraySorterHelper.php
+++ b/Classes/Fusion/Helper/PositionalArraySorterHelper.php
@@ -15,7 +15,7 @@ use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Utility\PositionalArraySorter;
 
 /**
- * @internal
+ * @todo EEL helpers are still to be declared as internal
  */
 class PositionalArraySorterHelper implements ProtectedContextAwareInterface
 {

--- a/Classes/Fusion/Helper/PositionalArraySorterHelper.php
+++ b/Classes/Fusion/Helper/PositionalArraySorterHelper.php
@@ -14,6 +14,9 @@ namespace Neos\Neos\Ui\Fusion\Helper;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Utility\PositionalArraySorter;
 
+/**
+ * @internal
+ */
 class PositionalArraySorterHelper implements ProtectedContextAwareInterface
 {
     /**

--- a/Classes/Fusion/Helper/StaticResourcesHelper.php
+++ b/Classes/Fusion/Helper/StaticResourcesHelper.php
@@ -14,6 +14,9 @@ namespace Neos\Neos\Ui\Fusion\Helper;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
 
+/**
+ * @internal
+ */
 class StaticResourcesHelper implements ProtectedContextAwareInterface
 {
     /**

--- a/Classes/Fusion/Helper/StaticResourcesHelper.php
+++ b/Classes/Fusion/Helper/StaticResourcesHelper.php
@@ -15,7 +15,7 @@ use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
 
 /**
- * @internal
+ * @todo EEL helpers are still to be declared as internal
  */
 class StaticResourcesHelper implements ProtectedContextAwareInterface
 {

--- a/Classes/Fusion/Helper/WorkspaceHelper.php
+++ b/Classes/Fusion/Helper/WorkspaceHelper.php
@@ -22,6 +22,7 @@ use Neos\Neos\Ui\ContentRepository\Service\WorkspaceService;
 
 /**
  * The Workspace helper for EEL contexts
+ * @internal
  */
 class WorkspaceHelper implements ProtectedContextAwareInterface
 {

--- a/Classes/Fusion/Helper/WorkspaceHelper.php
+++ b/Classes/Fusion/Helper/WorkspaceHelper.php
@@ -22,7 +22,7 @@ use Neos\Neos\Ui\ContentRepository\Service\WorkspaceService;
 
 /**
  * The Workspace helper for EEL contexts
- * @internal
+ * @todo EEL helpers are still to be declared as internal
  */
 class WorkspaceHelper implements ProtectedContextAwareInterface
 {

--- a/Classes/Fusion/RenderConfigurationImplementation.php
+++ b/Classes/Fusion/RenderConfigurationImplementation.php
@@ -16,6 +16,9 @@ use Neos\Flow\Exception;
 use Neos\Fusion\FusionObjects\AbstractFusionObject;
 use Neos\Neos\Ui\Domain\Service\ConfigurationRenderingService;
 
+/**
+ * @internal
+ */
 class RenderConfigurationImplementation extends AbstractFusionObject
 {
     /**

--- a/Classes/Infrastructure/Configuration/InitialStateProvider.php
+++ b/Classes/Infrastructure/Configuration/InitialStateProvider.php
@@ -23,6 +23,9 @@ use Neos\Neos\Ui\Domain\InitialData\InitialStateProviderInterface;
 use Neos\Neos\Ui\Domain\Service\ConfigurationRenderingService;
 use Neos\Neos\Ui\Service\NodeClipboard;
 
+/**
+ * @internal
+ */
 #[Flow\Scope("singleton")]
 final class InitialStateProvider implements InitialStateProviderInterface
 {

--- a/Classes/Infrastructure/ContentRepository/NodeTypeGroupsAndRolesProvider.php
+++ b/Classes/Infrastructure/ContentRepository/NodeTypeGroupsAndRolesProvider.php
@@ -17,6 +17,9 @@ namespace Neos\Neos\Ui\Infrastructure\ContentRepository;
 use Neos\Flow\Annotations as Flow;
 use Neos\Neos\Ui\Domain\InitialData\NodeTypeGroupsAndRolesProviderInterface;
 
+/**
+ * @internal
+ */
 #[Flow\Scope("singleton")]
 final class NodeTypeGroupsAndRolesProvider implements NodeTypeGroupsAndRolesProviderInterface
 {

--- a/Classes/Infrastructure/Neos/MenuProvider.php
+++ b/Classes/Infrastructure/Neos/MenuProvider.php
@@ -20,6 +20,9 @@ use Neos\Neos\Controller\Backend\MenuHelper;
 use Neos\Neos\Ui\Domain\InitialData\MenuProviderInterface;
 use Neos\Utility\PositionalArraySorter;
 
+/**
+ * @internal
+ */
 #[Flow\Scope("singleton")]
 final class MenuProvider implements MenuProviderInterface
 {

--- a/Classes/NodeCreationHandler/ContentTitleNodeCreationHandler.php
+++ b/Classes/NodeCreationHandler/ContentTitleNodeCreationHandler.php
@@ -24,6 +24,7 @@ use Neos\Neos\Service\TransliterationService;
  *
  * Note: This is not actually a Command Handler in the sense of CQRS but rather some kind of
  *       "command enricher"
+ * @internal
  */
 class ContentTitleNodeCreationHandler implements NodeCreationHandlerInterface
 {

--- a/Classes/NodeCreationHandler/CreationDialogPropertiesCreationHandler.php
+++ b/Classes/NodeCreationHandler/CreationDialogPropertiesCreationHandler.php
@@ -23,6 +23,7 @@ use Neos\Utility\TypeHandling;
  * Generic creation dialog node creation handler that iterates
  * properties that are configured to appear in the Creation Dialog (via "ui.showInCreationDialog" setting)
  * and sets the initial property values accordingly
+ * @internal
  */
 class CreationDialogPropertiesCreationHandler implements NodeCreationHandlerInterface
 {

--- a/Classes/NodeCreationHandler/DocumentTitleNodeCreationHandler.php
+++ b/Classes/NodeCreationHandler/DocumentTitleNodeCreationHandler.php
@@ -30,6 +30,7 @@ use Neos\Neos\Service\TransliterationService;
  *
  * Note: This is not actually a Command Handler in the sense of CQRS but rather some kind of
  *       "command enricher"
+ * @internal
  */
 class DocumentTitleNodeCreationHandler implements NodeCreationHandlerInterface
 {

--- a/Classes/NodeCreationHandler/NodeCreationHandlerInterface.php
+++ b/Classes/NodeCreationHandler/NodeCreationHandlerInterface.php
@@ -17,6 +17,7 @@ use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregate
 /**
  * Contract for Node Creation handler that allow to hook into the process just before a node is being added
  * via the Neos UI
+ * @api
  */
 interface NodeCreationHandlerInterface
 {

--- a/Classes/Service/NodeClipboard.php
+++ b/Classes/Service/NodeClipboard.php
@@ -18,6 +18,7 @@ use Neos\Flow\Annotations as Flow;
  * This is a container for clipboard state that needs to be persisted server side
  *
  * @Flow\Scope("session")
+ * @internal
  */
 class NodeClipboard
 {

--- a/Classes/Service/NodePropertyValidationService.php
+++ b/Classes/Service/NodePropertyValidationService.php
@@ -22,6 +22,7 @@ use Psr\Log\LoggerInterface;
 
 /**
  * @Flow\Scope("singleton")
+ * @internal
  */
 class NodePropertyValidationService
 {

--- a/Classes/Service/PublishingService.php
+++ b/Classes/Service/PublishingService.php
@@ -25,6 +25,7 @@ use Neos\Flow\Annotations as Flow;
  *
  * @api
  * @Flow\Scope("singleton")
+ * @internal
  */
 class PublishingService
 {

--- a/Classes/TypeConverter/ChangeCollectionConverter.php
+++ b/Classes/TypeConverter/ChangeCollectionConverter.php
@@ -30,6 +30,7 @@ use Neos\Utility\ObjectAccess;
  * An Object Converter for ChangeCollections.
  *
  * @Flow\Scope("singleton")
+ * @internal
  */
 class ChangeCollectionConverter
 {

--- a/Classes/View/OutOfBandRenderingCapable.php
+++ b/Classes/View/OutOfBandRenderingCapable.php
@@ -18,6 +18,7 @@ use Psr\Http\Message\ResponseInterface;
 
 /**
  * The interface for views capable of out-of-band rendering by accepting string serialized entry points
+ * @internal experimental
  */
 interface OutOfBandRenderingCapable
 {

--- a/Classes/View/OutOfBandRenderingFusionView.php
+++ b/Classes/View/OutOfBandRenderingFusionView.php
@@ -18,6 +18,7 @@ use Neos\Neos\View\FusionView;
 
 /**
  * A Fusion view capable of out-of-band rendering
+ * @internal
  */
 class OutOfBandRenderingFusionView extends FusionView implements OutOfBandRenderingCapable
 {

--- a/Classes/View/OutOfBandRenderingViewFactory.php
+++ b/Classes/View/OutOfBandRenderingViewFactory.php
@@ -17,6 +17,9 @@ namespace Neos\Neos\Ui\View;
 use Neos\Flow\Mvc\View\AbstractView;
 use Neos\Flow\Annotations as Flow;
 
+/**
+ * @internal
+ */
 class OutOfBandRenderingViewFactory
 {
     /**


### PR DESCRIPTION
Depends on https://github.com/neos/neos-ui/pull/3682/ which must be merged first.

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

I recently had someone ask me how to use this `Property` thing in Neos9. At first i was confused. And then i understood he was trying to use the Neos.Ui "change" classes.
To avoid that in the future and make it also easier to clean up our php mess in the Neos UI ^^ i placed a few internal annotations around.

and the changes now explicitly warn from being used :D (which is spoiler really hard anyway ^^ - otherwise we would have tests *g)

```php
/**
 * Changes a property on a node
 * @internal These objects internally reflect possible operations made by the Neos.Ui.
 *           They are sorely an implementation detail. You should not use them!
 *           Please look into the php command API of the Neos CR instead.
 */
class Property extends AbstractChange
```

_If_ you happen to use any class from the Neos Ui previously (which should not be the case, as the ui has nothing to offer for php users ^^), which is not declared as api anymore, you should please prepare to refactor it.

**What I did**
 

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
