### PR TITLE
FEATURE: Separated references and properties in Neos UI

### DIFF
--- a/packages/neos-ts-interfaces/src/index.ts
+++ b/packages/neos-ts-interfaces/src/index.ts
@@ -147,16 +147,8 @@ export interface ReferencesConfiguration {
     ui?: {
         label?: string;
         reloadIfChanged?: boolean;
-        inline?: {
-            editor?: string;
-            editorOptions?: {
-                [propName: string]: any;
-            };
-        }
-        inlineEditable?: boolean;
         inspector?: {
             hidden?: boolean;
-            defaultValue?: string;
             editor?: string;
             editorOptions?: {
                 [propName: string]: any;
@@ -168,9 +160,6 @@ export interface ReferencesConfiguration {
             message?: string;
             thumbnail?: string;
         };
-    };
-    validation?: {
-        [propName: string]: ValidatorConfiguration | undefined;
     };
     properties?: {
         [propName: string]: PropertyConfiguration | undefined;

--- a/packages/neos-ts-interfaces/src/index.ts
+++ b/packages/neos-ts-interfaces/src/index.ts
@@ -161,9 +161,6 @@ export interface ReferencesConfiguration {
             thumbnail?: string;
         };
     };
-    properties?: {
-        [propName: string]: PropertyConfiguration | undefined;
-    };
 }
 export interface NodeType {
     name?: string;
@@ -238,7 +235,7 @@ export interface NodeType {
         [propName: string]: PropertyConfiguration | undefined;
     };
     references?: {
-        [propName: string]: ReferencesConfiguration | undefined;
+        [referenceName: string]: ReferencesConfiguration | undefined;
     };
 }
 

--- a/packages/neos-ts-interfaces/src/index.ts
+++ b/packages/neos-ts-interfaces/src/index.ts
@@ -142,7 +142,40 @@ export interface PropertyConfiguration {
         [propName: string]: ValidatorConfiguration | undefined;
     };
 }
-
+export interface ReferencesConfiguration {
+    type?: string;
+    ui?: {
+        label?: string;
+        reloadIfChanged?: boolean;
+        inline?: {
+            editor?: string;
+            editorOptions?: {
+                [propName: string]: any;
+            };
+        }
+        inlineEditable?: boolean;
+        inspector?: {
+            hidden?: boolean;
+            defaultValue?: string;
+            editor?: string;
+            editorOptions?: {
+                [propName: string]: any;
+            }
+            group?: string;
+            position?: number | string;
+        };
+        help?: {
+            message?: string;
+            thumbnail?: string;
+        };
+    };
+    validation?: {
+        [propName: string]: ValidatorConfiguration | undefined;
+    };
+    properties?: {
+        [propName: string]: PropertyConfiguration | undefined;
+    };
+}
 export interface NodeType {
     name?: string;
     superTypes: {
@@ -214,6 +247,9 @@ export interface NodeType {
     };
     properties?: {
         [propName: string]: PropertyConfiguration | undefined;
+    };
+    references?: {
+        [propName: string]: ReferencesConfiguration | undefined;
     };
 }
 

--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.ts
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.ts
@@ -194,8 +194,6 @@ export default class NodeTypesRegistry extends SynchronousRegistry<NodeType> {
         const _references = Object.values(withId(nodeType.references || {}));
         const references = positionalArraySorter(_references, 'position', 'id');
 
-        console.log(references);
-        console.log(properties);
         const viewConfiguration = {
             tabs: tabs.map(tab => ({
                 ...tab,

--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.ts
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.ts
@@ -219,7 +219,7 @@ export default class NodeTypesRegistry extends SynchronousRegistry<NodeType> {
                                 })
                             ),
                         ...references.filter(p => p.ui?.inspector?.group === group.id)
-                                .map(property => ({
+                                .map(reference => ({
                                     type: 'editor',
                                     id: property.id,
                                     label: property.ui?.label,

--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.ts
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.ts
@@ -221,15 +221,14 @@ export default class NodeTypesRegistry extends SynchronousRegistry<NodeType> {
                         ...references.filter(p => p.ui?.inspector?.group === group.id)
                                 .map(reference => ({
                                     type: 'editor',
-                                    id: property.id,
-                                    label: property.ui?.label,
-                                    editor: property.ui?.inspector?.editor,
-                                    editorOptions: property.ui?.inspector?.editorOptions,
-                                    position: property.ui?.inspector?.position,
-                                    hidden: property.ui?.inspector?.hidden,
-                                    helpMessage: property.ui?.help?.message,
-                                    helpThumbnail: property.ui?.help?.thumbnail,
-                                    properties: property?.properties
+                                    id: reference.id,
+                                    label: reference.ui?.label,
+                                    editor: reference.ui?.inspector?.editor,
+                                    editorOptions: reference.ui?.inspector?.editorOptions,
+                                    position: reference.ui?.inspector?.position,
+                                    hidden: reference.ui?.inspector?.hidden,
+                                    helpMessage: reference.ui?.help?.message,
+                                    helpThumbnail: reference.ui?.help?.thumbnail
                                 })
                             ),
                         ...views.filter(v => v.group === group.id)

--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.ts
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.ts
@@ -191,6 +191,11 @@ export default class NodeTypesRegistry extends SynchronousRegistry<NodeType> {
         const _properties = Object.values(withId(nodeType.properties || {}));
         const properties = positionalArraySorter(_properties, 'position', 'id');
 
+        const _references = Object.values(withId(nodeType.references || {}));
+        const references = positionalArraySorter(_references, 'position', 'id');
+
+        console.log(references);
+        console.log(properties);
         const viewConfiguration = {
             tabs: tabs.map(tab => ({
                 ...tab,
@@ -213,6 +218,20 @@ export default class NodeTypesRegistry extends SynchronousRegistry<NodeType> {
                                     hidden: property.ui?.inspector?.hidden,
                                     helpMessage: property.ui?.help?.message,
                                     helpThumbnail: property.ui?.help?.thumbnail
+                                })
+                            ),
+                        ...references.filter(p => p.ui?.inspector?.group === group.id)
+                                .map(property => ({
+                                    type: 'editor',
+                                    id: property.id,
+                                    label: property.ui?.label,
+                                    editor: property.ui?.inspector?.editor,
+                                    editorOptions: property.ui?.inspector?.editorOptions,
+                                    position: property.ui?.inspector?.position,
+                                    hidden: property.ui?.inspector?.hidden,
+                                    helpMessage: property.ui?.help?.message,
+                                    helpThumbnail: property.ui?.help?.thumbnail,
+                                    properties: property?.properties
                                 })
                             ),
                         ...views.filter(v => v.group === group.id)


### PR DESCRIPTION
**What I did**
Currently, we are merging the references into the properties in the Neos UI. Since they are now separated into properties: and references: in the config, we should also handle them as such in the UI. 

The logic for the core is changed here: https://github.com/neos/neos-development-collection/pull/5156 