### PR TITLE
FIX: Sizing of icons in alerts 

### DIFF
--- a/packages/neos-ui/src/Containers/FlashMessages/FlashMessage/style.module.css
+++ b/packages/neos-ui/src/Containers/FlashMessages/FlashMessage/style.module.css
@@ -39,6 +39,7 @@
     margin: 0;
     vertical-align: text-top;
     border-right: 1px solid rgba(255, 255, 255, .3);
+    box-sizing: border-box !important;
 }
 
 .flashMessage__heading {


### PR DESCRIPTION
**What I did**
With the FontAwesome icons update the icons in the alerts now are too wide. 

![Bildschirmfoto 2024-09-27 um 13 10 40](https://github.com/user-attachments/assets/8acd31a7-43cd-43e4-a657-203c181621a3)

**How I did it**
FontAwesome sets the box-sizing to content box now:

![Bildschirmfoto 2024-09-27 um 13 11 07](https://github.com/user-attachments/assets/bef23f9b-4c65-456e-9722-a1c539e6b574)

**How to verify it**
Icons are small again: 

![Bildschirmfoto 2024-09-27 um 13 10 27](https://github.com/user-attachments/assets/f7a6fc38-9ca1-4462-b87e-29576f4e2694)

Do not know if we should change box-sizing for icons globally or not, but I could not find any other place where it does not work.
