### PR TITLE
FEATURE: Level up to PHPStan 8

### DIFF
--- a/Classes/Application/SyncWorkspace/ConflictsBuilder.php
+++ b/Classes/Application/SyncWorkspace/ConflictsBuilder.php
@@ -109,13 +109,13 @@ final class ConflictsBuilder
             $nodeAggregateId
         );
         $affectedSite = $nodeAggregateId
-            ? $subgraph->findClosestNode(
+            ? $subgraph?->findClosestNode(
                 $nodeAggregateId,
                 FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_SITE)
             )
             : null;
         $affectedDocument = $nodeAggregateId
-            ? $subgraph->findClosestNode(
+            ? $subgraph?->findClosestNode(
                 $nodeAggregateId,
                 FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_DOCUMENT)
             )
@@ -214,11 +214,11 @@ final class ConflictsBuilder
                 $dimensionSpacePoint = $this->extractValidDimensionSpacePointFromNodeAggregate(
                     $nodeAggregate
                 );
-
-                if ($dimensionSpacePoint === null) {
-                    return null;
-                }
             }
+        }
+
+        if ($dimensionSpacePoint === null) {
+            return null;
         }
 
         return $contentGraph->getSubgraph(

--- a/Classes/Application/SyncWorkspace/SyncWorkspaceCommand.php
+++ b/Classes/Application/SyncWorkspace/SyncWorkspaceCommand.php
@@ -32,7 +32,7 @@ final readonly class SyncWorkspaceCommand
     public function __construct(
         public ContentRepositoryId $contentRepositoryId,
         public WorkspaceName $workspaceName,
-        public DimensionSpacePoint $preferredDimensionSpacePoint,
+        public ?DimensionSpacePoint $preferredDimensionSpacePoint,
         public RebaseErrorHandlingStrategy $rebaseErrorHandlingStrategy
     ) {
     }

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -146,6 +146,7 @@ class BackendController extends ActionController
         }
 
         $currentAccount = $this->securityContext->getAccount();
