### PR TITLE
TASK: Dont use react inside `terminateDueToFatalInitializationError`

### DIFF
--- a/packages/neos-ui/src/Containers/ErrorBoundary/style.module.css
+++ b/packages/neos-ui/src/Containers/ErrorBoundary/style.module.css
@@ -29,3 +29,7 @@
     flex-wrap: wrap;
     gap: var(--spacing-Half) var(--spacing-Full);
 }
+
+.logo > svg {
+    height: 40px;
+}

--- a/packages/neos-ui/src/System/terminateDueToFatalInitializationError.js
+++ b/packages/neos-ui/src/System/terminateDueToFatalInitializationError.js
@@ -1,5 +1,4 @@
-import {Logo} from '@neos-project/react-ui-components';
-
+import logoSvg from '@neos-project/react-ui-components/src/Logo/resource/logo.svg';
 import styles from '../Containers/ErrorBoundary/style.module.css';
 
 export function terminateDueToFatalInitializationError(reason) {
@@ -11,8 +10,7 @@ export function terminateDueToFatalInitializationError(reason) {
     document.body.innerHTML = `
         <div class="${styles.container}">
             <div>
-                <Logo />
-                <img style="height: 24px; width: auto;" src='${logo}' alt="Neos" />
+                <span class="${styles.logo}">${logoSvg}</span>
                 <h1 class="${styles.title}">
                     Sorry, but the Neos UI could not be initialized.
                 </h1>


### PR DESCRIPTION
Fixes faulty upmerge of https://github.com/neos/neos-ui/pull/3836

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

<img width="1060" alt="image" src="https://github.com/user-attachments/assets/3dd946f0-3f95-48b6-ae4d-77d8347204aa">


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
