### PR TITLE
BUGFIX: Prevent warnings for unrecognized DOM props

### DIFF
--- a/packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/Helpers/renderToolbarComponents.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/Helpers/renderToolbarComponents.js
@@ -31,7 +31,7 @@ export default richtextToolbarRegistry => {
                 const restProps = omit(props, ['isVisible', 'isActive']);
                 const isActiveProp = isToolbarItemActive(formattingUnderCursor, inlineEditorOptions)(componentDefinition);
 
-                const finalProps = {
+                let finalProps = {
                     ...restProps,
                     key: index,
                     isActive: isActiveProp,
@@ -40,6 +40,11 @@ export default richtextToolbarRegistry => {
                     formattingUnderCursor,
                     [callbackPropName]: e => e.stopPropagation() || executeCommand(commandName, ...commandArgs)
                 };
+
+                // filter out props that are not needed by the component and lead to a render warning
+                if (commandName === 'code') {
+                    finalProps = omit(finalProps, ['executeCommand', 'formattingUnderCursor']);
+                }
 
                 const Component = component;
 

--- a/packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/Helpers/renderToolbarComponents.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/Helpers/renderToolbarComponents.js
@@ -41,7 +41,11 @@ export default richtextToolbarRegistry => {
                     [callbackPropName]: e => e.stopPropagation() || executeCommand(commandName, ...commandArgs)
                 };
 
-                // filter out props that are not needed by the component and lead to a render warning
+                // Filter out properties that are not needed by the component
+                // and cause render warnings. Specifically for the 'code' command,
+                // we omit 'executeCommand' and 'formattingUnderCursor' as they
+                // are custom properties from Neos and not required by CKEditor's
+                // code plugin.
                 if (commandName === 'code') {
                     finalProps = omit(finalProps, ['executeCommand', 'formattingUnderCursor']);
                 }


### PR DESCRIPTION
This change addresses React warnings related to invalid DOM attributes:
- Removed `executeCommand` and `formattingUnderCursor` from being passed to DOM elements.
- Ensured these props are only handled within components where they are relevant, preventing them from being incorrectly rendered on DOM elements.

These update prevent unnecessary warnings in the console.

Resolves: #3894
