### PR TITLE
FEATURE: Speed up UI flow queries with custom queries

### DIFF
--- a/Classes/Aspects/AugmentationAspect.php
+++ b/Classes/Aspects/AugmentationAspect.php
@@ -40,21 +40,9 @@ class AugmentationAspect
 
     /**
      * @Flow\Inject
-     * @var UserLocaleService
-     */
-    protected $userLocaleService;
-
-    /**
-     * @Flow\Inject
      * @var HtmlAugmenter
      */
     protected $htmlAugmenter;
-
-    /**
-     * @Flow\Inject
-     * @var NodeInfoHelper
-     */
-    protected $nodeInfoHelper;
 
     /**
      * @Flow\Inject
@@ -126,15 +114,7 @@ class AugmentationAspect
         $attributes['data-__neos-node-contextpath'] = $node->getContextPath();
         $attributes['data-__neos-fusion-path'] = $fusionPath;
 
-        $this->userLocaleService->switchToUILocale();
-
-        $serializedNode = json_encode($this->nodeInfoHelper->renderNodeWithMinimalPropertiesAndChildrenInformation($node, $this->controllerContext));
-        $attributes['data-__neos-nodedata'] = $serializedNode;
-
-        $this->userLocaleService->switchToUILocale(true);
-
-        $wrappedContent = $this->htmlAugmenter->addAttributes($content, $attributes, 'div');
-        return $wrappedContent;
+        return $this->htmlAugmenter->addAttributes($content, $attributes);
     }
 
     /**

--- a/Classes/Aspects/AugmentationAspect.php
+++ b/Classes/Aspects/AugmentationAspect.php
@@ -128,13 +128,12 @@ class AugmentationAspect
 
         $this->userLocaleService->switchToUILocale();
 
-        $serializedNode = json_encode($this->nodeInfoHelper->renderNodeWithPropertiesAndChildrenInformation($node, $this->controllerContext));
+        $serializedNode = json_encode($this->nodeInfoHelper->renderNodeWithMinimalPropertiesAndChildrenInformation($node, $this->controllerContext));
+        $attributes['data-__neos-nodedata'] = $serializedNode;
 
         $this->userLocaleService->switchToUILocale(true);
 
         $wrappedContent = $this->htmlAugmenter->addAttributes($content, $attributes, 'div');
-        $wrappedContent .= "<script data-neos-nodedata>(function(){(this['@Neos.Neos.Ui:Nodes'] = this['@Neos.Neos.Ui:Nodes'] || {})['{$node->getContextPath()}'] = {$serializedNode}})()</script>";
-
         return $wrappedContent;
     }
 

--- a/Classes/ContentRepository/Service/NodeService.php
+++ b/Classes/ContentRepository/Service/NodeService.php
@@ -11,8 +11,12 @@ namespace Neos\Neos\Ui\ContentRepository\Service;
  * source code.
  */
 
+use Doctrine\ORM\EntityManagerInterface;
+use Neos\ContentRepository\Domain\Factory\NodeFactory;
+use Neos\ContentRepository\Domain\Model\NodeData;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Model\Workspace;
+use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
 use Neos\ContentRepository\Domain\Service\Context;
 use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 use Neos\ContentRepository\Domain\Utility\NodePaths;
@@ -46,6 +50,24 @@ class NodeService
      * @var DomainRepository
      */
     protected $domainRepository;
