### PR TITLE
BUGFIX: Prevent proptype warning regarding canBePasted property

### DIFF
--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/PasteClipBoardNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/PasteClipBoardNode/index.js
@@ -15,7 +15,7 @@ import {selectors, actions} from '@neos-project/neos-ui-redux-store';
 
     return (state, {contextPath}) => {
         const clipboardNodesContextPaths = selectors.CR.Nodes.clipboardNodesContextPathsSelector(state);
-        const canBePasted = clipboardNodesContextPaths.length && (clipboardNodesContextPaths.every(clipboardNodeContextPath => {
+        const canBePasted = Boolean(clipboardNodesContextPaths.length && clipboardNodesContextPaths.every(clipboardNodeContextPath => {
             return canBePastedSelector(state, {
                 subject: clipboardNodeContextPath,
                 reference: contextPath


### PR DESCRIPTION
**What I did**

If `clipboardNodesContextPaths.length` is 0, this part will be interpreted as false (because 0 is considered "falsy" in JavaScript). The entire expression will then be 0 without evaluating the second part. This happens due to short-circuit evaluation in JavaScript.

**How I did it**
With this change we ensure that the value is always a boolean value.

Resolves: #3899