### PR TITLE
BUGFIX: 9.0 infinite (real) reloads after exception

### DIFF
--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -344,7 +344,10 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
             $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
             $nodeAddress = $nodeAddressFactory->createFromNode($nodeAddress);
         }
-        return (string)NodeUriBuilder::fromRequest($actionRequest)->uriFor($nodeAddress);
+        $uriBuilder = new UriBuilder();
+        $uriBuilder->setRequest($actionRequest);
+        $uriBuilder->setCreateAbsoluteUri(true);
+        return (string)NodeUriBuilder::fromUriBuilder($uriBuilder)->uriFor($nodeAddress);
     }
 
     public function previewUri(Node $node, ActionRequest $actionRequest): string

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -355,7 +355,11 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
         $contentRepository = $this->contentRepositoryRegistry->get($node->subgraphIdentity->contentRepositoryId);
         $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
         $nodeAddress = $nodeAddressFactory->createFromNode($node);
-        return (string)NodeUriBuilder::fromRequest($actionRequest)->previewUriFor($nodeAddress);
+
+        $uriBuilder = new UriBuilder();
+        $uriBuilder->setRequest($actionRequest);
+        $uriBuilder->setCreateAbsoluteUri(true);
+        return (string)NodeUriBuilder::fromUriBuilder($uriBuilder)->previewUriFor($nodeAddress);
     }
 
     public function createRedirectToNode(Node $node, ActionRequest $actionRequest): string


### PR DESCRIPTION
**What I did**
Update the NodeInfoHelper to build an initial absolute URL, instead of a relative one.

**How to verify it**

Throw an exception (or return an abnormal response) in any places and expect the iframe to be only loaded once.
The orange loading bar will keep spinning but that is part of  #3477.

```php
throw new \Exception(rand());
``` 

But currently this results in an endless reload, because in the condition of the frame `win.location.href` will not equal `this.props.src` causing `win.location.replace(this.props.src)` being retriggered infinitely:

https://github.com/neos/neos-ui/blob/5e1675897032a0dba73b3a1bb445ffad55162680/packages/react-ui-components/src/Frame/frame.tsx#L96