+
+    /**
+     * @Flow\Inject
+     * @var NodeDataRepository
+     */
+    protected $nodeDataRepository;
+
+    /**
+     * @Flow\Inject
+     * @var EntityManagerInterface
+     */
+    protected $entityManager;
+
+    /**
+     * @Flow\Inject
+     * @var NodeFactory
+     */
+    protected $nodeFactory;
 
     /**
      * @var array<string, Context>

--- a/Classes/ContentRepository/Service/NodeService.php
+++ b/Classes/ContentRepository/Service/NodeService.php
@@ -53,6 +53,12 @@ class NodeService
     protected array $contextCache = [];
 
     /**
+     * @Flow\InjectConfiguration(path="nodeTypeRoles.ignored", package="Neos.Neos.Ui")
+     * @var string
+     */
+    protected $ignoredNodeTypeRole;
+
+    /**
      * Helper method to retrieve the closest document for a node
      *
      * @param NodeInterface $node
@@ -132,6 +138,233 @@ class NodeService
         }
 
         return $context->getNode($nodePath);
+    }
+
+    /**
+     * Converts given context paths to a node objects
+     *
+     * @param string[] $nodeContextPaths
+     * @return NodeInterface[]|Error
+     */
+    public function getNodesFromContextPaths(array $nodeContextPaths, Site $site = null, Domain $domain = null, $includeAll = false): array|Error
+    {
+        if (!$nodeContextPaths) {
+            return [];
+        }
+
+        $nodePaths = array_map(static function($nodeContextPath) {
+            return NodePaths::explodeContextPath($nodeContextPath)['nodePath'];
+        }, $nodeContextPaths);
+
+        $nodePathAndContext = NodePaths::explodeContextPath($nodeContextPaths[0]);
+        $nodePath = $nodePathAndContext['nodePath'];
+        $workspaceName = $nodePathAndContext['workspaceName'];
+        $dimensions = $nodePathAndContext['dimensions'];
+        $siteNodeName = explode('/', $nodePath)[2];
+        $contextProperties = $this->prepareContextProperties($workspaceName, $dimensions);
+
+        if ($site === null) {
+            $site = $this->siteRepository->findOneByNodeName($siteNodeName);
+        }
+
+        if ($domain === null) {
+            $domain = $this->domainRepository->findOneBySite($site);
+        }
+
+        $contextProperties['currentSite'] = $site;
+        $contextProperties['currentDomain'] = $domain;
+        if ($includeAll === true) {
+            $contextProperties['invisibleContentShown'] = true;
+            $contextProperties['removedContentShown'] = true;
+            $contextProperties['inaccessibleContentShown'] = true;
+        }
+        $context = $this->contextFactory->create($contextProperties);
+
+        $workspace = $context->getWorkspace(false);
+        if (!$workspace) {
+            return new Error(
+                sprintf('Could not convert the given source to Node object because the workspace "%s" as specified in the context node path does not exist.', $workspaceName),
+                1451392329
+            );
+        }
+
+        // Query nodes and their variants from the database
+        $queryBuilder = $this->entityManager->createQueryBuilder();
+        $workspaces = $this->collectWorkspaceAndAllBaseWorkspaces($workspace);
+        $workspacesNames = array_map(static function(Workspace $workspace) { return $workspace->getName(); }, $workspaces);
+
+        // Filter by workspace and its parents
+        $queryBuilder->select('n')
+            ->from(NodeData::class, 'n')
+            ->where('n.workspace IN (:workspaces)')
+            ->andWhere('n.movedTo IS NULL')
+            ->andWhere('n.path IN (:nodePaths)')
+            ->setParameter('workspaces', $workspacesNames)
+            ->setParameter('nodePaths', $nodePaths);
+        $query = $queryBuilder->getQuery();
+        $nodeDataWithVariants = $query->getResult();
+
+        // Remove node duplicates
+        $reducedNodeData = $this->reduceNodeVariantsByWorkspacesAndDimensions($nodeDataWithVariants, $workspaces, $dimensions);
+
+        // Convert nodedata objects to nodes
+        return array_reduce($reducedNodeData, function (array $carry, NodeData $nodeData) use ($context) {
+            $node = $this->nodeFactory->createFromNodeData($nodeData, $context);
+            if ($node !== null) {
+                $carry[] = $node;
+            }
+            $context->getFirstLevelNodeCache()->setByPath($node->getPath(), $node);
+            return $carry;
+        }, []);
+    }
+
+    /**
+     * @param NodeInterface[] $parentNodes
+     */
+    public function preloadChildNodesForNodes(array $parentNodes): void
+    {
+        if (empty($parentNodes)) {
+            return;
+        }
+
+        $workspace = $parentNodes[0]->getWorkspace();
+        $context = $parentNodes[0]->getContext();
+        $dimensions = $context->getDimensions();
+
+        $parentPaths = array_map(static function(NodeInterface $parentNode) {
+            return $parentNode->getPath();
+        }, $parentNodes);
+
+        // Query nodes and their variants from the database
+        $queryBuilder = $this->entityManager->createQueryBuilder();
+        $workspaces = $this->collectWorkspaceAndAllBaseWorkspaces($workspace);
+        $workspacesNames = array_map(static function(Workspace $workspace) { return $workspace->getName(); }, $workspaces);
+
+        // Filter by workspace and its parents
+        $queryBuilder->select('n')
+            ->from(NodeData::class, 'n')
+            ->where('n.workspace IN (:workspaces)')
+            ->andWhere('n.movedTo IS NULL')
+            ->andWhere('n.parentPath IN (:parentPaths)')
+            ->setParameter('workspaces', $workspacesNames)
+            ->setParameter('parentPaths', $parentPaths);
+        $query = $queryBuilder->getQuery();
+        $nodeDataWithVariants = $query->getResult();
+
+        // Remove node duplicates
+        $reducedNodeData = $this->reduceNodeVariantsByWorkspacesAndDimensions(
+            $nodeDataWithVariants,
+            $workspaces,
+            $dimensions
+        );
+
+        // Convert nodedata objects to nodes and group them by parent path
+        $childNodesByParentPath = array_reduce($reducedNodeData, function (array $carry, NodeData $nodeData) use ($context) {
+            $node = $this->nodeFactory->createFromNodeData($nodeData, $context);
+            if ($node !== null) {
+                if (!isset($carry[$node->getParentPath()])) {
+                    $carry[$node->getParentPath()] = [$node];
+                } else {
+                    $carry[$node->getParentPath()][] = $node;
+                }
+            }
+            return $carry;
+        }, []);
+
+        foreach ($childNodesByParentPath as $parentPath => $childNodes) {
+            usort($childNodes, static function(NodeInterface $a, NodeInterface $b) {
+                return $a->getIndex() <=> $b->getIndex();
+            });
+            $context->getFirstLevelNodeCache()->setChildNodesByPathAndNodeTypeFilter(
+                $parentPath, '!' .
+                $this->ignoredNodeTypeRole,
+                $childNodes
+            );
+        }
+    }
+
+    /**
+     * Given an array with duplicate nodes (from different workspaces and dimensions) those are reduced to uniqueness (by node identifier)
+     * Copied from Neos\ContentRepository\Domain\Repository\NodeDataRepository
+     *
+     * @param NodeData[] $nodes NodeData result with multiple and duplicate identifiers (different nodes and redundant results for node variants with different dimensions)
+     * @param Workspace[] $workspaces
+     * @param array $dimensions
+     * @return NodeData[] Array of unique node results indexed by identifier
+     */
+    protected function reduceNodeVariantsByWorkspacesAndDimensions(array $nodes, array $workspaces, array $dimensions): array
+    {
+        $reducedNodes = [];
+
+        $minimalDimensionPositionsByIdentifier = [];
+
+        $workspaceNames = array_map(static fn (Workspace $workspace) => $workspace->getName(), $workspaces);
+
+        foreach ($nodes as $node) {
+            $nodeDimensions = $node->getDimensionValues();
+
+            // Find the position of the workspace, a smaller value means more priority
+            $workspacePosition = array_search($node->getWorkspace()->getName(), $workspaceNames);
+            if ($workspacePosition === false) {
+                throw new \Exception(sprintf(
+                    'Node workspace "%s" not found in allowed workspaces (%s), this could result from a detached workspace entity in the context.',
+                    $node->getWorkspace()->getName(),
+                    implode(', ', $workspaceNames)
+                ), 1718740117);
+            }
+
+            // Find positions in dimensions, add workspace in front for highest priority
+            $dimensionPositions = [];
+
+            // Special case for no dimensions
+            if ($dimensions === []) {
+                // We can just decide if the given node has no dimensions.
+                $dimensionPositions[] = ($nodeDimensions === []) ? 0 : 1;
+            }
+
+            foreach ($dimensions as $dimensionName => $dimensionValues) {
+                if (isset($nodeDimensions[$dimensionName])) {
+                    foreach ($nodeDimensions[$dimensionName] as $nodeDimensionValue) {
+                        $position = array_search($nodeDimensionValue, $dimensionValues);
+                        if ($position === false) {
+                            $position = PHP_INT_MAX;
+                        }
+                        $dimensionPositions[$dimensionName] = isset($dimensionPositions[$dimensionName]) ? min(
+                            $dimensionPositions[$dimensionName],
+                            $position
+                        ) : $position;
+                    }
+                } else {
+                    $dimensionPositions[$dimensionName] = isset($dimensionPositions[$dimensionName]) ? min(
+                        $dimensionPositions[$dimensionName],
+                        PHP_INT_MAX
+                    ) : PHP_INT_MAX;
+                }
+            }
+            $dimensionPositions[] = $workspacePosition;
+
+            $identifier = $node->getIdentifier();
+            // Yes, it seems to work comparing arrays that way!
+            if (!isset($minimalDimensionPositionsByIdentifier[$identifier]) || $dimensionPositions < $minimalDimensionPositionsByIdentifier[$identifier]) {
+                $reducedNodes[$identifier] = $node;
+                $minimalDimensionPositionsByIdentifier[$identifier] = $dimensionPositions;
+            }
+        }
+
+        return $reducedNodes;
+    }
+
+    /**
+     * @return Workspace[]
+     */
+    protected function collectWorkspaceAndAllBaseWorkspaces(Workspace $workspace): array
+    {
+        $workspaces = [];
+        while ($workspace !== null) {
+            $workspaces[] = $workspace;
+            $workspace = $workspace->getBaseWorkspace();
+        }
+        return $workspaces;
     }
 
     /**

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -545,25 +545,28 @@ class BackendServiceController extends ActionController
             $flowQuery = call_user_func_array([$flowQuery, $operation['type']], $operation['payload']);
         }
 
+        $nodes = array_filter($flowQuery->get());
+        $this->nodeService->preloadChildNodesForNodes(array_values($nodes));
+
         $nodeInfoHelper = new NodeInfoHelper();
         $result = [];
         switch ($finisher['type']) {
             case 'get':
                 $result = $nodeInfoHelper->renderNodes(
-                    array_filter($flowQuery->get()),
+                    $nodes,
                     $this->getControllerContext()
                 );
                 break;
             case 'getForTree':
                 $result = $nodeInfoHelper->renderNodes(
-                    array_filter($flowQuery->get()),
+                    $nodes,
                     $this->getControllerContext(),
                     true
                 );
                 break;
             case 'getForTreeWithParents':
                 $result = $nodeInfoHelper->renderNodesWithParents(
-                    array_filter($flowQuery->get()),
+                    $nodes,
                     $this->getControllerContext()
                 );
                 break;

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -547,13 +547,23 @@ class BackendServiceController extends ActionController
         $result = [];
         switch ($finisher['type']) {
             case 'get':
-                $result = $nodeInfoHelper->renderNodes(array_filter($flowQuery->get()), $this->getControllerContext());
+                $result = $nodeInfoHelper->renderNodes(array_filter(
+                    $flowQuery->get()),
+                    $this->getControllerContext()
+                );
                 break;
             case 'getForTree':
-                $result = $nodeInfoHelper->renderNodes(array_filter($flowQuery->get()), $this->getControllerContext(), true);
+                $result = $nodeInfoHelper->renderNodes(
+                    array_filter($flowQuery->get()),
+                    $this->getControllerContext(),
+                    true
+                );
                 break;
             case 'getForTreeWithParents':
-                $result = $nodeInfoHelper->renderNodesWithParents(array_filter($flowQuery->get()), $this->getControllerContext());
+                $result = $nodeInfoHelper->renderNodesWithParents(
+                    array_filter($flowQuery->get()),
+                    $this->getControllerContext()
+                );
                 break;
         }
 

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -532,11 +532,13 @@ class BackendServiceController extends ActionController
         $createContext = array_shift($chain);
         $finisher = array_pop($chain);
 
+        $nodeContextPaths = array_unique(array_column($createContext['payload'], '$node'));
+
         $flowQuery = new FlowQuery(array_map(
-            function ($envelope) {
-                return $this->nodeService->getNodeFromContextPath($envelope['$node']);
+            function ($contextPath) {
+                return $this->nodeService->getNodeFromContextPath($contextPath);
             },
-            $createContext['payload']
+            $nodeContextPaths
         ));
 
         foreach ($chain as $operation) {
@@ -547,8 +549,8 @@ class BackendServiceController extends ActionController
         $result = [];
         switch ($finisher['type']) {
             case 'get':
-                $result = $nodeInfoHelper->renderNodes(array_filter(
-                    $flowQuery->get()),
+                $result = $nodeInfoHelper->renderNodes(
+                    array_filter($flowQuery->get()),
                     $this->getControllerContext()
                 );
                 break;

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -533,13 +533,9 @@ class BackendServiceController extends ActionController
         $finisher = array_pop($chain);
 
         $nodeContextPaths = array_unique(array_column($createContext['payload'], '$node'));
+        $nodes = $this->nodeService->getNodesFromContextPaths($nodeContextPaths);
 
-        $flowQuery = new FlowQuery(array_map(
-            function ($contextPath) {
-                return $this->nodeService->getNodeFromContextPath($contextPath);
-            },
-            $nodeContextPaths
-        ));
+        $flowQuery = new FlowQuery($nodes);
 
         foreach ($chain as $operation) {
             $flowQuery = call_user_func_array([$flowQuery, $operation['type']], $operation['payload']);

--- a/Classes/Domain/Service/UserLocaleService.php
+++ b/Classes/Domain/Service/UserLocaleService.php
@@ -38,6 +38,13 @@ class UserLocaleService
     protected $rememberedContentLocale;
 
     /**
+     * Remebered content locale for locale switching
+     *
+     * @var Locale
+     */
+    protected $rememberedUserLocale;
+
+    /**
      * For serialization, we need to respect the UI locale, rather than the content locale
      *
      * @param boolean $reset Reset to remebered locale
@@ -47,11 +54,15 @@ class UserLocaleService
         if ($reset === true) {
             // Reset the locale
             $this->i18nService->getConfiguration()->setCurrentLocale($this->rememberedContentLocale);
+        } elseif ($this->rememberedUserLocale) {
+            // Restore the local
+            $this->i18nService->getConfiguration()->setCurrentLocale($this->rememberedUserLocale);
         } else {
             $this->rememberedContentLocale = $this->i18nService->getConfiguration()->getCurrentLocale();
             $userLocalePreference = ($this->userService->getCurrentUser() ? $this->userService->getCurrentUser()->getPreferences()->getInterfaceLanguage() : null);
             $defaultLocale = $this->i18nService->getConfiguration()->getDefaultLocale();
             $userLocale = $userLocalePreference ? new Locale($userLocalePreference) : $defaultLocale;
+            $this->rememberedUserLocale = $userLocale;
             $this->i18nService->getConfiguration()->setCurrentLocale($userLocale);
         }
     }

--- a/Classes/FlowQueryOperations/NeosUiDefaultNodesOperation.php
+++ b/Classes/FlowQueryOperations/NeosUiDefaultNodesOperation.php
@@ -72,8 +72,9 @@ class NeosUiDefaultNodesOperation extends AbstractOperation
     public function evaluate(FlowQuery $flowQuery, array $arguments)
     {
         /** @var TraversableNodeInterface $siteNode */
