### PR TITLE
BUGFIX: `LinkEditor` placeholder now uses the custom placeholder correctly

### DIFF
--- a/packages/neos-ui-editors/src/Library/LinkInput.js
+++ b/packages/neos-ui-editors/src/Library/LinkInput.js
@@ -297,7 +297,7 @@ export default class LinkInput extends PureComponent {
                     value={''}
                     plainInputMode={isUri(this.state.searchTerm)}
                     onValueChange={this.handleValueChange}
-                    placeholder={this.props.i18nRegistry.translate($get('options.placeholder', this.props))}
+                    placeholder={this.props.i18nRegistry.translate($get('options.placeholder', this.props) || 'Neos.Neos:Main:content.inspector.editors.linkEditor.search', $get('options.placeholder', this.props) || 'Paste a link, or type to search')}
                     displayLoadingIndicator={this.state.isLoading}
                     displaySearchBox={true}
                     setFocus={this.props.setFocus}

--- a/packages/neos-ui-editors/src/Library/LinkInput.js
+++ b/packages/neos-ui-editors/src/Library/LinkInput.js
@@ -297,7 +297,7 @@ export default class LinkInput extends PureComponent {
                     value={''}
                     plainInputMode={isUri(this.state.searchTerm)}
                     onValueChange={this.handleValueChange}
-                    placeholder={this.props.i18nRegistry.translate($get('options.placeholder', this.props) || 'Neos.Neos.Ui:Main:ckeditor__toolbar__link__placeholder', 'Paste a link, or search')}
+                    placeholder={this.props.i18nRegistry.translate($get('options.placeholder', this.props))}
                     displayLoadingIndicator={this.state.isLoading}
                     displaySearchBox={true}
                     setFocus={this.props.setFocus}


### PR DESCRIPTION
Fixes #3797


**What I did**
If the user now sets a placeholder for the `LinkEditor` the placeholder will now be correctly shown in the neos frontend.

**How I did it**
I removed a (imo) unnecessary condition, which caused the custom placeholder to be always overridden with a static placeholder.

**How to verify it**
Try to set a placeholder for the `LinkEditor` like you would/expect with any other editor component

**Before:**
![Video before](https://github.com/neos/neos-ui/assets/110388306/c75d004a-7c9c-4a64-bae9-123961a39b91)

**After:**
![Video after](https://github.com/neos/neos-ui/assets/110388306/6edcac58-f091-4194-80f0-111512fef9a0)


