### PR TITLE
BUGFIX: Remove duplicate focus ckeditor border

### DIFF
--- a/packages/neos-ui-guest-frame/src/style.module.css
+++ b/packages/neos-ui-guest-frame/src/style.module.css
@@ -22,11 +22,11 @@
     outline-color: var(--colors-Warn);
 }
 
-:global(.neos-inline-editable:focus) {
+:global([data-__neos-property][contenteditable]) {
     outline: none;
 }
 
-:global([data-neos-inline-editor-is-initialized]:hover) {
+:global([data-__neos-property][contenteditable]:hover) {
     outline-offset: 5px;
     outline: 2px dashed var(--colors-PrimaryBlue);
 }


### PR DESCRIPTION
With https://github.com/neos/neos-development-collection/pull/3618 the legacy ember css class `.neos-inline-editable` was removed (previously set here: https://github.com/neos/neos-development-collection/blob/881675b91185cbd8c41cb5e64f7467bf78710e04/Neos.Neos/Classes/Service/ContentElementEditableService.php#L69)

This leads to the default ckeditor focus outline styling not being removable.

Instead, we use `[data-__neos-property][contenteditable]` to target ckeditor inline elements now.



| before | after |
|--------|--------|
| <img width="257" alt="image" src="https://github.com/user-attachments/assets/9422119b-e89d-482c-9f04-fac49dcfa455"> | <img width="229" alt="image" src="https://github.com/user-attachments/assets/7f12f3d3-4158-4d0f-9ab4-53b00953ea6e"> |


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
