### PR TITLE
FEATURE: Collapse All Button in Content and Page Tree

### DIFF
--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -622,6 +622,10 @@
                 <source>Inside</source>
         <target state="translated">Innen</target>
       </trans-unit>
+      <trans-unit id="collapseAll" xml:space="preserve">
+          <source>Collapse All</source>
+          <target state="translated">Alle Ordner zuklappen</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -374,6 +374,9 @@
             <trans-unit id="errorBoundary.footer" xml:space="preserve">
                 <source>For more information about the error please refer to the JavaScript console.</source>
             </trans-unit>
+            <trans-unit id="collapseAll" xml:space="preserve">
+              <source>Collapse All</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/packages/neos-ui-redux-store/src/CR/Nodes/selectors.ts
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/selectors.ts
@@ -66,7 +66,7 @@ export const makeGetDocumentNodes = (nodeTypesRegistry: NodeTypesRegistry) => cr
     }
 );
 
-export const makeGetCollapsableDocumentNodes = (nodeTypesRegistry: NodeTypesRegistry) => createSelector(
+export const makeGetCollapsibleDocumentNodes = (nodeTypesRegistry: NodeTypesRegistry) => createSelector(
     [
         nodesByContextPathSelector
     ],
@@ -83,10 +83,10 @@ export const makeGetCollapsableDocumentNodes = (nodeTypesRegistry: NodeTypesRegi
             if (!node) {
                 throw new Error('This error should never be thrown, it\'s a way to fool TypeScript');
             }
-            const isCollapsable = node.children.some(
+            const isCollapsible = node.children.some(
                 child => child ? documentSubNodeTypes.includes(child.nodeType) : false
             )
-            if (documentSubNodeTypes.includes(node.nodeType) && isCollapsable) {
+            if (documentSubNodeTypes.includes(node.nodeType) && isCollapsible) {
                 result[contextPath] = node;
             }
         });
@@ -94,7 +94,7 @@ export const makeGetCollapsableDocumentNodes = (nodeTypesRegistry: NodeTypesRegi
     }
 );
 
-export const makeGetCollapsableContentNodes = (nodeTypesRegistry: NodeTypesRegistry) => createSelector(
+export const makeGetCollapsibleContentNodes = (nodeTypesRegistry: NodeTypesRegistry) => createSelector(
     [
         nodesByContextPathSelector
     ],
@@ -116,10 +116,10 @@ export const makeGetCollapsableContentNodes = (nodeTypesRegistry: NodeTypesRegis
             if (!node) {
                 throw new Error('This error should never be thrown, it\'s a way to fool TypeScript');
             }
-            const isCollapsable = node.children.some(
+            const isCollapsible = node.children.some(
                 child => child ? contentSubNodeTypes.includes(child.nodeType) : false
             )
-            if (contentSubNodeTypes.includes(node.nodeType) && isCollapsable) {
+            if (contentSubNodeTypes.includes(node.nodeType) && isCollapsible) {
                 result[contextPath] = node;
             }
         });

--- a/packages/neos-ui-redux-store/src/UI/ContentTree/index.ts
+++ b/packages/neos-ui-redux-store/src/UI/ContentTree/index.ts
@@ -106,7 +106,6 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
 
             collapsedByDefaultNodeContextPaths.forEach(path => {
                 if (draft.toggled.includes(path)) {
-                    draft.toggled.push(path);
                     draft.toggled = draft.toggled.filter(i => i !== path);
                 }
             });

--- a/packages/neos-ui-redux-store/src/UI/ContentTree/index.ts
+++ b/packages/neos-ui-redux-store/src/UI/ContentTree/index.ts
@@ -31,6 +31,7 @@ export enum actionTypes {
     REQUEST_CHILDREN = '@neos/neos-ui/UI/ContentTree/REQUEST_CHILDREN',
     SET_AS_LOADING = '@neos/neos-ui/UI/ContentTree/SET_AS_LOADING',
     SET_AS_LOADED = '@neos/neos-ui/UI/ContentTree/SET_AS_LOADED',
+    COLLAPSE_ALL = '@neos/neos-ui/UI/ContentTree/COLLAPSE_ALL'
 }
 
 const toggle = (contextPath: NodeContextPath) => createAction(actionTypes.TOGGLE, contextPath);
@@ -40,6 +41,10 @@ const reloadTree = () => createAction(actionTypes.RELOAD_TREE);
 const requestChildren = (contextPath: NodeContextPath, {unCollapse = true, activate = false} = {}) => createAction(actionTypes.REQUEST_CHILDREN, {contextPath, opts: {unCollapse, activate}});
 const setAsLoading = (contextPath: NodeContextPath) => createAction(actionTypes.SET_AS_LOADING, {contextPath});
 const setAsLoaded = (contextPath: NodeContextPath) => createAction(actionTypes.SET_AS_LOADED, {contextPath});
+const collapseAll = (
+    nodeContextPaths: NodeContextPath[],
+    collapsedByDefaultNodeContextPaths: NodeContextPath[]
+) => createAction(actionTypes.COLLAPSE_ALL, {nodeContextPaths, collapsedByDefaultNodeContextPaths});
 
 //
 // Export the actions
@@ -51,7 +56,8 @@ export const actions = {
     reloadTree,
     requestChildren,
     setAsLoading,
-    setAsLoaded
+    setAsLoaded,
+    collapseAll
 };
 
 export type Action = ActionType<typeof actions>;
@@ -87,6 +93,23 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
         case actionTypes.SET_AS_LOADED: {
             const {contextPath} = action.payload;
             draft.loading = draft.loading.filter(i => i !== contextPath);
+            break;
+        }
+        case actionTypes.COLLAPSE_ALL: {
+            const {nodeContextPaths, collapsedByDefaultNodeContextPaths} = action.payload;
+
+            nodeContextPaths.forEach(path => {
+                if (!draft.toggled.includes(path)) {
+                    draft.toggled.push(path);
+                }
+            });
+
+            collapsedByDefaultNodeContextPaths.forEach(path => {
+                if (draft.toggled.includes(path)) {
+                    draft.toggled.push(path);
+                    draft.toggled = draft.toggled.filter(i => i !== path);
+                }
+            });
             break;
         }
     }

--- a/packages/neos-ui-redux-store/src/UI/PageTree/index.ts
+++ b/packages/neos-ui-redux-store/src/UI/PageTree/index.ts
@@ -40,7 +40,8 @@ export enum actionTypes {
     SET_AS_LOADED = '@neos/neos-ui/UI/PageTree/SET_AS_LOADED',
     REQUEST_CHILDREN = '@neos/neos-ui/UI/PageTree/REQUEST_CHILDREN',
     COMMENCE_SEARCH = '@neos/neos-ui/UI/PageTree/COMMENCE_SEARCH',
-    SET_SEARCH_RESULT = '@neos/neos-ui/UI/PageTree/SET_SEARCH_RESULT'
+    SET_SEARCH_RESULT = '@neos/neos-ui/UI/PageTree/SET_SEARCH_RESULT',
+    COLLAPSE_ALL = '@neos/neos-ui/UI/PageTree/COLLAPSE_ALL'
 }
 
 const focus = (contextPath: NodeContextPath, _: undefined, selectionMode: SelectionModeTypes = SelectionModeTypes.SINGLE_SELECT) => createAction(actionTypes.FOCUS, {contextPath, selectionMode});
@@ -49,6 +50,11 @@ const invalidate = (contextPath: NodeContextPath) => createAction(actionTypes.IN
 const requestChildren = (contextPath: NodeContextPath, {unCollapse = true, activate = false} = {}) => createAction(actionTypes.REQUEST_CHILDREN, {contextPath, opts: {unCollapse, activate}});
 const setAsLoading = (contextPath: NodeContextPath) => createAction(actionTypes.SET_AS_LOADING, {contextPath});
 const setAsLoaded = (contextPath: NodeContextPath) => createAction(actionTypes.SET_AS_LOADED, {contextPath});
+const collapseAll = (
+    nodeContextPaths: NodeContextPath[],
+    collapsedByDefaultNodeContextPaths: NodeContextPath[]
+) => createAction(actionTypes.COLLAPSE_ALL, {nodeContextPaths, collapsedByDefaultNodeContextPaths});
+
 interface CommenceSearchOptions extends Readonly<{
     query: string;
     filterNodeType: string;
@@ -72,7 +78,8 @@ export const actions = {
     setAsLoaded,
     requestChildren,
     commenceSearch,
-    setSearchResult
+    setSearchResult,
+    collapseAll
 };
 
 export type Action = ActionType<typeof actions>;
@@ -132,6 +139,23 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
             // Store search arguments, to be used during tree reload
             draft.query = action.payload.query;
             draft.filterNodeType = action.payload.filterNodeType;
+            break;
+        }
+        case actionTypes.COLLAPSE_ALL: {
+            const {nodeContextPaths, collapsedByDefaultNodeContextPaths} = action.payload;
+
+            nodeContextPaths.forEach(path => {
+                if (!draft.toggled.includes(path)) {
+                    draft.toggled.push(path);
+                }
+            });
+
+            collapsedByDefaultNodeContextPaths.forEach(path => {
+                if (draft.toggled.includes(path)) {
+                    draft.toggled.push(path);
+                    draft.toggled = draft.toggled.filter(i => i !== path);
+                }
+            });
             break;
         }
     }

--- a/packages/neos-ui-redux-store/src/UI/PageTree/index.ts
+++ b/packages/neos-ui-redux-store/src/UI/PageTree/index.ts
@@ -152,7 +152,6 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
 
             collapsedByDefaultNodeContextPaths.forEach(path => {
                 if (draft.toggled.includes(path)) {
-                    draft.toggled.push(path);
                     draft.toggled = draft.toggled.filter(i => i !== path);
                 }
             });

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
@@ -150,8 +150,9 @@ export default class NodeTree extends PureComponent {
                     role="button"
                     onClick={this.handleCollapseAll}
                     className={style.collapseAll}
+                    title="Collapse All"
                 >
-                    Collapse All
+                    <Icon icon="compress-alt"/>
                 </a>
                 <ConnectedDragLayer
                     nodeDndType={dndTypes.NODE}

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
@@ -146,14 +146,13 @@ export default class NodeTree extends PureComponent {
 
         return (
             <Tree className={classNames}>
-                <a
-                    role="button"
+                <button
                     onClick={this.handleCollapseAll}
                     className={style.collapseAll}
                     title="Collapse All"
                 >
-                    <Icon icon="compress-alt"/>
-                </a>
+                    <Icon className={style.collapseAllIcon} icon="compress-alt"/>
+                </button>
                 <ConnectedDragLayer
                     nodeDndType={dndTypes.NODE}
                     ChildRenderer={ChildRenderer}

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
@@ -35,7 +35,7 @@ export default class NodeTree extends PureComponent {
         setActiveContentCanvasSrc: PropTypes.func,
         setActiveContentCanvasContextPath: PropTypes.func,
         moveNodes: PropTypes.func,
-        allCollapsableNodes: PropTypes.object,
+        allCollapsibleNodes: PropTypes.object,
         loadingDepth: PropTypes.number
     };
 
@@ -50,11 +50,11 @@ export default class NodeTree extends PureComponent {
     }
 
     handleCollapseAll = () => {
-        const {collapseAll, allCollapsableNodes, rootNode, loadingDepth} = this.props
+        const {collapseAll, allCollapsibleNodes, rootNode, loadingDepth} = this.props
         let nodeContextPaths = []
         const collapsedByDefaultNodesContextPaths = []
 
-        Object.values(allCollapsableNodes).forEach(node => {
+        Object.values(allCollapsibleNodes).forEach(node => {
             const collapsedByDefault = loadingDepth === 0 ? false : node.depth - rootNode.depth >= loadingDepth
             if (collapsedByDefault) {
                 collapsedByDefaultNodesContextPaths.push(node.contextPath)
@@ -183,14 +183,14 @@ const withNodeTypeRegistry = neos(globalRegistry => ({
 
 export const PageTree = withNodeTypeRegistry(connect(
     (state, {neos, nodeTypesRegistry}) => {
-        const documentNodesSelector = selectors.CR.Nodes.makeGetCollapsableDocumentNodes(nodeTypesRegistry);
+        const documentNodesSelector = selectors.CR.Nodes.makeGetCollapsibleDocumentNodes(nodeTypesRegistry);
         return ({
             rootNode: selectors.CR.Nodes.siteNodeSelector(state),
             focusedNodesContextPaths: selectors.UI.PageTree.getAllFocused(state),
             ChildRenderer: PageTreeNode,
             allowOpeningNodesInNewWindow: true,
             loadingDepth: neos.configuration.structureTree.loadingDepth,
-            allCollapsableNodes: documentNodesSelector(state)
+            allCollapsibleNodes: documentNodesSelector(state)
         })
     }, {
         toggle: actions.UI.PageTree.toggle,
@@ -208,14 +208,14 @@ export const PageTree = withNodeTypeRegistry(connect(
 
 export const ContentTree = withNodeTypeRegistry(connect(
     (state, {neos, nodeTypesRegistry}) => {
-        const contentNodesSelector = selectors.CR.Nodes.makeGetCollapsableContentNodes(nodeTypesRegistry);
+        const contentNodesSelector = selectors.CR.Nodes.makeGetCollapsibleContentNodes(nodeTypesRegistry);
         return ({
             rootNode: selectors.CR.Nodes.documentNodeSelector(state),
             focusedNodesContextPaths: selectors.CR.Nodes.focusedNodePathsSelector(state),
             ChildRenderer: ContentTreeNode,
             allowOpeningNodesInNewWindow: false,
             loadingDepth: neos.configuration.structureTree.loadingDepth,
-            allCollapsableNodes: contentNodesSelector(state)
+            allCollapsibleNodes: contentNodesSelector(state)
         })
     }, {
         toggle: actions.UI.ContentTree.toggle,

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
@@ -150,7 +150,7 @@ export default class NodeTree extends PureComponent {
                 <button
                     onClick={this.handleCollapseAll}
                     className={style.collapseAll}
-                    title={i18nRegistry.translate('collapseAll')}
+                    title={i18nRegistry.translate('Neos.Neos.Ui:Main:collapseAll')}
                 >
                     <Icon className={style.collapseAllIcon} icon="compress-alt"/>
                 </button>

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
@@ -36,7 +36,8 @@ export default class NodeTree extends PureComponent {
         setActiveContentCanvasContextPath: PropTypes.func,
         moveNodes: PropTypes.func,
         allCollapsibleNodes: PropTypes.object,
-        loadingDepth: PropTypes.number
+        loadingDepth: PropTypes.number,
+        i18nRegistry: PropTypes.object.isRequired
     };
 
     state = {
@@ -131,7 +132,7 @@ export default class NodeTree extends PureComponent {
     }
 
     render() {
-        const {rootNode, ChildRenderer} = this.props;
+        const {rootNode, ChildRenderer, i18nRegistry} = this.props;
         if (!rootNode) {
             return (
                 <div className={style.loader}>
@@ -149,7 +150,7 @@ export default class NodeTree extends PureComponent {
                 <button
                     onClick={this.handleCollapseAll}
                     className={style.collapseAll}
-                    title="Collapse All"
+                    title={i18nRegistry.translate('collapseAll')}
                 >
                     <Icon className={style.collapseAllIcon} icon="compress-alt"/>
                 </button>
@@ -177,11 +178,12 @@ export default class NodeTree extends PureComponent {
     }
 }
 
-const withNodeTypeRegistry = neos(globalRegistry => ({
-    nodeTypesRegistry: globalRegistry.get('@neos-project/neos-ui-contentrepository')
+const withNodeTypeRegistryAndI18nRegistry = neos(globalRegistry => ({
+    nodeTypesRegistry: globalRegistry.get('@neos-project/neos-ui-contentrepository'),
+    i18nRegistry: globalRegistry.get('i18n')
 }));
 
-export const PageTree = withNodeTypeRegistry(connect(
+export const PageTree = withNodeTypeRegistryAndI18nRegistry(connect(
     (state, {neos, nodeTypesRegistry}) => {
         const documentNodesSelector = selectors.CR.Nodes.makeGetCollapsibleDocumentNodes(nodeTypesRegistry);
         return ({
@@ -206,7 +208,7 @@ export const PageTree = withNodeTypeRegistry(connect(
     }
 )(NodeTree));
 
-export const ContentTree = withNodeTypeRegistry(connect(
+export const ContentTree = withNodeTypeRegistryAndI18nRegistry(connect(
     (state, {neos, nodeTypesRegistry}) => {
         const contentNodesSelector = selectors.CR.Nodes.makeGetCollapsibleContentNodes(nodeTypesRegistry);
         return ({

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/style.module.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/style.module.css
@@ -6,7 +6,22 @@
     background: var(--colors-ContrastDarker);
     border-bottom: 1px solid var(--colors-ContrastDark);
     border-right: 1px solid var(--colors-ContrastDark);
+    position: relative;
 }
 .loader {
     margin: var(--spacing-Quarter);
+}
+.collapseAll {
+    position: absolute;
+    right: 0;
+    top: 0;
+    opacity: .5;
+    text-align: center;
+    cursor: pointer;
+    z-index: 5;
+    padding: 10px 5px 0 5px;
+
+    &:hover {
+        color: var(--colors-PrimaryBlueHover);
+    }
 }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/style.module.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/style.module.css
@@ -19,9 +19,18 @@
     cursor: pointer;
     z-index: 5;
     padding: var(--spacing-Half);
-    font-size: 1.4em;
+    background-color: transparent;
+    border: 0;
 
-    &:hover > svg {
+    .collapseAllIcon {
+        font-size: 1.2em;
+    }
+
+    &:hover > .collapseAllIcon {
         color: var(--colors-PrimaryBlueHover);
+    }
+
+    &:hover {
+        opacity: 1;
     }
 }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/style.module.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/style.module.css
@@ -18,7 +18,7 @@
     opacity: .5;
     cursor: pointer;
     z-index: 5;
-    padding: 8px;
+    padding: var(--spacing-Half);
     font-size: 1.4em;
 
     &:hover > svg {

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/style.module.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/style.module.css
@@ -16,12 +16,12 @@
     right: 0;
     top: 0;
     opacity: .5;
-    text-align: center;
     cursor: pointer;
     z-index: 5;
-    padding: 10px 5px 0 5px;
+    padding: 8px;
+    font-size: 1.4em;
 
-    &:hover {
+    &:hover > svg {
         color: var(--colors-PrimaryBlueHover);
     }
 }


### PR DESCRIPTION
**What I did**

Add a Button to collapse all collapsable Nodes in the Content and Page Tree in the LeftSideBar. Since I didn't like how it looked as an IconButton, it's just text indicating exactly what it does.

Note: Currently Nodes that are closed by default behave differently than other Nodes (Instead of being added to the toggled state in the Redux Store when collapsed, they are added when they are expanded). I wasn't able to make it work without generating new Bugs so I just gave up, but I think this should be looked into at some point.

**How I did it**

* Add a selector to either select all document nodes or content nodes that are collapsable (DocumentNodes must have children with subtypes of Document and ContentNodes must have children with SubTypes of Content and contentCollection )

* Add the Button on the top right of the Tree Container

**How to verify it**

Open all the Nodes and click  "Collapse all" :)

![collapseAllPreview](https://github.com/neos/neos-ui/assets/56877180/e0830dfc-3e59-48ec-8f92-3c856cd750b5)

