### PR TITLE
BUGFIX: Use 12/24 hour format for DateTimePicker depending on configured `format`

### DIFF
--- a/packages/neos-ui-editors/src/Editors/DateTime/helpers.js
+++ b/packages/neos-ui-editors/src/Editors/DateTime/helpers.js
@@ -46,3 +46,8 @@ export const hasDateFormat = format => /[yYFmMntdDjlNSw]/.test(format);
 // Check if given format has a time formatting
 //
 export const hasTimeFormat = format => /[gGhHis]/.test(format);
+
+//
+// Check if the time is 24 hour or 12 hour format
+//
+export const has24HourFormat = format => /[GH]/.test(format);

--- a/packages/neos-ui-editors/src/Editors/DateTime/index.js
+++ b/packages/neos-ui-editors/src/Editors/DateTime/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import DateInput from '@neos-project/react-ui-components/src/DateInput/';
 import moment from 'moment';
 import {neos} from '@neos-project/neos-ui-decorators';
-import convertPhpDateFormatToMoment, {hasDateFormat, hasTimeFormat} from './helpers';
+import convertPhpDateFormatToMoment, {has24HourFormat, hasDateFormat, hasTimeFormat} from './helpers';
 import {connect} from 'react-redux';
 import {$transform, $get} from 'plow-js';
 
