### PR TITLE
BUGFIX: Fix inconsistencies in document tree with node tree presets

### DIFF
--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -545,6 +545,7 @@ class BackendServiceController extends ActionController
 
         $nodeInfoHelper = new NodeInfoHelper();
         $result = [];
+
         switch ($finisher['type']) {
             case 'get':
                 $result = $nodeInfoHelper->renderNodes(array_filter($flowQuery->get()), $this->getControllerContext());
@@ -553,7 +554,8 @@ class BackendServiceController extends ActionController
                 $result = $nodeInfoHelper->renderNodes(array_filter($flowQuery->get()), $this->getControllerContext(), true);
                 break;
             case 'getForTreeWithParents':
-                $result = $nodeInfoHelper->renderNodesWithParents(array_filter($flowQuery->get()), $this->getControllerContext());
+                $nodeTypeFilter = $finisher['payload']['nodeTypeFilter'] ?? null;
+                $result = $nodeInfoHelper->renderNodesWithParents(array_filter($flowQuery->get()), $this->getControllerContext(), $nodeTypeFilter);
                 break;
         }
 

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -275,9 +275,10 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
     /**
      * @param array $nodes
      * @param ControllerContext $controllerContext
+     * @param null|string $nodeTypeFilter
      * @return array
      */
-    public function renderNodesWithParents(array $nodes, ControllerContext $controllerContext): array
+    public function renderNodesWithParents(array $nodes, ControllerContext $controllerContext, ?string $nodeTypeFilter = null): array
     {
         // For search operation we want to include all nodes, not respecting the "baseNodeType" setting
         $baseNodeTypeOverride = $this->documentNodeTypeRole;
@@ -287,7 +288,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
         foreach ($nodes as $node) {
             if (array_key_exists($node->getPath(), $renderedNodes)) {
                 $renderedNodes[$node->getPath()]['matched'] = true;
-            } elseif ($renderedNode = $this->renderNodeWithMinimalPropertiesAndChildrenInformation($node, $controllerContext, $baseNodeTypeOverride)) {
+            } elseif ($renderedNode = $this->renderNodeWithMinimalPropertiesAndChildrenInformation($node, $controllerContext, $nodeTypeFilter ?? $baseNodeTypeOverride)) {
                 $renderedNode['matched'] = true;
                 $renderedNodes[$node->getPath()] = $renderedNode;
             } else {

--- a/Tests/IntegrationTests/Fixtures/1Dimension/SitePackage/Resources/Private/Content/Sites.xml
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/SitePackage/Resources/Private/Content/Sites.xml
@@ -16,6 +16,19 @@
       <uriPathSegment __type="string">home</uriPathSegment>
      </properties>
     </variant>
+    <variant sortingIndex="100" workspace="live" nodeType="Neos.TestNodeTypes:Document.Page" version="3" removed="" hidden="" hiddenInIndex="">
+     <dimensions>
+      <language>da</language>
+     </dimensions>
+     <accessRoles __type="array"/>
+     <creationDateTime __type="object" __classname="DateTime">2019-03-19T16:18:09+00:00</creationDateTime>
+     <lastModificationDateTime __type="object" __classname="DateTime">2019-03-19T16:18:47+00:00</lastModificationDateTime>
+     <lastPublicationDateTime __type="object" __classname="DateTime">2019-03-19T16:18:47+00:00</lastPublicationDateTime>
+     <properties>
+      <title __type="string">Hjem</title>
+      <uriPathSegment __type="string">home</uriPathSegment>
+     </properties>
+    </variant>
     <variant sortingIndex="100" workspace="live" nodeType="Neos.TestNodeTypes:Document.Page" version="5" removed="" hidden="" hiddenInIndex="">
      <dimensions>
       <language>en_US</language>
@@ -27,7 +40,7 @@
      <properties>
       <title __type="string">Home</title>
       <uriPathSegment __type="string">home</uriPathSegment>
-      <image __type="object" __identifier="50cd4a3e-1cc3-4bbb-b2ab-919abb4011f1" __classname="Neos\Media\Domain\Model\ImageVariant" __encoding="json">{&quot;__identity&quot;:&quot;50cd4a3e-1cc3-4bbb-b2ab-919abb4011f1&quot;,&quot;__type&quot;:&quot;Neos\\Media\\Domain\\Model\\ImageVariant&quot;,&quot;originalAsset&quot;:{&quot;__identity&quot;:&quot;ee3d239e-48b0-4f99-90be-054301b91792&quot;,&quot;__type&quot;:&quot;Neos\\Media\\Domain\\Model\\Image&quot;,&quot;title&quot;:&quot;&quot;,&quot;copyrightNotice&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;resource&quot;:{&quot;filename&quot;:&quot;neos_primary.png&quot;,&quot;collectionName&quot;:&quot;persistent&quot;,&quot;relativePublicationPath&quot;:&quot;&quot;,&quot;mediaType&quot;:&quot;image\/png&quot;,&quot;sha1&quot;:&quot;aac28f51e5ca842e2646e88e7d242ac3c27e1f25&quot;,&quot;hash&quot;:&quot;aac28f51e5ca842e2646e88e7d242ac3c27e1f25&quot;,&quot;__identity&quot;:&quot;71abb35f-f167-4677-a3f5-386785e9d874&quot;}},&quot;adjustments&quot;:[{&quot;aspectRatio&quot;:null,&quot;height&quot;:126,&quot;position&quot;:10,&quot;width&quot;:126,&quot;x&quot;:328,&quot;y&quot;:0,&quot;__identity&quot;:&quot;206ccf9b-ddd8-4021-951b-c7df0adf893a&quot;,&quot;__type&quot;:&quot;Neos\\Media\\Domain\\Model\\Adjustment\\CropImageAdjustment&quot;}]}</image>
+      <image __type="object" __identifier="50cd4a3e-1cc3-4bbb-b2ab-919abb4011f1" __classname="Neos\Media\Domain\Model\ImageVariant" __encoding="json">{&quot;__identity&quot;:&quot;50cd4a3e-1cc3-4bbb-b2ab-919abb4011f1&quot;,&quot;__type&quot;:&quot;Neos\\Media\\Domain\\Model\\ImageVariant&quot;,&quot;originalAsset&quot;:{&quot;__identity&quot;:&quot;ee3d239e-48b0-4f99-90be-054301b91792&quot;,&quot;__type&quot;:&quot;Neos\\Media\\Domain\\Model\\Image&quot;,&quot;title&quot;:&quot;&quot;,&quot;copyrightNotice&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;resource&quot;:{&quot;filename&quot;:&quot;neos_primary.png&quot;,&quot;collectionName&quot;:&quot;persistent&quot;,&quot;relativePublicationPath&quot;:&quot;&quot;,&quot;mediaType&quot;:&quot;image\/png&quot;,&quot;sha1&quot;:&quot;aac28f51e5ca842e2646e88e7d242ac3c27e1f25&quot;,&quot;hash&quot;:&quot;aac28f51e5ca842e2646e88e7d242ac3c27e1f25&quot;,&quot;__identity&quot;:&quot;71abb35f-f167-4677-a3f5-386785e9d874&quot;},&quot;tags&quot;:[],&quot;assetCollections&quot;:[]},&quot;adjustments&quot;:[{&quot;aspectRatio&quot;:null,&quot;height&quot;:126,&quot;position&quot;:10,&quot;width&quot;:126,&quot;x&quot;:328,&quot;y&quot;:0,&quot;__identity&quot;:&quot;82719b51-e1c7-493a-abd3-0fa945155851&quot;,&quot;__type&quot;:&quot;Neos\\Media\\Domain\\Model\\Adjustment\\CropImageAdjustment&quot;}]}</image>
      </properties>
     </variant>
     <variant sortingIndex="100" workspace="live" nodeType="Neos.TestNodeTypes:Document.Page" version="3" removed="" hidden="" hiddenInIndex="">
@@ -41,7 +54,7 @@
      <properties>
       <title __type="string">Home</title>
       <uriPathSegment __type="string">home</uriPathSegment>
-      <image __type="object" __identifier="50cd4a3e-1cc3-4bbb-b2ab-919abb4011f1" __classname="Neos\Media\Domain\Model\ImageVariant" __encoding="json">{&quot;__identity&quot;:&quot;50cd4a3e-1cc3-4bbb-b2ab-919abb4011f1&quot;,&quot;__type&quot;:&quot;Neos\\Media\\Domain\\Model\\ImageVariant&quot;,&quot;originalAsset&quot;:{&quot;__identity&quot;:&quot;ee3d239e-48b0-4f99-90be-054301b91792&quot;,&quot;__type&quot;:&quot;Neos\\Media\\Domain\\Model\\Image&quot;,&quot;title&quot;:&quot;&quot;,&quot;copyrightNotice&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;resource&quot;:{&quot;filename&quot;:&quot;neos_primary.png&quot;,&quot;collectionName&quot;:&quot;persistent&quot;,&quot;relativePublicationPath&quot;:&quot;&quot;,&quot;mediaType&quot;:&quot;image\/png&quot;,&quot;sha1&quot;:&quot;aac28f51e5ca842e2646e88e7d242ac3c27e1f25&quot;,&quot;hash&quot;:&quot;aac28f51e5ca842e2646e88e7d242ac3c27e1f25&quot;,&quot;__identity&quot;:&quot;71abb35f-f167-4677-a3f5-386785e9d874&quot;}},&quot;adjustments&quot;:[{&quot;aspectRatio&quot;:null,&quot;height&quot;:126,&quot;position&quot;:10,&quot;width&quot;:126,&quot;x&quot;:328,&quot;y&quot;:0,&quot;__identity&quot;:&quot;206ccf9b-ddd8-4021-951b-c7df0adf893a&quot;,&quot;__type&quot;:&quot;Neos\\Media\\Domain\\Model\\Adjustment\\CropImageAdjustment&quot;}]}</image>
+      <image __type="object" __identifier="50cd4a3e-1cc3-4bbb-b2ab-919abb4011f1" __classname="Neos\Media\Domain\Model\ImageVariant" __encoding="json">{&quot;__identity&quot;:&quot;50cd4a3e-1cc3-4bbb-b2ab-919abb4011f1&quot;,&quot;__type&quot;:&quot;Neos\\Media\\Domain\\Model\\ImageVariant&quot;,&quot;originalAsset&quot;:{&quot;__identity&quot;:&quot;ee3d239e-48b0-4f99-90be-054301b91792&quot;,&quot;__type&quot;:&quot;Neos\\Media\\Domain\\Model\\Image&quot;,&quot;title&quot;:&quot;&quot;,&quot;copyrightNotice&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;resource&quot;:{&quot;filename&quot;:&quot;neos_primary.png&quot;,&quot;collectionName&quot;:&quot;persistent&quot;,&quot;relativePublicationPath&quot;:&quot;&quot;,&quot;mediaType&quot;:&quot;image\/png&quot;,&quot;sha1&quot;:&quot;aac28f51e5ca842e2646e88e7d242ac3c27e1f25&quot;,&quot;hash&quot;:&quot;aac28f51e5ca842e2646e88e7d242ac3c27e1f25&quot;,&quot;__identity&quot;:&quot;71abb35f-f167-4677-a3f5-386785e9d874&quot;},&quot;tags&quot;:[],&quot;assetCollections&quot;:[]},&quot;adjustments&quot;:[{&quot;aspectRatio&quot;:null,&quot;height&quot;:126,&quot;position&quot;:10,&quot;width&quot;:126,&quot;x&quot;:328,&quot;y&quot;:0,&quot;__identity&quot;:&quot;82719b51-e1c7-493a-abd3-0fa945155851&quot;,&quot;__type&quot;:&quot;Neos\\Media\\Domain\\Model\\Adjustment\\CropImageAdjustment&quot;}]}</image>
      </properties>
     </variant>
     <variant sortingIndex="100" workspace="live" nodeType="Neos.TestNodeTypes:Document.Page" version="3" removed="" hidden="" hiddenInIndex="">
@@ -83,68 +96,14 @@
       <uriPathSegment __type="string">home</uriPathSegment>
      </properties>
     </variant>
-    <variant sortingIndex="100" workspace="live" nodeType="Neos.TestNodeTypes:Document.Page" version="3" removed="" hidden="" hiddenInIndex="">
-     <dimensions>
-      <language>da</language>
-     </dimensions>
-     <accessRoles __type="array"/>
-     <creationDateTime __type="object" __classname="DateTime">2019-03-19T16:18:09+00:00</creationDateTime>
-     <lastModificationDateTime __type="object" __classname="DateTime">2019-03-19T16:18:47+00:00</lastModificationDateTime>
-     <lastPublicationDateTime __type="object" __classname="DateTime">2019-03-19T16:18:47+00:00</lastPublicationDateTime>
-     <properties>
-      <title __type="string">Hjem</title>
-      <uriPathSegment __type="string">home</uriPathSegment>
-     </properties>
-    </variant>
     <node identifier="6c302e0e-1d54-4697-a7ec-88d4e0d010cf" nodeName="main">
      <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
       <dimensions>
-       <language>fr</language>
+       <language>en_US</language>
       </dimensions>
       <accessRoles __type="array"/>
-      <creationDateTime __type="object" __classname="DateTime">2019-03-19T16:19:22+00:00</creationDateTime>
-      <lastModificationDateTime __type="object" __classname="DateTime">2019-03-19T16:19:37+00:00</lastModificationDateTime>
-      <lastPublicationDateTime __type="object" __classname="DateTime">2019-03-19T16:19:37+00:00</lastPublicationDateTime>
-      <properties/>
-     </variant>
-     <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
-      <dimensions>
-       <language>en_UK</language>
-      </dimensions>
-      <accessRoles __type="array"/>
-      <creationDateTime __type="object" __classname="DateTime">2019-03-25T15:23:14+00:00</creationDateTime>
-      <lastModificationDateTime __type="object" __classname="DateTime">2019-03-25T15:23:55+00:00</lastModificationDateTime>
-      <lastPublicationDateTime __type="object" __classname="DateTime">2019-03-25T15:23:55+00:00</lastPublicationDateTime>
-      <properties/>
-     </variant>
-     <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
-      <dimensions>
-       <language>de</language>
-      </dimensions>
-      <accessRoles __type="array"/>
-      <creationDateTime __type="object" __classname="DateTime">2019-03-19T16:19:45+00:00</creationDateTime>
-      <lastModificationDateTime __type="object" __classname="DateTime">2019-03-19T16:20:23+00:00</lastModificationDateTime>
-      <lastPublicationDateTime __type="object" __classname="DateTime">2019-03-19T16:20:23+00:00</lastPublicationDateTime>
-      <properties/>
-     </variant>
-     <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
-      <dimensions>
-       <language>nl</language>
-      </dimensions>
-      <accessRoles __type="array"/>
-      <creationDateTime __type="object" __classname="DateTime">2019-03-19T16:18:55+00:00</creationDateTime>
-      <lastModificationDateTime __type="object" __classname="DateTime">2019-03-19T16:19:13+00:00</lastModificationDateTime>
-      <lastPublicationDateTime __type="object" __classname="DateTime">2019-03-19T16:19:12+00:00</lastPublicationDateTime>
-      <properties/>
-     </variant>
-     <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
-      <dimensions>
-       <language>da</language>
-      </dimensions>
-      <accessRoles __type="array"/>
-      <creationDateTime __type="object" __classname="DateTime">2019-03-19T16:18:09+00:00</creationDateTime>
-      <lastModificationDateTime __type="object" __classname="DateTime">2019-03-19T16:18:14+00:00</lastModificationDateTime>
-      <lastPublicationDateTime __type="object" __classname="DateTime">2019-03-19T16:18:14+00:00</lastPublicationDateTime>
+      <creationDateTime __type="object" __classname="DateTime">2018-06-26T23:20:17+00:00</creationDateTime>
+      <lastModificationDateTime __type="object" __classname="DateTime">2019-03-19T15:59:34+00:00</lastModificationDateTime>
       <properties/>
      </variant>
      <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
@@ -159,11 +118,52 @@
      </variant>
      <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
       <dimensions>
-       <language>en_US</language>
+       <language>da</language>
       </dimensions>
       <accessRoles __type="array"/>
-      <creationDateTime __type="object" __classname="DateTime">2018-06-26T23:20:17+00:00</creationDateTime>
-      <lastModificationDateTime __type="object" __classname="DateTime">2019-03-19T15:59:34+00:00</lastModificationDateTime>
+      <creationDateTime __type="object" __classname="DateTime">2019-03-19T16:18:09+00:00</creationDateTime>
+      <lastModificationDateTime __type="object" __classname="DateTime">2019-03-19T16:18:14+00:00</lastModificationDateTime>
+      <lastPublicationDateTime __type="object" __classname="DateTime">2019-03-19T16:18:14+00:00</lastPublicationDateTime>
+      <properties/>
+     </variant>
+     <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+      <dimensions>
+       <language>nl</language>
+      </dimensions>
+      <accessRoles __type="array"/>
+      <creationDateTime __type="object" __classname="DateTime">2019-03-19T16:18:55+00:00</creationDateTime>
+      <lastModificationDateTime __type="object" __classname="DateTime">2019-03-19T16:19:13+00:00</lastModificationDateTime>
+      <lastPublicationDateTime __type="object" __classname="DateTime">2019-03-19T16:19:12+00:00</lastPublicationDateTime>
+      <properties/>
+     </variant>
+     <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+      <dimensions>
+       <language>fr</language>
+      </dimensions>
+      <accessRoles __type="array"/>
+      <creationDateTime __type="object" __classname="DateTime">2019-03-19T16:19:22+00:00</creationDateTime>
+      <lastModificationDateTime __type="object" __classname="DateTime">2019-03-19T16:19:37+00:00</lastModificationDateTime>
+      <lastPublicationDateTime __type="object" __classname="DateTime">2019-03-19T16:19:37+00:00</lastPublicationDateTime>
+      <properties/>
+     </variant>
+     <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+      <dimensions>
+       <language>de</language>
+      </dimensions>
+      <accessRoles __type="array"/>
+      <creationDateTime __type="object" __classname="DateTime">2019-03-19T16:19:45+00:00</creationDateTime>
+      <lastModificationDateTime __type="object" __classname="DateTime">2019-03-19T16:20:23+00:00</lastModificationDateTime>
+      <lastPublicationDateTime __type="object" __classname="DateTime">2019-03-19T16:20:23+00:00</lastPublicationDateTime>
+      <properties/>
+     </variant>
+     <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+      <dimensions>
+       <language>en_UK</language>
+      </dimensions>
+      <accessRoles __type="array"/>
+      <creationDateTime __type="object" __classname="DateTime">2019-03-25T15:23:14+00:00</creationDateTime>
+      <lastModificationDateTime __type="object" __classname="DateTime">2019-03-25T15:23:55+00:00</lastModificationDateTime>
+      <lastPublicationDateTime __type="object" __classname="DateTime">2019-03-25T15:23:55+00:00</lastPublicationDateTime>
       <properties/>
      </variant>
      <node identifier="53c72be8-befb-409f-b2b6-ad54b68cbe05" nodeName="node-chdxek8m9mgp8">
@@ -548,6 +548,411 @@
         <lastPublicationDateTime __type="object" __classname="DateTime">2019-12-20T17:01:03+00:00</lastPublicationDateTime>
         <properties/>
        </variant>
+      </node>
+     </node>
+    </node>
+    <node identifier="942eba43-aff0-4855-b6dc-c4548a344d0a" nodeName="node-s1mwwritoux69">
+     <variant sortingIndex="850" workspace="live" nodeType="Neos.TestNodeTypes:Document.Blog" version="2" removed="" hidden="" hiddenInIndex="">
+      <dimensions>
+       <language>en_US</language>
+      </dimensions>
+      <accessRoles __type="array"/>
+      <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:42+00:00</creationDateTime>
+      <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+      <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+      <properties>
+       <uriPathSegment __type="string">blog</uriPathSegment>
+       <title __type="string">Blog</title>
+      </properties>
+     </variant>
+     <node identifier="ccec5445-d64d-7b6c-565a-8348bf58aae4" nodeName="main">
+      <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+       <dimensions>
+        <language>en_US</language>
+       </dimensions>
+       <accessRoles __type="array"/>
+       <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:42+00:00</creationDateTime>
+       <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+       <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+       <properties/>
+      </variant>
+     </node>
+     <node identifier="db35982e-232b-412e-878e-93e0d3bd7064" nodeName="node-4tukkydme1hgo">
+      <variant sortingIndex="300" workspace="live" nodeType="Neos.TestNodeTypes:Document.BlogArticle" version="3" removed="" hidden="" hiddenInIndex="">
+       <dimensions>
+        <language>en_US</language>
+       </dimensions>
+       <accessRoles __type="array"/>
+       <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:52+00:00</creationDateTime>
+       <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+       <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+       <properties>
+        <uriPathSegment __type="string">writing-blog-articles-considered-harmful</uriPathSegment>
+        <title __type="string">Writing Blog Articles considered harmful</title>
+       </properties>
+      </variant>
+      <node identifier="06a3fd15-f0ce-8127-ae8b-d03a37731502" nodeName="main">
+       <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+        <dimensions>
+         <language>en_US</language>
+        </dimensions>
+        <accessRoles __type="array"/>
+        <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:52+00:00</creationDateTime>
+        <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+        <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+        <properties/>
+       </variant>
+      </node>
+     </node>
+     <node identifier="c116e6d7-4498-4488-b8c5-63a2e844898f" nodeName="node-5pzrrfakbjez6">
+      <variant sortingIndex="250" workspace="live" nodeType="Neos.TestNodeTypes:Document.BlogArticle" version="3" removed="" hidden="" hiddenInIndex="">
+       <dimensions>
+        <language>en_US</language>
+       </dimensions>
+       <accessRoles __type="array"/>
+       <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:48+00:00</creationDateTime>
+       <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+       <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+       <properties>
+        <uriPathSegment __type="string">fix-all-the-bugs-with-this-weird-little-trick</uriPathSegment>
+        <title __type="string">Fix all the bugs with this weird little trick!</title>
+       </properties>
+      </variant>
+      <node identifier="b27fd7fb-7a0a-3960-674e-d1ecb2e33514" nodeName="main">
+       <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+        <dimensions>
+         <language>en_US</language>
+        </dimensions>
+        <accessRoles __type="array"/>
+        <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:48+00:00</creationDateTime>
+        <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+        <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+        <properties/>
+       </variant>
+      </node>
+     </node>
+     <node identifier="24b9acbb-d05b-4d8a-ada4-5472fb7f37a9" nodeName="node-c4htt8oy8600u">
+      <variant sortingIndex="200" workspace="live" nodeType="Neos.TestNodeTypes:Document.BlogArticle" version="2" removed="" hidden="" hiddenInIndex="">
+       <dimensions>
+        <language>en_US</language>
+       </dimensions>
+       <accessRoles __type="array"/>
+       <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:45+00:00</creationDateTime>
+       <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+       <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+       <properties>
+        <uriPathSegment __type="string">hello-world</uriPathSegment>
+        <title __type="string">Hello World!</title>
+       </properties>
+      </variant>
+      <node identifier="ee681f71-4cf3-a3bb-4fbd-f9a18fecff69" nodeName="main">
+       <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+        <dimensions>
+         <language>en_US</language>
+        </dimensions>
+        <accessRoles __type="array"/>
+        <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:45+00:00</creationDateTime>
+        <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+        <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+        <properties/>
+       </variant>
+      </node>
+     </node>
+    </node>
+    <node identifier="3e29b306-7dc1-479c-88c4-330dba4eb14b" nodeName="node-w04fof8s4zhgb">
+     <variant sortingIndex="750" workspace="live" nodeType="Neos.TestNodeTypes:Document.Page" version="2" removed="" hidden="" hiddenInIndex="">
+      <dimensions>
+       <language>en_US</language>
+      </dimensions>
+      <accessRoles __type="array"/>
+      <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:07+00:00</creationDateTime>
+      <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+      <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+      <properties>
+       <uriPathSegment __type="string">nested-pages</uriPathSegment>
+       <title __type="string">Nested Pages</title>
+      </properties>
+     </variant>
+     <node identifier="e8891aa6-c9c7-c34f-4bc1-1cd0b57732db" nodeName="main">
+      <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+       <dimensions>
+        <language>en_US</language>
+       </dimensions>
+       <accessRoles __type="array"/>
+       <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:07+00:00</creationDateTime>
+       <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+       <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+       <properties/>
+      </variant>
+     </node>
+     <node identifier="0fb1aa8e-5fbc-4654-9c05-a3bfccb14e6a" nodeName="node-m2npwf5q37m5f">
+      <variant sortingIndex="200" workspace="live" nodeType="Neos.TestNodeTypes:Document.Page" version="2" removed="" hidden="" hiddenInIndex="">
+       <dimensions>
+        <language>en_US</language>
+       </dimensions>
+       <accessRoles __type="array"/>
+       <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:10+00:00</creationDateTime>
+       <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+       <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+       <properties>
+        <uriPathSegment __type="string">nested-page-1</uriPathSegment>
+        <title __type="string">Nested Page #1</title>
+       </properties>
+      </variant>
+      <node identifier="41ec5658-49b2-09e7-6b50-4054c1294818" nodeName="main">
+       <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+        <dimensions>
+         <language>en_US</language>
+        </dimensions>
+        <accessRoles __type="array"/>
+        <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:10+00:00</creationDateTime>
+        <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+        <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+        <properties/>
+       </variant>
+      </node>
+      <node identifier="95dade5d-2986-4370-a362-96999caa0aaa" nodeName="node-e1shubu8w4hpa">
+       <variant sortingIndex="200" workspace="live" nodeType="Neos.TestNodeTypes:Document.Page" version="2" removed="" hidden="" hiddenInIndex="">
+        <dimensions>
+         <language>en_US</language>
+        </dimensions>
+        <accessRoles __type="array"/>
+        <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:13+00:00</creationDateTime>
+        <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+        <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+        <properties>
+         <uriPathSegment __type="string">nested-page-2</uriPathSegment>
+         <title __type="string">Nested Page #2</title>
+        </properties>
+       </variant>
+       <node identifier="b405f52b-1709-e482-ec79-6ff91424ef99" nodeName="main">
+        <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+         <dimensions>
+          <language>en_US</language>
+         </dimensions>
+         <accessRoles __type="array"/>
+         <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:13+00:00</creationDateTime>
+         <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+         <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+         <properties/>
+        </variant>
+       </node>
+       <node identifier="d5fddc18-91dd-4299-99cf-0d7dfcc2e2fe" nodeName="node-l5mvlwvp5aw0r">
+        <variant sortingIndex="200" workspace="live" nodeType="Neos.TestNodeTypes:Document.Page" version="2" removed="" hidden="" hiddenInIndex="">
+         <dimensions>
+          <language>en_US</language>
+         </dimensions>
+         <accessRoles __type="array"/>
+         <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:16+00:00</creationDateTime>
+         <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+         <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+         <properties>
+          <uriPathSegment __type="string">nested-page-3</uriPathSegment>
+          <title __type="string">Nested Page #3</title>
+         </properties>
+        </variant>
+        <node identifier="9075c8ee-b4f1-d491-e439-b98265a493ad" nodeName="main">
+         <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+          <dimensions>
+           <language>en_US</language>
+          </dimensions>
+          <accessRoles __type="array"/>
+          <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:16+00:00</creationDateTime>
+          <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+          <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+          <properties/>
+         </variant>
+        </node>
+        <node identifier="dea1a6b0-39c7-4153-a742-3efe9915e4db" nodeName="node-1llj5wdjiletd">
+         <variant sortingIndex="200" workspace="live" nodeType="Neos.TestNodeTypes:Document.Page" version="2" removed="" hidden="" hiddenInIndex="">
+          <dimensions>
+           <language>en_US</language>
+          </dimensions>
+          <accessRoles __type="array"/>
+          <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:19+00:00</creationDateTime>
+          <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+          <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+          <properties>
+           <uriPathSegment __type="string">nested-page-4</uriPathSegment>
+           <title __type="string">Nested Page #4</title>
+          </properties>
+         </variant>
+         <node identifier="b0456b7a-9a85-0ca4-0141-f3bab9a036bf" nodeName="main">
+          <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+           <dimensions>
+            <language>en_US</language>
+           </dimensions>
+           <accessRoles __type="array"/>
+           <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:19+00:00</creationDateTime>
+           <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+           <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+           <properties/>
+          </variant>
+         </node>
+         <node identifier="e5a42289-803a-446f-a373-81b485cdd3c7" nodeName="node-tabv49lpw16xn">
+          <variant sortingIndex="200" workspace="live" nodeType="Neos.TestNodeTypes:Document.Page" version="2" removed="" hidden="" hiddenInIndex="">
+           <dimensions>
+            <language>en_US</language>
+           </dimensions>
+           <accessRoles __type="array"/>
+           <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:22+00:00</creationDateTime>
+           <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+           <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+           <properties>
+            <uriPathSegment __type="string">nested-page-5</uriPathSegment>
+            <title __type="string">Nested Page #5</title>
+           </properties>
+          </variant>
+          <node identifier="8591ba21-3929-1314-a31b-69f5258193c1" nodeName="main">
+           <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+            <dimensions>
+             <language>en_US</language>
+            </dimensions>
+            <accessRoles __type="array"/>
+            <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:22+00:00</creationDateTime>
+            <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+            <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+            <properties/>
+           </variant>
+          </node>
+          <node identifier="fd6acd5e-55ba-4ce1-8518-2ebf4fba45a2" nodeName="node-n9ykrtn2b42xt">
+           <variant sortingIndex="200" workspace="live" nodeType="Neos.TestNodeTypes:Document.Page" version="2" removed="" hidden="" hiddenInIndex="">
+            <dimensions>
+             <language>en_US</language>
+            </dimensions>
+            <accessRoles __type="array"/>
+            <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:26+00:00</creationDateTime>
+            <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+            <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+            <properties>
+             <uriPathSegment __type="string">nested-page-6</uriPathSegment>
+             <title __type="string">Nested Page #6</title>
+            </properties>
+           </variant>
+           <node identifier="6e002d19-8bf1-4262-0b06-e644aeea325d" nodeName="main">
+            <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+             <dimensions>
+              <language>en_US</language>
+             </dimensions>
+             <accessRoles __type="array"/>
+             <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:26+00:00</creationDateTime>
+             <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+             <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+             <properties/>
+            </variant>
+           </node>
+           <node identifier="6613448a-be6c-44e3-bc70-a85cc7f9da0a" nodeName="node-6nua3xp6z3x8r">
+            <variant sortingIndex="200" workspace="live" nodeType="Neos.TestNodeTypes:Document.Page" version="2" removed="" hidden="" hiddenInIndex="">
+             <dimensions>
+              <language>en_US</language>
+             </dimensions>
+             <accessRoles __type="array"/>
+             <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:28+00:00</creationDateTime>
+             <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+             <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+             <properties>
+              <uriPathSegment __type="string">nested-page-7</uriPathSegment>
+              <title __type="string">Nested Page #7</title>
+             </properties>
+            </variant>
+            <node identifier="a9a3826d-30f4-793a-6ef4-daad24bb01c4" nodeName="main">
+             <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+              <dimensions>
+               <language>en_US</language>
+              </dimensions>
+              <accessRoles __type="array"/>
+              <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:28+00:00</creationDateTime>
+              <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+              <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+              <properties/>
+             </variant>
+            </node>
+            <node identifier="05564f83-9ed3-44ec-a785-53ee7e3f1824" nodeName="node-uucrsb66mtijd">
+             <variant sortingIndex="200" workspace="live" nodeType="Neos.TestNodeTypes:Document.Page" version="2" removed="" hidden="" hiddenInIndex="">
+              <dimensions>
+               <language>en_US</language>
+              </dimensions>
+              <accessRoles __type="array"/>
+              <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:32+00:00</creationDateTime>
+              <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+              <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+              <properties>
+               <uriPathSegment __type="string">nested-page-8</uriPathSegment>
+               <title __type="string">Nested Page #8</title>
+              </properties>
+             </variant>
+             <node identifier="265d9d32-0884-60b4-845f-0accf81dd157" nodeName="main">
+              <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+               <dimensions>
+                <language>en_US</language>
+               </dimensions>
+               <accessRoles __type="array"/>
+               <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:32+00:00</creationDateTime>
+               <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+               <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+               <properties/>
+              </variant>
+             </node>
+             <node identifier="df84838a-68ac-401b-bcb6-5d6c0723b987" nodeName="node-bo7idoo4bsuga">
+              <variant sortingIndex="200" workspace="live" nodeType="Neos.TestNodeTypes:Document.Page" version="2" removed="" hidden="" hiddenInIndex="">
+               <dimensions>
+                <language>en_US</language>
+               </dimensions>
+               <accessRoles __type="array"/>
+               <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:35+00:00</creationDateTime>
+               <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+               <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+               <properties>
+                <uriPathSegment __type="string">nested-page-9</uriPathSegment>
+                <title __type="string">Nested Page #9</title>
+               </properties>
+              </variant>
+              <node identifier="b8597c1e-517e-a73e-cf15-99ac535a8abc" nodeName="main">
+               <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+                <dimensions>
+                 <language>en_US</language>
+                </dimensions>
+                <accessRoles __type="array"/>
+                <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:35+00:00</creationDateTime>
+                <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+                <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+                <properties/>
+               </variant>
+              </node>
+              <node identifier="a15ed6c4-93af-422c-b505-7472991d92ee" nodeName="node-16rge2m5xui5u">
+               <variant sortingIndex="200" workspace="live" nodeType="Neos.TestNodeTypes:Document.Page" version="2" removed="" hidden="" hiddenInIndex="">
+                <dimensions>
+                 <language>en_US</language>
+                </dimensions>
+                <accessRoles __type="array"/>
+                <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:38+00:00</creationDateTime>
+                <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+                <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+                <properties>
+                 <uriPathSegment __type="string">nested-page-10</uriPathSegment>
+                 <title __type="string">Nested Page #10</title>
+                </properties>
+               </variant>
+               <node identifier="6c01b832-220e-0f26-53b8-727fe77945b7" nodeName="main">
+                <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+                 <dimensions>
+                  <language>en_US</language>
+                 </dimensions>
+                 <accessRoles __type="array"/>
+                 <creationDateTime __type="object" __classname="DateTime">2024-07-02T13:21:38+00:00</creationDateTime>
+                 <lastModificationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:56+00:00</lastModificationDateTime>
+                 <lastPublicationDateTime __type="object" __classname="DateTime">2024-07-02T13:23:55+00:00</lastPublicationDateTime>
+                 <properties/>
+                </variant>
+               </node>
+              </node>
+             </node>
+            </node>
+           </node>
+          </node>
+         </node>
+        </node>
+       </node>
       </node>
      </node>
     </node>

--- a/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
@@ -94,7 +94,7 @@ test('Node tree preset "blog" shows nothing but page [🗋 Blog]', async (t) => 
         .ok('[🗋 Blog] did not show up after switching to node tree preset "blog".');
 });
 
-test.skip('In node tree preset "blog", page [🗋 Blog] has no toggle handle', async (t) => {
+test('In node tree preset "blog", page [🗋 Blog] has no toggle handle', async (t) => {
     await t.click('#btn-ToggleDocumentTreeFilter');
     await t.click('#neos-NodeTreeFilter');
     await t.click(Selector('[role="button"]').withText('Show Blog only'));

--- a/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
@@ -112,7 +112,7 @@ test('Node tree preset "blog-articles" shows page [🗋 Blog] and all articles b
 //
 // Original issue: https://github.com/neos/neos-ui/issues/3816
 //
-test.skip('BUG #3816: Switching back from node tree preset "blog" does not affect loading children in node tree preset "default"', async (t) => {
+test('BUG #3816: Switching back from node tree preset "blog" does not affect loading children in node tree preset "default"', async (t) => {
     await t.click(Page.getToggleChildrenButtonOf('Nested Page #1'));
     await t.expect(Page.treeNode.withExactText('Nested Page #2').exists)
         .ok('[🗋 Nested Page #2] did not show up after toggling children of [🗋 Nested Page #1] the first time.');
@@ -141,7 +141,7 @@ test.skip('BUG #3816: Switching back from node tree preset "blog" does not affec
 //
 // Original issue: https://github.com/neos/neos-ui/issues/2583
 //
-test.skip('BUG #2583: Searching the document tree does not break expansion in node tree preset "default"', async (t) => {
+test('BUG #2583: Searching the document tree does not break expansion in node tree preset "default"', async (t) => {
     await t.click(Page.getToggleChildrenButtonOf('Nested Page #1'));
     await t.expect(Page.treeNode.withExactText('Nested Page #2').exists)
         .ok('[🗋 Nested Page #2] did not show up after toggling children of [🗋 Nested Page #1] the first time.');

--- a/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
@@ -170,7 +170,7 @@ test('BUG #2583: Searching the document tree does not break expansion in node tr
 //
 // Original issue: https://github.com/neos/neos-ui/issues/2800
 //
-test.skip('BUG #2800: Moving pages in a filtered view does not lead to the disappearance of nodes', async (t) => {
+test('BUG #2800 1/2: Moving pages before/after in a filtered view does not lead to the disappearance of nodes', async (t) => {
     await t.click('#btn-ToggleDocumentTreeFilter');
     await t.click('#neos-NodeTreeFilter');
     await t.click(Selector('[role="button"]').withText('Show Blog Articles only'));
@@ -181,6 +181,23 @@ test.skip('BUG #2800: Moving pages in a filtered view does not lead to the disap
     await t.dragToElement(
         Page.getTreeNodeButton('Hello World!'),
         Page.getTreeNodeButton('Writing Blog Articles considered harmful').prevSibling()
+    );
+
+    await t.expect(Page.treeNode.withExactText('Blog').exists)
+        .ok('[🗋 Blog] disappeared after moving nodes in node tree preset "blog-articles".');
+    await t.expect(Page.treeNode.withExactText('Hello World!').exists)
+        .ok('[🗋 Hello World!] disappeared after moving nodes in node tree preset "blog-articles".');
+    await t.expect(Page.treeNode.withExactText('Fix all the bugs with this weird little trick!').exists)
+        .ok('[🗋 Fix all the bugs with this weird little trick!] disappeared after moving nodes in node tree preset "blog-articles".');
+    await t.expect(Page.treeNode.withExactText('Writing Blog Articles considered harmful').exists)
+        .ok('[🗋 Writing Blog Articles considered harmful] disappeared after moving nodes in node tree preset "blog-articles".');
+
+    //
+    // Move Blog Article [🗋 Hello World!] after [🗋 Writing Blog Articles considered harmful]
+    //
+    await t.dragToElement(
+        Page.getTreeNodeButton('Hello World!'),
+        Page.getTreeNodeButton('Writing Blog Articles considered harmful').nextSibling()
     );
 
     await t.expect(Page.treeNode.withExactText('Blog').exists)

--- a/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
@@ -167,3 +167,28 @@ test.skip('BUG #2583: Searching the document tree does not break expansion in no
         .notOk('[🗋 Nested Page #2] did not disappear after toggling children of [🗋 Nested Page #1] the fourth time.');
 });
 
+//
+// Original issue: https://github.com/neos/neos-ui/issues/2800
+//
+test.skip('BUG #2800: Moving pages in a filtered view does not lead to the disappearance of nodes', async (t) => {
+    await t.click('#btn-ToggleDocumentTreeFilter');
+    await t.click('#neos-NodeTreeFilter');
+    await t.click(Selector('[role="button"]').withText('Show Blog Articles only'));
+
+    //
+    // Move Blog Article [🗋 Hello World!] before [🗋 Writing Blog Articles considered harmful]
+    //
+    await t.dragToElement(
+        Page.getTreeNodeButton('Hello World!'),
+        Page.getTreeNodeButton('Writing Blog Articles considered harmful').prevSibling()
+    );
+
+    await t.expect(Page.treeNode.withExactText('Blog').exists)
+        .ok('[🗋 Blog] disappeared after moving nodes in node tree preset "blog-articles".');
+    await t.expect(Page.treeNode.withExactText('Hello World!').exists)
+        .ok('[🗋 Hello World!] disappeared after moving nodes in node tree preset "blog-articles".');
+    await t.expect(Page.treeNode.withExactText('Fix all the bugs with this weird little trick!').exists)
+        .ok('[🗋 Fix all the bugs with this weird little trick!] disappeared after moving nodes in node tree preset "blog-articles".');
+    await t.expect(Page.treeNode.withExactText('Writing Blog Articles considered harmful').exists)
+        .ok('[🗋 Writing Blog Articles considered harmful] disappeared after moving nodes in node tree preset "blog-articles".');
+});

--- a/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
@@ -1,0 +1,113 @@
+import {beforeEach, checkPropTypes} from './../../utils.js';
+import {Page} from './../../pageModel';
+import {Selector} from 'testcafe';
+
+/* global fixture:true */
+
+fixture`Node Tree Presets`
+    .beforeEach(beforeEach)
+    .afterEach(() => checkPropTypes())
+    .before(async () => {
+        const response = await fetch('http://127.0.0.1:8081/test/write-additional-settings', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({settings: SETTINGS_WITH_NODE_TREE_PRESETS})
+        });
+        const json = await response.json();
+        if (!('success' in json) || !json.success) {
+            throw new Error('Additional settings could not be written.');
+        }
+    })
+    .after(async () => {
+        const response = await fetch('http://127.0.0.1:8081/test/remove-additional-settings', {
+            method: 'POST'
+        });
+        const json = await response.json();
+        if (!('success' in json) || !json.success) {
+            throw new Error('Additional settings could not be removed.');
+        }
+    });
+
+const SETTINGS_WITH_NODE_TREE_PRESETS = {
+    Neos: {
+        Neos: {
+            userInterface: {
+                navigateComponent: {
+                    nodeTree: {
+                        loadingDepth: 2,
+                        presets: {
+                            'default': {
+                                baseNodeType: 'Neos.Neos:Document,!Neos.TestNodeTypes:Document.Blog,!Neos.TestNodeTypes:Document.BlogArticle'
+                            },
+                            'blog': {
+                                ui: {
+                                    icon: 'newspaper-o',
+                                    label: 'Show Blog only'
+                                },
+                                baseNodeType: 'Neos.TestNodeTypes:Document.Blog'
+                            },
+                            'blog-articles': {
+                                ui: {
+                                    icon: 'file-text-o',
+                                    label: 'Show Blog Articles only'
+                                },
+                                baseNodeType: 'Neos.TestNodeTypes:Document.BlogArticle'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+test('Node tree preset "default" removes all blog related nodes and only loads nodes with depth <= 2', async (t) => {
+    //
+    // Assert that all documents with a depth > 2 are no longer visible in
+    // "default" preset
+    //
+    await t.expect(Page.treeNode.withExactText('Nested Page #2').exists)
+        .notOk('[🗋 Nested Page #2] can still be found in the document tree with preset "default".');
+
+    //
+    // Assert that all the blog-related documents are not visible in "default"
+    // preset
+    //
+    await t.expect(Page.treeNode.withExactText('Blog').exists)
+        .notOk('[🗋 Blog] can still be found in the document tree with preset "default".');
+    await t.expect(Page.treeNode.withExactText('Hello World!').exists)
+        .notOk('[🗋 Hello World!] can still be found in the document tree with preset "default".');
+    await t.expect(Page.treeNode.withExactText('Fix all the bugs with this weird little trick!').exists)
+        .notOk('[🗋 Fix all the bugs with this weird little trick!] can still be found in the document tree with preset "default".');
+    await t.expect(Page.treeNode.withExactText('Writing Blog Articles considered harmful').exists)
+        .notOk('[🗋 Writing Blog Articles considered harmful] can still be found in the document tree with preset "default".');
+});
+
+test('Node tree preset "blog" shows nothing but page [🗋 Blog]', async (t) => {
+    await t.click('#btn-ToggleDocumentTreeFilter');
+    await t.click('#neos-NodeTreeFilter');
+    await t.click(Selector('[role="button"]').withText('Show Blog only'));
+
+    await t.expect(Page.treeNode.withExactText('Blog').exists)
+        .ok('[🗋 Blog] did not show up after switching to node tree preset "blog".');
+});
+
+test('Node tree preset "blog-articles" shows page [🗋 Blog] and all articles beneath it', async (t) => {
+    await t.click('#btn-ToggleDocumentTreeFilter');
+    await t.click('#neos-NodeTreeFilter');
+    await t.click(Selector('[role="button"]').withText('Show Blog Articles only'));
+
+    await t.expect(Page.treeNode.withExactText('Blog').exists)
+        .ok('[🗋 Blog] did not show up after switching to node tree preset "blog-articles".');
+    await t.expect(Page.treeNode.withExactText('Hello World!').exists)
+        .ok('[🗋 Hello World!] did not show up after switching to node tree preset "blog-articles".');
+    await t.expect(Page.treeNode.withExactText('Fix all the bugs with this weird little trick!').exists)
+        .ok('[🗋 Fix all the bugs with this weird little trick!] did not show up after switching to node tree preset "blog-articles".');
+    await t.expect(Page.treeNode.withExactText('Writing Blog Articles considered harmful').exists)
+        .ok('[🗋 Writing Blog Articles considered harmful] did not show up after switching to node tree preset "blog-articles".');
+});
+
+//
+// Original issue: https://github.com/neos/neos-ui/issues/3816

--- a/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
@@ -111,3 +111,32 @@ test('Node tree preset "blog-articles" shows page [🗋 Blog] and all articles b
 
 //
 // Original issue: https://github.com/neos/neos-ui/issues/3816
+//
+test.skip('BUG #3816: Switching back from node tree preset "blog" does not affect loading children in node tree preset "default"', async (t) => {
+    await t.click(Page.getToggleChildrenButtonOf('Nested Page #1'));
+    await t.expect(Page.treeNode.withExactText('Nested Page #2').exists)
+        .ok('[🗋 Nested Page #2] did not show up after toggling children of [🗋 Nested Page #1] the first time.');
+    await t.click(Page.getToggleChildrenButtonOf('Nested Page #1'));
+    await t.expect(Page.treeNode.withExactText('Nested Page #2').exists)
+        .notOk('[🗋 Nested Page #2] did not disappear after toggling children of [🗋 Nested Page #1] the second time.');
+
+    await t.click('#btn-ToggleDocumentTreeFilter');
+    await t.click('#neos-NodeTreeFilter');
+    await t.click(Selector('[role="button"]').withText('Show Blog only'));
+    await t.expect(Page.treeNode.withExactText('Blog').exists)
+        .ok('[🗋 Blog] did not show up after switching to node tree preset "blog".');
+
+    await t.click('#neos-NodeTreeFilter-SelectBox-btn-reset');
+    await t.expect(Page.treeNode.withExactText('Blog').exists)
+        .notOk('[🗋 Blog] did not disappear after switching back to node tree preset "default".');
+
+    await t.click(Page.getToggleChildrenButtonOf('Nested Page #1'));
+    await t.expect(Page.treeNode.withExactText('Nested Page #2').exists)
+        .ok('[🗋 Nested Page #2] did not show up after toggling children of [🗋 Nested Page #1] the third time.');
+    await t.click(Page.getToggleChildrenButtonOf('Nested Page #1'));
+    await t.expect(Page.treeNode.withExactText('Nested Page #2').exists)
+        .notOk('[🗋 Nested Page #2] did not disappear after toggling children of [🗋 Nested Page #1] the fourth time.');
+});
+
+//
+// Original issue: https://github.com/neos/neos-ui/issues/2583

--- a/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
@@ -94,7 +94,7 @@ test('Node tree preset "blog" shows nothing but page [🗋 Blog]', async (t) => 
         .ok('[🗋 Blog] did not show up after switching to node tree preset "blog".');
 });
 
-test.skip('Reloading the node tree while in preset "blog" results in nothing but page [🗋 Blog]', async (t) => {
+test('Reloading the node tree while in preset "blog" results in nothing but page [🗋 Blog]', async (t) => {
     await t.click('#btn-ToggleDocumentTreeFilter');
     await t.click('#neos-NodeTreeFilter');
     await t.click(Selector('[role="button"]').withText('Show Blog only'));

--- a/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
@@ -94,6 +94,15 @@ test('Node tree preset "blog" shows nothing but page [🗋 Blog]', async (t) => 
         .ok('[🗋 Blog] did not show up after switching to node tree preset "blog".');
 });
 
+test.skip('In node tree preset "blog", page [🗋 Blog] has no toggle handle', async (t) => {
+    await t.click('#btn-ToggleDocumentTreeFilter');
+    await t.click('#neos-NodeTreeFilter');
+    await t.click(Selector('[role="button"]').withText('Show Blog only'));
+
+    await t.expect(Page.getToggleChildrenButtonOf('Blog').exists)
+        .notOk('[🗋 Blog] has a toggle handle, even though its children do not match the currently set filter in node tree preset "blog".');
+});
+
 test('Reloading the node tree while in preset "blog" results in nothing but page [🗋 Blog]', async (t) => {
     await t.click('#btn-ToggleDocumentTreeFilter');
     await t.click('#neos-NodeTreeFilter');

--- a/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
@@ -210,7 +210,7 @@ test('BUG #2800 1/2: Moving pages before/after in a filtered view does not lead 
         .ok('[🗋 Writing Blog Articles considered harmful] disappeared after moving nodes in node tree preset "blog-articles".');
 });
 
-test.skip('BUG #2800 2/2: Moving pages into each other in a filtered view does not break expansion', async (t) => {
+test('BUG #2800 2/2: Moving pages into each other in a filtered view does not break expansion', async (t) => {
     await t.click('#btn-ToggleDocumentTreeFilter');
     await t.click('#neos-NodeTreeFilter');
     await t.click(Selector('[role="button"]').withText('Show Blog Articles only'));

--- a/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
@@ -209,3 +209,30 @@ test('BUG #2800 1/2: Moving pages before/after in a filtered view does not lead 
     await t.expect(Page.treeNode.withExactText('Writing Blog Articles considered harmful').exists)
         .ok('[🗋 Writing Blog Articles considered harmful] disappeared after moving nodes in node tree preset "blog-articles".');
 });
+
+test.skip('BUG #2800 2/2: Moving pages into each other in a filtered view does not break expansion', async (t) => {
+    await t.click('#btn-ToggleDocumentTreeFilter');
+    await t.click('#neos-NodeTreeFilter');
+    await t.click(Selector('[role="button"]').withText('Show Blog Articles only'));
+
+    //
+    // Move Blog Article [🗋 Hello World!] into [🗋 Writing Blog Articles considered harmful]
+    //
+    await t.dragToElement(
+        Page.getTreeNodeButton('Hello World!'),
+        Page.getTreeNodeButton('Writing Blog Articles considered harmful')
+    );
+
+    await t.expect(Page.treeNode.withExactText('Blog').exists)
+        .ok('[🗋 Blog] disappeared after moving nodes in node tree preset "blog-articles".');
+    await t.expect(Page.treeNode.withExactText('Fix all the bugs with this weird little trick!').exists)
+        .ok('[🗋 Fix all the bugs with this weird little trick!] disappeared after moving nodes in node tree preset "blog-articles".');
+    await t.expect(Page.treeNode.withExactText('Writing Blog Articles considered harmful').exists)
+        .ok('[🗋 Writing Blog Articles considered harmful] disappeared after moving nodes in node tree preset "blog-articles".');
+
+    await t.expect(Page.treeNode.withExactText('Hello World!').exists)
+        .notOk('[🗋 Hello World!] unexpectedly appeared before uncollapsing [🗋 Writing Blog Articles considered harmful].');
+    await t.click(Page.getToggleChildrenButtonOf('Writing Blog Articles considered harmful'));
+    await t.expect(Page.treeNode.withExactText('Hello World!').exists)
+        .ok('[🗋 Writing Blog Articles considered harmful] cannot be uncollapsed after [🗋 Hello World!] was moved into it in node tree preset "blog-articles".');
+});

--- a/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
@@ -94,6 +94,16 @@ test('Node tree preset "blog" shows nothing but page [🗋 Blog]', async (t) => 
         .ok('[🗋 Blog] did not show up after switching to node tree preset "blog".');
 });
 
+test.skip('Reloading the node tree while in preset "blog" results in nothing but page [🗋 Blog]', async (t) => {
+    await t.click('#btn-ToggleDocumentTreeFilter');
+    await t.click('#neos-NodeTreeFilter');
+    await t.click(Selector('[role="button"]').withText('Show Blog only'));
+    await t.click('#neos-PageTree-RefreshPageTree');
+
+    await t.expect(Page.treeNode.withExactText('Blog').exists)
+        .ok('[🗋 Blog] did not show up after switching to node tree preset "blog".');
+});
+
 test('Node tree preset "blog-articles" shows page [🗋 Blog] and all articles beneath it', async (t) => {
     await t.click('#btn-ToggleDocumentTreeFilter');
     await t.click('#neos-NodeTreeFilter');

--- a/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/nodeTreePresets.e2e.js
@@ -140,3 +140,30 @@ test.skip('BUG #3816: Switching back from node tree preset "blog" does not affec
 
 //
 // Original issue: https://github.com/neos/neos-ui/issues/2583
+//
+test.skip('BUG #2583: Searching the document tree does not break expansion in node tree preset "default"', async (t) => {
+    await t.click(Page.getToggleChildrenButtonOf('Nested Page #1'));
+    await t.expect(Page.treeNode.withExactText('Nested Page #2').exists)
+        .ok('[🗋 Nested Page #2] did not show up after toggling children of [🗋 Nested Page #1] the first time.');
+    await t.click(Page.getToggleChildrenButtonOf('Nested Page #1'));
+    await t.expect(Page.treeNode.withExactText('Nested Page #2').exists)
+        .notOk('[🗋 Nested Page #2] did not disappear after toggling children of [🗋 Nested Page #1] the second time.');
+
+    await t.click('#btn-ToggleDocumentTreeFilter');
+
+    await t.typeText(Selector('#neos-NodeTreeSearchInput input[type="search"]'), 'Nested Page #10');
+    await t.expect(Page.treeNode.withExactText('Nested Page #10').exists)
+        .ok('[🗋 Nested Page #10] did not show up after searching for "Nested Page #10".');
+
+    await t.click('#neos-NodeTreeSearchInput-btn-reset');
+    await t.expect(Page.treeNode.withExactText('Nested Page #10').exists)
+        .notOk('[🗋 Nested Page #10] did not disappear after clearing search.');
+
+    await t.click(Page.getToggleChildrenButtonOf('Nested Page #1'));
+    await t.expect(Page.treeNode.withExactText('Nested Page #2').exists)
+        .ok('[🗋 Nested Page #2] did not show up after toggling children of [🗋 Nested Page #1] the third time.');
+    await t.click(Page.getToggleChildrenButtonOf('Nested Page #1'));
+    await t.expect(Page.treeNode.withExactText('Nested Page #2').exists)
+        .notOk('[🗋 Nested Page #2] did not disappear after toggling children of [🗋 Nested Page #1] the fourth time.');
+});
+

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Classes/Application/RemoveAdditionalSettings/Controller/RemoveAdditionalSettingsController.php
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Classes/Application/RemoveAdditionalSettings/Controller/RemoveAdditionalSettingsController.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\TestNodeTypes\Application\RemoveAdditionalSettings\Controller;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Mvc\ActionResponse;
+use Neos\Flow\Mvc\Controller\ControllerInterface;
+use Neos\TestNodeTypes\Application\RemoveAdditionalSettings\RemoveAdditionalSettingsCommand;
+use Neos\TestNodeTypes\Application\RemoveAdditionalSettings\RemoveAdditionalSettingsCommandHandler;
+
+#[Flow\Scope("singleton")]
+final class RemoveAdditionalSettingsController implements ControllerInterface
+{
+    #[Flow\Inject]
+    protected RemoveAdditionalSettingsCommandHandler $commandHandler;
+
+    public function processRequest(ActionRequest $request, ActionResponse $response)
+    {
+        $request->setDispatched(true);
+        $response->setContentType('application/json');
+
+        try {
+            $command = RemoveAdditionalSettingsCommand::fromArray($request->getArguments());
+            $this->commandHandler->handle($command);
+
+            $response->setStatusCode(200);
+            $response->setContent(
+                json_encode(
+                    ['success' => true],
+                    JSON_THROW_ON_ERROR
+                )
+            );
+        } catch (\InvalidArgumentException $e) {
+            $response->setStatusCode(400);
+            $response->setContent(
+                json_encode(
+                    ['error' => [
+                        'type' => $e::class,
+                        'code' => $e->getCode(),
+                        'message' => $e->getMessage(),
+                    ]],
+                    JSON_THROW_ON_ERROR
+                )
+            );
+        } catch (\Exception $e) {
+            $response->setStatusCode(500);
+            $response->setContent(
+                json_encode(
+                    ['error' => [
+                        'type' => $e::class,
+                        'code' => $e->getCode(),
+                        'message' => $e->getMessage(),
+                    ]],
+                    JSON_THROW_ON_ERROR
+                )
+            );
+        }
+    }
+}

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Classes/Application/RemoveAdditionalSettings/RemoveAdditionalSettingsCommand.php
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Classes/Application/RemoveAdditionalSettings/RemoveAdditionalSettingsCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\TestNodeTypes\Application\RemoveAdditionalSettings;
+
+use Neos\Flow\Annotations as Flow;
+
+#[Flow\Proxy(false)]
+final class RemoveAdditionalSettingsCommand
+{
+    public function __construct(
+    ) {
+    }
+
+    public static function fromArray(array $array): self
+    {
+        return new self();
+    }
+}

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Classes/Application/RemoveAdditionalSettings/RemoveAdditionalSettingsCommandHandler.php
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Classes/Application/RemoveAdditionalSettings/RemoveAdditionalSettingsCommandHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\TestNodeTypes\Application\RemoveAdditionalSettings;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Cache\CacheManager;
+use Neos\Flow\Core\Bootstrap;
+use Neos\Utility\Files;
+
+#[Flow\Scope("singleton")]
+final class RemoveAdditionalSettingsCommandHandler
+{
+    #[Flow\Inject]
+    protected Bootstrap $bootstrap;
+
+    public function handle(RemoveAdditionalSettingsCommand $command): void
+    {
+        $additionalSettingsFileName = Files::concatenatePaths([
+            FLOW_PATH_CONFIGURATION,
+            'Settings.Additional.yaml'
+        ]);
+
+        if (file_exists($additionalSettingsFileName)) {
+            unlink($additionalSettingsFileName);
+            $dispatcher = $this->bootstrap->getSignalSlotDispatcher();
+            $dispatcher->connect(Bootstrap::class, 'bootstrapShuttingDown', function () {
+                $this->bootstrap->getObjectManager()->get(CacheManager::class)->flushCaches();
+            });
+        }
+    }
+}

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Classes/Application/WriteAdditionalSettings/Controller/WriteAdditionalSettingsController.php
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Classes/Application/WriteAdditionalSettings/Controller/WriteAdditionalSettingsController.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\TestNodeTypes\Application\WriteAdditionalSettings\Controller;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Mvc\ActionResponse;
+use Neos\Flow\Mvc\Controller\ControllerInterface;
+use Neos\TestNodeTypes\Application\WriteAdditionalSettings\WriteAdditionalSettingsCommand;
+use Neos\TestNodeTypes\Application\WriteAdditionalSettings\WriteAdditionalSettingsCommandHandler;
+
+#[Flow\Scope("singleton")]
+final class WriteAdditionalSettingsController implements ControllerInterface
+{
+    #[Flow\Inject]
+    protected WriteAdditionalSettingsCommandHandler $commandHandler;
+
+    public function processRequest(ActionRequest $request, ActionResponse $response)
+    {
+        $request->setDispatched(true);
+        $response->setContentType('application/json');
+
+        try {
+            $command = WriteAdditionalSettingsCommand::fromArray($request->getArguments());
+            $this->commandHandler->handle($command);
+
+            $response->setStatusCode(200);
+            $response->setContent(
+                json_encode(
+                    ['success' => true],
+                    JSON_THROW_ON_ERROR
+                )
+            );
+        } catch (\InvalidArgumentException $e) {
+            $response->setStatusCode(400);
+            $response->setContent(
+                json_encode(
+                    ['error' => [
+                        'type' => $e::class,
+                        'code' => $e->getCode(),
+                        'message' => $e->getMessage(),
+                    ]],
+                    JSON_THROW_ON_ERROR
+                )
+            );
+        } catch (\Exception $e) {
+            $response->setStatusCode(500);
+            $response->setContent(
+                json_encode(
+                    ['error' => [
+                        'type' => $e::class,
+                        'code' => $e->getCode(),
+                        'message' => $e->getMessage(),
+                    ]],
+                    JSON_THROW_ON_ERROR
+                )
+            );
+        }
+    }
+}

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Classes/Application/WriteAdditionalSettings/WriteAdditionalSettingsCommand.php
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Classes/Application/WriteAdditionalSettings/WriteAdditionalSettingsCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\TestNodeTypes\Application\WriteAdditionalSettings;
+
+use Neos\Flow\Annotations as Flow;
+
+#[Flow\Proxy(false)]
+final class WriteAdditionalSettingsCommand
+{
+    /**
+     * @param array<mixed> $settings
+     */
+    public function __construct(
+        public readonly array $settings
+    ) {
+    }
+
+    public static function fromArray(array $array): self
+    {
+        isset($array['settings']) or
+            throw new \InvalidArgumentException('"settings" must be set.');
+
+        is_array($array['settings']) or
+            throw new \InvalidArgumentException('"settings" must be an array.');
+
+        return new self(
+            settings: $array['settings']
+        );
+    }
+}

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Classes/Application/WriteAdditionalSettings/WriteAdditionalSettingsCommandHandler.php
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Classes/Application/WriteAdditionalSettings/WriteAdditionalSettingsCommandHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\TestNodeTypes\Application\WriteAdditionalSettings;
+
+use DirectoryIterator;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Cache\CacheManager;
+use Neos\Flow\Configuration\Source\YamlSource;
+use Neos\Flow\Core\Bootstrap;
+use Neos\Utility\Files;
+
+#[Flow\Scope("singleton")]
+final class WriteAdditionalSettingsCommandHandler
+{
+    #[Flow\Inject]
+    protected YamlSource $yamlConfigurationSource;
+
+    #[Flow\Inject]
+    protected Bootstrap $bootstrap;
+
+    public function handle(WriteAdditionalSettingsCommand $command): void
+    {
+        $this->yamlConfigurationSource->save(
+            Files::concatenatePaths([
+                FLOW_PATH_CONFIGURATION,
+                'Settings.Additional'
+            ]),
+            $command->settings
+        );
+
+        $dispatcher = $this->bootstrap->getSignalSlotDispatcher();
+        $dispatcher->connect(Bootstrap::class, 'bootstrapShuttingDown', function () {
+            $this->bootstrap->getObjectManager()->get(CacheManager::class)->flushCaches();
+        });
+    }
+}

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/Policy.yaml
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/Policy.yaml
@@ -1,0 +1,15 @@
+---
+privilegeTargets:
+
+  'Neos\Flow\Security\Authorization\Privilege\Method\MethodPrivilege':
+
+    'Neos.TestNodeTypes:TestApiAccess':
+      matcher: 'method(Neos\TestNodeTypes\Application\.*\Controller\.*Controller->processRequest())'
+
+roles:
+
+    'Neos.Flow:Everybody':
+      privileges:
+        -
+          privilegeTarget: 'Neos.TestNodeTypes:TestApiAccess'
+          permission: GRANT

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/Routes.yaml
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/Routes.yaml
@@ -1,0 +1,17 @@
+-
+  name: 'RemoveAdditionalSettings Command'
+  uriPattern: 'test/remove-additional-settings'
+  defaults:
+    '@package': 'Neos.TestNodeTypes'
+    '@subpackage': 'Application\RemoveAdditionalSettings'
+    '@controller': 'RemoveAdditionalSettings'
+    '@action': 'ignored'
+
+-
+  name: 'WriteAdditionalSettings Command'
+  uriPattern: 'test/write-additional-settings'
+  defaults:
+    '@package': 'Neos.TestNodeTypes'
+    '@subpackage': 'Application\WriteAdditionalSettings'
+    '@controller': 'WriteAdditionalSettings'
+    '@action': 'ignored'

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/Settings.Neos.Flow.yaml
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/Configuration/Settings.Neos.Flow.yaml
@@ -1,0 +1,6 @@
+Neos:
+  Flow:
+    mvc:
+      routes:
+        'Neos.TestNodeTypes':
+          position: 'before Neos.Neos'

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/NodeTypes/Document/Blog.yaml
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/NodeTypes/Document/Blog.yaml
@@ -1,0 +1,17 @@
+'Neos.TestNodeTypes:Document.Blog':
+  superTypes:
+    'Neos.Neos:Document': true
+
+  ui:
+    icon: newspaper-o
+    label: 'Blog'
+
+  constraints:
+    nodeTypes:
+      '*': false
+      'Neos.Neos:Document': false
+      'Neos.TestNodeTypes:Document.BlogArticle': true
+
+  childNodes:
+    main:
+      type: 'Neos.Neos:ContentCollection'

--- a/Tests/IntegrationTests/SharedNodeTypesPackage/NodeTypes/Document/BlogArticle.yaml
+++ b/Tests/IntegrationTests/SharedNodeTypesPackage/NodeTypes/Document/BlogArticle.yaml
@@ -1,0 +1,17 @@
+'Neos.TestNodeTypes:Document.BlogArticle':
+  superTypes:
+    'Neos.Neos:Document': true
+
+  ui:
+    icon: file-text-o
+    label: 'Blog Article'
+
+  constraints:
+    nodeTypes:
+      '*': false
+      'Neos.Neos:Document': false
+      'Neos.TestNodeTypes:Document.BlogArticle': true
+
+  childNodes:
+    main:
+      type: 'Neos.Neos:ContentCollection'

--- a/Tests/IntegrationTests/pageModel.js
+++ b/Tests/IntegrationTests/pageModel.js
@@ -9,6 +9,10 @@ export class Page {
 
     static getTreeNodeButton = (name) => Page.treeNode.withExactText(name).parent('[role="button"]');
 
+    static getToggleChildrenButtonOf = (name) => Page
+        .getTreeNodeButton(name)
+        .sibling('[data-neos-integrational-test="tree__item__nodeHeader__subTreetoggle"]');
+
     static async goToPage(pageTitle) {
         await t.click(this.treeNode.withText(pageTitle));
         await this.waitForIframeLoading(t);

--- a/packages/neos-ui-backend-connector/src/FlowQuery/Operations/GetForTreeWithParents/index.ts
+++ b/packages/neos-ui-backend-connector/src/FlowQuery/Operations/GetForTreeWithParents/index.ts
@@ -1,4 +1,4 @@
-export default () => () => ({
+export default () => (nodeTypeFilter = null) => ({
     type: 'getForTreeWithParents',
-    payload: ''
+    payload: {nodeTypeFilter}
 });

--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
@@ -73,16 +73,31 @@ export enum actionTypes {
     SET_DOCUMENT_NODE = '@neos/neos-ui/CR/Nodes/SET_DOCUMENT_NODE',
     SET_STATE = '@neos/neos-ui/CR/Nodes/SET_STATE',
     RELOAD_STATE = '@neos/neos-ui/CR/Nodes/RELOAD_STATE',
+    /**
+     * @deprecated `COPY_MULTIPLE` should be used
+     */
     COPY = '@neos/neos-ui/CR/Nodes/COPY',
     COPY_MULTIPLE = '@neos/neos-ui/CR/Nodes/COPY_MULTIPLE',
+    /**
+     * @deprecated `CUT_MULTIPLE` should be used
+     */
     CUT = '@neos/neos-ui/CR/Nodes/CUT',
     CUT_MULTIPLE = '@neos/neos-ui/CR/Nodes/CUT_MULTIPLE',
+    /**
+     * @deprecated `MOVE_MULTIPLE` should be used
+     */
     MOVE = '@neos/neos-ui/CR/Nodes/MOVE',
     MOVE_MULTIPLE = '@neos/neos-ui/CR/Nodes/MOVE_MULTIPLE',
     PASTE = '@neos/neos-ui/CR/Nodes/PASTE',
     COMMIT_PASTE = '@neos/neos-ui/CR/Nodes/COMMIT_PASTE',
+    /**
+     * @deprecated `HIDE_MULTIPLE` should be used
+     */
     HIDE = '@neos/neos-ui/CR/Nodes/HIDE',
     HIDE_MULTIPLE = '@neos/neos-ui/CR/Nodes/HIDE_MULTIPLE',
+    /**
+     * @deprecated `SHOW_MULTIPLE` should be used
+     */
     SHOW = '@neos/neos-ui/CR/Nodes/SHOW',
     SHOW_MULTIPLE = '@neos/neos-ui/CR/Nodes/SHOW_MULTIPLE',
     UPDATE_PATH = '@neos/neos-ui/CR/Nodes/UPDATE_PATH',
@@ -227,6 +242,7 @@ const adoptDataToHost = <T>(object: T): T => JSON.parse(JSON.stringify(object));
 /**
  * Mark a node for copy on paste
  *
+ * @deprecated `copyMultiple` should be used
  * @param {String} contextPath The context path of the node to be copied
  */
 const copy = (contextPath: NodeContextPath) => createAction(actionTypes.COPY, contextPath);
@@ -236,6 +252,7 @@ const copyMultiple = (contextPaths: NodeContextPath[]) => createAction(actionTyp
 /**
  * Mark a node for cut on paste
  *
+ * @deprecated `cutMultiple` should be used
  * @param {String} contextPath The context path of the node to be cut
  */
 const cut = (contextPath: NodeContextPath) => createAction(actionTypes.CUT, contextPath);
@@ -245,6 +262,7 @@ const cutMultiple = (contextPaths: NodeContextPath[]) => createAction(actionType
 /**
  * Move a node
  *
+ * @deprecated `moveMultiple` should be used
  * @param {String} nodeToBeMoved The context path of the node to be moved
  * @param {String} targetNode The context path of the target node
  * @param {String} position "into", "before" or "after"
@@ -278,6 +296,7 @@ const commitPaste = (clipboardMode: ClipboardMode) => createAction(actionTypes.C
 /**
  * Hide the given node draft.documentNode !== action.payload
  *
+ * @deprecated `hideMultiple` should be used
  * @param {String} contextPath The context path of the node to be hidden
  */
 const hide = (contextPath: NodeContextPath) => createAction(actionTypes.HIDE, contextPath);
@@ -287,6 +306,7 @@ const hideMultiple = (contextPaths: NodeContextPath[]) => createAction(actionTyp
 /**
  * Show the given node
  *
+ * @deprecated `showMultiple` should be used
  * @param {String} contextPath The context path of the node to be shown
  */
 const show = (contextPath: NodeContextPath) => createAction(actionTypes.SHOW, contextPath);

--- a/packages/neos-ui-redux-store/src/UI/PageTree/index.spec.js
+++ b/packages/neos-ui-redux-store/src/UI/PageTree/index.spec.js
@@ -1,7 +1,8 @@
 import {actionTypes, actions, reducer} from './index';
 import {SelectionModeTypes} from '@neos-project/neos-ts-interfaces';
 
-import {actionTypes as system} from '../../System/index';
+import {actions as system} from '../../System/index';
+import {actions as nodes} from '../../CR/Nodes/index';
 
 test(`should export actionTypes`, () => {
     expect(actionTypes).not.toBe(undefined);
@@ -25,20 +26,17 @@ test(`should export a reducer`, () => {
 });
 
 test(`The reducer should return a plain JS object as the initial state.`, () => {
-    const nextState = reducer(undefined, {
-        type: system.INIT,
-        payload: {
-            ui: {
-                pageTree: {}
-            },
-            cr: {
-                nodes: {
-                    siteNode: 'siteNode',
-                    documentNode: 'documentNode'
-                }
+    const nextState = reducer(undefined, system.init({
+        ui: {
+            pageTree: {}
+        },
+        cr: {
+            nodes: {
+                siteNode: 'siteNode',
+                documentNode: 'documentNode'
             }
         }
-    });
+    }));
 
     expect(typeof nextState).toBe('object');
 });
@@ -48,7 +46,7 @@ test(`The "focus" action should set the focused node context path.`, () => {
         ui: {
             focused: [],
             toggled: [],
-            hidden: [],
+            visible: [],
             intermediate: [],
             loading: [],
             errors: []
@@ -153,4 +151,110 @@ test(`The "setAsLoaded" action should remove the given node to loading state`, (
     expect(nextState1.loading).toEqual(['someOtherContextPath']);
     expect(nextState2.loading).toEqual(['someContextPath']);
     expect(nextState3.loading).toEqual([]);
+});
+
+test(`"visible" state is initially null`, () => {
+    const state = reducer(undefined, system.init({
+        cr: {
+            nodes: {
+                siteNode: 'siteNode',
+                documentNode: 'documentNode'
+            }
+        }
+    }));
+
+    expect(state.visible).toBeNull();
+});
+
+test(`"visible" state can be set to an array of context paths by SET_SEARCH_RESULT action`, () => {
+    const state = reducer({visible: null}, actions.setSearchResult({
+        visibleContextPaths: ['some-visible-context-path'],
+        toggledContextPaths: [],
+        intermediateContextPaths: []
+    }));
+
+    expect(state.visible).toStrictEqual(['some-visible-context-path']);
+});
+
+test(`"visible" state can be set to null by SET_SEARCH_RESULT action`, () => {
+    const state = reducer({visible: null}, actions.setSearchResult({
+        visibleContextPaths: null,
+        toggledContextPaths: [],
+        intermediateContextPaths: []
+    }));
+
+    expect(state.visible).toBeNull();
+});
+
+test(`When "visible" state is null and CR.Nodes.ADD occurs, "visible" state remains null`, () => {
+    const state = reducer({visible: null}, nodes.add({
+        'some-visible-context-path': {},
+        'some-other-context-path': {}
+    }));
+
+    expect(state.visible).toBeNull();
+});
+
+test(`When "visible" state is not null and CR.Nodes.ADD occurs, all added nodes are made visible`, () => {
+    const state = reducer({visible: ['some-visible-context-path']}, nodes.add({
+        'some-visible-context-path': {},
+        'some-other-context-path': {}
+    }));
+
+    expect(state.visible).toStrictEqual([
+        'some-visible-context-path',
+        'some-other-context-path'
+    ]);
+});
+
+test(`When "visible" state is null and CR.Nodes.MERGE occurs, "visible" state remains null`, () => {
+    const state = reducer({visible: null}, nodes.merge({
+        'some-visible-context-path': {},
+        'some-other-context-path': {}
+    }));
+
+    expect(state.visible).toBeNull();
+});
+
+test(`When "visible" state is not null and CR.Nodes.MERGE occurs, all added nodes are made visible`, () => {
+    const state = reducer({visible: ['some-visible-context-path']}, nodes.merge({
+        'some-visible-context-path': {},
+        'some-other-context-path': {}
+    }));
+
+    expect(state.visible).toStrictEqual([
+        'some-visible-context-path',
+        'some-other-context-path'
+    ]);
+});
+
+test(`When "visible" state is null and CR.Nodes.SET_STATE occurs, "visible" state remains null`, () => {
+    const state = reducer({visible: null}, nodes.setState({
+        siteNodeContextPath: 'siteNode',
+        documentNodeContextPath: 'documentNode',
+        nodes: {
+            'some-visible-context-path': {},
+            'some-other-context-path': {}
+        },
+        merge: true
+    }));
+
+    expect(state.visible).toBeNull();
+});
+
+test(`When "visible" state is not null and CR.Nodes.SET_STATE occurs, all added nodes are made visible`, () => {
+    const state = reducer({visible: ['some-visible-context-path']}, nodes.setState({
+        siteNodeContextPath: 'siteNode',
+        documentNodeContextPath: 'documentNode',
+        nodes: {
+            'some-visible-context-path': {},
+            'some-other-context-path': {}
+        },
+        merge: true
+    }));
+
+    expect(state.visible).toStrictEqual([
+        'some-visible-context-path',
+        'some-other-context-path'
+    ]);
 });

--- a/packages/neos-ui-redux-store/src/UI/PageTree/index.spec.js
+++ b/packages/neos-ui-redux-store/src/UI/PageTree/index.spec.js
@@ -258,3 +258,35 @@ test(`When "visible" state is not null and CR.Nodes.SET_STATE occurs, all added 
         'some-other-context-path'
     ]);
 });
+
+test(`When "visible" state is null and CR.Nodes.UPDATE_PATH occurs, "visible" state remains null`, () => {
+    const state = reducer({visible: null}, nodes.updatePath(
+        'some-visible-context-path',
+        'some-visible-context-path-with-a-different-name'
+    ));
+
+    expect(state.visible).toBeNull();
+});
+
+test(`When "visible" state is not null and CR.Nodes.UPDATE_PATH occurs, the context path will be updated in "visible" as well`, () => {
+    const state = reducer({visible: ['some-visible-context-path']}, nodes.updatePath(
+        'some-visible-context-path',
+        'some-visible-context-path-with-a-different-name'
+    ));
+
+    expect(state.visible).toStrictEqual([
+        'some-visible-context-path-with-a-different-name'
+    ]);
+});
+
+test(`When "visible" state is not null and CR.Nodes.UPDATE_PATH occurs with an unknown old context path, the new context path will be added to "visible"`, () => {
+    const state = reducer({visible: ['some-visible-context-path']}, nodes.updatePath(
+        'another-visible-context-path',
+        'another-visible-context-path-with-a-different-name'
+    ));
+
+    expect(state.visible).toStrictEqual([
+        'some-visible-context-path',
+        'another-visible-context-path-with-a-different-name'
+    ]);
+});

--- a/packages/neos-ui-redux-store/src/UI/PageTree/index.ts
+++ b/packages/neos-ui-redux-store/src/UI/PageTree/index.ts
@@ -2,6 +2,7 @@ import produce from 'immer';
 import {action as createAction, ActionType} from 'typesafe-actions';
 
 import {actionTypes as system, InitAction, GlobalState} from '../../System';
+import {actionTypes as nodes, Action as NodesAction} from '../../CR/Nodes';
 import {NodeContextPath, SelectionModeTypes} from '@neos-project/neos-ts-interfaces';
 
 import * as selectors from './selectors';
@@ -10,7 +11,7 @@ import {calculateNewFocusedNodes} from '../../CR/Nodes/helpers';
 export interface State extends Readonly<{
     focused: NodeContextPath[];
     toggled: NodeContextPath[];
-    hidden: NodeContextPath[];
+    visible: null | NodeContextPath[];
     intermediate: NodeContextPath[];
     loading: NodeContextPath[];
     errors: NodeContextPath[];
@@ -21,7 +22,7 @@ export interface State extends Readonly<{
 export const defaultState: State = {
     focused: [],
     toggled: [],
-    hidden: [],
+    visible: null,
     intermediate: [],
     loading: [],
     errors: [],
@@ -55,7 +56,7 @@ interface CommenceSearchOptions extends Readonly<{
 }> {}
 const commenceSearch = (contextPath: NodeContextPath, {query, filterNodeType}: CommenceSearchOptions) => createAction(actionTypes.COMMENCE_SEARCH, {contextPath, query, filterNodeType});
 interface SearchResult extends Readonly<{
-    hiddenContextPaths: NodeContextPath[];
+    visibleContextPaths: null | NodeContextPath[];
     toggledContextPaths: NodeContextPath[];
     intermediateContextPaths: NodeContextPath[];
 }> {}
@@ -80,11 +81,34 @@ export type Action = ActionType<typeof actions>;
 //
 // Export the reducer
 //
-export const reducer = (state: State = defaultState, action: InitAction | Action, globalState: GlobalState) => produce(state, draft => {
+export const reducer = (state: State = defaultState, action: InitAction | NodesAction | Action, globalState: GlobalState) => produce(state, draft => {
     switch (action.type) {
         case system.INIT: {
             const contextPath = action.payload.cr.nodes.documentNode || action.payload.cr.nodes.siteNode;
             draft.focused = contextPath ? [contextPath] : [];
+            break;
+        }
+        case nodes.ADD:
+        case nodes.MERGE: {
+            if (state.visible !== null) {
+                const visible = new Set([
+                    ...state.visible,
+                    ...Object.keys(action.payload.nodeMap)
+                ]);
+
+                draft.visible = [...visible];
+            }
+            break;
+        }
+        case nodes.SET_STATE: {
+            if (state.visible !== null) {
+                const visible = new Set([
+                    ...state.visible,
+                    ...Object.keys(action.payload.nodes)
+                ]);
+
+                draft.visible = [...visible];
+            }
             break;
         }
         case actionTypes.FOCUS: {
@@ -123,7 +147,7 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
             break;
         }
         case actionTypes.SET_SEARCH_RESULT: {
-            draft.hidden = action.payload.hiddenContextPaths;
+            draft.visible = action.payload.visibleContextPaths;
             draft.toggled = action.payload.toggledContextPaths;
             draft.intermediate = action.payload.intermediateContextPaths;
             break;

--- a/packages/neos-ui-redux-store/src/UI/PageTree/index.ts
+++ b/packages/neos-ui-redux-store/src/UI/PageTree/index.ts
@@ -111,6 +111,16 @@ export const reducer = (state: State = defaultState, action: InitAction | NodesA
             }
             break;
         }
+        case nodes.UPDATE_PATH: {
+            if (state.visible !== null) {
+                const visible = new Set(state.visible);
+                visible.delete(action.payload.oldContextPath);
+                visible.add(action.payload.newContextPath);
+
+                draft.visible = [...visible];
+            }
+            break;
+        }
         case actionTypes.FOCUS: {
             const {contextPath, selectionMode} = action.payload;
             const newFocusedNodes = calculateNewFocusedNodes(selectionMode, contextPath, draft.focused, globalState.cr.nodes.byContextPath);

--- a/packages/neos-ui-redux-store/src/UI/PageTree/selectors.ts
+++ b/packages/neos-ui-redux-store/src/UI/PageTree/selectors.ts
@@ -13,7 +13,7 @@ export const getFocused = (state: GlobalState) => {
 export const getToggled = (state: GlobalState) => $get(['ui', 'pageTree', 'toggled'], state);
 export const getLoading = (state: GlobalState) => $get(['ui', 'pageTree', 'loading'], state);
 export const getErrors = (state: GlobalState) => $get(['ui', 'pageTree', 'errors'], state);
-export const getHidden = (state: GlobalState) => $get(['ui', 'pageTree', 'hidden'], state);
+export const getVisible = (state: GlobalState) => state?.ui?.pageTree?.visible;
 export const getIntermediate = (state: GlobalState) => $get(['ui', 'pageTree', 'intermediate'], state);
 
 export const destructiveOperationsAreDisabledForPageTreeSelector = createSelector(

--- a/packages/neos-ui-sagas/src/CR/NodeOperations/moveDroppedNode.js
+++ b/packages/neos-ui-sagas/src/CR/NodeOperations/moveDroppedNode.js
@@ -5,6 +5,9 @@ import {actions, actionTypes, selectors} from '@neos-project/neos-ui-redux-store
 
 import {calculateChangeTypeFromMode, calculateDomAddressesFromMode} from './helpers';
 
+/**
+ * @deprecated `moveDroppedNodes` should be used
+ */
 export default function * moveDroppedNode() {
     yield takeEvery(actionTypes.CR.Nodes.MOVE, function * handleNodeMove({payload}) {
         const {nodeToBeMoved: subject, targetNode: reference, position} = payload;

--- a/packages/neos-ui-sagas/src/CR/NodeOperations/moveDroppedNodes.js
+++ b/packages/neos-ui-sagas/src/CR/NodeOperations/moveDroppedNodes.js
@@ -10,14 +10,18 @@ export default function * moveDroppedNodes() {
 
         const referenceNodeSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector(reference);
         const referenceNode = yield select(referenceNodeSelector);
+        const baseNodeType = yield select(state => state?.ui?.pageTree?.filterNodeType);
 
         const changes = nodesToBeMoved.map(subject => ({
             type: calculateChangeTypeFromMode(position, 'Move'),
             subject,
-            payload: calculateDomAddressesFromMode(
-                position,
-                referenceNode
-            )
+            payload: {
+                ...calculateDomAddressesFromMode(
+                    position,
+                    referenceNode
+                ),
+                baseNodeType
+            }
         }));
 
         yield put(actions.Changes.persistChanges(changes));

--- a/packages/neos-ui-sagas/src/CR/NodeOperations/reloadState.js
+++ b/packages/neos-ui-sagas/src/CR/NodeOperations/reloadState.js
@@ -13,14 +13,25 @@ export default function * watchReloadState({configuration}) {
         const toggledNodes = yield select($get('ui.pageTree.toggled'));
         const siteNodeContextPath = $get('payload.siteNodeContextPath', action) || currentSiteNodeContextPath;
         const documentNodeContextPath = yield $get('payload.documentNodeContextPath', action) || select($get('cr.nodes.documentNode'));
+        const {query: searchQuery, filterNodeType} = yield select(state => state?.ui?.pageTree);
+        const effectiveFilterNodeType = filterNodeType || configuration.nodeTree.presets.default.baseNodeType;
+        const isSearch = Boolean(filterNodeType || searchQuery);
+
         yield put(actions.CR.Nodes.setDocumentNode(documentNodeContextPath, currentSiteNodeContextPath));
         yield put(actions.UI.PageTree.setAsLoading(currentSiteNodeContextPath));
-        const nodes = yield q([siteNodeContextPath, documentNodeContextPath]).neosUiDefaultNodes(
-            configuration.nodeTree.presets.default.baseNodeType,
-            configuration.nodeTree.loadingDepth,
-            toggledNodes,
-            clipboardNodesContextPaths
-        ).getForTree();
+
+        let nodes = [];
+        if (isSearch) {
+            nodes = yield q(siteNodeContextPath).search(searchQuery, effectiveFilterNodeType).getForTreeWithParents();
+        } else {
+            nodes = yield q([siteNodeContextPath, documentNodeContextPath]).neosUiDefaultNodes(
+                configuration.nodeTree.presets.default.baseNodeType,
+                configuration.nodeTree.loadingDepth,
+                toggledNodes,
+                clipboardNodesContextPaths
+            ).getForTree();
+        }
+
         const nodeMap = nodes.reduce((nodeMap, node) => {
             nodeMap[$get('contextPath', node)] = node;
             return nodeMap;

--- a/packages/neos-ui-sagas/src/CR/NodeOperations/reloadState.js
+++ b/packages/neos-ui-sagas/src/CR/NodeOperations/reloadState.js
@@ -22,7 +22,7 @@ export default function * watchReloadState({configuration}) {
 
         let nodes = [];
         if (isSearch) {
-            nodes = yield q(siteNodeContextPath).search(searchQuery, effectiveFilterNodeType).getForTreeWithParents();
+            nodes = yield q(siteNodeContextPath).search(searchQuery, effectiveFilterNodeType).getForTreeWithParents(effectiveFilterNodeType);
         } else {
             nodes = yield q([siteNodeContextPath, documentNodeContextPath]).neosUiDefaultNodes(
                 configuration.nodeTree.presets.default.baseNodeType,

--- a/packages/neos-ui-sagas/src/UI/PageTree/index.js
+++ b/packages/neos-ui-sagas/src/UI/PageTree/index.js
@@ -157,7 +157,7 @@ export function * watchSearch({configuration}) {
             const query = q(contextPath);
 
             if (isSearch) {
-                matchingNodes = yield query.search(searchQuery, effectiveFilterNodeType).getForTreeWithParents();
+                matchingNodes = yield query.search(searchQuery, effectiveFilterNodeType).getForTreeWithParents(effectiveFilterNodeType);
             } else {
                 const clipboardNodeContextPath = yield select($get('cr.nodes.clipboard'));
                 const toggledNodes = yield select($get('ui.pageTree.toggled'));

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -66,7 +66,7 @@ export default class Node extends PureComponent {
         isActive: PropTypes.bool,
         isFocused: PropTypes.bool,
         toggledNodeContextPaths: PropTypes.array,
-        hiddenContextPaths: PropTypes.array,
+        visibleContextPaths: PropTypes.array,
         intermediateContextPaths: PropTypes.array,
         loadingNodeContextPaths: PropTypes.array,
         errorNodeContextPaths: PropTypes.array,
@@ -230,9 +230,9 @@ export default class Node extends PureComponent {
         return isNodeCollapsed(node, isToggled, rootNode, loadingDepth);
     }
 
-    isHidden() {
-        const {node, hiddenContextPaths} = this.props;
-        return hiddenContextPaths && hiddenContextPaths.includes(node.contextPath);
+    isVisible() {
+        const {node, visibleContextPaths} = this.props;
+        return visibleContextPaths === null || visibleContextPaths.includes(node.contextPath);
     }
 
     isIntermediate() {
@@ -283,7 +283,7 @@ export default class Node extends PureComponent {
             isWorkspaceReadOnly
         } = this.props;
 
-        if (this.isHidden()) {
+        if (!this.isVisible()) {
             return null;
         }
         const refHandler = div => {
@@ -425,7 +425,7 @@ export const PageTreeNode = withNodeTypeRegistryAndI18nRegistry(connect(
                 isActive: selectors.CR.Nodes.documentNodeContextPathSelector(state) === node.contextPath,
                 isFocused: selectors.UI.PageTree.getAllFocused(state).includes(node.contextPath),
                 toggledNodeContextPaths: selectors.UI.PageTree.getToggled(state),
-                hiddenContextPaths: selectors.UI.PageTree.getHidden(state),
+                visibleContextPaths: selectors.UI.PageTree.getVisible(state),
                 intermediateContextPaths: selectors.UI.PageTree.getIntermediate(state),
                 loadingNodeContextPaths: selectors.UI.PageTree.getLoading(state),
                 errorNodeContextPaths: selectors.UI.PageTree.getErrors(state),

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -232,7 +232,7 @@ export default class Node extends PureComponent {
 
     isVisible() {
         const {node, visibleContextPaths} = this.props;
-        return visibleContextPaths === null || visibleContextPaths.includes(node.contextPath);
+        return !Array.isArray(visibleContextPaths) || visibleContextPaths.includes(node.contextPath);
     }
 
     isIntermediate() {

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/NodeTreeFilter/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/NodeTreeFilter/index.js
@@ -60,6 +60,7 @@ export default class NodeTreeFilter extends PureComponent {
         return (
             <div id="neos-NodeTreeFilter" className={style.searchBar}>
                 <SelectBox
+                    id="neos-NodeTreeFilter-SelectBox"
                     placeholder={label}
                     placeholderIcon={'filter'}
                     onValueChange={onChange}

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/NodeTreeSearchInput/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/NodeTreeSearchInput/index.js
@@ -45,6 +45,7 @@ const NodeTreeSearchInput = ({
                 />
             {showClear && (
                 <IconButton
+                    id="neos-NodeTreeSearchInput-btn-reset"
                     icon="times"
                     className={style.clearButton}
                     onClick={onClearClick}

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/index.js
@@ -96,6 +96,7 @@ class NodeTreeSearchBar extends PureComponent {
         return (
             <div className={style.searchWrapper}>
                 <IconButton
+                    id="btn-ToggleDocumentTreeFilter"
                     className={searchToggleClassName}
                     icon="ellipsis-v"
                     onClick={this.handleSearchToggle}

--- a/packages/react-ui-components/src/DropDown/contents.tsx
+++ b/packages/react-ui-components/src/DropDown/contents.tsx
@@ -51,6 +51,11 @@ interface ShallowDropDownContentsTheme {
 
 export interface ShallowDropDownContentsProps {
     /**
+     * An optional `id` to attach to the wrapper.
+     */
+    readonly id?: string;
+
+    /**
      * An optional `className` to attach to the wrapper.
      */
     readonly className?: string;
@@ -198,6 +203,7 @@ export default class ShallowDropDownContents extends PureComponent<ShallowDropDo
 
     public render(): JSX.Element | null {
         const {
+            id,
             className,
             children,
             theme,
@@ -217,6 +223,7 @@ export default class ShallowDropDownContents extends PureComponent<ShallowDropDo
         if (isOpen) {
             const contents = (
                 <ul
+                    id={id}
                     className={finalClassName}
                     aria-hidden={isOpen ? 'false' : 'true'}
                     aria-label="dropdown"

--- a/packages/react-ui-components/src/DropDown/header.tsx
+++ b/packages/react-ui-components/src/DropDown/header.tsx
@@ -15,6 +15,11 @@ interface ShallowDropDownHeaderTheme {
 
 export interface ShallowDropDownHeaderProps {
     /**
+     * An optional `id` to attach to the wrapper.
+     */
+    readonly id?: string;
+
+    /**
      * An optional `className` to attach to the wrapper.
      */
     readonly className?: string;
@@ -93,6 +98,7 @@ class ShallowDropDownHeader extends PureComponent<ShallowDropDownHeaderProps> {
 
     public render(): JSX.Element {
         const {
+            id,
             className,
             children,
             theme,
@@ -115,6 +121,7 @@ class ShallowDropDownHeader extends PureComponent<ShallowDropDownHeaderProps> {
 
         return (
             <div
+                id={id}
                 role="button"
                 onClick={disabled ? undefined : toggleDropDown}
                 ref={this.handleReferenceHandler}

--- a/packages/react-ui-components/src/DropDown/wrapper.tsx
+++ b/packages/react-ui-components/src/DropDown/wrapper.tsx
@@ -10,6 +10,11 @@ import PropTypes from 'prop-types';
 
 export interface DropDownWrapperProps {
     /**
+     * An optional `id` to attach to the wrapper.
+     */
+    readonly id?: string;
+
+    /**
      * An optional `className` to attach to the wrapper.
      */
     readonly className?: string;
@@ -95,7 +100,7 @@ class StatelessDropDownWrapperWithoutClickOutsideBehavior extends PureComponent<
     }
 
     public render(): JSX.Element {
-        const {children, className, theme, style, padded, ...restProps} = this.props;
+        const {id, children, className, theme, style, padded, ...restProps} = this.props;
         const rest = omit(restProps, ['isOpen', 'onToggle', 'onClose']);
         const styleClassName: string = style ? `dropDown--${style}` : '';
         const finalClassName = mergeClassNames(
@@ -109,7 +114,7 @@ class StatelessDropDownWrapperWithoutClickOutsideBehavior extends PureComponent<
         );
 
         return (
-            <div ref={this.ref} {...rest} className={finalClassName}>
+            <div id={id} ref={this.ref} {...rest} className={finalClassName}>
                 {React.Children.map(
                     children,
                     // @ts-ignore

--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -195,6 +195,7 @@ export default class SelectBox extends PureComponent {
 
     render() {
         const {
+            id,
             options,
             theme,
             showDropDownToggle,
@@ -231,11 +232,11 @@ export default class SelectBox extends PureComponent {
         });
 
         return (
-            <DropDown.Stateless className={theme.selectBox} isOpen={isExpanded} onToggle={this.handleToggleExpanded} onClose={this.handleClose}>
-                <DropDown.Header className={headerClassName} shouldKeepFocusState={false} showDropDownToggle={showDropDownToggle && Boolean(options.length)}>
+            <DropDown.Stateless id={id} className={theme.selectBox} isOpen={isExpanded} onToggle={this.handleToggleExpanded} onClose={this.handleClose}>
+                <DropDown.Header id={id ? `${id}-header` : undefined} className={headerClassName} shouldKeepFocusState={false} showDropDownToggle={showDropDownToggle && Boolean(options.length)}>
                     {this.renderHeader()}
                 </DropDown.Header>
-                <DropDown.Contents className={dropDownContentsClassName} scrollable={true}>
+                <DropDown.Contents id={id ? `${id}-contents` : undefined} className={dropDownContentsClassName} scrollable={true}>
                     {!plainInputMode && <ul className={theme.selectBox__list}>
                         <SelectBox_ListPreview
                             {...this.props}

--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -44,6 +44,11 @@ export default class SelectBox extends PureComponent {
         disabled: PropTypes.bool,
 
         /**
+         * Optional id for the element
+         */
+        id: PropTypes.string,
+
+        /**
          * Additional className wich will be applied
          */
         className: PropTypes.string,

--- a/packages/react-ui-components/src/SelectBox_Header/selectBox_Header.js
+++ b/packages/react-ui-components/src/SelectBox_Header/selectBox_Header.js
@@ -54,7 +54,7 @@ class SelectBox_Header extends PureComponent {
 
             return (
                 <span>
-                    <IconButton className={theme.selectBoxHeader__icon} disabled={disabled} icon="times" onClick={onClick}/>
+                    <IconButton id={this.props.id ? `${this.props.id}-btn-reset` : undefined} className={theme.selectBoxHeader__icon} disabled={disabled} icon="times" onClick={onClick}/>
                     <span className={theme.selectBoxHeader__seperator}/>
                 </span>
             );

--- a/packages/react-ui-components/src/Tree/node.module.css
+++ b/packages/react-ui-components/src/Tree/node.module.css
@@ -132,23 +132,25 @@
     right: 0;
     padding-left: 15px;
     height: 2px;
-    visibility: hidden;
-
-    [data-is-drag-happening] & {
-        visibility: visible;
-    }
+    z-index: -1;
 }
 .dropTarget--before {
     top: -5px;
-    z-index: var(--zIndex-SideBar-DropTargetBefore);
     padding-top: 4px;
     padding-bottom: 4px;
+
+    [data-is-drag-happening] & {
+        z-index: var(--zIndex-SideBar-DropTargetBefore);
+    }
 }
 .dropTarget--after {
     bottom: 1px;
-    z-index: var(--zIndex-SideBar-DropTargetAfter);
     padding-top: 6px;
     padding-bottom: 0;
+
+    [data-is-drag-happening] & {
+        z-index: var(--zIndex-SideBar-DropTargetAfter);
+    }
 }
 .dropTarget__inner {
     visibility: hidden;


### PR DESCRIPTION
fixes: #3816, #2583, #2800

## Add settings during E2E test run

This PR indroduces a mechanism to add additional settings during E2E test run.

This is necessary, because the newly introduced `nodeTreePresets.e2e.js` test fixture requires node tree presets to be configured. Node tree presets are not active by default, so we need to set up additional settings for this test fixture specifically.

<details>
<summary>Read details on how this is achieved</summary>

The mechanism is achieved by providing two public endpoints in the test distribution:

### `POST /test/write-additional-settings`

> [!WARNING]
> This endpoint is only available in the test distribution and should never be replicated for production use. **DO NOT DO THIS IN PRODUCTION!**

This endpoint accepts a JSON-encoded object as a body. It's top-most key must be `settings`. Any value passed to `settings` will be YAML-serialised and written to `FLOW_PATH_CONFIGURATION/Settings.Additional.yaml`.

This endpoint then also registers a signal handler for `bootstrapShuttingDown`, in which it will flush all caches, so that the additional configuration will be used upon the next request.

#### EXAMPLE

```sh
$ curl -X POST -d '{"settings":{"foo": "bar"}}' http://127.0.0.1:8081/test/write-additional-settings --header "Content-Type:application/json"
{"success":true}
```

This will write the following `Settings.Additional.yaml`:
```yaml
foo: bar
```

### `POST /test/remove-additional-settings`

> [!WARNING]
> This endpoint is only available in the test distribution and should never be replicated for production use. **DO NOT DO THIS IN PRODUCTION!**

This endpoint does not require any data and will remove the `FLOW_PATH_CONFIGURATION/Settings.Additional.yaml` file, if it exists.

If the file was removed, this endpoint then also registers a signal handler for `bootstrapShuttingDown`, in which it will flush all caches, so that the removed configuration will no longer be used upon the next request.

#### EXAMPLE

```sh
$ curl -X POST -d '' http://127.0.0.1:8081/test/remove-additional-settings --header "Content-Type:application/json"
{"success":true}
```

This will remove `Settings.Additional.yaml`, if it exists.

</details>

## Fix for #3816 & #2583

### The Problem

The `PageTree` redux state is tracking `hidden` nodes, presumably for the purpose to hide all nodes that are not part of the current search result set.

This is indicated by how `hiddenContextPaths` for page tree search results are calculated:
https://github.com/neos/neos-ui/blob/fd5c917e70b1ba3f1abe2d4681fd5f4dad5229bc/packages/neos-ui-sagas/src/UI/PageTree/index.js#L191-L193

When node type filter and search term are cleared, the nodes that have been flagged as  `hidden` during the last search, remain `hidden` aftwards, because the page tree state is not properly cleaned up.

### The Solution

For clarity, I decided to flip the `hidden` state into a `visible` state. By default `visible` is set to `null`, indicating that every node should be shown in the tree.

When a search term or node type filter is set, `visible` will at first contain all context paths in the search result set (including intermediaries that are only ancestors of matching nodes).

While `visible` is not `null`, every node that is added to the in-memory store will be added to the `visible` list as well.

`visible` here only means "This node is invited to the tree party". A node that is invited, may still not be shown, because its parent is collapsed. Every node that is not invited, will never be shown, no matter what other toggle state may be set.

## Fix for #2800 Part I

### The Problem

Since https://github.com/neos/neos-ui/pull/2794 all structural change operations handle an optional `baseNodeType` to account for currently set tree filters.

#2794 had been introduced in October 2020. About a year before that, in December 2019, batch operations for tree nodes had been introduced via https://github.com/neos/neos-ui/pull/2568. #2794 did not consider the changes made in #2568, so the `baseNodeType` isn't being sent when tree nodes are moved. This leads to the disappearance of all nodes beneath the reference parent.

The logic for this would have needed to be handled in the `moveDroppedNodes.js` saga. Oddly enough, the 4 years old merge commit of #2794 shows that it wasn't present then:
https://github.com/neos/neos-ui/tree/ed9e04cdcaf5774914a60d866a8589709b4704f8/packages/neos-ui-sagas/src/CR/NodeOperations

In the 5 years old merge commit for #2568, `moveDroppedNodes.js` does indeed exist:
https://github.com/neos/neos-ui/tree/48233fee50c106334a949647ed3deef6d66dfa3c/packages/neos-ui-sagas/src/CR/NodeOperations

I have no explanation for this.

### The Solution

I added the missing `baseNodeType` to `moveDroppedNodes.js`.

## Fix for #2800 Part II

### The problem

Similar to #3816 & #2583, the PageTree state did not recognize when a context path changed (which is what happens, if a node gets moved "into" another one).

### The solution

I modified the PageTree reducer, so it tracks the `CR.Nodes.UPDATE_PATH` action as well.

## Additional Changes

- One more bugfix: Reloading the tree when in filtered state was broken -> this is fixed now
- Tree nodes no longer show superfluous toggle handles
  - For this I had to add a nodeTypeFilter option to the `getForTreeWithParents` finisher of the FlowQuery API
  - The result is still not technically correct (as the entire API is quite broken), but it'll at least *look* correct :sweat_smile:
- I have added deprecation markers to all *singular* node operations (stuff like `copy` as opposed to `copyMultiple`, `move` as opposed to `moveMultiple` and so on)
  - While I was attempting to fix #2800, I stumbled upon this confusion, and since all singular operations can just as well be expressed as *multiple* operations, we should drop the singular ones entirely
  - Follow up to this PR: The operations should be removed in 9.0 (this will require additional work)

## Remaining TODOs

- [x] Write E2E test cases for node tree presets
  - [x] Create Mechanism to add additional settings during E2E test run
  - [x] Write some basic assertions that verify that node tree presets are basically working
  - [x] Write a failing test for #3816
  - [x] Write a failing test for #2583
  - [x] Write a failing test for #2800
- [x] Fix #3816
- [x] Fix #2583
- [x] Fix #2800
  - [x] Part 1: Nodes of an entire level disappear when any of them is moved
  - [x] Part 2: Parent cannot be uncollapsed after a node has been moved "into" it
- [x] Fix: Reloading the node tree while filters are set leads to wrong or empty result
  - [x] Happens on Discard as well
- [x] Fix: "Toggle children"-handle shows up, even though the node should have no children as per node type filter