### PR TITLE
BUGFIX: findNodeToEdit() checks if the node belongs to the correct site

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -224,7 +224,7 @@ class BackendController extends ActionController
         $reflectionMethod->setAccessible(true);
         $node = $reflectionMethod->invoke($this->backendRedirectionService, $siteNode->getContext()->getWorkspaceName());
 
-        if ($node === null) {
+        if ($node === null || !str_starts_with($node->findNodePath()->jsonSerialize(), $siteNode->findNodePath()->jsonSerialize())) {
             $node = $siteNode;
         }
 

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -224,7 +224,7 @@ class BackendController extends ActionController
         $reflectionMethod->setAccessible(true);
         $node = $reflectionMethod->invoke($this->backendRedirectionService, $siteNode->getContext()->getWorkspaceName());
 
-        if ($node === null || !str_starts_with($node->findNodePath()->jsonSerialize(), $siteNode->findNodePath()->jsonSerialize())) {
+        if ($node === null || !str_starts_with($node->getPath(), $siteNode->getPath())) {
             $node = $siteNode;
         }
 


### PR DESCRIPTION
Fixes #3795

Neos uses shared sessions when working with multiple sites on different domains. This fix ensures that we do not try to open a lastVisitedNode within a site the node does not belong to.

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**
Added a check to findNodeToEdit() that ensures the found node (from lastVisitedNode) belongs to the currently opened site.

**How I did it**
The check confirms that the found node is within the site node's sub-tree by comparing the node path.

**How to verify it**
Check the issue for step-by-step instructions on how to reproduce the bug. With this fix, the bug no longer occurs (instead of a rendering error, the backend displays the site node). Remembering the last visited node within the same site still works.
<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
