### PR TITLE
TASK: Remove obsolote apply button from dateInput snapshot

### DIFF
--- a/packages/react-ui-components/src/DateInput/__snapshots__/dateInput.spec.tsx.snap
+++ b/packages/react-ui-components/src/DateInput/__snapshots__/dateInput.spec.tsx.snap
@@ -88,22 +88,6 @@ exports[`<DateInput/> should format time in 24 hour format 1`] = `
       timeFormat="HH:m"
       utc={false}
     />
-    <ThemedButton
-      _refHandler={[Function]}
-      className="applyBtnClassName"
-      composeTheme="deeply"
-      disabled={false}
-      hoverStyle="brand"
-      isActive={false}
-      isFocused={false}
-      mapThemrProps={[Function]}
-      onClick={[Function]}
-      size="regular"
-      style="brand"
-      type="button"
-    >
-      applyLabel
-    </ThemedButton>
   </UnmountClosed>
 </div>
 `;


### PR DESCRIPTION
On our `8.3` branch, jest complains:

```
  ● <DateInput/> › should format time in 24 hour format

    expect(received).toMatchSnapshot()

    Snapshot name: `<DateInput/> should format time in 24 hour format 1`

    - Snapshot  - 16
    + Received  +  0

    @@ -83,23 +83,7 @@
              }
            }
            timeFormat="HH:m"
            utc={false}
          />
    -     <ThemedButton
    -       _refHandler={[Function]}
    -       className="applyBtnClassName"
    -       composeTheme="deeply"
    -       disabled={false}
    -       hoverStyle="brand"
    -       isActive={false}
    -       isFocused={false}
    -       mapThemrProps={[Function]}
    -       onClick={[Function]}
    -       size="regular"
    -       style="brand"
    -       type="button"
    -     >
    -       applyLabel
    -     </ThemedButton>
        </UnmountClosed>
      </div>
```

This is due to a conflict between these two PRs:

- https://github.com/neos/neos-ui/pull/3736 - Removes the extra "Apply"-button from our date input component
- https://github.com/neos/neos-ui/pull/3737  - Adds a new jest snapshot, which still contains the "Apply" button

With both combined, jest tries to match the snapshot and finds (correctly so) that the "Apply" button is missing.

This PR removes the obsolete part from said snapshot.