### PR TITLE
FEATURE: Mark inherited disabled nodes in document and content tree

### DIFF
--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -105,6 +105,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
             // TODO: we should export this correctly named, but that needs changes throughout the JS code as well.
             '_hidden' => $node->tags->withoutInherited()->contain(NeosSubtreeTag::disabled()),
             'hiddenInMenu' => $node->getProperty('hiddenInMenu'),
+            '_hiddenByAncestors' => $node->tags->onlyInherited()->contain(NeosSubtreeTag::disabled()),
             '_hiddenInIndex' => $node->getProperty('hiddenInMenu'),
             '_hasTimeableNodeVisibility' =>
                 $node->getProperty('enableAfterDateTime') instanceof \DateTimeInterface
@@ -147,6 +148,14 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
         $nodeInfo['properties'] = $this->nodePropertyConverterService->getPropertiesArray($node);
         $nodeInfo['tags'] = $node->tags;
         $nodeInfo['isFullyLoaded'] = true;
+        $nodeInfo['properties'] = array_merge($nodeInfo['properties'], [
+            // TODO: we should export this correctly named, but that needs changes throughout the JS code as well.
+            '_hidden' => $node->tags->withoutInherited()->contain(NeosSubtreeTag::disabled()),
+            '_hiddenByAncestors' => $node->tags->onlyInherited()->contain(NeosSubtreeTag::disabled()),
+            '_hasTimeableNodeVisibility' =>
+                $node->getProperty('enableAfterDateTime') instanceof \DateTimeInterface
+                || $node->getProperty('disableAfterDateTime') instanceof \DateTimeInterface,
+        ]);
 
         if ($actionRequest !== null) {
             $nodeInfo = array_merge($nodeInfo, $this->getUriInformation($node, $actionRequest));

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -170,6 +170,7 @@ export default class Node extends PureComponent {
         const {node} = this.props;
 
         const isDisabled = node?.properties?._hidden;
+        const isDisabledByAncestors = node?.properties?._hiddenByAncestors;
         const hasTimeableNodeVisibility = node?.properties?._hasTimeableNodeVisibility;
 
         if (hasTimeableNodeVisibility) {
@@ -188,6 +189,16 @@ export default class Node extends PureComponent {
                 <span className="fa-layers fa-fw">
                     <Icon icon={this.getIcon()} />
                     <Icon icon="circle" color="error" transform="shrink-3 down-6 right-4" />
+                    <Icon icon="times" transform="shrink-7 down-6 right-4" />
+                </span>
+            );
+        }
+
+        if (isDisabledByAncestors) {
+            return (
+                <span className="fa-layers fa-fw">
+                    <Icon icon={this.getIcon()} />
+                    <Icon icon="circle" color="contrastDark" transform="shrink-3 down-6 right-4" />
                     <Icon icon="times" transform="shrink-7 down-6 right-4" />
                 </span>
             );

--- a/packages/react-ui-components/src/Icon/__snapshots__/icon.spec.tsx.snap
+++ b/packages/react-ui-components/src/Icon/__snapshots__/icon.spec.tsx.snap
@@ -10,6 +10,7 @@ exports[`<Icon/> should render correctly. 1`] = `
     Object {
       "icon": "iconClassName",
       "icon--big": "bigClassName",
+      "icon--color-contrastDark": "color-contrastDarkClassName",
       "icon--color-error": "color-errorClassName",
       "icon--color-primaryBlue": "color-primaryBlueClassName",
       "icon--color-warn": "color-warnClassName",

--- a/packages/react-ui-components/src/Icon/fontAwesomeIcon.spec.tsx
+++ b/packages/react-ui-components/src/Icon/fontAwesomeIcon.spec.tsx
@@ -21,6 +21,7 @@ describe('<FontAwesomeIcon/>', () => {
             'icon--big': 'bigClassName',
             'icon--color-error': 'color-errorClassName',
             'icon--color-primaryBlue': 'color-primaryBlueClassName',
+            'icon--color-contrastDark': 'color-contrastDarkClassName',
             'icon--color-warn': 'color-warnClassName',
             'icon--paddedLeft': 'paddedLeftClassName',
             'icon--paddedRight': 'paddedRightClassName',

--- a/packages/react-ui-components/src/Icon/fontAwesomeIcon.tsx
+++ b/packages/react-ui-components/src/Icon/fontAwesomeIcon.tsx
@@ -22,7 +22,8 @@ class FontAwesomeIcon extends PureComponent<IconProps> {
                 [theme!['icon--paddedRight']]: padded === 'right',
                 [theme!['icon--color-warn']]: color === 'warn',
                 [theme!['icon--color-error']]: color === 'error',
-                [theme!['icon--color-primaryBlue']]: color === 'primaryBlue'
+                [theme!['icon--color-primaryBlue']]: color === 'primaryBlue',
+                [theme!['icon--color-contrastDark']]: color === 'contrastDark'
             }
         );
 

--- a/packages/react-ui-components/src/Icon/icon.spec.tsx
+++ b/packages/react-ui-components/src/Icon/icon.spec.tsx
@@ -13,6 +13,7 @@ describe('<Icon/>', () => {
             'icon--big': 'bigClassName',
             'icon--color-error': 'color-errorClassName',
             'icon--color-primaryBlue': 'color-primaryBlueClassName',
+            'icon--color-contrastDark': 'color-contrastDarkClassName',
             'icon--color-warn': 'color-warnClassName',
             'icon--paddedLeft': 'paddedLeftClassName',
             'icon--paddedRight': 'paddedRightClassName',

--- a/packages/react-ui-components/src/Icon/icon.tsx
+++ b/packages/react-ui-components/src/Icon/icon.tsx
@@ -7,7 +7,7 @@ import {defaultProps} from './iconDefaultProps';
 
 type IconSize = 'xs' | 'sm' | 'lg' | '2x' | '3x';
 type IconPadding = 'none' | 'left' | 'right';
-type IconColor = 'default' | 'warn' | 'error' | 'primaryBlue';
+type IconColor = 'default' | 'warn' | 'error' | 'primaryBlue' | 'contrastDark';
 
 export interface IconTheme {
     readonly icon: string;
@@ -22,6 +22,7 @@ export interface IconTheme {
     readonly 'icon--color-warn': string;
     readonly 'icon--color-error': string;
     readonly 'icon--color-primaryBlue': string;
+    readonly 'icon--color-contrastDark': string;
 }
 
 export interface IconProps extends Omit<FontAwesomeIconProps, 'icon' | 'ref'> {

--- a/packages/react-ui-components/src/Icon/resourceIcon.tsx
+++ b/packages/react-ui-components/src/Icon/resourceIcon.tsx
@@ -39,6 +39,7 @@ class ResourceIcon extends PureComponent<ResourceIconProps> {
                 [theme!['icon--color-warn']]: color === 'warn',
                 [theme!['icon--color-error']]: color === 'error',
                 [theme!['icon--color-primaryBlue']]: color === 'primaryBlue',
+                [theme!['icon--color-contrastDark']]: color === 'contrastDark',
                 [theme!['icon--huge']]: size === '3x',
                 [theme!['icon--large']]: size === '2x',
                 [theme!['icon--big']]: size === 'lg',

--- a/packages/react-ui-components/src/Icon/style.module.css
+++ b/packages/react-ui-components/src/Icon/style.module.css
@@ -26,6 +26,10 @@
     color: var(--colors-PrimaryBlue);
 }
 
+.icon--color-contrastDark {
+    color: var(--colors-ContrastDark);
+}
+
 .icon--huge {
     & svg {
         height: 3em;


### PR DESCRIPTION
Fixes #3896 

This marks nodes, which are disabled by inheritence, because a ancestor node is disabled, with a dedicated icon.

![image](https://github.com/user-attachments/assets/14653e94-d558-432b-86a5-5acd1d4035b6)
