### PR TITLE
FEATURE: Make RightSideBar inspector resizable

### DIFF
--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/style.module.css
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/style.module.css
@@ -12,6 +12,7 @@
     left: var(--spacing-Quarter);
     right: 0;
     bottom: 0;
+    width: auto;
 }
 .discardButton,
 .publishButton {

--- a/packages/neos-ui/src/Containers/RightSideBar/style.module.css
+++ b/packages/neos-ui/src/Containers/RightSideBar/style.module.css
@@ -6,9 +6,13 @@
     right: unset;
     position: relative;
     background-color: var(--colors-ContrastDarkest);
+    direction: rtl;
+    resize: horizontal;
+    overflow: auto hidden;
 }
 .rightSideBar--isHidden {
     width: 0;
+    overflow: initial;
 }
 .rightSideBar--isHidden > div {
     display: none;
@@ -30,6 +34,7 @@
 .rightSideBar__components {
     background: var(--colors-ContrastDarkest);
     height: 100%;
+    direction: ltr;
 }
 
 .rightSideBar__section {


### PR DESCRIPTION
This uses some small html hacks to make RightSideBar resizable in a comparable way to LeftSideBar.

**What I did**
I added the resize-attribute to RightSideBar and moved the resize-handle to the left edge of the sidebar.

**How I did it**
Updated `Neos.Neos.Ui/packages/neos-ui/src/Containers/RightSideBar/style.module.css`

**How to verify it**
<img width="323" alt="Bildschirmfoto 2024-07-15 um 11 15 17" src="https://github.com/user-attachments/assets/92db2245-e2dd-4344-b230-6b93500b7096">
