### PR TITLE
BUGFIX: Hide preview central group if empty

### DIFF
--- a/packages/neos-ui/src/Containers/PrimaryToolbar/EditPreviewDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/EditPreviewDropDown/index.js
@@ -86,22 +86,26 @@ export default class EditPreviewModeDropDown extends PureComponent {
                                 </li>
                             ))}
                         </ul>
-                        <div className={style.dropDown__groupHeader}>
-                            <Icon className={style.dropDown__btnIcon} icon={'eye'}/> {i18nRegistry.translate('content.components.editPreviewPanel.previewCentral', 'Preview Central')}
-                        </div>
-                        <ul>
-                            {previewModes.map(previewMode => (
-                                <li className={style.dropDown__item} key={previewMode.id}>
-                                    <Button
-                                        disabled={previewMode.id === editPreviewMode}
-                                        onClick={this.handleEditPreviewModeClick(previewMode.id)}
-                                        style={previewMode.id === editPreviewMode ? 'brand' : null}
-                                    >
-                                        <I18n id={previewMode.title}/>
-                                    </Button>
-                                </li>
-                            ))}
-                        </ul>
+                        {previewModes.length > 0 && (
+                            <>
+                                <div className={style.dropDown__groupHeader}>
+                                    <Icon className={style.dropDown__btnIcon} icon={'eye'}/> {i18nRegistry.translate('content.components.editPreviewPanel.previewCentral', 'Preview Central')}
+                                </div>
+                                <ul>
+                                    {previewModes.map(previewMode => (
+                                        <li className={style.dropDown__item} key={previewMode.id}>
+                                            <Button
+                                                disabled={previewMode.id === editPreviewMode}
+                                                onClick={this.handleEditPreviewModeClick(previewMode.id)}
+                                                style={previewMode.id === editPreviewMode ? 'brand' : null}
+                                            >
+                                                <I18n id={previewMode.title}/>
+                                            </Button>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </>
+                        )}
                     </DropDown.Contents>
                 </DropDown>
             </div>


### PR DESCRIPTION
**What I did**

Only show group "Preview central" in edit/preview modes dropdown if there are entries.

**How to verify it**

Disable the preview modes in the Neos.Demo and the `desktop` mode of Neos.Neos.
The dropdown shouldn't not contain the header anymore without any entries.