### PR TITLE
BUGFIX: Neos logo icon width

### DIFF
--- a/packages/react-ui-components/src/ResourceIcon/style.module.css
+++ b/packages/react-ui-components/src/ResourceIcon/style.module.css
@@ -1,16 +1,12 @@
 .resource-icon {
     composes: reset from '../reset.module.css';
-    display: inline-block;
     font: normal normal normal FontAwesome;
     font-size: 14px/1;
     text-rendering: auto;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-}
 
-
-.resource-icon {
-    display: inline-grid;
+    display: inline-flex;
     width: 100%;
     justify-content: center;
 }


### PR DESCRIPTION
Regression from https://github.com/neos/neos-ui/pull/3836

When using additional plugins like the environment display thing, the neos logo is after the mentioned change of using inline `svg` tags instead `img` with base64 data url collapsed:

Before:
<img width="183" alt="image" src="https://github.com/user-attachments/assets/e53bde17-cc46-4413-aa6d-a6dc271b250c">

After:
<img width="275" alt="image" src="https://github.com/user-attachments/assets/b200c18a-1203-4c20-83e4-3a0a3480cc8e">

This fixed this state by using inline-flex instead.

**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
