### PR TITLE
FEATURE: Allow to set maximum rows to restrict height of the textarea editor in inspector

### DIFF
--- a/packages/neos-ui-editors/src/Editors/TextArea/index.js
+++ b/packages/neos-ui-editors/src/Editors/TextArea/index.js
@@ -23,6 +23,7 @@ export default class TextAreaEditor extends PureComponent {
         readonly: false,
         placeholder: '',
         minRows: 2,
+        maxRows: 24,
         expandedRows: 6
     };
 
@@ -42,6 +43,7 @@ export default class TextAreaEditor extends PureComponent {
             readOnly={finalOptions.readonly}
             placeholder={placeholder}
             minRows={finalOptions.minRows}
+            maxRows={finalOptions.maxRows}
             expandedRows={finalOptions.expandedRows}
         />);
     }

--- a/packages/react-ui-components/src/TextArea/textArea.tsx
+++ b/packages/react-ui-components/src/TextArea/textArea.tsx
@@ -42,6 +42,11 @@ export interface TextAreaProps extends Omit<React.InputHTMLAttributes<HTMLTextAr
     readonly minRows?: number;
 
     /**
+     * Optional number to set the maxRows of the TextArea if expanded
+     */
+    readonly maxRows?: number;
+
+    /**
      * Optional number to set the expandedRows of the TextArea if expanded
      */
     readonly expandedRows?: number;
@@ -77,6 +82,7 @@ export class TextArea extends PureComponent<TextAreaProps> {
             theme,
             disabled,
             minRows,
+            maxRows,
             expandedRows,
             value,
             style,
@@ -102,6 +108,7 @@ export class TextArea extends PureComponent<TextAreaProps> {
                 onChange={this.handleValueChange}
                 onClick={this.handleOnClick}
                 minRows={this.state.isFocused ? expandedRows : minRows}
+                maxRows={maxRows}
                 value={value}
                 // @ts-ignore -- WHY: type mismatch even though it shouldn't
                 style={style}


### PR DESCRIPTION
The textarea editor is not restricted in height. If you need to add a lot of content it grows as long as the content is. This PR allows to set a maximum rows and defines a default of max 24 rows.