### PR TITLE
BUGFIX: Adjust route to workspace module

### DIFF
--- a/Classes/Infrastructure/MVC/RoutesProvider.php
+++ b/Classes/Infrastructure/MVC/RoutesProvider.php
@@ -132,12 +132,12 @@ final class RoutesProvider implements RoutesProviderInterface
         ];
 
         $routes['core']['modules'] = [
-            'workspaces' =>
+            'workspace' =>
                 $helper->buildCoreRoute(
                     controllerName: 'Backend\\Module',
                     actionName: 'index',
                     arguments: [
-                        'module' => 'management/workspaces'
+                        'module' => 'management/workspace'
                     ]
                 ),
             'userSettings' =>

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -85,7 +85,7 @@ export default class PublishDropDown extends PureComponent {
             neos
         } = this.props;
 
-        const workspaceModuleUri = neos?.routes?.core?.modules?.workspaces;
+        const workspaceModuleUri = neos?.routes?.core?.modules?.workspace;
         const allowedWorkspaces = neos?.configuration?.allowedTargetWorkspaces;
         const baseWorkspaceTitle = allowedWorkspaces?.[baseWorkspace]?.title;
         const canPublishLocally = !isSaving && !isPublishing && !isDiscarding && publishableNodesInDocument && (publishableNodesInDocument.length > 0);


### PR DESCRIPTION
While extracting the workspace module into a separate package, the route was adjusted to `neos/management/workspace`.

Relates: neos/neos-development-collection#5118
