### PR TITLE
WIP FEATURE: Push history on clicking node link node

### DIFF
--- a/packages/react-ui-components/src/Tree/node.js
+++ b/packages/react-ui-components/src/Tree/node.js
@@ -205,7 +205,10 @@ export class Header extends PureComponent {
                 href: directLink,
                 target: '_blank',
                 rel: 'noopener noreferrer',
-                onClick: (event) => event.preventDefault()
+                onClick: (event) => {
+                    history.pushState({}, '', directLink);
+                    return event.preventDefault();
+                }
             };
         }
 


### PR DESCRIPTION
Resolves: https://github.com/neos/neos-ui/issues/3241

In the PR: [3440](https://github.com/neos/neos-ui/pull/3440) Nodes in the document tree were converted to a link.

I added that a click on the Node will push the URL change to the browser history object without reloading the page, so that you can navigate back in the document tree via the `back` functionality from the browser itself.

Clicking on a Node will push the new `url` to the `history.pushState`.

**How to verify it**
Clicking Nodes in the document and then clicking the `back` button from the browser should navigate you to the last selected Node.

