### PR TITLE
BUGFIX: Improve conflict resolution edge-cases in sync and publish workflow

### DIFF
--- a/Resources/Private/Translations/en/SyncWorkspaceDialog.xlf
+++ b/Resources/Private/Translations/en/SyncWorkspaceDialog.xlf
@@ -54,7 +54,7 @@
         <source>Discard all changes in workspace "{workspaceName}"</source>
       </trans-unit>
       <trans-unit id="resolutionStrategy.DISCARD_ALL.confirmation.message" xml:space="preserve">
-        <source>You are about to discard all changes in workspace "{workspaceName}". This includes all changes on other sites.
+        <source>You are about to discard all {numberOfChanges} change(s) in workspace "{workspaceName}". This includes all changes on other sites.
 
         Do you wish to proceed? Be careful: This cannot be undone!</source>
       </trans-unit>

--- a/Tests/IntegrationTests/Fixtures/1Dimension/syncing.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/syncing.e2e.js
@@ -20,7 +20,7 @@ fixture`Syncing`
 test('Syncing: Create a conflict state between two editors and choose "Discard all" as a resolution strategy during rebase', async t => {
     await prepareContentElementConflictBetweenAdminAndEditor(t);
     await chooseDiscardAllAsResolutionStrategy(t);
-    await confirmAndPerformDiscardAll(t);
+    await performResolutionStrategy(t);
 
     await assertThatWeAreOnPage(t, 'Home');
     await assertThatWeCannotSeePageInTree(t, 'Sync Demo #1');
@@ -31,7 +31,7 @@ test('Syncing: Create a conflict state between two editors and choose "Discard a
 test('Syncing: Create a conflict state between two editors and choose "Drop conflicting changes" as a resolution strategy during rebase', async t => {
     await prepareContentElementConflictBetweenAdminAndEditor(t);
     await chooseDropConflictingChangesAsResolutionStrategy(t);
-    await confirmDropConflictingChanges(t);
+    await performResolutionStrategy(t);
     await finishSynchronization(t);
 
     await assertThatWeAreOnPage(t, 'Home');
@@ -46,7 +46,7 @@ test('Syncing: Create a conflict state between two editors, start and cancel res
     await startSynchronization(t);
     await assertThatConflictResolutionHasStarted(t);
     await chooseDropConflictingChangesAsResolutionStrategy(t);
-    await confirmDropConflictingChanges(t);
+    await performResolutionStrategy(t);
     await finishSynchronization(t);
 
     await assertThatWeAreOnPage(t, 'Home');
@@ -58,9 +58,9 @@ test('Syncing: Create a conflict state between two editors, start and cancel res
 test('Syncing: Create a conflict state between two editors and choose "Drop conflicting changes" as a resolution strategy, then cancel and choose "Discard all" as a resolution strategy during rebase', async t => {
     await prepareContentElementConflictBetweenAdminAndEditor(t);
     await chooseDropConflictingChangesAsResolutionStrategy(t);
-    await cancelDropConflictingChanges(t);
+    await cancelResolutionStrategy(t);
     await chooseDiscardAllAsResolutionStrategy(t);
-    await confirmAndPerformDiscardAll(t);
+    await performResolutionStrategy(t);
 
     await assertThatWeAreOnPage(t, 'Home');
     await assertThatWeCannotSeePageInTree(t, 'Sync Demo #1');
@@ -73,7 +73,7 @@ test('Publish + Syncing: Create a conflict state between two editors, then try t
     await startPublishAll(t);
     await assertThatConflictResolutionHasStarted(t);
     await chooseDropConflictingChangesAsResolutionStrategy(t);
-    await confirmDropConflictingChanges(t);
+    await performResolutionStrategy(t);
     await finishPublish(t);
 
     await assertThatWeAreOnPage(t, 'Home');
@@ -85,7 +85,7 @@ test('Publish + Syncing: Create a conflict state between two editors, then try t
     await startPublishDocument(t);
     await assertThatConflictResolutionHasStarted(t);
     await chooseDropConflictingChangesAsResolutionStrategy(t);
-    await confirmDropConflictingChanges(t);
+    await performResolutionStrategy(t);
     await finishPublish(t);
 
     await assertThatWeAreOnPage(t, 'Home');
@@ -330,29 +330,17 @@ async function chooseDiscardAllAsResolutionStrategy(t) {
     await t.click(Selector('#neos-SelectResolutionStrategy-Accept'));
 }
 
-async function confirmAndPerformDiscardAll(t) {
-    await t.click(Selector('#neos-DiscardDialog-Confirm'));
-    await t.expect(Selector('#neos-DiscardDialog-Acknowledge').exists)
-        .ok('Acknowledge button for "Discard all" is not available.', {
-            timeout: 30000
-        });
-    // For reasons unknown, we have to press the acknowledge button really
-    // hard for testcafe to realize our intent...
-    await t.wait(500);
-    await t.click(Selector('#neos-DiscardDialog-Acknowledge'));
-}
-
 async function chooseDropConflictingChangesAsResolutionStrategy(t) {
     await t.click(Selector('#neos-SelectResolutionStrategy-SelectBox'));
     await t.click(Selector('[role="button"]').withText('Drop conflicting changes'));
     await t.click(Selector('#neos-SelectResolutionStrategy-Accept'));
 }
 
-async function confirmDropConflictingChanges(t) {
+async function performResolutionStrategy(t) {
     await t.click(Selector('#neos-ResolutionStrategyConfirmation-Confirm'));
 }
 
-async function cancelDropConflictingChanges(t) {
+async function cancelResolutionStrategy(t) {
     await t.click(Selector('#neos-ResolutionStrategyConfirmation-Cancel'));
 }
 

--- a/Tests/IntegrationTests/Fixtures/1Dimension/syncing.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/syncing.e2e.js
@@ -21,7 +21,6 @@ test('Syncing: Create a conflict state between two editors and choose "Discard a
     await prepareContentElementConflictBetweenAdminAndEditor(t);
     await chooseDiscardAllAsResolutionStrategy(t);
     await confirmAndPerformDiscardAll(t);
-    await finishSynchronization(t);
 
     await assertThatWeAreOnPage(t, 'Home');
     await assertThatWeCannotSeePageInTree(t, 'Sync Demo #1');
@@ -62,7 +61,6 @@ test('Syncing: Create a conflict state between two editors and choose "Drop conf
     await cancelDropConflictingChanges(t);
     await chooseDiscardAllAsResolutionStrategy(t);
     await confirmAndPerformDiscardAll(t);
-    await finishSynchronization(t);
 
     await assertThatWeAreOnPage(t, 'Home');
     await assertThatWeCannotSeePageInTree(t, 'Sync Demo #1');

--- a/Tests/IntegrationTests/Fixtures/1Dimension/syncing.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/syncing.e2e.js
@@ -21,6 +21,7 @@ test('Syncing: Create a conflict state between two editors and choose "Discard a
     await prepareContentElementConflictBetweenAdminAndEditor(t);
     await chooseDiscardAllAsResolutionStrategy(t);
     await performResolutionStrategy(t);
+    await finishDiscard(t);
 
     await assertThatWeAreOnPage(t, 'Home');
     await assertThatWeCannotSeePageInTree(t, 'Sync Demo #1');
@@ -55,12 +56,18 @@ test('Syncing: Create a conflict state between two editors, start and cancel res
     await assertThatWeCannotSeePageInTree(t, 'Sync Demo #3');
 });
 
-test('Syncing: Create a conflict state between two editors and choose "Drop conflicting changes" as a resolution strategy, then cancel and choose "Discard all" as a resolution strategy during rebase', async t => {
+test('Syncing: Create a conflict state between two editors and switch between "Drop conflicting changes" and "Discard all" as a resolution strategy during rebase', async t => {
     await prepareContentElementConflictBetweenAdminAndEditor(t);
+
+    // switch back and forth
+    await chooseDiscardAllAsResolutionStrategy(t);
+    await cancelResolutionStrategy(t);
     await chooseDropConflictingChangesAsResolutionStrategy(t);
     await cancelResolutionStrategy(t);
     await chooseDiscardAllAsResolutionStrategy(t);
+
     await performResolutionStrategy(t);
+    await finishDiscard(t);
 
     await assertThatWeAreOnPage(t, 'Home');
     await assertThatWeCannotSeePageInTree(t, 'Sync Demo #1');
@@ -68,7 +75,7 @@ test('Syncing: Create a conflict state between two editors and choose "Drop conf
     await assertThatWeCannotSeePageInTree(t, 'Sync Demo #3');
 });
 
-test('Publish + Syncing: Create a conflict state between two editors, then try to publish and choose "Drop conflicting changes" as a resolution strategy during automatic rebase', async t => {
+test('Publish + Syncing: Create a conflict state between two editors, then try to publish the site and choose "Drop conflicting changes" as a resolution strategy during automatic rebase', async t => {
     await prepareDocumentConflictBetweenAdminAndEditor(t);
     await startPublishAll(t);
     await assertThatConflictResolutionHasStarted(t);
@@ -80,13 +87,25 @@ test('Publish + Syncing: Create a conflict state between two editors, then try t
     await assertThatWeCannotSeePageInTree(t, 'This page will be deleted during sync');
 });
 
-test('Publish + Syncing: Create a conflict state between two editors, then try to publish the document only and choose "Drop conflicting changes" as a resolution strategy during automatic rebase', async t => {
+test('Publish + Syncing: Create a conflict state between two editors, then try to publish the document and choose "Drop conflicting changes" as a resolution strategy during automatic rebase', async t => {
     await prepareDocumentConflictBetweenAdminAndEditor(t);
     await startPublishDocument(t);
     await assertThatConflictResolutionHasStarted(t);
     await chooseDropConflictingChangesAsResolutionStrategy(t);
     await performResolutionStrategy(t);
     await finishPublish(t);
+
+    await assertThatWeAreOnPage(t, 'Home');
+    await assertThatWeCannotSeePageInTree(t, 'This page will be deleted during sync');
+});
+
+test('Publish + Syncing: Create a conflict state between two editors, then try to publish the site and choose "Discard all" as a resolution strategy', async t => {
+    await prepareDocumentConflictBetweenAdminAndEditor(t);
+    await startPublishAll(t);
+    await assertThatConflictResolutionHasStarted(t);
+    await chooseDiscardAllAsResolutionStrategy(t);
+    await performResolutionStrategy(t);
+    await finishDiscard(t);
 
     await assertThatWeAreOnPage(t, 'Home');
     await assertThatWeCannotSeePageInTree(t, 'This page will be deleted during sync');
@@ -312,6 +331,11 @@ async function startPublishDocument(t) {
 async function finishPublish(t) {
     await assertThatPublishingHasFinishedWithoutError(t);
     await t.click(Selector('#neos-PublishDialog-Acknowledge'));
+    await t.wait(2000);
+}
+
+async function finishDiscard(t) {
+    await t.click(Selector('#neos-DiscardDialog-Acknowledge'));
     await t.wait(2000);
 }
 

--- a/packages/neos-ui-redux-store/src/CR/Publishing/index.ts
+++ b/packages/neos-ui-redux-store/src/CR/Publishing/index.ts
@@ -150,8 +150,16 @@ export const reducer = (state: State = defaultState, action: Action): State => {
 
         return null;
     }
-
     switch (action.type) {
+        // recursive publishing start, replacing the outer process
+        case actionTypes.STARTED:
+            return {
+                mode: action.payload.mode,
+                scope: action.payload.scope,
+                process: {
+                    phase: PublishingPhase.START
+                }
+            };
         case actionTypes.CANCELLED:
             return null;
         case actionTypes.CONFIRMED:

--- a/packages/neos-ui-sagas/src/Sync/index.ts
+++ b/packages/neos-ui-sagas/src/Sync/index.ts
@@ -120,8 +120,12 @@ export const makeResolveConflicts = (deps: {
                 }
 
                 if (strategy === ResolutionStrategy.DISCARD_ALL) {
-                    yield * discardAll();
-                    return true;
+                    if (yield * waitForResolutionConfirmation()) {
+                        yield * discardAll();
+                        return true;
+                    }
+
+                    continue;
                 }
             }
 
@@ -162,7 +166,7 @@ const makeDiscardAll = () => {
             PublishingMode.DISCARD,
             PublishingScope.ALL
         ));
-
+        yield put(actions.CR.Publishing.confirm());
         const {cancelled}: {
             cancelled: null | ReturnType<typeof actions.CR.Publishing.cancel>;
             failed: null | ReturnType<typeof actions.CR.Publishing.fail>;

--- a/packages/neos-ui-sagas/src/Sync/index.ts
+++ b/packages/neos-ui-sagas/src/Sync/index.ts
@@ -92,7 +92,7 @@ export const makeSyncPersonalWorkspace = (deps: {
 export const makeResolveConflicts = (deps: {
     syncPersonalWorkspace: ReturnType<typeof makeSyncPersonalWorkspace>
 }) => {
-    const discardAll = makeDiscardAll(deps);
+    const discardAll = makeDiscardAll();
 
     function * resolveConflicts(conflicts: Conflict[]): any {
         while (true) {
@@ -155,16 +155,14 @@ function * waitForRetry() {
     return Boolean(retried);
 }
 
-const makeDiscardAll = (deps: {
-    syncPersonalWorkspace: ReturnType<typeof makeSyncPersonalWorkspace>;
-}) => {
+const makeDiscardAll = () => {
     function * discardAll() {
         yield put(actions.CR.Publishing.start(
             PublishingMode.DISCARD,
             PublishingScope.ALL
         ));
 
-        const {cancelled, failed}: {
+        const {cancelled}: {
             cancelled: null | ReturnType<typeof actions.CR.Publishing.cancel>;
             failed: null | ReturnType<typeof actions.CR.Publishing.fail>;
             finished: null | ReturnType<typeof actions.CR.Publishing.finish>;
@@ -176,12 +174,8 @@ const makeDiscardAll = (deps: {
 
         if (cancelled) {
             yield put(actions.CR.Syncing.cancelResolution());
-        } else if (failed) {
-            yield put(actions.CR.Syncing.finish());
-        } else {
-            yield put(actions.CR.Syncing.confirmResolution());
-            yield * deps.syncPersonalWorkspace(false);
         }
+        yield put(actions.CR.Syncing.finish());
     }
 
     return discardAll;

--- a/packages/neos-ui-sagas/src/Sync/index.ts
+++ b/packages/neos-ui-sagas/src/Sync/index.ts
@@ -80,6 +80,7 @@ export const makeSyncPersonalWorkspace = (deps: {
                 yield put(actions.CR.Syncing.fail(result.error));
             }
         } catch (error) {
+            console.error(error); // log client site errors
             yield put(actions.CR.Syncing.fail(error as AnyError));
         } finally {
             window.removeEventListener('beforeunload', handleWindowBeforeUnload);

--- a/packages/neos-ui-sagas/src/Sync/index.ts
+++ b/packages/neos-ui-sagas/src/Sync/index.ts
@@ -122,7 +122,7 @@ export const makeResolveConflicts = (deps: {
                 if (strategy === ResolutionStrategy.DISCARD_ALL) {
                     if (yield * waitForResolutionConfirmation()) {
                         yield * discardAll();
-                        return true;
+                        return false; // don't continue publishing as this is a deletes all
                     }
 
                     continue;
@@ -166,7 +166,8 @@ const makeDiscardAll = () => {
             PublishingMode.DISCARD,
             PublishingScope.ALL
         ));
-        yield put(actions.CR.Publishing.confirm());
+        yield put(actions.CR.Publishing.confirm()); // todo auto-confirm this case
+        yield put(actions.CR.Syncing.finish()); // stop syncing as discarding takes now over
         const {cancelled}: {
             cancelled: null | ReturnType<typeof actions.CR.Publishing.cancel>;
             failed: null | ReturnType<typeof actions.CR.Publishing.fail>;
@@ -178,9 +179,9 @@ const makeDiscardAll = () => {
         });
 
         if (cancelled) {
-            yield put(actions.CR.Syncing.cancelResolution());
+            yield put(actions.CR.Publishing.cancel());
         }
-        yield put(actions.CR.Syncing.finish());
+        yield put(actions.CR.Publishing.finish());
     }
 
     return discardAll;

--- a/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ResolutionStrategyConfirmationDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ResolutionStrategyConfirmationDialog.tsx
@@ -175,8 +175,8 @@ const DiscardAllConfirmationDialog: React.FC<{
                     />
                 <I18n
                     id="Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.DISCARD_ALL.confirmation.message"
-                    fallback={`You are about to discard all changes in workspace "${props.workspaceName}". This includes all changes on other sites. Do you wish to proceed? Be careful: This cannot be undone!`}
-                    params={props}
+                    fallback={`You are about to discard all ${props.totalNumberOfChangesInWorkspace} change(s) in workspace "${props.workspaceName}". This includes all changes on other sites. Do you wish to proceed? Be careful: This cannot be undone!`}
+                    params={{numberOfChanges: props.totalNumberOfChangesInWorkspace, workspaceName: props.workspaceName}}
                     />
             </div>
         </Dialog>

--- a/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/SyncWorkspaceDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/SyncWorkspaceDialog.tsx
@@ -125,21 +125,18 @@ const SyncWorkspaceDialog: React.FC<SyncWorkspaceDialogProps> = (props) => {
                     />
             );
         case SyncingPhase.RESOLVING:
-            if (props.syncingState.process.strategy === ResolutionStrategy.FORCE) {
-                return (
-                    <ResolutionStrategyConfirmationDialog
-                        workspaceName={props.personalWorkspaceName}
-                        baseWorkspaceName={props.baseWorkspaceName}
-                        totalNumberOfChangesInWorkspace={props.totalNumberOfChangesInWorkspace}
-                        strategy={props.syncingState.process.strategy}
-                        conflicts={props.syncingState.process.conflicts}
-                        i18n={props.i18nRegistry}
-                        onCancelConflictResolution={handleCancelConflictResolution}
-                        onConfirmResolutionStrategy={handleConfirmResolutionStrategy}
-                        />
-                );
-            }
-            return null;
+            return (
+                <ResolutionStrategyConfirmationDialog
+                    workspaceName={props.personalWorkspaceName}
+                    baseWorkspaceName={props.baseWorkspaceName}
+                    totalNumberOfChangesInWorkspace={props.totalNumberOfChangesInWorkspace}
+                    strategy={props.syncingState.process.strategy}
+                    conflicts={props.syncingState.process.conflicts}
+                    i18n={props.i18nRegistry}
+                    onCancelConflictResolution={handleCancelConflictResolution}
+                    onConfirmResolutionStrategy={handleConfirmResolutionStrategy}
+                    />
+            );
         case SyncingPhase.ERROR:
         case SyncingPhase.SUCCESS:
             return (


### PR DESCRIPTION
Resolves #3908

fixes edecases during the conflict resolution:
- stopping publish if the attempted changes were dropped after a conflict:  #3908
- fixes 'Discard workspace "User workspace"' as resolution during publishing (previously froze)
- fixes navigating back after selecting 'Discard workspace "User workspace"' in sync mode and selecting another strategy


<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
