### PR TITLE
BUGFIX: Forgiving `I18nRegistry.translate` for strings with colons and `undefined`

### DIFF
--- a/packages/neos-ui-i18n/README.md
+++ b/packages/neos-ui-i18n/README.md
@@ -22,7 +22,7 @@ Neos:
             // ...
 ```
 
-At the beginning of the UI bootstrapping process, translations are loaded from an enpoint (see: [`\Neos\Neos\Controller\Backend\BackendController->xliffAsJsonAction()`](https://neos.github.io/neos/9.0/Neos/Neos/Controller/Backend/BackendController.html#method_xliffAsJsonAction)) and are available afterwards via the `translate` function exposed by this package.
+At the beginning of the UI bootstrapping process, translations are loaded from an endpoint (see: [`\Neos\Neos\Controller\Backend\BackendController->xliffAsJsonAction()`](https://neos.github.io/neos/9.0/Neos/Neos/Controller/Backend/BackendController.html#method_xliffAsJsonAction)) and are available afterwards via the `translate` function exposed by this package.
 
 ## API
 
@@ -90,18 +90,18 @@ Copy {source} to {target}
 
 For numerically indexed placeholders, you can pass an array of strings to the `parameters` argument of `translate`. For named parameters, you can pass an object with string values and keys identifying the parameters.
 
-Translations may also have plural forms. `translate` uses the [`Intl` Web API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) to pick the currect plural form for the current `Locale` based on the given `quantity`.
+Translations may also have plural forms. `translate` uses the [`Intl` Web API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) to pick the correct plural form for the current `Locale` based on the given `quantity`.
 
-Fallbacks can also provide plural forms, but will always treated as if we're in locale `en-US`, so you can only provide two different plural forms.
+Fallbacks can also provide plural forms, but will always be treated as if we're in locale `en-US`, so you can only provide two different plural forms.
 
 #### Arguments
 
-| Name | Description |
-|-|-|
-| `fullyQualifiedTranslationAddressAsString` | The translation address for the translation to use, e.g.: `"Neos.Neos.Ui:Main:errorBoundary.title"` |
-| `fallback` | The string to return, if no translation can be found under the given address. If a tuple of two strings is passed here, these will be treated as singular and plural forms of the translation. |
-| `parameters` | Values to replace placeholders in the translation with. This can be passed as an array of strings (to replace numerically indexed placeholders) or as a `Record<string, string>` (to replace named placeholders) |
-| `quantity` | The quantity is used to determine which plural form (if any) to use for the translation |
+| Name                                       | Description                                                                                                                                                                                                      |
+|--------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `fullyQualifiedTranslationAddressAsString` | The translation address for the translation to use, e.g.: `"Neos.Neos.Ui:Main:errorBoundary.title"`                                                                                                              |
+| `fallback`                                 | The string to return, if no translation can be found under the given address. If a tuple of two strings is passed here, these will be treated as singular and plural forms of the translation.                   |
+| `parameters`                               | Values to replace placeholders in the translation with. This can be passed as an array of strings (to replace numerically indexed placeholders) or as a `Record<string, string>` (to replace named placeholders) |
+| `quantity`                                 | The quantity is used to determine which plural form (if any) to use for the translation                                                                                                                          |
 
 #### Examples
 
@@ -168,7 +168,7 @@ async function initializeI18n(): Promise<void>;
 
 This function loads the translations from the translations endpoint and makes them available globally. It must be run exactly once before any call to `translate`.
 
-The exact URL of the translations endpoint is discoverd via the DOM. The document needs to have a link tag with the id `neos-ui-uri:/neos/xliff.json`, with the following attributes:
+The exact URL of the translations endpoint is discovered via the DOM. The document needs to have a link tag with the id `neos-ui-uri:/neos/xliff.json`, with the following attributes:
 ```html
 <link
   id="neos-ui-uri:/neos/xliff.json"
