### PR TITLE
BUGFIX: Prevent copy nodes across dimensions

### DIFF
--- a/Classes/Domain/Model/Changes/CopyAfter.php
+++ b/Classes/Domain/Model/Changes/CopyAfter.php
@@ -64,15 +64,17 @@ class CopyAfter extends AbstractStructuralChange
             try {
                 $succeedingSibling = $this->findChildNodes($parentNodeOfPreviousSibling)->next($previousSibling);
             } catch (\InvalidArgumentException $e) {
-                // do nothing; $succeedingSibling is null.
+                // do nothing; $succeedingSibling is null. Todo add Nodes::contain()
             }
-
+            if (!$subject->dimensionSpacePoint->equals($parentNodeOfPreviousSibling->dimensionSpacePoint)) {
+                throw new \RuntimeException('Copying across dimensions is not supported yet (https://github.com/neos/neos-development-collection/issues/5054)', 1733586265);
+            }
             $this->nodeDuplicationService->copyNodesRecursively(
                 $subject->contentRepositoryId,
                 $subject->workspaceName,
                 $subject->dimensionSpacePoint,
                 $subject->aggregateId,
-                OriginDimensionSpacePoint::fromDimensionSpacePoint($subject->dimensionSpacePoint),
+                OriginDimensionSpacePoint::fromDimensionSpacePoint($parentNodeOfPreviousSibling->dimensionSpacePoint),
                 $parentNodeOfPreviousSibling->aggregateId,
                 $succeedingSibling?->aggregateId,
                 NodeAggregateIdMapping::createEmpty()

--- a/Classes/Domain/Model/Changes/CopyBefore.php
+++ b/Classes/Domain/Model/Changes/CopyBefore.php
@@ -62,12 +62,15 @@ class CopyBefore extends AbstractStructuralChange
         if ($this->canApply() && !is_null($succeedingSibling)
             && !is_null($parentNodeOfSucceedingSibling)
         ) {
+            if (!$subject->dimensionSpacePoint->equals($succeedingSibling->dimensionSpacePoint)) {
+                throw new \RuntimeException('Copying across dimensions is not supported yet (https://github.com/neos/neos-development-collection/issues/5054)', 1733586265);
+            }
             $this->nodeDuplicationService->copyNodesRecursively(
                 $subject->contentRepositoryId,
                 $subject->workspaceName,
                 $subject->dimensionSpacePoint,
                 $subject->aggregateId,
-                OriginDimensionSpacePoint::fromDimensionSpacePoint($subject->dimensionSpacePoint),
+                OriginDimensionSpacePoint::fromDimensionSpacePoint($succeedingSibling->dimensionSpacePoint),
                 $parentNodeOfSucceedingSibling->aggregateId,
                 $succeedingSibling->aggregateId,
                 NodeAggregateIdMapping::createEmpty()

--- a/Classes/Domain/Model/Changes/CopyInto.php
+++ b/Classes/Domain/Model/Changes/CopyInto.php
@@ -72,12 +72,15 @@ class CopyInto extends AbstractStructuralChange
         $subject = $this->getSubject();
         $parentNode = $this->getParentNode();
         if ($parentNode && $this->canApply()) {
+            if (!$subject->dimensionSpacePoint->equals($parentNode->dimensionSpacePoint)) {
+                throw new \RuntimeException('Copying across dimensions is not supported yet (https://github.com/neos/neos-development-collection/issues/5054)', 1733586265);
+            }
             $this->nodeDuplicationService->copyNodesRecursively(
                 $subject->contentRepositoryId,
                 $subject->workspaceName,
                 $subject->dimensionSpacePoint,
                 $subject->aggregateId,
-                OriginDimensionSpacePoint::fromDimensionSpacePoint($subject->dimensionSpacePoint),
+                OriginDimensionSpacePoint::fromDimensionSpacePoint($parentNode->dimensionSpacePoint),
                 $parentNode->aggregateId,
                 null,
                 NodeAggregateIdMapping::createEmpty()

--- a/packages/neos-ui-redux-store/src/CR/Nodes/selectors.ts
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/selectors.ts
@@ -455,12 +455,25 @@ export const makeCanBeMovedAlongsideSelector = (nodeTypesRegistry: NodeTypesRegi
     (canBeInsertedInto, referenceIsDescendantOfSubject) => canBeInsertedInto && !referenceIsDescendantOfSubject
 );
 
+const makeNodeIsOfCurrentDimension = (_: GlobalState, {subject, reference}: {subject: NodeContextPath | null, reference: NodeContextPath | null}) => {
+    if (subject === null || reference === null) {
+        return false;
+    }
+
+    // todo centralise client side NodeAddress logic
+    const subjectDimension = JSON.parse(subject).dimensionSpacePoint;
+    const referenceDimension = JSON.parse(reference).dimensionSpacePoint;
+
+    return JSON.stringify(subjectDimension) === JSON.stringify(referenceDimension);
+};
+
 export const makeCanBeCopiedSelector = (nodeTypesRegistry: NodeTypesRegistry) => createSelector(
     [
+        makeNodeIsOfCurrentDimension,
         makeCanBeCopiedAlongsideSelector(nodeTypesRegistry),
         makeCanBeCopiedIntoSelector(nodeTypesRegistry)
     ],
-    (canBeInsertedAlongside, canBeInsertedInto) => (canBeInsertedAlongside || canBeInsertedInto)
+    (nodeIsOfCurrentDimension, canBeInsertedAlongside, canBeInsertedInto) => nodeIsOfCurrentDimension && (canBeInsertedAlongside || canBeInsertedInto)
 );
 
 export const makeCanBeMovedSelector = (nodeTypesRegistry: NodeTypesRegistry) => createSelector(


### PR DESCRIPTION
see https://github.com/neos/neos-development-collection/issues/5054#issuecomment-2523060805
    
Previously the `$targetDimensionSpacePoint` was also wrongly chosen, and it was attempted to paste the node into the subjects home dimension

Also we hide the paste button in the Neos Ui if its across dimensions (im not sure if this is the best idea but yeah) - maybe an error is better?

**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
