### PR TITLE
TASK: Update workspace review URL

### DIFF
--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -186,7 +186,7 @@ export default class PublishDropDown extends PureComponent {
                             </AbstractButton>
                         </li>
                         {publishableNodesCount > 0 && (<li className={style.dropDown__item}>
-                            <a id="neos-PublishDropDown-ReviewChanges" href={workspaceModuleUri + '/show?moduleArguments[workspace]=' + this.props.personalWorkspaceName}>
+                            <a id="neos-PublishDropDown-ReviewChanges" href={workspaceModuleUri + '/review?moduleArguments[workspace]=' + this.props.personalWorkspaceName}>
                                 <div className={style.dropDown__iconWrapper}>
                                     <Icon icon="check-circle"/>
                                 </div>


### PR DESCRIPTION
**What I did**
With https://github.com/neos/neos-development-collection/pull/5132 the workspace URL is switched from /show to /review. 
We need to update the URL in the Neos UI that links to the workspace detail view. 

**How to verify it**
The "review changes" button works with the new Workspace UX PR. 
<img width="257" alt="Bildschirmfoto 2024-12-20 um 09 25 22" src="https://github.com/user-attachments/assets/3e70542d-d7ec-4cd3-ae86-37e24e3e9e4c" />
