### PR TITLE
BUGFIX: Improve UI loading performance by removing UI nodedata script tag and using less data

### DIFF
--- a/Classes/Aspects/AugmentationAspect.php
+++ b/Classes/Aspects/AugmentationAspect.php
@@ -40,21 +40,9 @@ class AugmentationAspect
 
     /**
      * @Flow\Inject
-     * @var UserLocaleService
-     */
-    protected $userLocaleService;
-
-    /**
-     * @Flow\Inject
      * @var HtmlAugmenter
      */
     protected $htmlAugmenter;
-
-    /**
-     * @Flow\Inject
-     * @var NodeInfoHelper
-     */
-    protected $nodeInfoHelper;
 
     /**
      * @Flow\Inject
@@ -126,15 +114,7 @@ class AugmentationAspect
         $attributes['data-__neos-node-contextpath'] = $node->getContextPath();
         $attributes['data-__neos-fusion-path'] = $fusionPath;
 
-        $this->userLocaleService->switchToUILocale();
-
-        $serializedNode = json_encode($this->nodeInfoHelper->renderNodeWithMinimalPropertiesAndChildrenInformation($node, $this->controllerContext));
-        $attributes['data-__neos-nodedata'] = $serializedNode;
-
-        $this->userLocaleService->switchToUILocale(true);
-
-        $wrappedContent = $this->htmlAugmenter->addAttributes($content, $attributes, 'div');
-        return $wrappedContent;
+        return $this->htmlAugmenter->addAttributes($content, $attributes);
     }
 
     /**

--- a/Classes/Aspects/AugmentationAspect.php
+++ b/Classes/Aspects/AugmentationAspect.php
@@ -128,13 +128,12 @@ class AugmentationAspect
 
         $this->userLocaleService->switchToUILocale();
 
-        $serializedNode = json_encode($this->nodeInfoHelper->renderNodeWithPropertiesAndChildrenInformation($node, $this->controllerContext));
+        $serializedNode = json_encode($this->nodeInfoHelper->renderNodeWithMinimalPropertiesAndChildrenInformation($node, $this->controllerContext));
+        $attributes['data-__neos-nodedata'] = $serializedNode;
 
         $this->userLocaleService->switchToUILocale(true);
 
         $wrappedContent = $this->htmlAugmenter->addAttributes($content, $attributes, 'div');
-        $wrappedContent .= "<script data-neos-nodedata>(function(){(this['@Neos.Neos.Ui:Nodes'] = this['@Neos.Neos.Ui:Nodes'] || {})['{$node->getContextPath()}'] = {$serializedNode}})()</script>";
-
         return $wrappedContent;
     }
 

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -532,6 +532,7 @@ class BackendServiceController extends ActionController
         $createContext = array_shift($chain);
         $finisher = array_pop($chain);
 
+        // we deduplicate passed nodes here
         $nodeContextPaths = array_unique(array_column($createContext['payload'], '$node'));
 
         $flowQuery = new FlowQuery(array_map(

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -567,7 +567,7 @@ class BackendServiceController extends ActionController
                 $nodeTypeFilter = $finisher['payload']['nodeTypeFilter'] ?? null;
                 $result = $nodeInfoHelper->renderNodesWithParents(
                     array_filter($flowQuery->get()),
-                    $this->getControllerContext(), 
+                    $this->getControllerContext(),
                     $nodeTypeFilter
                 );
                 break;

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -532,11 +532,13 @@ class BackendServiceController extends ActionController
         $createContext = array_shift($chain);
         $finisher = array_pop($chain);
 
+        $nodeContextPaths = array_unique(array_column($createContext['payload'], '$node'));
+
         $flowQuery = new FlowQuery(array_map(
-            function ($envelope) {
-                return $this->nodeService->getNodeFromContextPath($envelope['$node']);
+            function ($contextPath) {
+                return $this->nodeService->getNodeFromContextPath($contextPath);
             },
-            $createContext['payload']
+            $nodeContextPaths
         ));
 
         foreach ($chain as $operation) {
@@ -548,8 +550,8 @@ class BackendServiceController extends ActionController
 
         switch ($finisher['type']) {
             case 'get':
-                $result = $nodeInfoHelper->renderNodes(array_filter(
-                    $flowQuery->get()),
+                $result = $nodeInfoHelper->renderNodes(
+                    array_filter($flowQuery->get()),
                     $this->getControllerContext()
                 );
                 break;

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -548,14 +548,25 @@ class BackendServiceController extends ActionController
 
         switch ($finisher['type']) {
             case 'get':
-                $result = $nodeInfoHelper->renderNodes(array_filter($flowQuery->get()), $this->getControllerContext());
+                $result = $nodeInfoHelper->renderNodes(array_filter(
+                    $flowQuery->get()),
+                    $this->getControllerContext()
+                );
                 break;
             case 'getForTree':
-                $result = $nodeInfoHelper->renderNodes(array_filter($flowQuery->get()), $this->getControllerContext(), true);
+                $result = $nodeInfoHelper->renderNodes(
+                    array_filter($flowQuery->get()),
+                    $this->getControllerContext(),
+                    true
+                );
                 break;
             case 'getForTreeWithParents':
                 $nodeTypeFilter = $finisher['payload']['nodeTypeFilter'] ?? null;
-                $result = $nodeInfoHelper->renderNodesWithParents(array_filter($flowQuery->get()), $this->getControllerContext(), $nodeTypeFilter);
+                $result = $nodeInfoHelper->renderNodesWithParents(
+                    array_filter($flowQuery->get()),
+                    $this->getControllerContext(), 
+                    $nodeTypeFilter
+                );
                 break;
         }
 

--- a/Classes/Domain/Service/UserLocaleService.php
+++ b/Classes/Domain/Service/UserLocaleService.php
@@ -38,6 +38,13 @@ class UserLocaleService
     protected $rememberedContentLocale;
 
     /**
+     * Remebered content locale for locale switching
+     *
+     * @var Locale
+     */
+    protected $rememberedUserLocale;
+
+    /**
      * For serialization, we need to respect the UI locale, rather than the content locale
      *
      * @param boolean $reset Reset to remebered locale
@@ -47,11 +54,15 @@ class UserLocaleService
         if ($reset === true) {
             // Reset the locale
             $this->i18nService->getConfiguration()->setCurrentLocale($this->rememberedContentLocale);
+        } elseif ($this->rememberedUserLocale) {
+            // Restore the local
+            $this->i18nService->getConfiguration()->setCurrentLocale($this->rememberedUserLocale);
         } else {
             $this->rememberedContentLocale = $this->i18nService->getConfiguration()->getCurrentLocale();
             $userLocalePreference = ($this->userService->getCurrentUser() ? $this->userService->getCurrentUser()->getPreferences()->getInterfaceLanguage() : null);
             $defaultLocale = $this->i18nService->getConfiguration()->getDefaultLocale();
             $userLocale = $userLocalePreference ? new Locale($userLocalePreference) : $defaultLocale;
+            $this->rememberedUserLocale = $userLocale;
             $this->i18nService->getConfiguration()->setCurrentLocale($userLocale);
         }
     }

--- a/Classes/Domain/Service/UserLocaleService.php
+++ b/Classes/Domain/Service/UserLocaleService.php
@@ -15,6 +15,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\I18n\Locale;
 use Neos\Flow\I18n\Service as I18nService;
 use Neos\Neos\Domain\Service\UserService;
+use Neos\Neos\Fusion\Helper\NodeLabelToken;
 
 class UserLocaleService
 {
@@ -38,14 +39,17 @@ class UserLocaleService
     protected $rememberedContentLocale;
 
     /**
-     * Remebered content locale for locale switching
+     * The current user's locale (cached for performance)
      *
      * @var Locale
      */
