### PR TITLE
BUGFIX: Neos Ui JSON serializable property values

### DIFF
--- a/Classes/Domain/Service/NodePropertyConverterService.php
+++ b/Classes/Domain/Service/NodePropertyConverterService.php
@@ -27,6 +27,7 @@ use Neos\Flow\Property\Exception as PropertyException;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+use Neos\Flow\Property\TypeConverter\DenormalizingObjectConverter;
 use Neos\Flow\Property\TypeConverterInterface;
 use Neos\Neos\Utility\NodeTypeWithFallbackProvider;
 use Neos\Utility\ObjectAccess;
@@ -188,15 +189,27 @@ class NodePropertyConverterService
     }
 
     /**
-     * Convert the given value to a simple type or an array of simple types.
+     * Convert the given value to a simple type or an array of simple types or to a \JsonSerializable.
      *
-     * @param mixed $propertyValue
-     * @param string $dataType
-     * @return mixed
+     * @param mixed $propertyValue the deserialized node property value
+     * @param string $dataType the property type from the node type schema
+     * @return \JsonSerializable|int|float|string|bool|null|array<mixed>
      * @throws PropertyException
      */
     protected function convertValue($propertyValue, $dataType)
     {
+        if ($propertyValue instanceof \JsonSerializable && DenormalizingObjectConverter::isDenormalizable($propertyValue::class)) {
+            /**
+             * Value object support, as they can be stored directly the node properties flow_json_array
+             *
+             * If the value is json-serializable and deserializable via the {@see DenormalizingObjectConverter} (via e.g. fromArray)
+             * We return the json-serializable directly.
+             *
+             * {@see \Neos\Flow\Persistence\Doctrine\DataTypes\JsonArrayType::deserializeValueObject()}
+             */
+            return $propertyValue;
+        }
+
         $parsedType = TypeHandling::parseType($dataType);
 
         // This hardcoded handling is to circumvent rewriting PropertyMappers that convert objects.

--- a/Classes/Domain/Service/NodePropertyConverterService.php
+++ b/Classes/Domain/Service/NodePropertyConverterService.php
@@ -30,7 +30,6 @@ use Neos\Flow\Property\PropertyMappingConfigurationInterface;
 use Neos\Flow\Property\TypeConverter\DenormalizingObjectConverter;
 use Neos\Flow\Property\TypeConverterInterface;
 use Neos\Neos\Utility\NodeTypeWithFallbackProvider;
-use Neos\Utility\ObjectAccess;
 use Neos\Utility\TypeHandling;
 use Psr\Log\LoggerInterface;
 
@@ -200,12 +199,12 @@ class NodePropertyConverterService
     {
         if ($propertyValue instanceof \JsonSerializable && DenormalizingObjectConverter::isDenormalizable($propertyValue::class)) {
             /**
-             * Value object support, as they can be stored directly the node properties flow_json_array
+             * Value object support, as they can be stored directly the node properties
              *
-             * If the value is json-serializable and deserializable via the {@see DenormalizingObjectConverter} (via e.g. fromArray)
+             * If the value is json-serializable and deserializable via the {@see \Neos\ContentRepository\Core\Infrastructure\Property\Normalizer\ValueObjectArrayDenormalizer} (via e.g. fromArray)
              * We return the json-serializable directly.
              *
-             * {@see \Neos\Flow\Persistence\Doctrine\DataTypes\JsonArrayType::deserializeValueObject()}
+             * FIXME the DenormalizingObjectConverter is not used by the 9.0 ESCR but our new symfony serializers dont provide a way to check if something is an value object and no other place either.
              */
             return $propertyValue;
         }

--- a/Tests/Functional/Domain/Service/NodePropertyConverterServiceTest.php
+++ b/Tests/Functional/Domain/Service/NodePropertyConverterServiceTest.php
@@ -1,0 +1,253 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Neos\Ui\Tests\Functional\Domain\Service;
+
+use GuzzleHttp\Psr7\Uri;
+use Neos\ContentRepository\Core\NodeType\NodeType;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Media\Domain\Model\ImageInterface;
+use Neos\Neos\Domain\Model\Domain;
+use Neos\Neos\Ui\Domain\Service\NodePropertyConverterService;
+
+/**
+ * Functional test case which tests the node property converter
+ */
+class NodePropertyConverterServiceTest extends FunctionalTestCase
+{
+    /**
+     * @test
+     */
+    public function anArrayOfArrayIsReturnedAsIs()
+    {
+        $this->markTestSkipped('Has to be converted into behat test.');
+
+        $expected = $propertyValue = [[]];
+
+        $nodeType = $this
+            ->getMockBuilder(NodeType::class)
+            ->setMethods(['getPropertyType'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $nodeType
+            ->expects(self::once())
+            ->method('getPropertyType')
+            ->willReturn('array');
+
+        $node = $this
+            ->getMockBuilder(Node::class)
+            ->setMethods(['getProperty', 'getNodeType'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $node
+            ->expects(self::once())
+            ->method('getProperty')
+            ->willReturn($propertyValue);
+        $node
+            ->expects(self::once())
+            ->method('getNodeType')
+            ->willReturn($nodeType);
+
+        $nodePropertyConverterService = new NodePropertyConverterService();
+
+        $actual = $nodePropertyConverterService->getProperty($node, 'dontcare');
+
+        self::assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function arrayOfObjectsWithToStringMethodIsReturnedAsIsUnlessTypeConverterIsProvided()
+    {
+        $this->markTestSkipped('Has to be converted into behat test.');
+
+
+        $objectWithToStringMethod = new Domain();
+        $objectWithToStringMethod->setScheme('http');
+        $objectWithToStringMethod->setHostname('neos.io');
+        $objectWithToStringMethod->setPort(80);
+
+        $expected = $propertyValue = [$objectWithToStringMethod];
+
+        $nodeType = $this
+            ->getMockBuilder(NodeType::class)
+            ->setMethods(['getPropertyType'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $nodeType
+            ->expects(self::once())
+            ->method('getPropertyType')
+            ->willReturn('array');
+
+        $node = $this
+            ->getMockBuilder(Node::class)
+            ->setMethods(['getProperty', 'getNodeType'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $node
+            ->expects(self::once())
+            ->method('getProperty')
+            ->willReturn($propertyValue);
+        $node
+            ->expects(self::once())
+            ->method('getNodeType')
+            ->willReturn($nodeType);
+
+        $nodePropertyConverterService = new NodePropertyConverterService();
+
+        $actual = $nodePropertyConverterService->getProperty($node, 'dontcare');
+
+        self::assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function arrayOfStringsHasToProvideTypeConverterToBeConvertedToArrayOfStrings()
+    {
+        $this->markTestSkipped('Has to be converted into behat test.');
+
+        $expected = $propertyValue = ['Hello'];
+
+        $nodeType = $this
+            ->getMockBuilder(NodeType::class)
+            ->setMethods(['getPropertyType'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $nodeType
+            ->expects(self::once())
+            ->method('getPropertyType')
+            ->willReturn('array<string>');
+
+        $node = $this
+            ->getMockBuilder(Node::class)
+            ->setMethods(['getProperty', 'getNodeType'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $node
+            ->expects(self::once())
+            ->method('getProperty')
+            ->willReturn($propertyValue);
+        $node
+            ->expects(self::once())
+            ->method('getNodeType')
+            ->willReturn($nodeType);
+
+        $nodePropertyConverterService = new NodePropertyConverterService();
+
+        $actual = $nodePropertyConverterService->getProperty($node, 'dontcare');
+
+        self::assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function complexTypesWithGivenTypeConverterAreConvertedByTypeConverter()
+    {
+        $this->markTestSkipped('Has to be converted into behat test.');
+
+        $propertyValue = $this->getMockForAbstractClass(ImageInterface::class);
+        $expected = [
+            '__identity' => null,
+            '__type' => get_class($propertyValue)
+        ];
+
+        $nodeType = $this
+            ->getMockBuilder(NodeType::class)
+            ->setMethods(['getPropertyType'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $nodeType
+            ->expects(self::any())
+            ->method('getPropertyType')
+            ->willReturn(ImageInterface::class);
+
+        $node = $this
+            ->getMockBuilder(Node::class)
+            ->setMethods(['getProperty', 'getNodeType'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $node
+            ->expects(self::any())
+            ->method('getProperty')
+            ->willReturn($propertyValue);
+        $node
+            ->expects(self::any())
+            ->method('getNodeType')
+            ->willReturn($nodeType);
+
+        $nodePropertyConverterService = new NodePropertyConverterService();
+
+        $actual = $nodePropertyConverterService->getProperty($node, 'dontcare');
+
+        self::assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function jsonSerializedAbleTypesAreDirectlySerialized()
+    {
+        $this->markTestSkipped('Has to be converted into behat test.');
+
+        $voClassName = 'Value' . md5(uniqid(mt_rand(), true));
+        eval('class ' . $voClassName . ' implements \JsonSerializable' . <<<'PHP'
+        {
+            public function __construct(
+                public \Psr\Http\Message\UriInterface $uri
+            ) {
+            }
+
+            public static function fromArray(array $array): self
+            {
+                return new self(
+                    new \GuzzleHttp\Psr7\Uri($array['uri'])
+                );
+            }
+
+            public function jsonSerialize(): array
+            {
+                return [
+                    'uri' => $this->uri->__toString()
+                ];
+            }
+        }
+        PHP);
+
+        $propertyValue = new $voClassName(new Uri('localhost://foo.html'));
+        $expected = '{"uri":"localhost:\\/\\/foo.html"}';
+
+        $nodeType = $this
+            ->getMockBuilder(NodeType::class)
+            ->setMethods(['getPropertyType'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $nodeType
+            ->expects(self::any())
+            ->method('getPropertyType')
+            ->willReturn(ImageInterface::class);
+
+        $node = $this
+            ->getMockBuilder(Node::class)
+            ->setMethods(['getProperty', 'getNodeType'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $node
+            ->expects(self::any())
+            ->method('getProperty')
+            ->willReturn($propertyValue);
+        $node
+            ->expects(self::any())
+            ->method('getNodeType')
+            ->willReturn($nodeType);
+
+        $nodePropertyConverterService = new NodePropertyConverterService();
+
+        $actual = $nodePropertyConverterService->getProperty($node, 'dontcare');
+
+        self::assertEquals($expected, json_encode($actual));
+    }
+}


### PR DESCRIPTION
Ports https://github.com/neos/neos-development-collection/pull/4638 to the Neos Ui, as the class was moved in Neos 9.
Required for https://github.com/neos/neos-ui/pull/3996

Unfortunately the property serialisation for the NeosUi does NOT use the expected `\JsonSerializable::jsonSerialize` but the property mapper and the `ArrayFromObjectConverter` for object types to get an array that will be json encoded.

This works mostly fine but in some cases it fails:
- when your `fromArray` fields and property names values dont match
- when a "object" subtypes the object mapper is no convertable like the `GuzzleHttp\Psr7\Uri`:

```
Too few arguments to function GuzzleHttp\Psr7\Uri::isAbsolute(), 0 passed in /core/neos-manufacture-highest/Packages/Framework/Neos.Utility.ObjectHandling/Classes/ObjectAccess.php on line 151 and exactly 1 expected
```

Current workarounds are AOP:

https://github.com/sitegeist/Sitegeist.InspectorGadget/blob/78f5f4a206287b1c4bedf5cb88582ed51cb4a311/Classes/Infrastructure/NodeInfo/NodeInfoPostProcessingAspect.php#L17

Or to use a dumb property mapper:
  https://github.com/sitegeist/Sitegeist.Archaeopteryx/blob/9322b9cb8e4824bcaf7aaa247c23b1244a2f1167/Classes/LinkToArrayForNeosUiConverter.php#L12C16-L12C78

------

We fix this by early returning any \JsonSerializable so the native `json_encode` is used in a later step. Additionally we also check if the class of the value object itself would know how to be deserialised from a plain scalar value. This is done by checking for `fromArray` and friends which is necessary to be implemented by a value object in the Flow and Neos universe.

---------

During the upmerge to 9.0 i noticed that we obviously dont use the `DenormalizingObjectConverter` of Flows property mapper anymore. Instead we use custom written denormalisers for symfony. But they again dont allow for a simple check like `DenormalizingObjectConverter::isDenormalizable()`. And in order to avoid adding this verbose "hacky" code this upmerge keeps using this Flow helper as its essentially what the CR would do as well:

```php
(new ValueObjectArrayDenormalizer())->supportsDenormalization([], $propertyValue::class)
&& (new ValueObjectBoolDenormalizer())->supportsDenormalization(true, $propertyValue::class)
&& (new ValueObjectFloatDenormalizer())->supportsDenormalization(1.1, $propertyValue::class)
&& (new ValueObjectIntDenormalizer())->supportsDenormalization(1, $propertyValue::class)
&& (new ValueObjectStringDenormalizer())->supportsDenormalization('', $propertyValue::class)
```





**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
