### PR TITLE
BUGFIX #3671: add check if custom ratios for images are allowed

### DIFF
--- a/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/AspectRatioDropDown/index.js
+++ b/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/AspectRatioDropDown/index.js
@@ -37,13 +37,14 @@ export default class AspectRatioDropDown extends PureComponent {
             PropTypes.instanceOf(AspectRatioOption)
         ),
         placeholder: PropTypes.string,
+        allowCustomRatios: PropTypes.boolean,
 
         onSelect: PropTypes.func.isRequired,
         onClear: PropTypes.func.isRequired
     };
 
     render() {
-        const {options, current, placeholder, onSelect, onClear} = this.props;
+        const {options, current, placeholder, allowCustomRatios, onSelect, onClear} = this.props;
 
         const dropDownHeaderClasses = mergeClassNames({
             [style.dropDown__btn]: true,
@@ -58,7 +59,8 @@ export default class AspectRatioDropDown extends PureComponent {
                             <DropDown.Header className={dropDownHeaderClasses}>
                                 {current.label}
                             </DropDown.Header>
-                            <IconButton icon="times" onClick={onClear} className={style.dropDown__clear}/>
+                            {allowCustomRatios && (
+                            <IconButton icon="times" onClick={onClear} className={style.dropDown__clear}/>)}
                         </div>
                     ) : (
                         <DropDown.Header className={dropDownHeaderClasses}>

--- a/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/index.js
+++ b/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/index.js
@@ -203,6 +203,7 @@ export default class ImageCropper extends PureComponent {
                     {!aspectRatioLocked && <AspectRatioDropDown
                         placeholder={`${i18nRegistry.translate('Neos.Neos:Main:imageCropper__aspect-ratio-placeholder')}`}
                         current={cropConfiguration.aspectRatioStrategy}
+                        allowCustomRatios={allowCustomRatios}
                         options={cropConfiguration.aspectRatioOptions}
                         onSelect={this.handleSetAspectRatio}
                         onClear={this.handleClearAspectRatio}


### PR DESCRIPTION
**What I did**
I prevent the clear button in the image cropper view to appear, if the yaml-configuration says `allowCostum: false`. This way, we show only allowed aspect ratios.

**How I did it**
I changed the code, so that the yaml settings 'allowCustom' for the image editor is respected.

**How to verify it**
As described in the issue:
Configure a property with an image, forcing the editor to crop the image to one of the provided aspect-ratios.
```
  properties:
    image:
      type: Neos\Media\Domain\Model\ImageInterface
      ui:
        inspector:
          group: 'media'
          position: 50
          editorOptions:
            crop:
              aspectRatio:
                # we want to force an aspect-ratio when selecting the image
                forceCrop: true
                # we explicitely don't want custom aspect-ratios
                allowCustom: false
                # we set a defaultOption so we don't end up without selected aspect-ratio
                defaultOption: portrait
                options:
                  portrait:
                    label: Portrait
                    width: 2
                    height: 3
                  landscape:
                    label: Landscape
                    width: 3
                    height: 2
```

### Before:
![grafik](https://github.com/neos/neos-ui/assets/11499598/66e6bfa4-f195-4012-8f4f-d14c42565f9e)

### With bugfix:
![grafik](https://github.com/neos/neos-ui/assets/11499598/44733127-cf21-4347-b8b3-f79f65976318)