-    protected $rememberedUserLocale;
+    protected $userLocaleRuntimeCache;
 
     /**
      * For serialization, we need to respect the UI locale, rather than the content locale
+     * This is done to translate the node labels correctly.
+     * For example {@see NodeLabelToken::resolveLabelFromNodeType()} will call the translator which will uses the globally set locale.
+     * FIXME we should eliminate hacking the global state and passing the locale differently
      *
      * @param boolean $reset Reset to remebered locale
      */
@@ -54,16 +58,17 @@ class UserLocaleService
         if ($reset === true) {
             // Reset the locale
             $this->i18nService->getConfiguration()->setCurrentLocale($this->rememberedContentLocale);
-        } elseif ($this->rememberedUserLocale) {
-            // Restore the local
-            $this->i18nService->getConfiguration()->setCurrentLocale($this->rememberedUserLocale);
-        } else {
-            $this->rememberedContentLocale = $this->i18nService->getConfiguration()->getCurrentLocale();
-            $userLocalePreference = ($this->userService->getCurrentUser() ? $this->userService->getCurrentUser()->getPreferences()->getInterfaceLanguage() : null);
-            $defaultLocale = $this->i18nService->getConfiguration()->getDefaultLocale();
-            $userLocale = $userLocalePreference ? new Locale($userLocalePreference) : $defaultLocale;
-            $this->rememberedUserLocale = $userLocale;
-            $this->i18nService->getConfiguration()->setCurrentLocale($userLocale);
+            return;
         }
