### PR TITLE
BUGFIX: Remove required flag from showResetButton prop on selectbox

### DIFF
--- a/packages/react-ui-components/src/SelectBox_Header/selectBox_Header.js
+++ b/packages/react-ui-components/src/SelectBox_Header/selectBox_Header.js
@@ -18,7 +18,7 @@ class SelectBox_Header extends PureComponent {
         placeholder: PropTypes.string,
         placeholderIcon: PropTypes.string,
         headerIcon: PropTypes.string,
-        showResetButton: PropTypes.bool.isRequired,
+        showResetButton: PropTypes.bool,
         onReset: PropTypes.func,
         onClick: PropTypes.func,
         displayLoadingIndicator: PropTypes.bool,


### PR DESCRIPTION
The prop is actually not required in its implementation and the UI tends to throw warnings because of the required flag.
