### PR TITLE
TASK: Show testcafe output in circle ci overview

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,19 +138,24 @@ jobs:
             # Save the variable to BASH_ENV to be able to access it in the next steps
             echo "export TARGET_BRANCH=$TARGET_BRANCH" >> $BASH_ENV
       - run:
-          name: Use target branch
-          command: |
-            echo "Using target branch: $TARGET_BRANCH"
-      - run:
           name: Prepare and run e2e tests
           no_output_timeout: 30m
           command: |
+            echo "Using target branch: $TARGET_BRANCH"
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             cd /home/circleci/app/Packages/Application/Neos.Neos.Ui
             nvm install
             nvm use
             make test-e2e-saucelabs
+      - run:
+          name: Show testcafe output
+          command: |
+            for file in /home/circleci/app/Data/Logs/saucelabs-artifacts/**/console.log; do
+              echo $file
+              cat $file
+            done
+          when: always
       - store_artifacts:
           path: /home/circleci/app/Data/Logs
       - persist_to_workspace:

--- a/.sauce/config1Dimension.yml
+++ b/.sauce/config1Dimension.yml
@@ -8,9 +8,8 @@ sauce:
   retries: 0
   metadata:
     tags:
-      - e2e
       - $TARGET_BRANCH
-    build: $TARGET_BRANCH
+    build: $TARGET_BRANCH $CIRCLE_PR_NUMBER
   tunnel:
     name: "circleci-tunnel"
 testcafe:
@@ -44,7 +43,7 @@ artifacts:
       - sauce-test-report.json
     when: always
     allAttempts: true
-    directory: ../../Data/Logs/saucelabs-artifacts/
+    directory: ../../../Data/Logs/saucelabs-artifacts/
 
 reporters:
   json:


### PR DESCRIPTION
Apparently none of the options for `saucectl run`

--show-console-log
--verbose
--live-logs

do output the actual live console logs from testcafe to the circle ci shell.

--show-console-log seems to output them at the end but only for happy cases.
This pr introduces a separate window where just the output is cleanly shown - hopefully also on error.

<img width="850" alt="image" src="https://github.com/user-attachments/assets/b92aba93-d013-4ba4-9a23-21f870dbe50a" />

Further the artifact upload was fixed as the path was wrong.

**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