@@ -60,6 +60,7 @@ class DateTime extends PureComponent {
                 labelFormat={convertPhpDateFormatToMoment(options.format)}
                 dateOnly={!hasTimeFormat(options.format)}
                 timeOnly={!hasDateFormat(options.format)}
+                is24Hour={hasTimeFormat(options.format) && has24HourFormat(options.format)}
                 placeholder={i18nRegistry.translate($get('placeholder', options) || 'Neos.Neos:Main:content.inspector.editors.dateTimeEditor.noDateSet')}
                 todayLabel={i18nRegistry.translate('content.inspector.editors.dateTimeEditor.today', 'Today', {}, 'Neos.Neos', 'Main')}
                 applyLabel={i18nRegistry.translate('content.inspector.editors.dateTimeEditor.apply', 'Apply', {}, 'Neos.Neos', 'Main')}

--- a/packages/react-ui-components/src/DateInput/__snapshots__/dateInput.spec.tsx.snap
+++ b/packages/react-ui-components/src/DateInput/__snapshots__/dateInput.spec.tsx.snap
@@ -88,6 +88,22 @@ exports[`<DateInput/> should format time in 24 hour format 1`] = `
       timeFormat="HH:m"
       utc={false}
     />
+    <ThemedButton
+      _refHandler={[Function]}
+      className="applyBtnClassName"
+      composeTheme="deeply"
+      disabled={false}
+      hoverStyle="brand"
+      isActive={false}
+      isFocused={false}
+      mapThemrProps={[Function]}
+      onClick={[Function]}
+      size="regular"
+      style="brand"
+      type="button"
+    >
+      applyLabel
+    </ThemedButton>
   </UnmountClosed>
 </div>
 `;

--- a/packages/react-ui-components/src/DateInput/__snapshots__/dateInput.spec.tsx.snap
+++ b/packages/react-ui-components/src/DateInput/__snapshots__/dateInput.spec.tsx.snap
@@ -1,5 +1,97 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<DateInput/> should format time in 24 hour format 1`] = `
+<div
+  className="wrapperClassName"
+>
+  <div
+    className="calendarInputWrapperClassName"
+  >
+    <button
+      className="calendarIconBtnClassName"
+      onClick={[Function]}
+    >
+      <ThemedIcon
+        color="default"
+        composeTheme="deeply"
+        icon="far calendar-alt"
+        mapThemrProps={[Function]}
+        padded="none"
+        size="sm"
+      />
+    </button>
+    <div
+      className="calendarFakeInputWrapperClassName"
+    >
+      <div
+        className="calendarFakeInputMirrorClassName"
+        onClick={[Function]}
+        role="presentation"
+      />
+      <input
+        className="calendarFakeInputClassName"
+        onFocus={[Function]}
+        readOnly={true}
+        type="datetime"
+        value=""
+      />
+    </div>
+    <button
+      className="closeCalendarIconBtnClassName"
+      onClick={[Function]}
+    >
+      <ThemedIcon
+        color="default"
+        composeTheme="deeply"
+        icon="times"
+        mapThemrProps={[Function]}
+        padded="none"
+        size="sm"
+      />
+    </button>
+  </div>
+  <UnmountClosed
+    isOpened={false}
+  >
+    <button
+      className="selectTodayBtnClassName"
+      onClick={[Function]}
+    >
+      todayLabel
+    </button>
+    <DateTime
+      className=""
+      closeOnSelect={false}
+      closeOnTab={true}
+      dateFormat={true}
+      defaultValue=""
+      input={true}
+      inputProps={Object {}}
+      locale="en-US"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onNavigateBack={[Function]}
+      onNavigateForward={[Function]}
+      onViewModeChange={[Function]}
+      open={true}
+      strictParsing={true}
+      timeConstraints={
+        Object {
+          "minutes": Object {
+            "max": 59,
+            "min": 0,
+            "step": 5,
+          },
+        }
+      }
+      timeFormat="HH:m"
+      utc={false}
+    />
+  </UnmountClosed>
+</div>
+`;
+
 exports[`<DateInput/> should render correctly. 1`] = `
 <div
   className="wrapperClassName"
@@ -85,7 +177,7 @@ exports[`<DateInput/> should render correctly. 1`] = `
           },
         }
       }
-      timeFormat={true}
+      timeFormat="HH:m"
       utc={false}
     />
     <ThemedButton

--- a/packages/react-ui-components/src/DateInput/dateInput.spec.tsx
+++ b/packages/react-ui-components/src/DateInput/dateInput.spec.tsx
@@ -34,7 +34,6 @@ describe('<DateInput/>', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
-
     it('should initialize with a state of {isOpen = false}.', () => {
         const wrapper = shallow(<DateInput {...props}/>);
 

--- a/packages/react-ui-components/src/DateInput/dateInput.spec.tsx
+++ b/packages/react-ui-components/src/DateInput/dateInput.spec.tsx
@@ -29,10 +29,11 @@ describe('<DateInput/>', () => {
     };
 
     it('should render correctly.', () => {
-        const wrapper = shallow(<DateInput {...props}/>);
+        const wrapper = shallow(<DateInput {...props} is24Hour/>);
 
         expect(toJson(wrapper)).toMatchSnapshot();
     });
+
 
     it('should initialize with a state of {isOpen = false}.', () => {
         const wrapper = shallow(<DateInput {...props}/>);
@@ -115,5 +116,11 @@ describe('<DateInput/>', () => {
         expect(receivedDate.getUTCMinutes()).toBe(0);
         expect(receivedDate.getUTCSeconds()).toBe(0);
         expect(receivedDate.getUTCMilliseconds()).toBe(0);
+    });
+
+    it('should format time in 24 hour format', () => {
+        const wrapper = shallow(<DateInput {...props} is24Hour/>);
+
+        expect(toJson(wrapper)).toMatchSnapshot();
     });
 });

--- a/packages/react-ui-components/src/DateInput/dateInput.tsx
+++ b/packages/react-ui-components/src/DateInput/dateInput.tsx
@@ -60,6 +60,11 @@ export interface DateInputProps {
     readonly timeOnly?: boolean;
 
     /**
+     * Show the Time in 24 hours or 12 hours format
+     */
+    readonly is24Hour?: boolean;
+
+    /**
      * Add some constraints to the timepicker.
      * It accepts an object with the format { hours: { min: 9, max: 15, step: 2 }},
      * this example means the hours can't be lower than 9 and higher than 15,
@@ -104,7 +109,7 @@ interface DateInputTheme {
 }
 
 const defaultProps: PickDefaultProps<DateInputProps, 'labelFormat' | 'timeConstraints'> = {
-    labelFormat: 'DD-MM-YYYY hh:mm',
+    labelFormat: 'DD-MM-YYYY hh:mm A',
     timeConstraints: {
         minutes: {
             min: 0,
@@ -141,6 +146,7 @@ export class DateInput extends PureComponent<DateInputProps, DateInputState> {
             labelFormat,
             dateOnly,
             timeOnly,
+            is24Hour,
             locale,
             disabled
         } = this.props;
@@ -175,6 +181,15 @@ export class DateInput extends PureComponent<DateInputProps, DateInputState> {
                 [theme!['disabled-cursor']]: disabled
             },
         );
+
+        const getTimeFormat = () => {
+            if (dateOnly) {
+                return false
+            }
+
+            console.log('getTimeFormat', is24Hour);
+            return is24Hour ? 'HH:m' : 'hh:m A'
+        }
 
         return (
             <div className={wrapper}>
@@ -221,7 +236,7 @@ export class DateInput extends PureComponent<DateInputProps, DateInputState> {
                         dateFormat={!timeOnly}
                         utc={dateOnly}
                         locale={locale}
-                        timeFormat={!dateOnly}
+                        timeFormat={getTimeFormat()}
                         onChange={this.handleChange}
                         timeConstraints={this.props.timeConstraints}
                     />

--- a/packages/react-ui-components/src/DateInput/dateInput.tsx
+++ b/packages/react-ui-components/src/DateInput/dateInput.tsx
@@ -146,7 +146,6 @@ export class DateInput extends PureComponent<DateInputProps, DateInputState> {
             labelFormat,
             dateOnly,
             timeOnly,
-            is24Hour,
             locale,
             disabled
         } = this.props;
@@ -181,15 +180,6 @@ export class DateInput extends PureComponent<DateInputProps, DateInputState> {
                 [theme!['disabled-cursor']]: disabled
             },
         );
-
-        const getTimeFormat = () => {
-            if (dateOnly) {
-                return false
-            }
-
-            console.log('getTimeFormat', is24Hour);
-            return is24Hour ? 'HH:m' : 'hh:m A'
-        }
 
         return (
             <div className={wrapper}>
@@ -236,7 +226,7 @@ export class DateInput extends PureComponent<DateInputProps, DateInputState> {
                         dateFormat={!timeOnly}
                         utc={dateOnly}
                         locale={locale}
-                        timeFormat={getTimeFormat()}
+                        timeFormat={this.timeFormat}
                         onChange={this.handleChange}
                         timeConstraints={this.props.timeConstraints}
                     />
@@ -317,6 +307,13 @@ export class DateInput extends PureComponent<DateInputProps, DateInputState> {
         this.setState({
             isOpen: false
         });
+    }
+
+    private get timeFormat(): false | string {
+        if (this.props.dateOnly) {
+            return false;
+        }
+        return this.props.is24Hour ? 'HH:m' : 'hh:m A';
     }
 }
 


### PR DESCRIPTION
Currently the DateTimePicker always uses the 12h time format even if the time format specified is in 24h format.

Currently supported hour formats from docs:
> g: hour without leading zeros - 12-hour format - 1 through 12
> G: hour without leading zeros - 24-hour format - 0 through 23
> h: 12-hour format of an hour with leading zeros - 01 through 12
> H: 24-hour format of an hour with leading zeros - 00 through 23

This change ensures that the 24h format is used for entering times when a 24h format was configured.

For testing:
```
dateTime24h:
  type: DateTime
    inspector:
      editorOptions:
        format: d-m-Y H:i
dateTime12h:
  type: DateTime
    inspector:
      editorOptions:
        format: d-m-Y h:i a
```

Fixes partly : [#3412](https://github.com/neos/neos-ui/issues/3412)