### PR TITLE
BUGFIX: Hide paste button in inline ui if no nodes are in clipboard

### DIFF
--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/PasteClipBoardNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/PasteClipBoardNode/index.js
@@ -15,7 +15,7 @@ import {selectors, actions} from '@neos-project/neos-ui-redux-store';
 
     return (state, {contextPath}) => {
         const clipboardNodesContextPaths = selectors.CR.Nodes.clipboardNodesContextPathsSelector(state);
-        const canBePasted = (clipboardNodesContextPaths.every(clipboardNodeContextPath => {
+        const canBePasted = clipboardNodesContextPaths.length && (clipboardNodesContextPaths.every(clipboardNodeContextPath => {
             return canBePastedSelector(state, {
                 subject: clipboardNodeContextPath,
                 reference: contextPath


### PR DESCRIPTION
before:

button is always visible:

<img width="285" alt="image" src="https://github.com/user-attachments/assets/81404fe0-0e13-47e7-a79d-9799fdc1f1e6">



<img width="990" alt="image" src="https://github.com/user-attachments/assets/6a90aa71-0baf-488f-a275-424006551b83">


after:

button is hidden, todo maybe just grey out to prevent moving of buttons?

<img width="298" alt="image" src="https://github.com/user-attachments/assets/ae79d088-2b48-4bf5-86ae-0332aa9f7b11">

though after copying from inline, the buttons jump now:

<img width="298" alt="image" src="https://github.com/user-attachments/assets/46d6202b-a4e0-4b6c-8938-cb06ecb5c271">


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
