### PR TITLE
BUGFIX: Prevent unneccessary server calls when inline editor is unchanged

### DIFF
--- a/packages/neos-ui-guest-frame/src/initializePropertyDomNode.js
+++ b/packages/neos-ui-guest-frame/src/initializePropertyDomNode.js
@@ -1,6 +1,6 @@
 import {$get, $contains} from 'plow-js';
 
-import {actions} from '@neos-project/neos-ui-redux-store';
+import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {validateElement} from '@neos-project/neos-ui-validators';
 
 import {getGuestFrameWindow, closestContextPathInGuestFrame} from './dom';
@@ -74,6 +74,14 @@ export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry,
                         actions.Changes.persistChanges([change])
                     ),
                     onChange: value => {
+                        const node = selectors.CR.Nodes.byContextPathSelector(contextPath)(store.getState());
+                        if (node) {
+                            const oldValue = node.properties[propertyName];
+                            if (oldValue === value) {
+                                return;
+                            }
+                        }
+
                         const validationResult = validateElement(value, $get(['properties', propertyName], nodeType), globalRegistry.get('validators'));
                         // Update inline validation errors
                         store.dispatch(


### PR DESCRIPTION
fixes: #3832

Straight-forward fix: This PR adds a check to prevent calls to the change API when the inline editor is unchanged.
