### PR TITLE
BUGFIX: Change update interval on CKEditor 

### DIFF
--- a/Tests/IntegrationTests/Fixtures/1Dimension/createNewNodes.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/createNewNodes.e2e.js
@@ -177,21 +177,21 @@ test('Can create content node from inside InlineUI', async t => {
 
     subSection('Inline validation');
     // We have to wait for ajax requests to be triggered, since they are debounced for 0.5s
-    await t.wait(600);
+    await t.wait(1600);
     await changeRequestLogger.clear();
     await t
         .expect(Selector('.test-headline h1').exists).ok('Validation tooltip appeared')
         .click('.test-headline h1')
         .pressKey('ctrl+a delete')
         .switchToMainWindow()
-        .wait(600)
+        .wait(1600)
         .expect(ReactSelector('InlineValidationTooltips').exists).ok('Validation tooltip appeared');
     await t
         .expect(changeRequestLogger.count(() => true)).eql(0, 'No requests were fired with invalid state');
     await t
         .switchToIframe(contentIframeSelector)
         .typeText(Selector('.test-headline h1'), 'Some text')
-        .wait(600);
+        .wait(1600);
     await t.expect(changeRequestLogger.count(() => true)).eql(1, 'Request fired when field became valid');
 
     subSection('Create a link to node');
@@ -228,7 +228,7 @@ test('Inline CKEditor mode `paragraph: false` works as expected', async t => {
         .expect(Selector('.neos-contentcollection').withText('Foo Bar').exists).ok('Inserted text exists');
 
     await t.switchToMainWindow();
-    await t.wait(500); // we debounce the change
+    await t.wait(1500); // we debounce the change
     await t.expect(ReactSelector('Inspector TextAreaEditor').withProps({ value: 'Foo Bar<br>Bun Buz'}).exists).ok('The TextAreaEditor mirrors the expected value')
 });
 

--- a/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
@@ -57,7 +57,6 @@ export const createEditor = store => async options => {
     return NeosEditor
         .create(propertyDomNode, ckEditorConfig)
         .then(editor => {
-            console.log('editor.ui', editor.ui);
             editor.ui.focusTracker.on('change:isFocused', event => {
                 if (!event.source.isFocused) {
                     onChange(cleanupContentBeforeCommit(editor.getData()))

--- a/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
@@ -57,12 +57,16 @@ export const createEditor = store => async options => {
     return NeosEditor
         .create(propertyDomNode, ckEditorConfig)
         .then(editor => {
+            console.log('editor.ui', editor.ui);
             editor.ui.focusTracker.on('change:isFocused', event => {
-                if (event.source.isFocused) {
-                    currentEditor = editor;
-                    editorConfig.setCurrentlyEditedPropertyName(propertyName);
-                    handleUserInteractionCallback();
+                if (!event.source.isFocused) {
+                    onChange(cleanupContentBeforeCommit(editor.getData()))
+                    return
                 }
+
+                currentEditor = editor;
+                editorConfig.setCurrentlyEditedPropertyName(propertyName);
+                handleUserInteractionCallback();
             });
 
             editor.keystrokes.set('Ctrl+K', (_, cancel) => {
@@ -71,7 +75,7 @@ export const createEditor = store => async options => {
             });
 
             editor.model.document.on('change', () => handleUserInteractionCallback());
-            editor.model.document.on('change:data', debounce(() => onChange(cleanupContentBeforeCommit(editor.getData())), 500, {maxWait: 5000}));
+            editor.model.document.on('change:data', debounce(() => onChange(cleanupContentBeforeCommit(editor.getData())), 1500, {maxWait: 5000}));
             return editor;
         }).catch(e => {
             if (e instanceof TypeError && e.message.match(/Class constructor .* cannot be invoked without 'new'/)) {


### PR DESCRIPTION
Related: https://github.com/neos/neos-ui/issues/887

Currently, the CKEditor send the onChange event after user stops typing for 500ms, this results in a lot of unnecessary events that bloats the server. 

This adjustment was initially made in response to a new server behavior observed in Neos9, where the server temporarily blocks incoming change requests during publishing processes. Extending the debounce interval aims to mitigate the risk of overlap between change requests and publishing operations.

**What I did**
The debounce timer has been extended from 500ms to 1500ms. This reduces the frequency of onChange events, thereby decreasing server load.

An additional onChange event has been introduced to trigger whenever the editor loses focus. This ensures that all changes are captured, even if the user does not pause in their typing.

**How to verify it**
Engage with the CKEditor by typing. Upon ceasing typing, observe that the publish button (located in the top right corner) indicates a change was made, after a delay of 1500ms.

While typing in CKEditor, shift focus to another element before the 1500ms debounce period concludes. The publish button should still update to reflect a change, ensuring that all modifications are captured accurately.