+        $this->rememberedContentLocale = $this->i18nService->getConfiguration()->getCurrentLocale();
+        if ($this->userLocaleRuntimeCache) {
+            $this->i18nService->getConfiguration()->setCurrentLocale($this->userLocaleRuntimeCache);
+            return;
+        }
+        $userLocalePreference = ($this->userService->getCurrentUser() ? $this->userService->getCurrentUser()->getPreferences()->getInterfaceLanguage() : null);
+        $defaultLocale = $this->i18nService->getConfiguration()->getDefaultLocale();
+        $userLocale = $userLocalePreference ? new Locale($userLocalePreference) : $defaultLocale;
+        $this->userLocaleRuntimeCache = $userLocale;
+        $this->i18nService->getConfiguration()->setCurrentLocale($userLocale);
     }
 }

--- a/Classes/FlowQueryOperations/NeosUiDefaultNodesOperation.php
+++ b/Classes/FlowQueryOperations/NeosUiDefaultNodesOperation.php
@@ -72,8 +72,9 @@ class NeosUiDefaultNodesOperation extends AbstractOperation
     public function evaluate(FlowQuery $flowQuery, array $arguments)
     {
         /** @var TraversableNodeInterface $siteNode */
+        $siteNode = $flowQuery->getContext()[0];
         /** @var TraversableNodeInterface $documentNode */
-        list($siteNode, $documentNode) = $flowQuery->getContext();
+        $documentNode = $flowQuery->getContext()[1] ?? $siteNode;
         /** @var string[] $toggledNodes */
         list($baseNodeType, $loadingDepth, $toggledNodes, $clipboardNodesContextPaths) = $arguments;
 

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -155,7 +155,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
     /**
      * @param NodeInterface $node
      * @param ControllerContext|null $controllerContext
-     * @param string $nodeTypeFilterOverride
+     * @param string|null $nodeTypeFilterOverride
      * @return array|null
      */
     public function renderNodeWithPropertiesAndChildrenInformation(NodeInterface $node, ControllerContext $controllerContext = null, string $nodeTypeFilterOverride = null)
@@ -177,7 +177,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
             }
         }
 
-        $baseNodeType = $nodeTypeFilterOverride ? $nodeTypeFilterOverride : (isset($presetBaseNodeType) ? $presetBaseNodeType : $this->defaultBaseNodeType);
+        $baseNodeType = $nodeTypeFilterOverride ?: (isset($presetBaseNodeType) ? $presetBaseNodeType : $this->defaultBaseNodeType);
         $nodeInfo['children'] = $this->renderChildrenInformation($node, $baseNodeType);
 
         $this->userLocaleService->switchToUILocale(true);
@@ -246,10 +246,10 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
         $contentChildNodes = $node->getChildNodes($this->buildContentChildNodeFilterString());
         $childNodes = array_merge($documentChildNodes, $contentChildNodes);
 
-        $mapper = function (NodeInterface $childNode) {
+        $mapper = static function (NodeInterface $childNode) {
             return [
                 'contextPath' => $childNode->getContextPath(),
-                'nodeType' => $childNode->getNodeType()->getName() // TODO: DUPLICATED; should NOT be needed!!!
+                'nodeType' => $childNode->getNodeType()->getName()
             ];
         };
 

--- a/packages/neos-ui-guest-frame/src/initializeContentDomNode.js
+++ b/packages/neos-ui-guest-frame/src/initializeContentDomNode.js
@@ -10,7 +10,8 @@ import initializePropertyDomNode from './initializePropertyDomNode';
 
 import style from './style.module.css';
 
-export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry, nodes}) => contentDomNode => {
+export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry}) => contentDomNode => {
+    const nodes = store.getState().cr.nodes.byContextPath;
     const contextPath = contentDomNode.getAttribute('data-__neos-node-contextpath');
 
     if (!nodes[contextPath]) {

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -87,17 +87,20 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
         return nodes;
     }, {}) : [];
 
-    const nodes = Object.assign(
+    let nodes = Object.assign(
         {},
         legacyNodeData, // Merge legacy node data from the guest frame - remove with Neos 9.0
-        nodesAlreadyPresentInStore,
         fullyLoadedNodesFromContent,
         {
             [documentInformation.metaData.documentNode]: documentInformation.metaData.documentNodeSerialization
         }
     );
 
+    // Merge new nodes into the store
     yield put(actions.CR.Nodes.merge(nodes));
+
+    // Combine new and existing nodes into a list for initialisation in the guest frame
+    nodes = Object.assign(nodes, nodesAlreadyPresentInStore);
 
     // Remove the legacy inline scripts after initialization - remove with Neos 9.0
     Array.prototype.forEach.call(guestFrameWindow.document.querySelectorAll('script[data-neos-nodedata]'), element => element.parentElement.removeChild(element));

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -62,7 +62,7 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
     }
 
     // Load legacy node data scripts from guest frame - remove with Neos 9.0
