### PR TITLE
TASK: adjust to overhauled node uri building

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -228,7 +228,7 @@ class BackendController extends ActionController
         $nodeAddress = NodeAddress::fromJsonString($node);
 
         $this->redirectToUri(
-            $this->nodeUriBuilderFactory->forRequest($this->request->getHttpRequest())
+            $this->nodeUriBuilderFactory->forActionRequest($this->request)
                 ->uriFor($nodeAddress)
         );
     }

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -24,6 +24,8 @@ use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Domain\Service\NodeTypeNameFactory;
 use Neos\Neos\Domain\Service\WorkspaceNameBuilder;
 use Neos\Neos\FrontendRouting\NodeAddressFactory;
+use Neos\Neos\FrontendRouting\NodeUriBuilderFactory;
+use Neos\Neos\FrontendRouting\NodeUriSpecification;
 use Neos\Neos\FrontendRouting\SiteDetection\SiteDetectionResult;
 use Neos\Neos\Service\UserService;
 use Neos\Neos\Ui\Domain\InitialData\ConfigurationProviderInterface;
@@ -117,6 +119,12 @@ class BackendController extends ActionController
      * @var InitialStateProviderInterface
      */
     protected $initialStateProvider;
+
+    /**
+     * @Flow\Inject
+     * @var NodeUriBuilderFactory
+     */
+    protected $nodeUriBuilderFactory;
 
     /**
      * Displays the backend interface
@@ -216,11 +224,15 @@ class BackendController extends ActionController
 
         $contentRepository = $this->contentRepositoryRegistry->get($siteDetectionResult->contentRepositoryId);
 
-        $nodeAddress = NodeAddressFactory::create($contentRepository)->createFromUriString($node);
+        $nodeAddress = NodeAddressFactory::create($contentRepository)->createCoreNodeAddressFromLegacyUriString($node);
         $this->response->setHttpHeader('Cache-Control', [
             'no-cache',
             'no-store'
         ]);
-        $this->redirect('show', 'Frontend\Node', 'Neos.Neos', ['node' => $nodeAddress]);
+
+        $this->redirectToUri(
+            $this->nodeUriBuilderFactory->forRequest($this->request->getHttpRequest())
+                ->uriFor(NodeUriSpecification::create($nodeAddress))
+        );
     }
 }

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -25,7 +25,7 @@ use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Domain\Service\NodeTypeNameFactory;
 use Neos\Neos\Domain\Service\WorkspaceNameBuilder;
 use Neos\Neos\FrontendRouting\NodeAddressFactory;
-use Neos\Neos\FrontendRouting\NodeUri\NodeUriBuilderFactory;
+use Neos\Neos\FrontendRouting\NodeUriBuilderFactory;
 use Neos\Neos\FrontendRouting\SiteDetection\SiteDetectionResult;
 use Neos\Neos\Service\UserService;
 use Neos\Neos\Ui\Domain\InitialData\ConfigurationProviderInterface;

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -14,6 +14,7 @@ namespace Neos\Neos\Ui\Controller;
 
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;
@@ -24,8 +25,7 @@ use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Domain\Service\NodeTypeNameFactory;
 use Neos\Neos\Domain\Service\WorkspaceNameBuilder;
 use Neos\Neos\FrontendRouting\NodeAddressFactory;
-use Neos\Neos\FrontendRouting\NodeUriBuilderFactory;
-use Neos\Neos\FrontendRouting\NodeUriSpecification;
+use Neos\Neos\FrontendRouting\NodeUri\NodeUriBuilderFactory;
 use Neos\Neos\FrontendRouting\SiteDetection\SiteDetectionResult;
 use Neos\Neos\Service\UserService;
 use Neos\Neos\Ui\Domain\InitialData\ConfigurationProviderInterface;
@@ -220,19 +220,16 @@ class BackendController extends ActionController
      */
     public function redirectToAction(string $node): void
     {
-        $siteDetectionResult = SiteDetectionResult::fromRequest($this->request->getHttpRequest());
-
-        $contentRepository = $this->contentRepositoryRegistry->get($siteDetectionResult->contentRepositoryId);
-
-        $nodeAddress = NodeAddressFactory::create($contentRepository)->createCoreNodeAddressFromLegacyUriString($node);
         $this->response->setHttpHeader('Cache-Control', [
             'no-cache',
             'no-store'
         ]);
 
+        $nodeAddress = NodeAddress::fromUriString($node);
+
         $this->redirectToUri(
             $this->nodeUriBuilderFactory->forRequest($this->request->getHttpRequest())
-                ->uriFor(NodeUriSpecification::create($nodeAddress))
+                ->uriFor($nodeAddress)
         );
     }
 }

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -225,7 +225,7 @@ class BackendController extends ActionController
             'no-store'
         ]);
 
