### PR TITLE
TASK: Update mariadb to 10.6 for e2e docker setups

### DIFF
--- a/Tests/IntegrationTests/docker-compose.neos-dev-instance.yaml
+++ b/Tests/IntegrationTests/docker-compose.neos-dev-instance.yaml
@@ -16,7 +16,7 @@ services:
       COMPOSER_CACHE_DIR: /home/circleci/.composer/cache
 
   db:
-    image: mysql:8
+    image: mariadb:10.6
     environment:
       MYSQL_DATABASE: neos
       MYSQL_ROOT_PASSWORD: not_a_real_password

--- a/Tests/IntegrationTests/docker-compose.yaml
+++ b/Tests/IntegrationTests/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       DB_HOST: db
 
   db:
-    image: mariadb:10.4
+    image: mariadb:10.6
     environment:
       MYSQL_DATABASE: neos
       MYSQL_ROOT_PASSWORD: not_a_real_password


### PR DESCRIPTION
Neos 9.0 requires at least mariadb v10.6 to run, because of: https://mariadb.com/kb/en/json_table/

In Circle CI mariadb was already pinned to 10.6, but the docker setup was pinned to 10.4. (The other one was pinned to mysql v8 - I took the liberty of changing that to mariadb v10.6 as well. Please do protest, if mysql was intentional there).