### PR TITLE
BUGFIX: Skip `null` when publishing nodes

### DIFF
--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -237,6 +237,14 @@ class BackendServiceController extends ActionController
 
             foreach ($nodeContextPaths as $contextPath) {
                 $node = $this->nodeService->getNodeFromContextPath($contextPath, null, null, true);
+                if ($node === null) {
+                    $error = new Info();
+                    $error->setMessage(sprintf('Could not find node for context path "%s"', $contextPath));
+
+                    $this->feedbackCollection->add($error);
+
+                    continue;
+                }
                 $this->publishingService->publishNode($node, $targetWorkspace);
 
                 if ($node->getNodeType()->isAggregate()) {

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -189,11 +189,18 @@ class BackendServiceController extends ActionController
     {
         $updateWorkspaceInfo = new UpdateWorkspaceInfo();
         $documentNode = $this->nodeService->getNodeFromContextPath($documentNodeContextPath, null, null, true);
-        $updateWorkspaceInfo->setWorkspace(
-            $documentNode->getContext()->getWorkspace()
-        );
+        if ($documentNode === null) {
+            $error = new Error();
+            $error->setMessage(sprintf('Could not find node for document node context path "%s"', $documentNodeContextPath));
 
-        $this->feedbackCollection->add($updateWorkspaceInfo);
+            $this->feedbackCollection->add($error);
+        } else {
+            $updateWorkspaceInfo->setWorkspace(
+                $documentNode->getContext()->getWorkspace()
+            );
+
+            $this->feedbackCollection->add($updateWorkspaceInfo);
+        }
     }
 
     /**


### PR DESCRIPTION
The `getNodeFromContextPath(…)` in the Neos.Ui `NodeService` may return `null`, passing that to `publishNodde(…)` fails:

```
Exception in line 240 of /…/Flow_Object_Classes/Neos_Neos_Ui_Controller_BackendServiceController.php:
Neos\Neos\Service\PublishingService_Original::publishNode(): Argument #1 ($node) must be of type
Neos\ContentRepository\Domain\Model\NodeInterface, null given, called in
/…/Neos_Neos_Ui_Controller_BackendServiceController.php on line 240
```

This change adds a check and skips those nodes.

**How to verify it**

I see this error in a client project quite often, but sadly do not have a reproducer. Looking at the code shows this can happen, though.