### PR TITLE
BUGFIX: Allow to insert node inside not editable content collection (via policy)

### DIFF
--- a/packages/neos-ui-redux-store/src/CR/Nodes/selectors.ts
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/selectors.ts
@@ -273,7 +273,7 @@ export const makeGetAllowedChildNodeTypesSelector = (nodeTypesRegistry: NodeType
         (_: GlobalState, {role}: {reference: NodeContextPath | null, role: string, subject: NodeContextPath | null}) => role
     ],
     (referenceNode, referenceParentNode, role) => {
-        if (referenceNode === null || (referenceNode.policy && referenceNode.policy.canEdit === false)) {
+        if (referenceNode === null) {
             return [];
         }
         const isSubjectNodeAutocreated = referenceNode.isAutoCreated;


### PR DESCRIPTION
The `canEdit` check is evaluated by another privilege - the `EditNodePrivilege` - which is separate from the `CreateNodePrivilege` to allow or disallow node creation.

If `EditNodePrivilege` restricts almost all nodes except a few - say headline (by `nodeIsOfType`) - and `CreateNodePrivilege` does the same: only allow to create the headline (by `createdNodeIsOfType`), this policy is correctly enforced via the cr. The Neos ui though is a little to restrictive and allows LESS than what is allowed by the core. The `EditNodePrivilege` would be required to be granted for content collections to be able to insert content. To avoid having to grant this privilege - which comes with the burden of otherwise having to allow content collections AND its subtypes which could be sliders, and to be technically correct, we just dont evaluate the can edit here.

The button is still grey-d out if ALL nodes are disallowed by policy see: https://github.com/neos/neos-ui/blob/2597ffef66f7901569b865e35ea634a941b50a7b/packages/neos-ui-redux-store/src/CR/Nodes/selectors.ts#L292-L299

This behaviour has been since the introduction of Neos Ui policy evaluation: https://github.com/neos/neos-ui/pull/1282

Though inside a commit shows that during the development the behavior was changed:

https://github.com/neos/neos-ui/commit/72b2614fc2eb5b3dbb1b88a2a60aad5abe03e201#diff-8b6869be808b6aad3e3ac19f6312c029d54112eb72aa09ffd757e4a7a686bcefR200

I can only assume that in "Enforce EditNodePrivilege for inline editing" the use of the `canEdit` flag was added to restrictive.

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
