### PR TITLE
BUGFIX: Let document tree searchbox scale with sidebar width

### DIFF
--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/NodeTreeSearchInput/style.module.css
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/NodeTreeSearchInput/style.module.css
@@ -1,4 +1,5 @@
 .searchInput {
+    flex: 1;
     & input {
         /* magic number, sorry */
         padding-left: var(--spacing-GoldenUnit);
@@ -27,9 +28,9 @@
 
 .wrapper {
     display: flex;
+    flex: 1;
     border-right: 1px solid var(--colors-ContrastDark);
     position: relative;
-    width: calc((var(--size-SidebarWidth) / 2) - var(--spacing-Quarter));
 }
 
 .wrapper--focused {


### PR DESCRIPTION
**What I did**

Let the search box use the space available when the left sidebar is resized

**How I did it**

Replace fixed width with flex value.

**How to verify it**

Before:

![CleanShot 2024-06-21 at 13 37 40@2x](https://github.com/neos/neos-ui/assets/596967/e4844723-786b-4dcb-ae58-c82847c690b7)

After

![CleanShot 2024-06-21 at 13 37 27@2x](https://github.com/neos/neos-ui/assets/596967/dcd2b744-eb27-45ed-9746-7cbb86772b94)
