### PR TITLE
BUGFIX: Prevent augmenter from applying data of multiple nodes into the same element

### DIFF
--- a/Classes/Aspects/AugmentationAspect.php
+++ b/Classes/Aspects/AugmentationAspect.php
@@ -114,7 +114,15 @@ class AugmentationAspect
         $attributes['data-__neos-node-contextpath'] = $node->getContextPath();
         $attributes['data-__neos-fusion-path'] = $fusionPath;
 
-        return $this->htmlAugmenter->addAttributes($content, $attributes);
+        // Define all attribute names as exclusive via the `exclusiveAttributes` parameter, to prevent the data of
+        // two different nodes to be concatenated into the attributes of a single html node.
+        // This way an outer div is added, if the wrapped content already has node related data-attributes set.
+        return $this->htmlAugmenter->addAttributes(
+            $content,
+            $attributes,
+            'div',
+            array_keys($attributes)
+        );
     }
 
     /**


### PR DESCRIPTION
**What I did**

This fixes a regression introduced in b56135a01ecf59ae3a4990e3fd54ac766732e0e6 which removed the script tag, causing the augmenter to add the data of multiple nodes into the same html element in certain cases instead of adding an outer div. This lead to an error with the FlowQuery JavaScript API as it couldn't handle two nodepaths separated by a space as a single nodepath.

With this change the augmenter automatically adds an outer div if a node attribute appears twice. Therefore we have a single element for each wrapped node.

**How to verify it**

Create the following nodetype in the demo package:

NodeType:
```yaml
Neos.Demo:Content.Test:
  ui:
    label: 'Test'
  superTypes:
    'Neos.Neos:Content': true
    'Neos.Demo:Constraint.Content.Main': true
  childNodes:
    test:
      type: 'Neos.Neos:ContentCollection'
```

Fusion prototype:
```
prototype(Neos.Demo:Content.Test) < prototype(Neos.Neos:ContentComponent) {
    renderer = afx`
        <Neos.Neos:ContentCollection nodePath="test"/>
    `
}
```

In 8.3.10 the rendered node in the backend would have two values in its context-path and fusion-path attributes and the FlowQuery endpoint throws an error when loading.

With the change the backend works fine again as in 8.3.9 and parent and child node are selectable.