-    const legacyNodeData = guestFrameWindow['@Neos.Neos.Ui:NodeData'] || {};
+    const legacyNodeData = guestFrameWindow['@Neos.Neos.Ui:Nodes'] || {};
 
     // Load all nodedata for nodes in the guest frame
     const {q} = yield backend.get();

--- a/packages/neos-ui-sagas/src/UI/ContentTree/index.js
+++ b/packages/neos-ui-sagas/src/UI/ContentTree/index.js
@@ -141,30 +141,23 @@ export function * watchCurrentDocument({globalRegistry, configuration}) {
             return;
         }
 
-        const state = yield select();
-        const childrenAreFullyLoaded = $get(['cr', 'nodes', 'byContextPath', contextPath, 'children'], state)
-        .filter(childEnvelope => nodeTypesRegistry.hasRole(childEnvelope.nodeType, 'content') || nodeTypesRegistry.hasRole(childEnvelope.nodeType, 'contentCollection'))
-        .every(
-            childEnvelope => Boolean($get(['cr', 'nodes', 'byContextPath', $get('contextPath', childEnvelope)], state))
-        );
+        // Always reload the nodes for the current page, when the document node changes.
+        // In the past, the guest frame loaded the latest nodedata from the rendered content, but this has been removed.
+        yield put(actions.UI.ContentTree.setAsLoading(contextPath));
 
-        if (!childrenAreFullyLoaded) {
-            yield put(actions.UI.ContentTree.setAsLoading(contextPath));
+        const nodeTypeFilter = `${nodeTypesRegistry.getRole('contentCollection')},${nodeTypesRegistry.getRole('content')}`;
+        const nodes = yield q([contextPath]).neosUiDefaultNodes(
+            nodeTypeFilter,
+            configuration.structureTree.loadingDepth,
+            [],
+            []
+        ).get();
+        const nodeMap = nodes.reduce((nodeMap, node) => {
+            nodeMap[$get('contextPath', node)] = node;
+            return nodeMap;
+        }, {});
 
-            const nodeTypeFilter = `${nodeTypesRegistry.getRole('contentCollection')},${nodeTypesRegistry.getRole('content')}`;
-            const nodes = yield q([contextPath]).neosUiDefaultNodes(
-                nodeTypeFilter,
-                configuration.structureTree.loadingDepth,
-                [],
-                []
-            ).get();
-            const nodeMap = nodes.reduce((nodeMap, node) => {
-                nodeMap[$get('contextPath', node)] = node;
-                return nodeMap;
-            }, {});
-
-            yield put(actions.CR.Nodes.merge(nodeMap));
-            yield put(actions.UI.ContentTree.setAsLoaded(contextPath));
-        }
+        yield put(actions.CR.Nodes.merge(nodeMap));
+        yield put(actions.UI.ContentTree.setAsLoaded(contextPath));
     });
 }

--- a/packages/neos-ui-sagas/src/UI/ContentTree/index.js
+++ b/packages/neos-ui-sagas/src/UI/ContentTree/index.js
@@ -152,7 +152,7 @@ export function * watchCurrentDocument({globalRegistry, configuration}) {
             yield put(actions.UI.ContentTree.setAsLoading(contextPath));
 
             const nodeTypeFilter = `${nodeTypesRegistry.getRole('contentCollection')},${nodeTypesRegistry.getRole('content')}`;
-            const nodes = yield q([contextPath, contextPath]).neosUiDefaultNodes(
+            const nodes = yield q([contextPath]).neosUiDefaultNodes(
                 nodeTypeFilter,
                 configuration.structureTree.loadingDepth,
                 [],


### PR DESCRIPTION
**What I did**

With this change the minimal required nodedata for each node in the rendered
content is inserted as data attribute and not as inline script anymore.
This improves performance as no extra function call is executed for each node.

Additonally the reduction in rendered node attributes reduces the output filesize and again improves loading time.

To prevent just-in-time loading of nodes all incomplete nodedata is requested after the guest frame has finished loading.

One big benefit of that is that the scripts tags won't interfere with JS plugins anymore and using the Fusion Augmenter will not wrap a single object with a ContentWrapping with another tag due to the script tag.

Fixes https://github.com/neos/neos-development-collection/issues/2988

**How to verify it**

To test this change one can use the `bugfix/remove-ui-script-tag-compiled-artifacts` branch in composer:

```
"neos/neos-ui": "dev-bugfix/remove-ui-script-tag-compiled-artifacts as 8.3.8",
```

* Check whether content is still properly editable
* Inspector shouldn't show a loading spinner when content is selected
* `preview` document should be smaller (10-30%) than before and load quicker (10-40%)
* No script tags with node data in the raw preview html document

- [x] Load nodedata async after guest frame has loaded
- [ ] Visualise for user that backend still loads data before page is fully editable