### PR TITLE
BUGFIX: Disable node text selection in document tree

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -3,6 +3,8 @@ const {compileWithCssVariables} = require('./cssVariables');
 const {cssModules} = require('./cssModules');
 const esbuild = require('esbuild');
 const { version } = require('./package.json')
+const { browserslistToTargets } = require('lightningcss');
+const browserslist = require('browserslist');
 
 const isProduction = process.argv.includes('--production');
 const isE2ETesting = process.argv.includes('--e2e-testing');
@@ -75,9 +77,7 @@ const options = {
         cssModules(
             {
                 visitor: compileWithCssVariables(),
-                targets: {
-                    chrome: 80 // aligns somewhat to es2020
-                },
+                targets: browserslistToTargets(browserslist('last 2 versions')),
                 drafts: {
                     nesting: true
                 }

--- a/esbuild.js
+++ b/esbuild.js
@@ -3,8 +3,6 @@ const {compileWithCssVariables} = require('./cssVariables');
 const {cssModules} = require('./cssModules');
 const esbuild = require('esbuild');
 const { version } = require('./package.json')
-const { browserslistToTargets } = require('lightningcss');
-const browserslist = require('browserslist');
 
 const isProduction = process.argv.includes('--production');
 const isE2ETesting = process.argv.includes('--e2e-testing');
@@ -77,7 +75,13 @@ const options = {
         cssModules(
             {
                 visitor: compileWithCssVariables(),
-                targets: browserslistToTargets(browserslist('last 2 versions')),
+                targets: { // only support es2020 browser
+                    // only supports browserList format
+                    chrome: (80 << 16), // 80
+                    safari: (13 << 16) | (1 << 8), // 13.1
+                    firefox: (72 << 16), // 72
+                    edge: (80 << 16) // 80
+                },
                 drafts: {
                     nesting: true
                 }

--- a/esbuild.js
+++ b/esbuild.js
@@ -77,6 +77,9 @@ const options = {
                 visitor: compileWithCssVariables(),
                 targets: { // only support es2020 browser
                     // only supports browserList format
+                    // https://lightningcss.dev/transpilation.html
+                    // list of supported browser version per es version
+                    // https://github.com/evanw/esbuild/issues/121#issuecomment-646956379
                     chrome: (80 << 16), // 80
                     safari: (13 << 16) | (1 << 8), // 13.1
                     firefox: (72 << 16), // 72

--- a/packages/react-ui-components/src/Tree/tree.module.css
+++ b/packages/react-ui-components/src/Tree/tree.module.css
@@ -9,8 +9,3 @@
     }
 }
 
-@supports (-webkit-user-select: none) {
-    .treeWrapper {
-        -webkit-user-select: none;
-    }
-}

--- a/packages/react-ui-components/src/Tree/tree.module.css
+++ b/packages/react-ui-components/src/Tree/tree.module.css
@@ -2,8 +2,15 @@
     composes: reset from '../reset.module.css';
 
     padding: 5px 0;
+    user-select: none;
 
     &:focus {
         outline: 0;
+    }
+}
+
+@supports (-webkit-user-select: none) {
+    .treeWrapper {
+        -webkit-user-select: none;
     }
 }


### PR DESCRIPTION
It was possible to select the HTML Text from the node elements in the documentation tree via `shift + left click`. 
This bug was found in the PR [3625](https://github.com/neos/neos-ui/pull/3635) via the [commit](https://github.com/neos/neos-ui/pull/3635#issuecomment-1898625946)

The issue arrived premier in the `safari` browser.

The issue was fixed be applying `user-select: none` to the whole tree element to prevent all children to be HTML text selectable. 

To verify this, try to select multiple elements with `shift + left click`  and there should not have the default blue selection highlight.

Wrong:
<img src="https://github.com/neos/neos-ui/assets/58438582/a35a7412-588f-4a3d-b7e2-5f8a3becfb8f" width="309">

Correct:
<img width="309" alt="image" src="https://github.com/neos/neos-ui/assets/58438582/2b8e2f30-00d6-4c34-aec4-a09ab44cab54">