@@ -194,11 +194,11 @@ This function can be used in unit tests to set up I18n.
 
 #### Arguments
 
-| Name | Description |
-|-|-|
-| `localeIdentifier` | A valid [Unicode Language Identifier](https://www.unicode.org/reports/tr35/#unicode-language-identifier), e.g.: `de-DE`, `en-US`, `ar-EG`, ... |
+| Name                  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `localeIdentifier`    | A valid [Unicode Language Identifier](https://www.unicode.org/reports/tr35/#unicode-language-identifier), e.g.: `de-DE`, `en-US`, `ar-EG`, ...                                                                                                                                                                                                                                                                                                 |
 | `pluralRulesAsString` | A comma-separated list of [Language Plural Rules](http://www.unicode.org/reports/tr35/#Language_Plural_Rules) matching the locale specified by `localeIdentifier`. Here, the output of [`\Neos\Flow\I18n\Cldr\Reader\PluralsReader->getPluralForms()`](https://neos.github.io/flow/9.0/Neos/Flow/I18n/Cldr/Reader/PluralsReader.html#method_getPluralForms) is expected, e.g.: `one,other` for `de-DE`, or `zero,one,two,few,many` for `ar-EG` |
-| `translations` | The XLIFF translations in their JSON-serialized form |
+| `translations`        | The XLIFF translations in their JSON-serialized form                                                                                                                                                                                                                                                                                                                                                                                           |
 
 ##### `TranslationsDTO`
 

--- a/packages/neos-ui-i18n/src/component/I18n.tsx
+++ b/packages/neos-ui-i18n/src/component/I18n.tsx
@@ -30,7 +30,7 @@ interface I18nProps {
 }
 
 /**
- * @deprecated Use `import {tranlsate} from '@neos-project/neos-ui-i18n'` instead
+ * @deprecated Use `import {translate} from '@neos-project/neos-ui-i18n'` instead
  */
 export class I18n extends React.PureComponent<I18nProps> {
     public render(): JSX.Element {

--- a/packages/neos-ui-i18n/src/global/globals.spec.ts
+++ b/packages/neos-ui-i18n/src/global/globals.spec.ts
@@ -7,7 +7,7 @@
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-import {GlobalsRuntimeContraintViolation, requireGlobals, setGlobals, unsetGlobals} from './globals';
+import {GlobalsRuntimeConstraintViolation, requireGlobals, setGlobals, unsetGlobals} from './globals';
 
 describe('globals', () => {
     afterEach(() => {
@@ -17,7 +17,7 @@ describe('globals', () => {
     test('requireGlobals throws when globals are not initialized yet', () => {
         expect(() => requireGlobals())
             .toThrow(
-                GlobalsRuntimeContraintViolation
+                GlobalsRuntimeConstraintViolation
                     .becauseGlobalsWereRequiredButHaveNotBeenSetYet()
             );
     });
@@ -31,7 +31,7 @@ describe('globals', () => {
         setGlobals('foo' as any);
         expect(() => setGlobals('bar' as any))
             .toThrow(
-                GlobalsRuntimeContraintViolation
+                GlobalsRuntimeConstraintViolation
                     .becauseGlobalsWereAttemptedToBeSetMoreThanOnce()
             );
     });

--- a/packages/neos-ui-i18n/src/global/globals.ts
+++ b/packages/neos-ui-i18n/src/global/globals.ts
@@ -18,7 +18,7 @@ export const globals = {
 
 export function requireGlobals(): NonNullable<(typeof globals)['current']> {
     if (globals.current === null) {
-        throw GlobalsRuntimeContraintViolation
+        throw GlobalsRuntimeConstraintViolation
             .becauseGlobalsWereRequiredButHaveNotBeenSetYet();
     }
 
@@ -31,7 +31,7 @@ export function setGlobals(value: NonNullable<(typeof globals)['current']>) {
         return;
     }
 
-    throw GlobalsRuntimeContraintViolation
+    throw GlobalsRuntimeConstraintViolation
         .becauseGlobalsWereAttemptedToBeSetMoreThanOnce();
 }
 
@@ -39,20 +39,20 @@ export function unsetGlobals() {
     globals.current = null;
 }
 
-export class GlobalsRuntimeContraintViolation extends Error {
+export class GlobalsRuntimeConstraintViolation extends Error {
     private constructor(message: string) {
         super(message);
     }
 
     public static becauseGlobalsWereRequiredButHaveNotBeenSetYet = () =>
-        new GlobalsRuntimeContraintViolation(
+        new GlobalsRuntimeConstraintViolation(
             'Globals for "@neos-project/neos-ui-i18n" are not available,'
             + ' because they have not been initialized yet. Make sure to run'
             + ' `loadI18n` or `setupI18n` (for testing).'
         );
 
     public static becauseGlobalsWereAttemptedToBeSetMoreThanOnce = () =>
-        new GlobalsRuntimeContraintViolation(
+        new GlobalsRuntimeConstraintViolation(
             'Globals for "@neos-project/neos-ui-i18n" have already been set. '
              + ' Make sure to only run one of `loadI18n` or `setupI18n` (for'
              + ' testing).  Neither function must ever be called more than'

--- a/packages/neos-ui-i18n/src/model/TranslationAddress.spec.ts
+++ b/packages/neos-ui-i18n/src/model/TranslationAddress.spec.ts
@@ -41,4 +41,23 @@ describe('TranslationAddress', () => {
                     .becauseStringDoesNotAdhereToExpectedFormat('foo bar')
             );
     });
+
+    it('can be try created from string', () => {
+        const translationAddress = TranslationAddress.tryFromString(
+            'Some.Package:SomeSource:some.transunit.id'
+        );
+
+        expect(translationAddress).not.toBeNull();
+        expect(translationAddress?.id).toBe('some.transunit.id');
+        expect(translationAddress?.sourceName).toBe('SomeSource');
+        expect(translationAddress?.packageKey).toBe('Some.Package');
+        expect(translationAddress?.fullyQualified).toBe('Some.Package:SomeSource:some.transunit.id');
+    });
+
+    it('try with invalid string returns null', () => {
+        expect(TranslationAddress.tryFromString('foo bar')).toBeNull();
+        expect(TranslationAddress.tryFromString('something:')).toBeNull();
+        // error in placeholder https://github.com/neos/neos-ui/pull/3907
+        expect(TranslationAddress.tryFromString('ClientEval: node.properties.tagName')).toBeNull();
+    });
 });

--- a/packages/neos-ui-i18n/src/model/TranslationAddress.ts
+++ b/packages/neos-ui-i18n/src/model/TranslationAddress.ts
@@ -24,16 +24,25 @@ export class TranslationAddress {
     }): TranslationAddress =>
         new TranslationAddress(props.id, props.sourceName, props.packageKey, `${props.packageKey}:${props.sourceName}:${props.id}`);
 
-    public static fromString = (string: string): TranslationAddress => {
+    public static tryFromString = (string: string): TranslationAddress|null => {
         const parts = string.split(TRANSLATION_ADDRESS_SEPARATOR);
         if (parts.length !== 3) {
-            throw TranslationAddressIsInvalid
-                .becauseStringDoesNotAdhereToExpectedFormat(string);
+            return null;
         }
 
         const [packageKey, sourceName, id] = parts;
 
         return new TranslationAddress(id, sourceName, packageKey, string);
+    }
+
+    public static fromString = (string: string): TranslationAddress => {
+        const translationAddress = TranslationAddress.tryFromString(string);
+        if (translationAddress === null) {
+            throw TranslationAddressIsInvalid
+                .becauseStringDoesNotAdhereToExpectedFormat(string);
+        }
+
+        return translationAddress;
     }
 }
 

--- a/packages/neos-ui-i18n/src/registry/I18nRegistry.spec.ts
+++ b/packages/neos-ui-i18n/src/registry/I18nRegistry.spec.ts
@@ -111,3 +111,11 @@ test(`
 
     expect(actual).toBe('Singular Translation');
 });
+
+test(`
+    Host > Containers > I18n: Returns undefined if no id is specified`, () => {
+    const registry = new I18nRegistry('');
+    const actual = registry.translate(undefined);
+
+    expect(actual).toBe(undefined);
+});

--- a/packages/neos-ui-i18n/src/registry/I18nRegistry.ts
+++ b/packages/neos-ui-i18n/src/registry/I18nRegistry.ts
@@ -20,11 +20,11 @@ import type {LegacyParameters} from './LegacyParameters';
 const errorCache: Record<string, boolean> = {};
 
 /**
- * @deprecated Use `import {tranlsate} from '@neos-project/neos-ui-i18n'` instead
+ * @deprecated Use `import {translate} from '@neos-project/neos-ui-i18n'` instead
  */
 export class I18nRegistry extends SynchronousRegistry<unknown> {
     /**
-     * Retrieves a the translation string that is identified by the given
+     * Retrieves the translation string that is identified by the given
      * identifier. If it is a fully qualified translation address (a string
      * following the pattern "{Package.Key:SourceName:actual.trans.unit.id}"),
      * then the translation will be looked up in the respective package and
@@ -34,13 +34,13 @@ export class I18nRegistry extends SynchronousRegistry<unknown> {
      * If no translation string can be found for the given id, the fully
      * qualified translation address will be returned.
      *
-     * @deprecated Use `import {tranlsate} from '@neos-project/neos-ui-i18n'` instead
+     * @deprecated Use `import {translate} from '@neos-project/neos-ui-i18n'` instead
      * @param {string} transUnitIdOrFullyQualifiedTranslationAddress A trans-unit id or a fully qualified translation address
      */
     translate(transUnitIdOrFullyQualifiedTranslationAddress: string): string;
 
     /**
-     * Retrieves a the translation string that is identified by the given
+     * Retrieves the translation string that is identified by the given
      * identifier. If it is a fully qualified translation address (a string
      * following the pattern "{Package.Key:SourceName:actual.trans.unit.id}"),
      * then the translation will be looked up in the respective package and
@@ -50,14 +50,14 @@ export class I18nRegistry extends SynchronousRegistry<unknown> {
      * If no translation string can be found for the given id, the given
      * fallback value will be returned.
      *
-     * @deprecated Use `import {tranlsate} from '@neos-project/neos-ui-i18n'` instead
+     * @deprecated Use `import {translate} from '@neos-project/neos-ui-i18n'` instead
      * @param {string} transUnitIdOrFullyQualifiedTranslationAddress A trans-unit id or a fully qualified translation address
      * @param {string} fallback The string that shall be displayed, when no translation string could be found.
      */
     translate(transUnitIdOrFullyQualifiedTranslationAddress: string, fallback: string): string;
 
     /**
-     * Retrieves a the translation string that is identified by the given
+     * Retrieves the translation string that is identified by the given
      * identifier. If it is a fully qualified translation address (a string
      * following the pattern "{Package.Key:SourceName:actual.trans.unit.id}"),
      * then the translation will be looked up in the respective package and
@@ -68,11 +68,11 @@ export class I18nRegistry extends SynchronousRegistry<unknown> {
      * fallback value will be returned. If no fallback value has been given,
      * the fully qualified translation address will be returned.
      *
-     * If a translation string was found and it contains substition placeholders
+     * If a translation string was found, and it contains substitution placeholders
      * (e.g.: "{0}", or "{somePlaceholder}"), the placeholders will be replaced
      * with the corresponding values that were passed as parameters.
      *
-     * @deprecated Use `import {tranlsate} from '@neos-project/neos-ui-i18n'` instead
+     * @deprecated Use `import {translate} from '@neos-project/neos-ui-i18n'` instead
      * @param {string} transUnitIdOrFullyQualifiedTranslationAddress The fully qualified translation address, that follows the format "{Package.Key:SourceName:trans.unit.id}"
      * @param {undefined|string} fallback The string that shall be displayed, when no translation string could be found.
      * @param {LegacyParameters} parameters The values to replace substitution placeholders with in the translation string
@@ -84,7 +84,7 @@ export class I18nRegistry extends SynchronousRegistry<unknown> {
     ): string;
 
     /**
-     * Retrieves a the translation string that is identified by the given
+     * Retrieves the translation string that is identified by the given
      * trans-unit id. The translation file will be looked up inside the package
      * identified by the given package key. The file itself will be the Main.xlf
      * in that package's resource translations.
@@ -93,11 +93,11 @@ export class I18nRegistry extends SynchronousRegistry<unknown> {
      * value will be returned. If no fallback value has been given, the fully
      * qualified translation address will be returned.
      *
-     * If a translation string was found and it contains substition placeholders
+     * If a translation string was found, and it contains substitution placeholders
      * (e.g.: "{0}", or "{somePlaceholder}"), the placeholders will be replaced
      * with the corresponding values that were passed as parameters.
      *
-     * @deprecated Use `import {tranlsate} from '@neos-project/neos-ui-i18n'` instead
+     * @deprecated Use `import {translate} from '@neos-project/neos-ui-i18n'` instead
      * @param {string} transUnitId The trans-unit id
      * @param {undefined|string} fallback The string that shall be displayed, when no translation string could be found.
      * @param {LegacyParameters} parameters The values to replace substitution placeholders with in the translation string
@@ -111,7 +111,7 @@ export class I18nRegistry extends SynchronousRegistry<unknown> {
     ): string;
 
     /**
-     * Retrieves a the translation string that is identified by the given
+     * Retrieves the translation string that is identified by the given
      * trans-unit id. The translation file will be looked up inside the package
      * identified by the given package key. The file itself will be the *.xlf file
      * in that package's resource translations that is identified by the given
@@ -121,11 +121,11 @@ export class I18nRegistry extends SynchronousRegistry<unknown> {
      * value will be returned. If no fallback value has been given, the fully
      * qualified translation address will be returned.
      *
-     * If a translation string was found and it contains substition placeholders
+     * If a translation string was found, and it contains substitution placeholders
      * (e.g.: "{0}", or "{somePlaceholder}"), the placeholders will be replaced
      * with the corresponding values that were passed as parameters.
      *
-     * @deprecated Use `import {tranlsate} from '@neos-project/neos-ui-i18n'` instead
+     * @deprecated Use `import {translate} from '@neos-project/neos-ui-i18n'` instead
      * @param {string} transUnitId The trans-unit id
      * @param {undefined|string} fallback The string that shall be displayed, when no translation string could be found.
      * @param {LegacyParameters} parameters The values to replace substitution placeholders with in the translation string
@@ -141,7 +141,7 @@ export class I18nRegistry extends SynchronousRegistry<unknown> {
     ): string;
 
     /**
-     * Retrieves a the translation string that is identified by the given
+     * Retrieves the translation string that is identified by the given
      * trans-unit id. The translation file will be looked up inside the package
      * identified by the given package key. The file itself will be the *.xlf file
      * in that package's resource translations that is identified by the given
@@ -155,11 +155,11 @@ export class I18nRegistry extends SynchronousRegistry<unknown> {
      * plural form, then the plural form will be used. If the quantity equals 1
      * or is smaller than 1, the singular form will be used.
      *
-     * If a translation string was found and it contains substition placeholders
+     * If a translation string was found, and it contains substitution placeholders
      * (e.g.: "{0}", or "{somePlaceholder}"), the placeholders will be replaced
      * with the corresponding values that were passed as parameters.
      *
-     * @deprecated Use `import {tranlsate} from '@neos-project/neos-ui-i18n'` instead
+     * @deprecated Use `import {translate} from '@neos-project/neos-ui-i18n'` instead
      * @param {string} transUnitId The trans-unit id
      * @param {undefined|string} fallback The string that shall be displayed, when no translation string could be found.
      * @param {LegacyParameters} parameters The values to replace substitution placeholders with in the translation string
@@ -184,10 +184,10 @@ export class I18nRegistry extends SynchronousRegistry<unknown> {
         quantity: number = 0
     ) {
         const fallback = explicitlyProvidedFallback || transUnitIdOrFullyQualifiedTranslationAddress;
-        const translationAddess = getTranslationAddress(transUnitIdOrFullyQualifiedTranslationAddress, explicitlyProvidedPackageKey, explicitlyProvidedSourceName);
-        const translation = this.getTranslation(translationAddess);
+        const translationAddress = getTranslationAddress(transUnitIdOrFullyQualifiedTranslationAddress, explicitlyProvidedPackageKey, explicitlyProvidedSourceName);
+        const translation = this.getTranslation(translationAddress);
         if (translation === null) {
-            this.logTranslationNotFound(translationAddess, fallback);
+            this.logTranslationNotFound(translationAddress, fallback);
             return fallback;
         }
 
@@ -209,6 +209,6 @@ export class I18nRegistry extends SynchronousRegistry<unknown> {
 }
 
 /**
- * @deprecated Use `import {tranlsate} from '@neos-project/neos-ui-i18n'` instead
+ * @deprecated Use `import {translate} from '@neos-project/neos-ui-i18n'` instead
  */
 export const i18nRegistry = new I18nRegistry('The i18n registry');

--- a/packages/neos-ui-i18n/src/registry/I18nRegistry.ts
+++ b/packages/neos-ui-i18n/src/registry/I18nRegistry.ts
@@ -24,6 +24,11 @@ const errorCache: Record<string, boolean> = {};
  */
 export class I18nRegistry extends SynchronousRegistry<unknown> {
     /**
+     * @deprecated Use `import {translate} from '@neos-project/neos-ui-i18n'` instead
+     */
+    translate(emptyAddress: undefined): undefined;
+
+    /**
      * Retrieves the translation string that is identified by the given
      * identifier. If it is a fully qualified translation address (a string
      * following the pattern "{Package.Key:SourceName:actual.trans.unit.id}"),
@@ -176,13 +181,17 @@ export class I18nRegistry extends SynchronousRegistry<unknown> {
     ): string;
 
     translate(
-        transUnitIdOrFullyQualifiedTranslationAddress: string,
+        transUnitIdOrFullyQualifiedTranslationAddress?: string,
         explicitlyProvidedFallback?: string,
         parameters?: LegacyParameters,
         explicitlyProvidedPackageKey: string = 'Neos.Neos',
         explicitlyProvidedSourceName: string = 'Main',
         quantity: number = 0
     ) {
+        if (typeof transUnitIdOrFullyQualifiedTranslationAddress !== 'string' || transUnitIdOrFullyQualifiedTranslationAddress === '') {
+            // legacy behaviour to guard against undefined
+            return explicitlyProvidedFallback;
+        }
         const fallback = explicitlyProvidedFallback || transUnitIdOrFullyQualifiedTranslationAddress;
         const translationAddress = getTranslationAddress(transUnitIdOrFullyQualifiedTranslationAddress, explicitlyProvidedPackageKey, explicitlyProvidedSourceName);
         const translation = this.getTranslation(translationAddress);

--- a/packages/neos-ui-i18n/src/registry/getTranslationAddress.spec.ts
+++ b/packages/neos-ui-i18n/src/registry/getTranslationAddress.spec.ts
@@ -31,4 +31,17 @@ describe('getTranslationAddress', () => {
         expect(translationAddress.sourceName).toBe('SomeSource');
         expect(translationAddress.packageKey).toBe('Some.Package');
     });
+
+    it('try with invalid string returns null', () => {
+        // error in placeholder https://github.com/neos/neos-ui/pull/3907
+        const translationAddress = getTranslationAddress(
+            'ClientEval: node.properties.tagName',
+            'Some.Package',
+            'SomeSource'
+        );
+
+        expect(translationAddress.id).toBe('ClientEval: node.properties.tagName');
+        expect(translationAddress.sourceName).toBe('SomeSource');
+        expect(translationAddress.packageKey).toBe('Some.Package');
+    });
 });

--- a/packages/neos-ui-i18n/src/registry/getTranslationAddress.ts
+++ b/packages/neos-ui-i18n/src/registry/getTranslationAddress.ts
@@ -9,6 +9,9 @@
  */
 import {TranslationAddress} from '../model';
 
+/**
+ * @deprecated legacy implementation for I18nRegistry we want to use the TranslationAddress instead.
+ */
 export function getTranslationAddress(
     fullyQualifiedTransUnitId: string
 ): TranslationAddress;
@@ -22,8 +25,9 @@ export function getTranslationAddress(
     packageKey?: string,
     sourceName?: string
 ) {
-    if (id && id.indexOf(':') !== -1) {
-        return TranslationAddress.fromString(id);
+    const fullyQualifiedTranslationAddress = TranslationAddress.tryFromString(id);
+    if (fullyQualifiedTranslationAddress !== null) {
+        return fullyQualifiedTranslationAddress;
     }
 
     if (packageKey === undefined) {

--- a/packages/neos-ui-i18n/src/translate.ts
+++ b/packages/neos-ui-i18n/src/translate.ts
@@ -12,7 +12,7 @@ import {TranslationAddress, type Parameters} from './model';
 import {substitutePlaceholders} from './registry';
 
 /**
- * Retrieves a the translation string that is identified by the given fully
+ * Retrieves the translation string that is identified by the given fully
  * qualified translation address (a string following the pattern
  * "{Package.Key:SourceName:actual.trans.unit.id}"), then the translation will
  * be looked up in the respective package and *.xlf file.
@@ -20,7 +20,7 @@ import {substitutePlaceholders} from './registry';
  * If no translation string can be found for the given address, the given
  * fallback value will be returned.
  *
- * If a translation string was found and it contains substition placeholders
+ * If a translation string was found, and it contains substitution placeholders
  * (e.g.: "{0}", or "{somePlaceholder}"), the placeholders will be replaced
  * with the corresponding values that were passed as parameters.
  *


### PR DESCRIPTION
The following node type configuration

```yaml
placeholder: 'ClientEval: node.properties.tagName'
```

currently yields an error which is caught by the error boundary for properties:

> Error: TranslationAddress must adhere to format "{packageKey}:{sourceName}:{transUnitId}". Got "ClientEval: node.properties.tagName" instead.

The newly added strictness in https://github.com/neos/neos-ui/pull/3804 introduces this regression here.

Previously the function `getTranslationAddress` would just attempt to spit a string and expect three items to be returned:

https://github.com/neos/neos-ui/blob/2cecfcf136aafcd9e3f72537f513eb81b01e993b/packages/neos-ui-i18n/src/registry/I18nRegistry.js#L7

The deconstruction would already cause an error in PHP but not in JavaScript:

```
const [packageKey, sourceName, id] = 'ClientEval: node.properties.tagName'.split(':')
```

Returns

```
packageKey: "ClientEval"
sourceName: " node.properties.tagName"
id: undefined
```

The previous forgiveness needs to be reintroduced as its easy to create errors with strings containing colons at any position which is definitely likely for placeholders. Imagine: `placeholder: "The title of the blog:"`.

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
