### PR TITLE
TASK: Add --prefer-source to composer command to force vcs sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ However, if you want to stay on bleeding-edge, or want to help out developing, y
 need the `9.0.x-dev` release. You can install the latest release using:
 
 ```
-composer require neos/neos-ui-compiled:9.0.x-dev neos/neos-ui:9.0.x-dev
+composer require neos/neos-ui-compiled:9.0.x-dev neos/neos-ui:9.0.x-dev --prefer-source
 ```
 
 ## Contributing


### PR DESCRIPTION


<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**
Add `--prefer-source` to composer command when installing Neos UI dev collection.

With `composer require [...] --prefer-source` we tell composer to use the git repository of neos-ui when installing the Neos UI development collection.

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
