### PR TITLE
BUGFIX Fix Neos.Ui version information in build script

### DIFF
--- a/Build/Jenkins/release-neos-ui.sh
+++ b/Build/Jenkins/release-neos-ui.sh
@@ -44,7 +44,7 @@ make install
 # acutal release process
 
 # build
-make build-production
+make build-subpackages
 
 # code quality
 make lint

--- a/Build/Jenkins/update-neos-ui-compiled.sh
+++ b/Build/Jenkins/update-neos-ui-compiled.sh
@@ -35,7 +35,7 @@ export NODE_OPTIONS="--max-old-space-size=4096"
 
 nvm install && nvm use
 make clean && make setup
-make build-production
+NEOS_UI_VERSION="${GIT_TAG:-${GIT_BRANCH}-dev}" make build-production
 
 rm -Rf tmp_compiled_pkg
 git clone git@github.com:neos/neos-ui-compiled.git tmp_compiled_pkg

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ called-with-version:
 ifeq ($(VERSION),)
 	@echo No version information given.
 	@echo Please run this command like this:
-	@echo VERSION=1.0.0 make bump-version
+	@echo VERSION=9.0.0 make ...
 	@false
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,9 @@ build-watch:
 	node esbuild.js --watch
 
 # clean anything before building for production just to be sure
-## Runs the production build. And also builds the subpackages for standalone use.
+## Runs the production build.
 build-production:
 	node esbuild.js --production
-	make build-subpackages
 
 build-e2e-testing:
 	node esbuild.js --production --e2e-testing

--- a/esbuild.js
+++ b/esbuild.js
@@ -2,12 +2,13 @@ const {sep} = require('path')
 const {compileWithCssVariables} = require('./cssVariables');
 const {cssModules} = require('./cssModules');
 const esbuild = require('esbuild');
-const { version } = require('./package.json')
 
 const isProduction = process.argv.includes('--production');
 const isE2ETesting = process.argv.includes('--e2e-testing');
 const isWatch = process.argv.includes('--watch');
 const isAnalyze = process.argv.includes('--analyze');
+
+const NEOS_UI_VERSION = process.env.NEOS_UI_VERSION ?? (isProduction ? 'production-build' : 'dev')
 
 if (isE2ETesting) {
     console.log('Building for E2E testing');
@@ -93,7 +94,7 @@ const options = {
     ],
     define: {
         // we dont declare `global = window` as we want to control everything and notice it, when something is odd
-        NEOS_UI_VERSION: JSON.stringify(isProduction ? `v${version}` : `v${version}-dev`)
+        NEOS_UI_VERSION: JSON.stringify(NEOS_UI_VERSION)
     }
 }
 


### PR DESCRIPTION
Resolves: #3781

it will show "UI version: 9.0.3" for tagged builds from neos-ui-compiled and "UI version: 9.0-dev" when requiring dev-9.0 of neos-ui-compiled