### PR TITLE
FEATURE: Simplify publish workflow

### DIFF
--- a/Tests/IntegrationTests/Fixtures/1Dimension/syncing.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/syncing.e2e.js
@@ -89,7 +89,7 @@ test('Publish + Syncing: Create a conflict state between two editors, then try t
 
 test('Publish + Syncing: Create a conflict state between two editors, then try to publish the document and choose "Drop conflicting changes" as a resolution strategy during automatic rebase', async t => {
     await prepareDocumentConflictBetweenAdminAndEditor(t);
-    await startPublishDocument(t);
+    await publishDocument(t);
     await assertThatConflictResolutionHasStarted(t);
     await chooseDropConflictingChangesAsResolutionStrategy(t);
     await performResolutionStrategy(t);
@@ -323,9 +323,8 @@ async function startPublishAll(t) {
     await t.click(Selector('#neos-PublishDialog-Confirm'));
 }
 
-async function startPublishDocument(t) {
+async function publishDocument(t) {
     await t.click(Selector('#neos-PublishDropDown-Publish'))
-    await t.click(Selector('#neos-PublishDialog-Confirm'));
 }
 
 async function finishPublish(t) {

--- a/packages/neos-ui-redux-store/src/CR/Publishing/index.ts
+++ b/packages/neos-ui-redux-store/src/CR/Publishing/index.ts
@@ -146,7 +146,7 @@ export const reducer = (state: State = defaultState, action: Action): State => {
                 mode: action.payload.mode,
                 scope: action.payload.scope,
                 process: action.payload.requireConfirmation ? {
-                    phase: PublishingPhase.START,
+                    phase: PublishingPhase.START
                 } : {
                     phase: PublishingPhase.ONGOING,
                     autoConfirmed: true

--- a/packages/neos-ui-redux-store/src/CR/Publishing/index.ts
+++ b/packages/neos-ui-redux-store/src/CR/Publishing/index.ts
@@ -37,6 +37,7 @@ export type State = null | {
         | { phase: PublishingPhase.START }
         | {
             phase: PublishingPhase.ONGOING,
+            autoConfirmed: boolean
           }
         | { phase: PublishingPhase.CONFLICTS }
         | {
@@ -148,6 +149,7 @@ export const reducer = (state: State = defaultState, action: Action): State => {
                     phase: PublishingPhase.START,
                 } : {
                     phase: PublishingPhase.ONGOING,
+                    autoConfirmed: true
                 }
             };
         }
@@ -170,7 +172,8 @@ export const reducer = (state: State = defaultState, action: Action): State => {
             return {
                 ...state,
                 process: {
-                    phase: PublishingPhase.ONGOING
+                    phase: PublishingPhase.ONGOING,
+                    autoConfirmed: false
                 }
             };
         case actionTypes.CONFLICTS_OCCURRED:
@@ -184,7 +187,8 @@ export const reducer = (state: State = defaultState, action: Action): State => {
             return {
                 ...state,
                 process: {
-                    phase: PublishingPhase.ONGOING
+                    phase: PublishingPhase.ONGOING,
+                    autoConfirmed: false
                 }
             };
         case actionTypes.FAILED:
@@ -199,7 +203,8 @@ export const reducer = (state: State = defaultState, action: Action): State => {
             return {
                 ...state,
                 process: {
-                    phase: PublishingPhase.ONGOING
+                    phase: PublishingPhase.ONGOING,
+                    autoConfirmed: false
                 }
             };
         case actionTypes.SUCEEDED:

--- a/packages/neos-ui-redux-store/src/CR/Publishing/index.ts
+++ b/packages/neos-ui-redux-store/src/CR/Publishing/index.ts
@@ -35,7 +35,9 @@ export type State = null | {
     scope: PublishingScope;
     process:
         | { phase: PublishingPhase.START }
-        | { phase: PublishingPhase.ONGOING }
+        | {
+            phase: PublishingPhase.ONGOING,
+          }
         | { phase: PublishingPhase.CONFLICTS }
         | {
               phase: PublishingPhase.ERROR;
@@ -65,8 +67,8 @@ export enum actionTypes {
 /**
  * Publishes or discards all changes in the given scope
  */
-const start = (mode: PublishingMode, scope: PublishingScope) =>
-    createAction(actionTypes.STARTED, {mode, scope});
+const start = (mode: PublishingMode, scope: PublishingScope, requireConfirmation: boolean) =>
+    createAction(actionTypes.STARTED, {mode, scope, requireConfirmation});
 
 /**
  * Cancel the ongoing publish/discard workflow
@@ -142,8 +144,10 @@ export const reducer = (state: State = defaultState, action: Action): State => {
             return {
                 mode: action.payload.mode,
                 scope: action.payload.scope,
-                process: {
-                    phase: PublishingPhase.START
+                process: action.payload.requireConfirmation ? {
+                    phase: PublishingPhase.START,
+                } : {
+                    phase: PublishingPhase.ONGOING,
                 }
             };
         }

--- a/packages/neos-ui-sagas/src/Sync/index.ts
+++ b/packages/neos-ui-sagas/src/Sync/index.ts
@@ -164,7 +164,8 @@ const makeDiscardAll = () => {
     function * discardAll() {
         yield put(actions.CR.Publishing.start(
             PublishingMode.DISCARD,
-            PublishingScope.ALL
+            PublishingScope.ALL,
+            true
         ));
         yield put(actions.CR.Publishing.confirm()); // todo auto-confirm this case
         yield put(actions.CR.Syncing.finish()); // stop syncing as discarding takes now over

--- a/packages/neos-ui-sagas/src/Sync/index.ts
+++ b/packages/neos-ui-sagas/src/Sync/index.ts
@@ -167,7 +167,7 @@ const makeDiscardAll = () => {
             PublishingScope.ALL,
             true
         ));
-        yield put(actions.CR.Publishing.confirm()); // todo auto-confirm this case
+        yield put(actions.CR.Publishing.confirm()); // we auto-confirm this case but do want to display a full result dialog
         yield put(actions.CR.Syncing.finish()); // stop syncing as discarding takes now over
         const {cancelled}: {
             cancelled: null | ReturnType<typeof actions.CR.Publishing.cancel>;

--- a/packages/neos-ui/src/Containers/Modals/PublishingDialog/ConfirmationDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/PublishingDialog/ConfirmationDialog.tsx
@@ -69,6 +69,7 @@ const ConfirmationDialogVariants = {
                 }
             }
         },
+        // NOTE that with https://github.com/neos/neos-ui/pull/3909 this variant is currently effectively not used as confirmation is not required
         [PublishingScope.DOCUMENT]: {
             label: {
                 title: {

--- a/packages/neos-ui/src/Containers/Modals/PublishingDialog/PublishingDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/PublishingDialog/PublishingDialog.tsx
@@ -7,7 +7,7 @@
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 // @ts-ignore
 import {connect} from 'react-redux';
 
@@ -85,7 +85,7 @@ const PublishingDialog: React.FC<PublishingDialogProps> = (props) => {
             );
 
         case PublishingPhase.ONGOING:
-            return (
+            const ongoingScreen = (
                 <ProcessIndicator
                     mode={props.publishingState.mode}
                     scope={props.publishingState.scope}
@@ -95,6 +95,8 @@ const PublishingDialog: React.FC<PublishingDialogProps> = (props) => {
                     numberOfChanges={props.numberOfChanges}
                     />
             );
+
+            return props.publishingState.process.autoConfirmed ? <DelayedDisplay component={ongoingScreen} delay={750} /> : ongoingScreen;
 
         case PublishingPhase.CONFLICTS:
             return null;
@@ -116,6 +118,21 @@ const PublishingDialog: React.FC<PublishingDialogProps> = (props) => {
             );
     }
 };
+
+const DelayedDisplay = (props: {component: React.ReactElement, delay: number}) => {
+    const [enable, setEnable] = useState(false);
+
+    useEffect(() => {
+        const id = setTimeout(() => {
+            setEnable(true);
+        }, props.delay)
+        return () => {
+            clearTimeout(id)
+        }
+    }, [props.delay])
+
+    return enable ? props.component : null;
+}
 
 export default connect((state: GlobalState): PublishingDialogProperties => {
     const {publishing: publishingState} = state.cr;

--- a/packages/neos-ui/src/Containers/Modals/PublishingDialog/PublishingDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/PublishingDialog/PublishingDialog.tsx
@@ -84,7 +84,7 @@ const PublishingDialog: React.FC<PublishingDialogProps> = (props) => {
                     />
             );
 
-        case PublishingPhase.ONGOING:
+        case PublishingPhase.ONGOING: {
             const ongoingScreen = (
                 <ProcessIndicator
                     mode={props.publishingState.mode}
@@ -97,6 +97,7 @@ const PublishingDialog: React.FC<PublishingDialogProps> = (props) => {
             );
 
             return props.publishingState.process.autoConfirmed ? <DelayedDisplay component={ongoingScreen} delay={750} /> : ongoingScreen;
+        }
 
         case PublishingPhase.CONFLICTS:
             return null;

--- a/packages/neos-ui/src/Containers/Modals/PublishingDialog/PublishingDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/PublishingDialog/PublishingDialog.tsx
@@ -27,9 +27,10 @@ import {ResultDialog} from './ResultDialog';
 const {
     publishableNodesSelector,
     publishableNodesInDocumentSelector,
-    personalWorkspaceNameSelector
-} = (selectors as any).CR.Workspaces;
-const {siteNodeSelector, documentNodeSelector} = (selectors as any).CR.Nodes;
+    personalWorkspaceNameSelector,
+    baseWorkspaceSelector
+} = selectors.CR.Workspaces;
+const {siteNodeSelector, documentNodeSelector} = selectors.CR.Nodes;
 
 type PublishingDialogProperties =
     | { publishingState: null }
@@ -142,7 +143,8 @@ export default connect((state: GlobalState): PublishingDialogProperties => {
     }
 
     const {scope} = publishingState;
-    const {name: sourceWorkspaceName, baseWorkspace} = state.cr.workspaces.personalWorkspace;
+    const sourceWorkspaceName = personalWorkspaceNameSelector(state);
+    const baseWorkspace = baseWorkspaceSelector(state);
     const targetWorkspaceName = publishingState.mode === PublishingMode.PUBLISH
         ? baseWorkspace
         : null;
@@ -160,11 +162,11 @@ export default connect((state: GlobalState): PublishingDialogProperties => {
 
     let scopeTitle = 'N/A';
     if (scope === PublishingScope.ALL) {
-        scopeTitle = personalWorkspaceNameSelector(state);
+        scopeTitle = sourceWorkspaceName;
     } else if (scope === PublishingScope.SITE) {
-        scopeTitle = siteNodeSelector(state).label;
+        scopeTitle = siteNodeSelector(state)?.label ?? scopeTitle;
     } else if (scope === PublishingScope.DOCUMENT) {
-        scopeTitle = documentNodeSelector(state).label;
+        scopeTitle = documentNodeSelector(state)?.label ?? scopeTitle;
     }
 
     return {

--- a/packages/neos-ui/src/Containers/Modals/PublishingDialog/ResultDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/PublishingDialog/ResultDialog.tsx
@@ -60,6 +60,7 @@ const ResultDialogVariants = {
                     }
                 }
             },
+            // NOTE that with https://github.com/neos/neos-ui/pull/3909 this variant is currently effectively not used as confirmation is not required
             [PublishingScope.DOCUMENT]: {
                 label: {
                     title: {

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable complexity */
-import React, {Fragment, PureComponent} from 'react';
+import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import mergeClassNames from 'classnames';

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -53,22 +53,22 @@ export default class PublishDropDown extends PureComponent {
 
     handlePublishClick = () => {
         const {start} = this.props;
-        start(PublishingMode.PUBLISH, PublishingScope.DOCUMENT);
+        start(PublishingMode.PUBLISH, PublishingScope.DOCUMENT, false);
     }
 
     handlePublishAllClick = () => {
         const {start} = this.props;
-        start(PublishingMode.PUBLISH, PublishingScope.SITE);
+        start(PublishingMode.PUBLISH, PublishingScope.SITE, true);
     }
 
     handleDiscardClick = () => {
         const {start} = this.props;
-        start(PublishingMode.DISCARD, PublishingScope.DOCUMENT);
+        start(PublishingMode.DISCARD, PublishingScope.DOCUMENT, true);
     }
 
     handleDiscardAllClick = () => {
         const {start} = this.props;
-        start(PublishingMode.DISCARD, PublishingScope.SITE);
+        start(PublishingMode.DISCARD, PublishingScope.SITE, true);
     }
 
     render() {

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -19,8 +19,9 @@ import style from './style.module.css';
 
 @connect(state => ({
     isSaving: state?.ui?.remote?.isSaving,
-    isPublishing: state?.ui?.remote?.isPublishing,
-    isDiscarding: state?.ui?.remote?.isDiscarding,
+    isPublishing: state?.cr?.publishing?.mode === PublishingMode.PUBLISH,
+    // todo the discard state is unused:
+    isDiscarding: state?.cr?.publishing?.mode === PublishingMode.DISCARD,
     publishableNodes: publishableNodesSelector(state),
     publishableNodesInDocument: publishableNodesInDocumentSelector(state),
     personalWorkspaceName: personalWorkspaceNameSelector(state),

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -20,8 +20,6 @@ import style from './style.module.css';
 @connect(state => ({
     isSaving: state?.ui?.remote?.isSaving,
     isPublishing: state?.cr?.publishing?.mode === PublishingMode.PUBLISH,
-    // todo the discard state is unused:
-    isDiscarding: state?.cr?.publishing?.mode === PublishingMode.DISCARD,
     publishableNodes: publishableNodesSelector(state),
     publishableNodesInDocument: publishableNodesInDocumentSelector(state),
     personalWorkspaceName: personalWorkspaceNameSelector(state),
@@ -39,7 +37,6 @@ export default class PublishDropDown extends PureComponent {
     static propTypes = {
         isSaving: PropTypes.bool,
         isPublishing: PropTypes.bool,
-        isDiscarding: PropTypes.bool,
         isWorkspaceReadOnly: PropTypes.bool,
         publishableNodes: PropTypes.array,
         publishableNodesInDocument: PropTypes.array,
@@ -78,7 +75,6 @@ export default class PublishDropDown extends PureComponent {
             publishableNodesInDocument,
             isSaving,
             isPublishing,
-            isDiscarding,
             isWorkspaceReadOnly,
             baseWorkspace,
             changeBaseWorkspaceAction,
@@ -89,16 +85,15 @@ export default class PublishDropDown extends PureComponent {
         const workspaceModuleUri = neos?.routes?.core?.modules?.workspace;
         const allowedWorkspaces = neos?.configuration?.allowedTargetWorkspaces;
         const baseWorkspaceTitle = allowedWorkspaces?.[baseWorkspace]?.title;
-        const canPublishLocally = !isSaving && !isPublishing && !isDiscarding && publishableNodesInDocument && (publishableNodesInDocument.length > 0);
-        const canPublishGlobally = !isSaving && !isPublishing && !isDiscarding && publishableNodes && (publishableNodes.length > 0);
+        const canPublishLocally = !isSaving && !isPublishing && publishableNodesInDocument && (publishableNodesInDocument.length > 0);
+        const canPublishGlobally = !isSaving && !isPublishing && publishableNodes && (publishableNodes.length > 0);
         const changingWorkspaceAllowed = !canPublishGlobally;
         const mainButton = this.getTranslatedMainButton(baseWorkspaceTitle);
         const dropDownBtnClassName = mergeClassNames({
             [style.dropDown__btn]: true,
             [style['dropDown__item--canPublish']]: canPublishGlobally,
             [style['dropDown__item--isPublishing']]: isPublishing,
-            [style['dropDown__item--isSaving']]: isSaving,
-            [style['dropDown__item--isDiscarding']]: isDiscarding
+            [style['dropDown__item--isSaving']]: isSaving
         });
         const publishableNodesInDocumentCount = publishableNodesInDocument ? publishableNodesInDocument.length : 0;
         const publishableNodesCount = publishableNodes ? publishableNodes.length : 0;
@@ -116,7 +111,7 @@ export default class PublishDropDown extends PureComponent {
                 </AbstractButton>
 
                 <DropDown className={style.dropDown}>
-                    {isPublishing || isSaving || isDiscarding ? (
+                    {isPublishing || isSaving ? (
                         <DropDown.Header
                             iconIsOpen={'spinner'}
                             iconIsClosed={'spinner'}
@@ -212,8 +207,7 @@ export default class PublishDropDown extends PureComponent {
         const {
             publishableNodesInDocument,
             isSaving,
-            isPublishing,
-            isDiscarding
+            isPublishing
         } = this.props;
         const canPublishLocally = publishableNodesInDocument && (publishableNodesInDocument.length > 0);
 
@@ -223,10 +217,6 @@ export default class PublishDropDown extends PureComponent {
 
         if (isPublishing) {
             return translate('Neos.Neos:Main:publishTo', 'Publish to {0}', [baseWorkspaceTitle]) + ' ...';
-        }
-
-        if (isDiscarding) {
-            return 'Discarding...';
         }
 
         if (canPublishLocally) {

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -6,7 +6,7 @@ import mergeClassNames from 'classnames';
 
 import {Badge, Icon, DropDown} from '@neos-project/react-ui-components';
 
-import I18n from '@neos-project/neos-ui-i18n';
+import I18n, {translate} from '@neos-project/neos-ui-i18n';
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {PublishingMode, PublishingScope} from '@neos-project/neos-ui-redux-store/src/CR/Publishing';
 import {neos} from '@neos-project/neos-ui-decorators';
@@ -218,11 +218,11 @@ export default class PublishDropDown extends PureComponent {
         const canPublishLocally = publishableNodesInDocument && (publishableNodesInDocument.length > 0);
 
         if (isSaving) {
-            return <I18n id="Neos.Neos:Main:saving" fallback="saving"/>;
+            return translate('Neos.Neos:Main:saving', 'saving');
         }
 
         if (isPublishing) {
-            return <I18n id="Neos.Neos:Main:publishTo" fallback="Publish to" params={{0: baseWorkspaceTitle}}/>;
+            return translate('Neos.Neos:Main:publishTo', 'Publish to {0}', [baseWorkspaceTitle]) + ' ...';
         }
 
         if (isDiscarding) {
@@ -230,14 +230,9 @@ export default class PublishDropDown extends PureComponent {
         }
 
         if (canPublishLocally) {
-            return <I18n id="Neos.Neos:Main:publishTo" fallback="Publish to" params={{0: baseWorkspaceTitle}}/>;
+            return translate('Neos.Neos:Main:publishTo', 'Publish to {0}', [baseWorkspaceTitle]);
         }
 
-        return (
-            <Fragment>
-                <I18n id="Neos.Neos:Main:published" fallback="Published"/>
-                {(baseWorkspaceTitle ? ' - ' + baseWorkspaceTitle : '')}
-            </Fragment>
-        );
+        return translate('Neos.Neos:Main:published', 'Published') + (baseWorkspaceTitle ? ' - ' + baseWorkspaceTitle : '');
     }
 }

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/style.module.css
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/style.module.css
@@ -151,10 +151,6 @@ for further information see https://github.com/neos/neos-ui/pull/3211
     background: var(--colors-Warn);
     opacity: .5;
 }
-.dropDown__item--isDiscarding {
-    opacity: .5;
-}
-
 
 .badge {
     margin-left: var(--spacing-Half);


### PR DESCRIPTION
Based on https://github.com/neos/neos-ui/pull/3910

The change https://github.com/neos/neos-ui/pull/3759 introduced a new publishing confirmation modal that provides information and will run the publish or discard operation when continuing.
This guarantees that no publish is triggered accidentally and also that the Ui is locked during publishing so that its not possible to edit content which would raise a server error. The workflow looked like this:

![image](https://github.com/user-attachments/assets/144b226c-7afe-4eb7-ac03-748a64a21767)

We discussed a lot of pros and cons if the workflow should be simplified and to which extend mainly because the Neos 8.3 publish workflow was a simple one click operation with no further interaction.

TLTR: Minor publish operations - just publishing the document - should be simplified to be a simple one click operation like in Neos 8.3. 

Reasons for simplifying the workflow of publishing the current document
- Initially the confirmation popup was also made to prevent mistakes when publishing
  - In the future we plan to insert additional information here in case a publish is different than normally, for example because changes in other dimensions are also published: https://github.com/neos/neos-development-collection/issues/5387
  - -> but any possible warnings in here will probably be auto-confirmed because the editor is used to clicking "ok", and we loose capabilities to warn. Also publishing a single site is not considered dangerous and editors work well with that since ever.
- The modals second task was to block user input during the publish operation in the Neos Ui - at the time this was really important as changes during publishing could mess with the content repository in unexpected ways. Since the content repository is guarded against these race conditions preventing user input is just a matter of cosmetics as we dont want the user to run in any (planned) server exceptions. The solution is that the Ui will be blocked if the server is busy for longer time as during short publishings user interaction is humanly not possible that fast (see screencast below).
- The sophisticated workflow was also designed when publishing took severely longer also for simple changes. It was anticipated that editors might leave the Neos Ui window and come back when the publishing was finished. For that reason a result dialog was shown so the editor could know where work was left of. Now with the content repository behaving faster (via the synchronous mode) publishing with a few changes is not noticeable.
- Other operations like synchronisation, discard, discard all and publish all still require the initial confirmation dialog and will present also a result dialog. These workflows are less important and dont require a short path for now. Any optimisation here too will also require probably a bigger refactoring to avoid dead code paths for then unused confirmation steps. Further we found that the confirmation step for these actions makes sense and gives us more transparency to show what the effect is of this action - possibly allowing a small review diagram like in the review module. Also for destructive actions like discard a confirmation dialog is generally good practice.

Case 1.) For quick servers the publish is done in no time while the Ui indicates this with a spinner in the publish dropdown:

https://github.com/user-attachments/assets/62262f75-bc7d-4efa-bdba-092cc0e47dac

Case 2.) For slightly longer operations after a timeout a modal with animation is shown (like in the other workflows) so that its not possible to make changes via the Ui, which would cause an exception:

https://github.com/user-attachments/assets/39657f1c-cf87-4604-892d-d6611a99df8a

