### PR TITLE
TASK: Use `docker-compose` rather than `docker compose`

### DIFF
--- a/Tests/IntegrationTests/start-neos-dev-instance.sh
+++ b/Tests/IntegrationTests/start-neos-dev-instance.sh
@@ -4,7 +4,7 @@ set -e
 
 function dc() {
     # use the docker composer plugin
-    docker compose -f ./Tests/IntegrationTests/docker-compose.neos-dev-instance.yaml $@
+    docker-compose -f ./Tests/IntegrationTests/docker-compose.neos-dev-instance.yaml $@
 }
 
 echo "#############################################################################"


### PR DESCRIPTION
I've been using `start-neos-dev-instance.sh` for local E2E tests as of late and stumbled upon an issue.

The `Tests/IntegrationTests/start-neos-dev-instance.sh` script refers to docker-compose thusly:
https://github.com/neos/neos-ui/blob/fe77db35c48e886b7a0421ccf3e2f0da6d098e52/Tests/IntegrationTests/start-neos-dev-instance.sh#L5-L8

Now, the comment `# use the docker composer plugin` sounds to me like a misconception, but apart from that there's the rather unusual `docker compose` call (without dash).

I suppose that in some environments docker-compose works like a docker plugin, so that it is available as a subcommand of the docker cli. But usually it is invoked via its own CLI binary `docker-compose`.

Since `docker compose` stopped working on my machine (though I'm not sure whether it ever did work), I'd like to suggest to change this call to `docker-compose`, which *should* work everywhere.
