### PR TITLE
BUGFIX: document-node is redirected to the nearest parent on workspace change

### DIFF
--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -359,11 +359,6 @@ class BackendServiceController extends ActionController
             $updateWorkspaceInfo->setWorkspace($userWorkspace);
             $this->feedbackCollection->add($updateWorkspaceInfo);
 
-            // Construct base workspace context
-            $contextProperties = $documentNode->getContext()->getProperties();
-            $contextProperties['workspaceName'] = $targetWorkspaceName;
-            $contentContext = $this->contextFactory->create($contextProperties);
-
             // If current document node doesn't exist in the base workspace, traverse its parents to find the one that exists
             $nodesOnPath = $documentNode->getContext()->getNodesOnPath($sitePath, $originalNodePath);
             $redirectNode = $nodesOnPath[count($nodesOnPath) - 1];

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -345,7 +345,7 @@ class BackendServiceController extends ActionController
                 throw new Exception('Your personal workspace currently contains unpublished changes. In order to switch to a different target workspace you need to either publish or discard pending changes first.', 1582800654);
             }
 
-            $sitePath = $documentNode->getContext()->getRootNode()->getPath();
+            $sitePath = $documentNode->getContext()->getCurrentSiteNode()->getPath();
             $originalNodePath = $documentNode->getPath();
 
             $userWorkspace->setBaseWorkspace($targetWorkspace);
@@ -361,7 +361,7 @@ class BackendServiceController extends ActionController
 
             // If current document node doesn't exist in the base workspace, traverse its parents to find the one that exists
             $nodesOnPath = $documentNode->getContext()->getNodesOnPath($sitePath, $originalNodePath);
-            $redirectNode = $nodesOnPath[count($nodesOnPath) - 1];
+            $redirectNode = array_pop($nodesOnPath) ?? $documentNode->getContext()->getCurrentSiteNode();
 
             // If current document node exists in the base workspace, then reload, else redirect
             if ($redirectNode === $documentNode) {


### PR DESCRIPTION
Previously, on changing from a workspace to another one that didn't contain the current document-node, an exception would be triggered if no new document-node could be found a single level up in the node-tree.

This PR changes this behaviour to walk up the node-tree until a document-node can be found (going up to the site-node eventually) and sets the new document node to the first shared one that can be found in the rootline.