### PR TITLE
TASK: Remove obsolete policy for removed temporary login controller

### DIFF
--- a/Configuration/Policy.yaml
+++ b/Configuration/Policy.yaml
@@ -6,9 +6,6 @@ privilegeTargets:
 
   'Neos\Flow\Security\Authorization\Privilege\Method\MethodPrivilege':
 
-    'Neos.Neos.Ui:BackendLogin':
-      matcher: 'method(Neos\Neos\Ui\Controller\LoginController->(index|authenticate)Action()) || method(Neos\Flow\Security\Authentication\Controller\AbstractAuthenticationController->authenticateAction())'
-
     'Neos.Neos.Ui:Backend.GeneralAccess':
       matcher: 'method(Neos\Neos\Ui\Controller\BackendController->.*())'
 
@@ -21,12 +18,6 @@ privilegeTargets:
       matcher: 'content'
 
 roles:
-
-    'Neos.Flow:Everybody':
-      privileges:
-        -
-          privilegeTarget: 'Neos.Neos.Ui:BackendLogin'
-          permission: GRANT
 
     'Neos.Neos:AbstractEditor':
       privileges:


### PR DESCRIPTION
Followup for https://github.com/neos/neos-ui/issues/93 which left the policy for the `PackageFactory\Guevara\Controller\LoginController` from the beginning of the revolution introduced with ce1f78cfda235c0015c2b5e4ec4138d5ddf66d7f

The line was later renamed and thus this zombie was created.

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
