### PR TITLE
BUGFIX: Store artifacts for logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,10 +112,12 @@ jobs:
           nvm install
           nvm use
           make test-e2e-saucelabs > /home/circleci/app/Data/Logs/AcceptanceTesting.log
+      - store_artifacts:
+          path: /home/circleci/app/Data/Logs
       - persist_to_workspace:
           root: /home/circleci/app/Data/Logs
           paths:
-            - AcceptanceTesting.log
+            - Data/Logs/AcceptanceTesting.log
 
   post-acceptance-tests-recordings:
     environment:
@@ -138,7 +140,7 @@ jobs:
       - run:
           name: Run Script
           command: |
-            JOB_IDS=$(cat /home/circleci/app/AcceptanceTesting.log | grep -o 'https://app.saucelabs.com/tests/[a-zA-Z0-9]\+' | sed 's/.*\///')
+            JOB_IDS=$(cat /home/circleci/app/Data/Logs/AcceptanceTesting.log | grep -o 'https://app.saucelabs.com/tests/[a-zA-Z0-9]\+' | sed 's/.*\///')
             echo "Job IDs: $JOB_IDS"
             /home/circleci/app/Build/comment-acceptance-tests.sh "$JOB_IDS" "$(basename "$CIRCLE_PULL_REQUEST")"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,19 +105,21 @@ jobs:
 
       - run: curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
       - run: chmod +x ~/.nvm/nvm.sh
-      - run: |
-          export NVM_DIR="$HOME/.nvm"
-          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-          cd /home/circleci/app/Packages/Application/Neos.Neos.Ui
-          nvm install
-          nvm use
-          make test-e2e-saucelabs > /home/circleci/app/Data/Logs/AcceptanceTesting.log
+      - run:
+          no_output_timeout: 20m
+          command: |
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            cd /home/circleci/app/Packages/Application/Neos.Neos.Ui
+            nvm install
+            nvm use
+            make test-e2e-saucelabs > /home/circleci/app/Data/Logs/AcceptanceTesting.log
       - store_artifacts:
           path: /home/circleci/app/Data/Logs
       - persist_to_workspace:
           root: /home/circleci/app/Data/Logs
           paths:
-            - Data/Logs/AcceptanceTesting.log
+            - .
 
   post-acceptance-tests-recordings:
     environment:
@@ -140,7 +142,7 @@ jobs:
       - run:
           name: Run Script
           command: |
-            JOB_IDS=$(cat /home/circleci/app/Data/Logs/AcceptanceTesting.log | grep -o 'https://app.saucelabs.com/tests/[a-zA-Z0-9]\+' | sed 's/.*\///')
+            JOB_IDS=$(cat /home/circleci/app/AcceptanceTesting.log | grep -o 'https://app.saucelabs.com/tests/[a-zA-Z0-9]\+' | sed 's/.*\///')
             echo "Job IDs: $JOB_IDS"
             /home/circleci/app/Build/comment-acceptance-tests.sh "$JOB_IDS" "$(basename "$CIRCLE_PULL_REQUEST")"
 


### PR DESCRIPTION
Related https://github.com/neos/neos-ui/pull/3698

The recent modification, which involved adding an end-to-end (e2e) recording step to generate a comment in the pull request (PR), encountered a problem with the logs. Consequently, the logs were no longer being attached correctly. To address this issue, we have implemented a solution where we now store the artifacts and pass through the logs from the acceptance tests to the workspace. This ensures that the logs are appropriately utilized in the subsequent step, which involves creating a comment in the PR.