+        $siteNode = $flowQuery->getContext()[0];
         /** @var TraversableNodeInterface $documentNode */
-        list($siteNode, $documentNode) = $flowQuery->getContext();
+        $documentNode = $flowQuery->getContext()[1] ?? $siteNode;
         /** @var string[] $toggledNodes */
         list($baseNodeType, $loadingDepth, $toggledNodes, $clipboardNodesContextPaths) = $arguments;
 

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -155,7 +155,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
     /**
      * @param NodeInterface $node
      * @param ControllerContext|null $controllerContext
-     * @param string $nodeTypeFilterOverride
+     * @param string|null $nodeTypeFilterOverride
      * @return array|null
      */
     public function renderNodeWithPropertiesAndChildrenInformation(NodeInterface $node, ControllerContext $controllerContext = null, string $nodeTypeFilterOverride = null)
@@ -177,7 +177,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
             }
         }
 
-        $baseNodeType = $nodeTypeFilterOverride ? $nodeTypeFilterOverride : (isset($presetBaseNodeType) ? $presetBaseNodeType : $this->defaultBaseNodeType);
+        $baseNodeType = $nodeTypeFilterOverride ?: (isset($presetBaseNodeType) ? $presetBaseNodeType : $this->defaultBaseNodeType);
         $nodeInfo['children'] = $this->renderChildrenInformation($node, $baseNodeType);
 
         $this->userLocaleService->switchToUILocale(true);
