### PR TITLE
BUGFIX: Allow float-point numbers without decimal places in FloatValidator

### DIFF
--- a/packages/neos-ui-validators/src/Float/index.tsx
+++ b/packages/neos-ui-validators/src/Float/index.tsx
@@ -8,7 +8,7 @@ interface FloatOptions {
 }
 const Float = (value: any, validatorOptions: FloatOptions) => {
     const number = parseFloat(value);
-    if (value !== null && value !== undefined && value.length !== 0 && ((isNaN(number) || value.toString().match(/^[-+]?[0-9]*\.[0-9]+([eE][-+]?[0-9]+)?$/) === null))) {
+    if (value !== null && value !== undefined && value.length !== 0 && ((isNaN(number) || value.toString().match(/^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$/) === null))) {
         const label = validatorOptions?.validationErrorMessage ?? 'content.inspector.validators.floatValidator.validFloatExpected';
         return <I18n id={label}/>;
     }


### PR DESCRIPTION
The current implementation of the floatValidator uses parseFloat, which strips decimal point and places if a whole number (eg. .0) is provided. This then causes the regex validation to fail because it always assumes there to be a decimal point and following decimal places. 

This change makes the decimal places in the regex-validation optional.
