### PR TITLE
BUGFIX: Remove duplicated apply button in DateInput & handle onChange on date selection

### DIFF
--- a/packages/neos-ui-editors/src/Editors/DateTime/index.js
+++ b/packages/neos-ui-editors/src/Editors/DateTime/index.js
@@ -62,7 +62,6 @@ class DateTime extends PureComponent {
                 timeOnly={!hasDateFormat(options.format)}
                 placeholder={i18nRegistry.translate($get('placeholder', options) || 'Neos.Neos:Main:content.inspector.editors.dateTimeEditor.noDateSet')}
                 todayLabel={i18nRegistry.translate('content.inspector.editors.dateTimeEditor.today', 'Today', {}, 'Neos.Neos', 'Main')}
-                applyLabel={i18nRegistry.translate('content.inspector.editors.dateTimeEditor.apply', 'Apply', {}, 'Neos.Neos', 'Main')}
                 locale={interfaceLanguage}
                 disabled={options.disabled}
                 timeConstraints={timeConstraints}

--- a/packages/react-ui-components/src/DateInput/__snapshots__/dateInput.spec.tsx.snap
+++ b/packages/react-ui-components/src/DateInput/__snapshots__/dateInput.spec.tsx.snap
@@ -88,22 +88,6 @@ exports[`<DateInput/> should render correctly. 1`] = `
       timeFormat={true}
       utc={false}
     />
-    <ThemedButton
-      _refHandler={[Function]}
-      className="applyBtnClassName"
-      composeTheme="deeply"
-      disabled={false}
-      hoverStyle="brand"
-      isActive={false}
-      isFocused={false}
-      mapThemrProps={[Function]}
-      onClick={[Function]}
-      size="regular"
-      style="brand"
-      type="button"
-    >
-      applyLabel
-    </ThemedButton>
   </UnmountClosed>
 </div>
 `;
@@ -196,22 +180,6 @@ exports[`<DateInput/> should set "utc" on DatePickerComponent if "dateOnly" prop
       timeFormat={false}
       utc={true}
     />
-    <ThemedButton
-      _refHandler={[Function]}
-      className="applyBtnClassName"
-      composeTheme="deeply"
-      disabled={false}
-      hoverStyle="brand"
-      isActive={false}
-      isFocused={false}
-      mapThemrProps={[Function]}
-      onClick={[Function]}
-      size="regular"
-      style="brand"
-      type="button"
-    >
-      applyLabel
-    </ThemedButton>
   </UnmountClosed>
 </div>
 `;

--- a/packages/react-ui-components/src/DateInput/dateInput.spec.tsx
+++ b/packages/react-ui-components/src/DateInput/dateInput.spec.tsx
@@ -4,14 +4,12 @@ import toJson from 'enzyme-to-json';
 import moment from 'moment';
 import DatePicker from 'react-datetime';
 
-import Button from '../Button';
 import {DateInput} from './dateInput';
 
 describe('<DateInput/>', () => {
     const props: DateInput['props'] = {
         onChange: jest.fn(),
         locale: 'en-US',
-        applyLabel: 'applyLabel',
         todayLabel: 'todayLabel',
         theme: {
             'wrapper': 'wrapperClassName',
@@ -62,15 +60,13 @@ describe('<DateInput/>', () => {
         expect(onChange.mock.calls[0][0]).toBe(null);
     });
 
-    it('should call the "onChange" prop when triggering the change event on the "DatePicker" Component and clicking apply.', () => {
+    it('should call the "onChange" prop when triggering the change event on the "DatePicker".', () => {
         const onChange = jest.fn();
         const wrapper = shallow(<DateInput {...props} value={new Date()} onChange={onChange}/>);
         const picker = wrapper.find(DatePicker);
-        const applyButton = wrapper.find(Button);
         const newVal = moment();
 
         picker.simulate('change', newVal);
-        applyButton.simulate('click');
 
         expect(onChange.mock.calls.length).toBe(1);
         expect(onChange.mock.calls[0][0].toTimeString()).toBe(newVal.toDate().toTimeString());

--- a/packages/react-ui-components/src/DateInput/dateInput.tsx
+++ b/packages/react-ui-components/src/DateInput/dateInput.tsx
@@ -7,7 +7,6 @@ import Collapse from 'react-collapse';
 import DatePicker, {TimeConstraints} from 'react-datetime';
 
 import {PickDefaultProps} from '../utils-typescript';
-import Button from '../Button';
 import Icon from '../Icon';
 
 // WHY: Because momentJs locales are not bundled automatically, we have to explicitly add them.
@@ -38,11 +37,6 @@ export interface DateInputProps {
      * The label which will be displayed within the `Select Today` btn.
      */
     readonly todayLabel: string;
-
-    /**
-     * The label which will be displayed within the `Apply` btn.
-     */
-    readonly applyLabel: string;
 
     /**
      * The moment format string to use to format the passed value.
@@ -137,7 +131,6 @@ export class DateInput extends PureComponent<DateInputProps, DateInputState> {
             className,
             id,
             todayLabel,
-            applyLabel,
             labelFormat,
             dateOnly,
             timeOnly,
@@ -223,15 +216,9 @@ export class DateInput extends PureComponent<DateInputProps, DateInputState> {
                         locale={locale}
                         timeFormat={!dateOnly}
                         onChange={this.handleChange}
+
                         timeConstraints={this.props.timeConstraints}
                     />
-                    <Button
-                        onClick={this.handleApply}
-                        className={theme!.applyBtn}
-                        style="brand"
-                    >
-                        {applyLabel}
-                    </Button>
                 </Collapse>
             </div>
         );
@@ -257,19 +244,13 @@ export class DateInput extends PureComponent<DateInputProps, DateInputState> {
         }
     }
 
-    private readonly handleApply = () => {
-        this.setState({
-            isOpen: false
-        }, () => {
-            this.props.onChange(this.state.transientDate);
-        });
-    }
-
     private readonly handleChange = (value: Moment | string) => {
         const momentVal: Moment = isMoment(value) ? value : moment(value);
+        const selectedDate = momentVal.toDate()
         this.setState({
-            transientDate: momentVal.toDate()
+            transientDate: selectedDate
         });
+        this.props.onChange(selectedDate);
     }
 
     private readonly handleSelectTodayBtnClick = () => {

--- a/packages/react-ui-components/src/DateInput/dateInput.tsx
+++ b/packages/react-ui-components/src/DateInput/dateInput.tsx
@@ -109,13 +109,12 @@ const defaultProps: PickDefaultProps<DateInputProps, 'labelFormat' | 'timeConstr
 };
 
 interface DateInputState {
-    readonly isOpen: boolean;
-    readonly transientDate: Date | null; // TODO do we have a breaking change when we use 'undefined' in favor of 'null'?
+    readonly isOpen: boolean
+
 }
 
 const initialState: DateInputState = {
-    isOpen: false,
-    transientDate: null
+    isOpen: false
 };
 
 export class DateInput extends PureComponent<DateInputProps, DateInputState> {
@@ -246,11 +245,7 @@ export class DateInput extends PureComponent<DateInputProps, DateInputState> {
 
     private readonly handleChange = (value: Moment | string) => {
         const momentVal: Moment = isMoment(value) ? value : moment(value);
-        const selectedDate = momentVal.toDate()
-        this.setState({
-            transientDate: selectedDate
-        });
-        this.props.onChange(selectedDate);
+        this.props.onChange(momentVal.toDate());
     }
 
     private readonly handleSelectTodayBtnClick = () => {


### PR DESCRIPTION
The current date picker required a separate click to a blue "apply" button to actually set the field value. Afterwards the editors still had to click the inspector apply which leads to confusion. This is especially problematic in the CreationDialog where the apply button often is below the visible area which causes additional confusion.

This change improved DateTime Editor UX by auto-applying date/time selections which allowed to remove the DatePicker's "Apply" button entirely. The DateTime Editor still closes once the editor clicks outside.

For testings: Define a DateTime property and verify that you can set the date value without second apply.

Fixes: #3421
