### PR TITLE
BUGFIX: Add content element wrapping to restricted nodes

### DIFF
--- a/Classes/Aspects/AugmentationAspect.php
+++ b/Classes/Aspects/AugmentationAspect.php
@@ -145,6 +145,10 @@ class AugmentationAspect
             return $content;
         }
 
+        if ($this->nodeAuthorizationService->isGrantedToEditNode($node) === false) {
+            return $content;
+        }
+
         $content = $joinPoint->getAdviceChain()->proceed($joinPoint);
 
         $attributes = [
@@ -166,6 +170,6 @@ class AugmentationAspect
         /** @var $contentContext ContentContext */
         $contentContext = $node->getContext();
 
-        return ($contentContext->isInBackend() === true && ($renderCurrentDocumentMetadata === true || $this->nodeAuthorizationService->isGrantedToEditNode($node) === true));
+        return $contentContext->isInBackend() === true || $renderCurrentDocumentMetadata === true;
     }
 }


### PR DESCRIPTION
Previously opening a document where some nodes were not permitted to be edited was hard to navigate, as the content element wrapping was not rendered. Clicking into the elements showed no outline and navigation via the content tree was not possible. But more importantly inserting nodes into the content collection were likely misplaced until reloading as the Neos Ui does not understand the structure of the site.

Instead - as reading the nodes and its information is permitted and needed for rendering - we will always wrap content elements if editable or not.

To avoid having to boot the ckeditor for inline elements we instead evaluate the edit permission there and decide to hide the inline element wrapping. (Previously they would be rendered but not booted because the neos ui didnt had the outer content element wrapping)

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
