### PR TITLE
BUGIFX: Show hidden state only for directly disabled nodes without inheritance

### DIFF
--- a/Classes/Domain/Service/NodePropertyConverterService.php
+++ b/Classes/Domain/Service/NodePropertyConverterService.php
@@ -135,7 +135,7 @@ class NodePropertyConverterService
     private function getProperty(Node $node, string $propertyName): mixed
     {
         if ($propertyName === '_hidden') {
-            return $node->tags->contain(SubtreeTag::fromString('disabled'));
+            return $node->tags->withoutInherited()->contain(SubtreeTag::fromString('disabled'));
         }
 
         $propertyValue = $node->getProperty($propertyName);


### PR DESCRIPTION
Before this fix the display of the hidden state in the content and document tree was broken. Initially only directly disabled nodes where marked as hidden. After opening a document node below a directly disabled node the icon of the selected node has changed also to "hidden".

In Neos <9 we only show disabled nodes with the "hidden" indicator and not the children. So this change ensures the same behavior as before.

In future we should think about a new indicator, which shows a "nodes hidden/disabled by inheritance" state.

Before:
![image](https://github.com/user-attachments/assets/6a5b97af-f3aa-43bb-a97a-a30844c57c72)

Now: 
![image](https://github.com/user-attachments/assets/a1d12386-9077-48af-9596-c2d94ca9593e)