-        $nodeAddress = NodeAddress::fromUriString($node);
+        $nodeAddress = NodeAddress::fromJsonString($node);
 
         $this->redirectToUri(
             $this->nodeUriBuilderFactory->forRequest($this->request->getHttpRequest())

--- a/Classes/Domain/Model/Changes/AbstractCreate.php
+++ b/Classes/Domain/Model/Changes/AbstractCreate.php
@@ -169,9 +169,12 @@ abstract class AbstractCreate extends AbstractStructuralChange
             $contentRepository->handle($command);
         }
 
-        /** @var Node $newlyCreatedNode */
         $newlyCreatedNode = $this->contentRepositoryRegistry->subgraphForNode($parentNode)
             ->findNodeById($nodeAggregateId);
+
+        if (!$newlyCreatedNode) {
+            throw new \RuntimeException(sprintf('Node %s was not created successfully or the graph was not up to date.', $nodeAggregateId->value));
+        }
 
         $this->finish($newlyCreatedNode);
         // NOTE: we need to run "finish" before "addNodeCreatedFeedback"

--- a/Classes/Domain/Model/Feedback/Operations/Redirect.php
+++ b/Classes/Domain/Model/Feedback/Operations/Redirect.php
@@ -110,7 +110,7 @@ class Redirect extends AbstractFeedback
         $redirectUri = $this->nodeUriBuilderFactory->forActionRequest($controllerContext->getRequest())
             ->uriFor(
                 NodeAddress::fromNode($node),
-                Options::create(forceAbsolute: true)
+                Options::createForceAbsolute()
             );
 
         $contentRepository = $this->contentRepositoryRegistry->get($node->contentRepositoryId);

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -357,15 +357,23 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
 
     public function createRedirectToNode(Node $node, ActionRequest $actionRequest): string
     {
+        // we always want to redirect to the node in the base workspace.
         $contentRepository = $this->contentRepositoryRegistry->get($node->contentRepositoryId);
-        $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
-        $nodeAddress = $nodeAddressFactory->createFromNode($node);
+        $workspace = $contentRepository->getWorkspaceFinder()->findOneByName($node->workspaceName);
+
+        $nodeAddress = NodeAddress::create(
+            $node->contentRepositoryId,
+            $workspace->baseWorkspaceName ?? WorkspaceName::forLive(),
+            $node->dimensionSpacePoint,
+            $node->aggregateId
+        );
+
         $uriBuilder = new UriBuilder();
         $uriBuilder->setRequest($actionRequest);
         return $uriBuilder
             ->setCreateAbsoluteUri(true)
             ->setFormat('html')
-            ->uriFor('redirectTo', ['node' => $nodeAddress->serializeForUri()], 'Backend', 'Neos.Neos.Ui');
+            ->uriFor('redirectTo', ['node' => $nodeAddress->toUriString()], 'Backend', 'Neos.Neos.Ui');
     }
 
     /**

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -373,7 +373,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
         return $uriBuilder
             ->setCreateAbsoluteUri(true)
             ->setFormat('html')
-            ->uriFor('redirectTo', ['node' => $nodeAddress->toUriString()], 'Backend', 'Neos.Neos.Ui');
+            ->uriFor('redirectTo', ['node' => $nodeAddress->toJson()], 'Backend', 'Neos.Neos.Ui');
     }
 
     /**

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -27,7 +27,6 @@ use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Neos\Domain\NodeLabel\NodeLabelGeneratorInterface;
 use Neos\Neos\FrontendRouting\NodeAddressFactory;
 use Neos\Neos\FrontendRouting\NodeUri\NodeUriBuilderFactory;
-use Neos\Neos\FrontendRouting\NodeUri\Options;
 use Neos\Neos\Ui\Domain\Service\NodePropertyConverterService;
 use Neos\Neos\Ui\Domain\Service\UserLocaleService;
 use Neos\Neos\Utility\NodeTypeWithFallbackProvider;
@@ -351,8 +350,8 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
     {
         $nodeAddress = NodeAddress::fromNode($node);
         return (string)$this->nodeUriBuilderFactory
-            ->forRequest($actionRequest->getHttpRequest())
-            ->previewUriFor($nodeAddress, Options::create(forceAbsolute: true));
+            ->forActionRequest($actionRequest)
+            ->previewUriFor($nodeAddress);
     }
 
     public function createRedirectToNode(Node $node, ActionRequest $actionRequest): string

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -17,6 +17,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFil
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateClassification;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
@@ -25,8 +26,8 @@ use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Neos\Domain\NodeLabel\NodeLabelGeneratorInterface;
 use Neos\Neos\FrontendRouting\NodeAddressFactory;
-use Neos\Neos\FrontendRouting\NodeUriBuilderFactory;
-use Neos\Neos\FrontendRouting\NodeUriSpecification;
+use Neos\Neos\FrontendRouting\NodeUri\NodeUriBuilderFactory;
+use Neos\Neos\FrontendRouting\NodeUri\Options;
 use Neos\Neos\Ui\Domain\Service\NodePropertyConverterService;
 use Neos\Neos\Ui\Domain\Service\UserLocaleService;
 use Neos\Neos\Utility\NodeTypeWithFallbackProvider;
@@ -349,10 +350,9 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
     public function previewUri(Node $node, ActionRequest $actionRequest): string
     {
         $nodeAddress = NodeAddress::fromNode($node);
-        // todo must be absolute
         return (string)$this->nodeUriBuilderFactory
             ->forRequest($actionRequest->getHttpRequest())
-            ->absolutePreviewUriFor(NodeUriSpecification::create($nodeAddress));
+            ->previewUriFor($nodeAddress, Options::create(forceAbsolute: true));
     }
 
     public function createRedirectToNode(Node $node, ActionRequest $actionRequest): string

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -26,7 +26,7 @@ use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Neos\Domain\NodeLabel\NodeLabelGeneratorInterface;
 use Neos\Neos\FrontendRouting\NodeAddressFactory;
-use Neos\Neos\FrontendRouting\NodeUri\NodeUriBuilderFactory;
+use Neos\Neos\FrontendRouting\NodeUriBuilderFactory;
 use Neos\Neos\Ui\Domain\Service\NodePropertyConverterService;
 use Neos\Neos\Ui\Domain\Service\UserLocaleService;
 use Neos\Neos\Utility\NodeTypeWithFallbackProvider;

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -136,7 +136,7 @@ Neos:
             personalWorkspace: '${Neos.Ui.Workspace.getPersonalWorkspace(documentNode.contentRepositoryId)}'
         ui:
           contentCanvas:
-            src: '${Neos.Ui.NodeInfo.uri(documentNode, request)}'
+            src: '${Neos.Ui.NodeInfo.previewUri(documentNode, request)}'
             backgroundColor: '${Configuration.setting(''Neos.Neos.Ui.contentCanvas.backgroundColor'')}'
           debugMode: false
           editPreviewMode: '${q(user).property("preferences.preferences")["contentEditing.editPreviewMode"] || Configuration.setting(''Neos.Neos.userInterface.defaultEditPreviewMode'')}'


### PR DESCRIPTION
Ui adjustments for https://github.com/neos/neos-development-collection/pull/4892

- we use `Neos.Ui.NodeInfo.previewUri` in eel instead of `uri` as the `documentNode` will always be in a non live workspace either way and to better symbolise that we want to render a ABSOLUTE preview uri. The `uri` method could be removed.
- the `redirectTo` action of the `Neos.Neos.Ui` `BackendController` will already work with the new node address
  - `Neos.Ui.NodeInfo.createRedirectToNode` redirected in 8.3 to the node in the base workspace, this behaviour was restored as currently the user workspace is targeted which would be new accidental? behaviour change
- replaced last reference of `LinkingService::createNodeUri` with new uri builder


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
