### PR TITLE
BUGFIX: Insert copied or moved nodes in order of selection

### DIFF
--- a/Classes/Domain/Model/Changes/CopyInto.php
+++ b/Classes/Domain/Model/Changes/CopyInto.php
@@ -73,8 +73,16 @@ class CopyInto extends AbstractCopy
     public function apply()
     {
         if ($this->canApply()) {
-            $nodeName = $this->generateUniqueNodeName($this->getParentNode());
-            $node = $this->getSubject()->copyInto($this->getParentNode(), $nodeName);
+            $parentNode = $this->getParentNode();
+            $nodeName = $this->generateUniqueNodeName($parentNode);
+            // If the parent node has children, we copy the node after the last child node to prevent the copied nodes
+            // from being mixed with the existing ones due the duplication of their relative indices.
+            if ($parentNode->hasChildNodes()) {
+                $lastChildNode = array_slice($parentNode->getChildNodes(), -1, 1)[0];
+                $node = $this->getSubject()->copyAfter($lastChildNode, $nodeName);
+            } else {
+                $node = $this->getSubject()->copyInto($parentNode, $nodeName);
+            }
             $this->finish($node);
         }
     }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
@@ -95,8 +95,14 @@ export default class NodeTree extends PureComponent {
     }
 
     handleDrop = (targetNode, position) => {
-        const {currentlyDraggedNodes} = this.state;
+        let {currentlyDraggedNodes} = this.state;
         const {moveNodes, focus} = this.props;
+
+        if (position === 'after') {
+            // Reverse the order of nodes to keep the correct order after each node is inserted after the target node individually
+            currentlyDraggedNodes = Array.from(currentlyDraggedNodes).reverse();
+        }
+
         moveNodes(currentlyDraggedNodes, $get('contextPath', targetNode), position);
         // We need to refocus the tree, so all focus would be reset, because its context paths have changed while moving
         // Could be removed with the new CR


### PR DESCRIPTION
This reverses the order of nodes for `insertAfter` (copy & move) operations to prevent the reverse order of insertion due to the way the atomic inserts are done by the change operations.

Also turns `insertInto` internally into a `insertAfter` if the selected target parent node already has children. Here the reversion is not necessary as always the last child node is picked to "insert after" and therefore keeping the order of the users selection (clipboard).

Resolves: #3040 