@@ -246,10 +246,10 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
         $contentChildNodes = $node->getChildNodes($this->buildContentChildNodeFilterString());
         $childNodes = array_merge($documentChildNodes, $contentChildNodes);
 
-        $mapper = function (NodeInterface $childNode) {
+        $mapper = static function (NodeInterface $childNode) {
             return [
                 'contextPath' => $childNode->getContextPath(),
-                'nodeType' => $childNode->getNodeType()->getName() // TODO: DUPLICATED; should NOT be needed!!!
+                'nodeType' => $childNode->getNodeType()->getName()
             ];
         };
 

--- a/Resources/Private/Translations/nl/Main.xlf
+++ b/Resources/Private/Translations/nl/Main.xlf
@@ -505,7 +505,7 @@
       </trans-unit>
       <trans-unit id="copyNodeTypeNameToClipboard" xml:space="preserve">
         <source>Copy node type to clipboard</source>
-        <target state="needs-translation">Kopieer node type naar klembord</target>
+        <target state="translated">Kopieer node type naar klembord</target>
       </trans-unit>
     </body>
   </file>

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -64,14 +64,14 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
     // Load legacy node data scripts from guest frame - remove with Neos 9.0
     const legacyNodeData = guestFrameWindow['@Neos.Neos.Ui:Nodes'] || {};
 
-    // Load all nodedata for nodes in the guest frame
+    // Load all nodedata for nodes in the guest frame and filter duplicates
     const {q} = yield backend.get();
     const nodeContextPathsInGuestFrame = findAllNodesInGuestFrame().map(node => node.getAttribute('data-__neos-node-contextpath'));
 
-    // Filter nodes that are already loaded in the redux store
+    // Filter nodes that are already present in the redux store and duplicates
     const nodesByContextPath = store.getState().cr.nodes.byContextPath;
     const nodesAlreadyPresentInStore = {};
-    const notFullyLoadedNodeContextPaths = nodeContextPathsInGuestFrame.filter((contextPath) => {
+    const notFullyLoadedNodeContextPaths = [...new Set(nodeContextPathsInGuestFrame)].filter((contextPath) => {
         const node = nodesByContextPath[contextPath];
         const nodeIsLoaded = node !== undefined && node.isFullyLoaded;
         if (nodeIsLoaded){
@@ -81,11 +81,11 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
         return true;
     });
 
-    // Load remaining list of nodes from the backend
-    const fullyLoadedNodesFromContent = (yield q(notFullyLoadedNodeContextPaths).get()).reduce((nodes, node) => {
+    // Load remaining list of not fully loaded nodes from the backend if there are any
+    const fullyLoadedNodesFromContent = notFullyLoadedNodeContextPaths.length > 0 ? (yield q(notFullyLoadedNodeContextPaths).get()).reduce((nodes, node) => {
         nodes[node.contextPath] = node;
         return nodes;
-    }, {});
+    }, {}) : [];
 
     const nodes = Object.assign(
         {},

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -62,7 +62,7 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
     }
 
     // Load legacy node data scripts from guest frame - remove with Neos 9.0
-    const legacyNodeData = guestFrameWindow['@Neos.Neos.Ui:NodeData'] || {};
+    const legacyNodeData = guestFrameWindow['@Neos.Neos.Ui:Nodes'] || {};
 
     // Load all nodedata for nodes in the guest frame
     const {q} = yield backend.get();


### PR DESCRIPTION
**What I did**

This is a follow up for #3770 in which we load all nodes requested by the UI directly from the database instead of querying each node by itself and its document and content children separately.

**How I did it**

Extract some methods from the NodeDataRepository and added them to the NodeService in the UI to resolve all requested nodes with one db query and prefetch all child nodes of the resulting nodes to fill them into the 1st-level cache.

**How to verify it**

Flow query performance for loading a large page in a large project with the page tree, content tree and nodes required for the displayed content. The page tree requests 175 nodes (the 332KB request), the content tree requests 58 nodes ( the 129kb request) and the guest frame requests 191 nodes (the 615kb request) which haven't been loaded by the content tree yet and with the duplicates removed.

Performance UI 8.3.8:
![neosui-83-838](https://github.com/neos/neos-ui/assets/596967/1ac97b58-b979-4d11-b939-c66c0bcc7e2d)

Performance with branch #3770:
![neosui-83-remove-ui-script-tag](https://github.com/neos/neos-ui/assets/596967/84164e0c-14de-4954-927c-ce70d4de04ea)

Performance with this branch:
![neosui-83-optimise-ui-flowqueries](https://github.com/neos/neos-ui/assets/596967/f4047e0a-466e-4f9b-b6a8-93b76a1ac7e7)