+        assert($currentAccount !== null);
         $workspaceName = WorkspaceNameBuilder::fromAccountIdentifier($currentAccount->getAccountIdentifier());
 
         try {

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -418,6 +418,7 @@ class BackendServiceController extends ActionController
         $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
 
         $currentAccount = $this->securityContext->getAccount();
+        assert($currentAccount !== null);
         $userWorkspaceName = WorkspaceNameBuilder::fromAccountIdentifier(
             $currentAccount->getAccountIdentifier()
         );

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -17,6 +17,7 @@ namespace Neos\Neos\Ui\Controller;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\WorkspaceModification\Exception\WorkspaceIsNotEmptyException;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Dto\RebaseErrorHandlingStrategy;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\Exception\NodeAggregateCurrentlyDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Exception\NodeAggregateDoesCurrentlyNotCoverDimensionSpacePoint;
@@ -477,17 +478,19 @@ class BackendServiceController extends ActionController
         // todo ensure that https://github.com/neos/neos-ui/pull/3734 doesnt need to be refixed in Neos 9.0
         $redirectNode = $documentNode;
         while (true) {
+            // @phpstan-ignore-next-line
             $redirectNodeInBaseWorkspace = $subgraph->findNodeById($redirectNode->aggregateId);
             if ($redirectNodeInBaseWorkspace) {
                 break;
             } else {
+                // @phpstan-ignore-next-line
                 $redirectNode = $subgraph->findParentNode($redirectNode->aggregateId);
                 // get parent always returns Node
                 if (!$redirectNode) {
                     throw new \Exception(
                         sprintf(
                             'Wasn\'t able to locate any valid node in rootline of node %s in the workspace %s.',
-                            $documentNode->aggregateId->value,
+                            $documentNode?->aggregateId->value,
                             $targetWorkspaceName
                         ),
                         1458814469
@@ -495,6 +498,8 @@ class BackendServiceController extends ActionController
                 }
             }
         }
+        /** @var Node $documentNode */
+        /** @var Node $redirectNode */
 
         // If current document node exists in the base workspace, then reload, else redirect
         if ($redirectNode->equals($documentNode)) {

--- a/Classes/Domain/Model/AbstractChange.php
+++ b/Classes/Domain/Model/AbstractChange.php
@@ -28,7 +28,7 @@ use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateWorkspaceInfo;
  */
 abstract class AbstractChange implements ChangeInterface
 {
-    protected ?Node $subject = null;
+    protected Node $subject;
 
     #[Flow\Inject]
     protected ContentRepositoryRegistry $contentRepositoryRegistry;
@@ -56,7 +56,7 @@ abstract class AbstractChange implements ChangeInterface
         $this->subject = $subject;
     }
 
-    final public function getSubject(): ?Node
+    final public function getSubject(): Node
     {
         return $this->subject;
     }
@@ -66,13 +66,11 @@ abstract class AbstractChange implements ChangeInterface
      */
     final protected function updateWorkspaceInfo(): void
     {
-        if (!is_null($this->subject)) {
-            $subgraph = $this->contentRepositoryRegistry->subgraphForNode($this->subject);
-            $documentNode = $subgraph->findClosestNode($this->subject->aggregateId, FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_DOCUMENT));
-            if (!is_null($documentNode)) {
-                $updateWorkspaceInfo = new UpdateWorkspaceInfo($documentNode->contentRepositoryId, $documentNode->workspaceName);
-                $this->feedbackCollection->add($updateWorkspaceInfo);
-            }
+        $subgraph = $this->contentRepositoryRegistry->subgraphForNode($this->subject);
+        $documentNode = $subgraph->findClosestNode($this->subject->aggregateId, FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_DOCUMENT));
+        if (!is_null($documentNode)) {
+            $updateWorkspaceInfo = new UpdateWorkspaceInfo($documentNode->contentRepositoryId, $documentNode->workspaceName);
+            $this->feedbackCollection->add($updateWorkspaceInfo);
         }
     }
 
@@ -108,11 +106,9 @@ abstract class AbstractChange implements ChangeInterface
      */
     final protected function addNodeCreatedFeedback(Node $subject = null): void
     {
-        $node = $subject ?: $this->getSubject();
-        if ($node) {
-            $nodeCreated = new NodeCreated();
-            $nodeCreated->setNode($node);
-            $this->feedbackCollection->add($nodeCreated);
-        }
+        $node = $subject ?? $this->getSubject();
+        $nodeCreated = new NodeCreated();
+        $nodeCreated->setNode($node);
+        $this->feedbackCollection->add($nodeCreated);
     }
 }

--- a/Classes/Domain/Model/ChangeInterface.php
+++ b/Classes/Domain/Model/ChangeInterface.php
@@ -29,7 +29,7 @@ interface ChangeInterface
     /**
      * Get the subject
      */
-    public function getSubject(): ?Node;
+    public function getSubject(): Node;
 
     /**
      * Checks whether this change can be applied to the subject

--- a/Classes/Domain/Model/Changes/AbstractStructuralChange.php
+++ b/Classes/Domain/Model/Changes/AbstractStructuralChange.php
@@ -173,14 +173,14 @@ abstract class AbstractStructuralChange extends AbstractChange
         }
     }
 
-    protected function findChildNodes(Node $node): Nodes
+    final protected function findChildNodes(Node $node): Nodes
     {
         // TODO REMOVE
         return $this->contentRepositoryRegistry->subgraphForNode($node)
             ->findChildNodes($node->aggregateId, FindChildNodesFilter::create());
     }
 
-    protected function isNodeTypeAllowedAsChildNode(Node $parentNode, NodeTypeName $nodeTypeNameToCheck): bool
+    final protected function isNodeTypeAllowedAsChildNode(Node $parentNode, NodeTypeName $nodeTypeNameToCheck): bool
     {
         $nodeTypeManager = $this->contentRepositoryRegistry->get($parentNode->contentRepositoryId)->getNodeTypeManager();
 
@@ -196,7 +196,7 @@ abstract class AbstractStructuralChange extends AbstractChange
             }
             return $parentNodeType->allowsChildNodeType($nodeTypeToCheck);
         }
-
+        assert($parentNode->name !== null); // were tethered
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($parentNode);
         $grandParentNode = $subgraph->findParentNode($parentNode->aggregateId);
 

--- a/Classes/Domain/Model/Changes/AbstractStructuralChange.php
+++ b/Classes/Domain/Model/Changes/AbstractStructuralChange.php
@@ -102,7 +102,7 @@ abstract class AbstractStructuralChange extends AbstractChange
      */
     public function getSiblingNode(): ?Node
     {
-        if ($this->siblingDomAddress === null || !$this->getSubject()) {
+        if ($this->siblingDomAddress === null) {
             return null;
         }
 

--- a/Classes/Domain/Model/Changes/CopyAfter.php
+++ b/Classes/Domain/Model/Changes/CopyAfter.php
@@ -30,9 +30,6 @@ class CopyAfter extends AbstractStructuralChange
      */
     public function canApply(): bool
     {
-        if (is_null($this->subject)) {
-            return false;
-        }
         $siblingNode = $this->getSiblingNode();
         if (is_null($siblingNode)) {
             return false;
@@ -57,7 +54,7 @@ class CopyAfter extends AbstractStructuralChange
             : null;
         $subject = $this->subject;
 
-        if ($this->canApply() && $subject && !is_null($previousSibling) && !is_null($parentNodeOfPreviousSibling)) {
+        if ($this->canApply() && !is_null($previousSibling) && !is_null($parentNodeOfPreviousSibling)) {
             $succeedingSibling = null;
             try {
                 $succeedingSibling = $this->findChildNodes($parentNodeOfPreviousSibling)->next($previousSibling);

--- a/Classes/Domain/Model/Changes/CopyAfter.php
+++ b/Classes/Domain/Model/Changes/CopyAfter.php
@@ -81,10 +81,13 @@ class CopyAfter extends AbstractStructuralChange
 
             $contentRepository->handle($command);
 
+            $newlyCreatedNodeId = $command->nodeAggregateIdMapping->getNewNodeAggregateId($subject->aggregateId);
+            assert($newlyCreatedNodeId !== null); // cannot happen
             $newlyCreatedNode = $this->contentRepositoryRegistry->subgraphForNode($parentNodeOfPreviousSibling)
-                ->findNodeById(
-                    $command->nodeAggregateIdMapping->getNewNodeAggregateId($subject->aggregateId)
-                );
+                ->findNodeById($newlyCreatedNodeId);
+            if (!$newlyCreatedNode) {
+                throw new \RuntimeException(sprintf('Node %s was not found after copy.', $newlyCreatedNodeId->value), 1716023308);
+            }
             $this->finish($newlyCreatedNode);
             // NOTE: we need to run "finish" before "addNodeCreatedFeedback"
             // to ensure the new node already exists when the last feedback is processed

--- a/Classes/Domain/Model/Changes/CopyBefore.php
+++ b/Classes/Domain/Model/Changes/CopyBefore.php
@@ -76,10 +76,13 @@ class CopyBefore extends AbstractStructuralChange
 
             $contentRepository->handle($command);
 
+            $newlyCreatedNodeId = $command->nodeAggregateIdMapping->getNewNodeAggregateId($subject->aggregateId);
+            assert($newlyCreatedNodeId !== null); // cannot happen
             $newlyCreatedNode = $this->contentRepositoryRegistry->subgraphForNode($parentNodeOfSucceedingSibling)
-                ->findNodeById(
-                    $command->nodeAggregateIdMapping->getNewNodeAggregateId($subject->aggregateId)
-                );
+                ->findNodeById($newlyCreatedNodeId);
+            if (!$newlyCreatedNode) {
+                throw new \RuntimeException(sprintf('Node %s was not found after copy.', $newlyCreatedNodeId->value), 1716023308);
+            }
             $this->finish($newlyCreatedNode);
             // NOTE: we need to run "finish" before "addNodeCreatedFeedback"
             // to ensure the new node already exists when the last feedback is processed

--- a/Classes/Domain/Model/Changes/CopyBefore.php
+++ b/Classes/Domain/Model/Changes/CopyBefore.php
@@ -28,9 +28,6 @@ class CopyBefore extends AbstractStructuralChange
      */
     public function canApply(): bool
     {
-        if (is_null($this->subject)) {
-            return false;
-        }
         $siblingNode = $this->getSiblingNode();
         if (is_null($siblingNode)) {
             return false;
@@ -57,7 +54,7 @@ class CopyBefore extends AbstractStructuralChange
             ? $this->findParentNode($succeedingSibling)
             : null;
         $subject = $this->subject;
-        if ($this->canApply() && !is_null($subject) && !is_null($succeedingSibling)
+        if ($this->canApply() && !is_null($succeedingSibling)
             && !is_null($parentNodeOfSucceedingSibling)
         ) {
             $contentRepository = $this->contentRepositoryRegistry->get($subject->contentRepositoryId);

--- a/Classes/Domain/Model/Changes/CopyInto.php
+++ b/Classes/Domain/Model/Changes/CopyInto.php
@@ -51,7 +51,7 @@ class CopyInto extends AbstractStructuralChange
     {
         $parentNode = $this->getParentNode();
 
-        return $this->subject && $parentNode && $this->isNodeTypeAllowedAsChildNode($parentNode, $this->subject->nodeTypeName);
+        return $parentNode && $this->isNodeTypeAllowedAsChildNode($parentNode, $this->subject->nodeTypeName);
     }
 
     public function getMode(): string
@@ -66,7 +66,7 @@ class CopyInto extends AbstractStructuralChange
     {
         $subject = $this->getSubject();
         $parentNode = $this->getParentNode();
-        if ($parentNode && $subject && $this->canApply()) {
+        if ($parentNode && $this->canApply()) {
             $contentRepository = $this->contentRepositoryRegistry->get($subject->contentRepositoryId);
             $command = CopyNodesRecursively::createFromSubgraphAndStartNode(
                 $contentRepository->getContentGraph($subject->workspaceName)->getSubgraph(

--- a/Classes/Domain/Model/Changes/Create.php
+++ b/Classes/Domain/Model/Changes/Create.php
@@ -40,7 +40,7 @@ class Create extends AbstractCreate
         $subject = $this->getSubject();
         $nodeTypeName = $this->getNodeTypeName();
 
-        return $subject && $nodeTypeName && $this->isNodeTypeAllowedAsChildNode($subject, $nodeTypeName);
+        return $nodeTypeName && $this->isNodeTypeAllowedAsChildNode($subject, $nodeTypeName);
     }
 
     /**
@@ -49,7 +49,7 @@ class Create extends AbstractCreate
     public function apply(): void
     {
         $parentNode = $this->getSubject();
-        if ($parentNode && $this->canApply()) {
+        if ($this->canApply()) {
             $this->createNode($parentNode, null);
             $this->updateWorkspaceInfo();
         }

--- a/Classes/Domain/Model/Changes/Create.php
+++ b/Classes/Domain/Model/Changes/Create.php
@@ -40,7 +40,7 @@ class Create extends AbstractCreate
         $subject = $this->getSubject();
         $nodeTypeName = $this->getNodeTypeName();
 
-        return $this->isNodeTypeAllowedAsChildNode($subject, $nodeTypeName);
+        return $subject && $nodeTypeName && $this->isNodeTypeAllowedAsChildNode($subject, $nodeTypeName);
     }
 
     /**

--- a/Classes/Domain/Model/Changes/CreateAfter.php
+++ b/Classes/Domain/Model/Changes/CreateAfter.php
@@ -32,9 +32,6 @@ class CreateAfter extends AbstractCreate
      */
     public function canApply(): bool
     {
-        if (is_null($this->subject)) {
-            return false;
-        }
         $parent = $this->findParentNode($this->subject);
         $nodeTypeName = $this->getNodeTypeName();
 
@@ -46,9 +43,9 @@ class CreateAfter extends AbstractCreate
      */
     public function apply(): void
     {
-        $parentNode = $this->subject ? $this->findParentNode($this->subject) : null;
+        $parentNode = $this->findParentNode($this->subject);
         $subject = $this->subject;
-        if ($this->canApply() && !is_null($subject) && !is_null($parentNode)) {
+        if ($this->canApply() && !is_null($parentNode)) {
             $succeedingSibling = null;
             try {
                 $succeedingSibling = $this->findChildNodes($parentNode)->next($subject);

--- a/Classes/Domain/Model/Changes/CreateAfter.php
+++ b/Classes/Domain/Model/Changes/CreateAfter.php
@@ -38,7 +38,7 @@ class CreateAfter extends AbstractCreate
         $parent = $this->findParentNode($this->subject);
         $nodeTypeName = $this->getNodeTypeName();
 
-        return $parent && $this->isNodeTypeAllowedAsChildNode($parent, $nodeTypeName);
+        return $parent && $nodeTypeName && $this->isNodeTypeAllowedAsChildNode($parent, $nodeTypeName);
     }
 
     /**

--- a/Classes/Domain/Model/Changes/CreateBefore.php
+++ b/Classes/Domain/Model/Changes/CreateBefore.php
@@ -38,7 +38,7 @@ class CreateBefore extends AbstractCreate
         $parent = $this->findParentNode($this->subject);
         $nodeTypeName = $this->getNodeTypeName();
 
-        return $parent && $this->isNodeTypeAllowedAsChildNode($parent, $nodeTypeName);
+        return $parent && $nodeTypeName && $this->isNodeTypeAllowedAsChildNode($parent, $nodeTypeName);
     }
 
     /**

--- a/Classes/Domain/Model/Changes/CreateBefore.php
+++ b/Classes/Domain/Model/Changes/CreateBefore.php
@@ -32,9 +32,6 @@ class CreateBefore extends AbstractCreate
      */
     public function canApply(): bool
     {
-        if (is_null($this->subject)) {
-            return false;
-        }
         $parent = $this->findParentNode($this->subject);
         $nodeTypeName = $this->getNodeTypeName();
 
@@ -46,9 +43,9 @@ class CreateBefore extends AbstractCreate
      */
     public function apply(): void
     {
-        $parent = $this->subject ? $this->findParentNode($this->subject) : null;
+        $parent = $this->findParentNode($this->subject);
         $subject = $this->subject;
-        if ($this->canApply() && !is_null($subject) && !is_null($parent)) {
+        if ($this->canApply() && !is_null($parent)) {
             $this->createNode($parent, $subject->aggregateId);
             $this->updateWorkspaceInfo();
         }

--- a/Classes/Domain/Model/Changes/MoveAfter.php
+++ b/Classes/Domain/Model/Changes/MoveAfter.php
@@ -30,9 +30,6 @@ class MoveAfter extends AbstractStructuralChange
      */
     public function canApply(): bool
     {
-        if (is_null($this->subject)) {
-            return false;
-        }
         $sibling = $this->getSiblingNode();
         if (is_null($sibling)) {
             return false;
@@ -58,9 +55,8 @@ class MoveAfter extends AbstractStructuralChange
         $parentNodeOfPreviousSibling = $precedingSibling ? $this->findParentNode($precedingSibling) : null;
         // "subject" is the to-be-moved node
         $subject = $this->subject;
-        $parentNode = $this->subject ? $this->findParentNode($this->subject) : null;
+        $parentNode = $this->findParentNode($this->subject);
         if ($this->canApply()
-            && !is_null($subject)
             && !is_null($precedingSibling)
             && !is_null($parentNodeOfPreviousSibling)
             && !is_null($parentNode)

--- a/Classes/Domain/Model/Changes/MoveBefore.php
+++ b/Classes/Domain/Model/Changes/MoveBefore.php
@@ -29,9 +29,6 @@ class MoveBefore extends AbstractStructuralChange
      */
     public function canApply(): bool
     {
-        if (is_null($this->subject)) {
-            return false;
-        }
         $siblingNode = $this->getSiblingNode();
         if (is_null($siblingNode)) {
             return false;
@@ -54,9 +51,9 @@ class MoveBefore extends AbstractStructuralChange
         $succeedingSibling = $this->getSiblingNode();
         // "subject" is the to-be-moved node
         $subject = $this->subject;
-        $parentNode = $subject ? $this->findParentNode($subject) : null;
+        $parentNode = $this->findParentNode($subject);
         $succeedingSiblingParent = $succeedingSibling ? $this->findParentNode($succeedingSibling) : null;
-        if ($this->canApply() && !is_null($subject) && !is_null($succeedingSibling)
+        if ($this->canApply() && !is_null($succeedingSibling)
             && !is_null($parentNode) && !is_null($succeedingSiblingParent)
         ) {
             $precedingSibling = null;

--- a/Classes/Domain/Model/Changes/MoveInto.php
+++ b/Classes/Domain/Model/Changes/MoveInto.php
@@ -33,7 +33,7 @@ class MoveInto extends AbstractStructuralChange
 
     public function getParentNode(): ?Node
     {
-        if ($this->parentContextPath === null || !$this->getSubject()) {
+        if ($this->parentContextPath === null) {
             return null;
         }
 
@@ -57,9 +57,6 @@ class MoveInto extends AbstractStructuralChange
      */
     public function canApply(): bool
     {
-        if (is_null($this->subject)) {
-            return false;
-        }
         $parent = $this->getParentNode();
 
         return $parent && $this->isNodeTypeAllowedAsChildNode($parent, $this->subject->nodeTypeName);
@@ -74,7 +71,7 @@ class MoveInto extends AbstractStructuralChange
         $parentNode = $this->getParentNode();
         // "subject" is the to-be-moved node
         $subject = $this->subject;
-        if ($this->canApply() && $parentNode && $subject) {
+        if ($this->canApply() && $parentNode) {
             $otherParent = $this->contentRepositoryRegistry->subgraphForNode($subject)
                 ->findParentNode($subject->aggregateId);
 

--- a/Classes/Domain/Model/Changes/MoveInto.php
+++ b/Classes/Domain/Model/Changes/MoveInto.php
@@ -33,7 +33,7 @@ class MoveInto extends AbstractStructuralChange
 
     public function getParentNode(): ?Node
     {
-        if ($this->parentContextPath === null) {
+        if ($this->parentContextPath === null || !$this->getSubject()) {
             return null;
         }
 

--- a/Classes/Domain/Model/Changes/Property.php
+++ b/Classes/Domain/Model/Changes/Property.php
@@ -126,7 +126,7 @@ class Property extends AbstractChange
     public function canApply(): bool
     {
         $propertyName = $this->getPropertyName();
-        if (!$this->subject || !$propertyName) {
+        if (!$propertyName) {
             return false;
         }
         $nodeType = $this->getNodeType($this->subject);
@@ -147,9 +147,9 @@ class Property extends AbstractChange
     public function apply(): void
     {
         $subject = $this->subject;
-        $nodeType = $subject ? $this->getNodeType($subject) : null;
+        $nodeType = $this->getNodeType($subject);
         $propertyName = $this->getPropertyName();
-        if (is_null($subject) || is_null($nodeType) || is_null($propertyName) || $this->canApply() === false) {
+        if (is_null($nodeType) || is_null($propertyName) || $this->canApply() === false) {
             return;
         }
 

--- a/Classes/Domain/Model/Changes/Remove.php
+++ b/Classes/Domain/Model/Changes/Remove.php
@@ -35,19 +35,13 @@ use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
 class Remove extends AbstractChange
 {
     /**
-     * @Flow\Inject
-     * @var ContentCacheFlusher
-     */
-    protected $contentCacheFlusher;
-
-    /**
      * Checks whether this change can be applied to the subject
      *
      * @return boolean
      */
     public function canApply(): bool
     {
-        return !is_null($this->subject);
+        return true;
     }
 
     /**
@@ -60,7 +54,7 @@ class Remove extends AbstractChange
     public function apply(): void
     {
         $subject = $this->subject;
-        if ($this->canApply() && !is_null($subject)) {
+        if ($this->canApply()) {
             $parentNode = $this->findParentNode($subject);
             if (is_null($parentNode)) {
                 throw new \InvalidArgumentException(

--- a/Classes/Domain/Model/Feedback/Operations/ReloadContentOutOfBand.php
+++ b/Classes/Domain/Model/Feedback/Operations/ReloadContentOutOfBand.php
@@ -127,7 +127,7 @@ class ReloadContentOutOfBand extends AbstractFeedback
     protected function renderContent(ControllerContext $controllerContext): string
     {
         if (!is_null($this->node)) {
-            $cacheTags = $this->cachingHelper->nodeTag($this->getNode());
+            $cacheTags = $this->cachingHelper->nodeTag($this->node);
             foreach ($cacheTags as $tag) {
                 $this->contentCache->flushByTag($tag);
             }

--- a/Classes/Domain/Model/Feedback/Operations/ReloadContentOutOfBand.php
+++ b/Classes/Domain/Model/Feedback/Operations/ReloadContentOutOfBand.php
@@ -136,7 +136,10 @@ class ReloadContentOutOfBand extends AbstractFeedback
                 $renderingMode = $this->renderingModeService->findByCurrentUser();
 
                 $view = $this->outOfBandRenderingViewFactory->resolveView();
-                $view->setControllerContext($controllerContext);
+                if (method_exists($view, 'setControllerContext')) {
+                    // deprecated
+                    $view->setControllerContext($controllerContext);
+                }
                 $view->setOption('renderingModeName', $renderingMode->name);
 
                 $view->assign('value', $this->node);

--- a/Classes/Domain/Model/Feedback/Operations/RenderContentOutOfBand.php
+++ b/Classes/Domain/Model/Feedback/Operations/RenderContentOutOfBand.php
@@ -190,7 +190,10 @@ class RenderContentOutOfBand extends AbstractFeedback
                 $renderingMode = $this->renderingModeService->findByCurrentUser();
 
                 $view = $this->outOfBandRenderingViewFactory->resolveView();
-                $view->setControllerContext($controllerContext);
+                if (method_exists($view, 'setControllerContext')) {
+                    // deprecated
+                    $view->setControllerContext($controllerContext);
+                }
                 $view->setOption('renderingModeName', $renderingMode->name);
 
                 $view->assign('value', $parentNode);

--- a/Classes/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
@@ -27,7 +27,7 @@ use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
  */
 class UpdateNodeInfo extends AbstractFeedback
 {
-    protected ?Node $node = null;
+    protected Node $node;
 
     /**
      * @Flow\Inject
@@ -68,7 +68,7 @@ class UpdateNodeInfo extends AbstractFeedback
         $this->isRecursive = true;
     }
 
-    public function getNode(): ?Node
+    public function getNode(): Node
     {
         return $this->node;
     }
@@ -80,7 +80,7 @@ class UpdateNodeInfo extends AbstractFeedback
 
     public function getDescription(): string
     {
-        return sprintf('Updated info for node "%s" is available.', $this->node?->aggregateId->value);
+        return sprintf('Updated info for node "%s" is available.', $this->node->aggregateId->value);
     }
 
     /**
@@ -102,11 +102,9 @@ class UpdateNodeInfo extends AbstractFeedback
      */
     public function serializePayload(ControllerContext $controllerContext): array
     {
-        return $this->node
-            ? [
-                'byContextPath' => $this->serializeNodeRecursively($this->node, $controllerContext->getRequest())
-            ]
-            : [];
+        return [
+            'byContextPath' => $this->serializeNodeRecursively($this->node, $controllerContext->getRequest())
+        ];
     }
 
     /**

--- a/Classes/Domain/Model/Feedback/Operations/UpdateWorkspaceInfo.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateWorkspaceInfo.php
@@ -26,8 +26,6 @@ use Neos\Neos\Domain\Workspace\WorkspaceProvider;
  */
 class UpdateWorkspaceInfo extends AbstractFeedback
 {
-    protected ?WorkspaceName $workspaceName = null;
-
     /**
      * @Flow\Inject
      * @var WorkspaceService
@@ -43,31 +41,17 @@ class UpdateWorkspaceInfo extends AbstractFeedback
     /**
      * UpdateWorkspaceInfo constructor.
      *
-     * @param WorkspaceName $workspaceName
      */
     public function __construct(
         private readonly ContentRepositoryId $contentRepositoryId,
-        WorkspaceName $workspaceName = null
+        private readonly WorkspaceName $workspaceName
     ) {
-        $this->workspaceName = $workspaceName;
-    }
-
-    /**
-     * Set the workspace
-     *
-     * @param Workspace $workspace
-     * @return void
-     * @deprecated
-     */
-    public function setWorkspace(Workspace $workspace)
-    {
-        $this->workspaceName = $workspace->workspaceName;
     }
 
     /**
      * Getter for WorkspaceName
      */
-    public function getWorkspaceName(): ?WorkspaceName
+    public function getWorkspaceName(): WorkspaceName
     {
         return $this->workspaceName;
     }
@@ -115,10 +99,6 @@ class UpdateWorkspaceInfo extends AbstractFeedback
      */
     public function serializePayload(ControllerContext $controllerContext)
     {
-        if (!$this->workspaceName) {
-            return null;
-        }
-
         $workspace = $this->workspaceProvider->provideForWorkspaceName(
             $this->contentRepositoryId,
             $this->workspaceName

--- a/Classes/Domain/Model/RenderedNodeDomAddress.php
+++ b/Classes/Domain/Model/RenderedNodeDomAddress.php
@@ -84,6 +84,7 @@ class RenderedNodeDomAddress implements \JsonSerializable
     public function getFusionPathForContentRendering(): string
     {
         $fusionPathForContentRendering = $this->getFusionPath();
+        /** @var string $fusionPathForContentRendering */
         $fusionPathForContentRendering = preg_replace(
             '/(\/itemRenderer<Neos\.Neos:ContentCase>)\/([^<>\/]+)<Neos\.Fusion:Matcher>\/element(<[^>]+>)$/',
             '$1',

--- a/Classes/Fusion/Helper/WorkspaceHelper.php
+++ b/Classes/Fusion/Helper/WorkspaceHelper.php
@@ -56,6 +56,7 @@ class WorkspaceHelper implements ProtectedContextAwareInterface
     public function getPersonalWorkspace(ContentRepositoryId $contentRepositoryId): array
     {
         $currentAccount = $this->securityContext->getAccount();
+        assert($currentAccount !== null);
         // todo use \Neos\Neos\Service\UserService::getPersonalWorkspaceName instead?
         $personalWorkspaceName = WorkspaceNameBuilder::fromAccountIdentifier($currentAccount->getAccountIdentifier());
 

--- a/Classes/TypeConverter/ChangeCollectionConverter.php
+++ b/Classes/TypeConverter/ChangeCollectionConverter.php
@@ -134,6 +134,7 @@ class ChangeCollectionConverter
 
         $subjectContextPath = $changeData['subject'];
         $subject = $this->nodeService->findNodeBySerializedNodeAddress($subjectContextPath, $contentRepositoryId);
+        // we guard that `setSubject` gets a Node!
         if (is_null($subject)) {
             throw new \RuntimeException('Could not find node for subject "' . $subjectContextPath . '"', 1645657340);
         }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,4 @@
 parameters:
-    level: 7
+    level: 8
     paths:
         - Classes


### PR DESCRIPTION
This gives us proper type errors when doing things on possible null values which is super important.

Following (non behaviour changing) adjustments were made:
- Handle nullability correctly
- Make `ChangeInterface::getSubject` not nullable (as we always call `setSubject`, and simplify code not having to deal with the possible nullability here (which was also not done previously correctly for all cases)
  - (Until commit https://github.com/neos/neos-ui/pull/3786/commits/716966726afc1d131890a2c52055ee46d0847848 i tried to go down the route of always handling the possible null case, which was started from sebastianK with the ESCR adjustments, but its just unnecessary complex and gives no advantage to have a `Change` without context node. Its useless)
- Make some internal helpers `final` for sanity
- wrap `$view->setControllerContext` (for out of band rendering) into a `method_exists` as the method is with FLow9 not part of the interface anymore
- Declare workspaceName of `UpdateWorkspaceInfo` non nullable as its set always in the constructor
- Declare node of `UpdateNodeInfo ` non nullable as its set always via setter
