### PR TITLE
TASK: Use new `translate()` method if possible

### DIFF
--- a/packages/neos-ui-containers/src/InsertModeSelector/index.js
+++ b/packages/neos-ui-containers/src/InsertModeSelector/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import {ButtonGroup, Button, ResourceIcon} from '@neos-project/react-ui-components';
 import {neos} from '@neos-project/neos-ui-decorators';
-import I18n from '@neos-project/neos-ui-i18n';
+import I18n, {translate} from '@neos-project/neos-ui-i18n';
 
 import style from './style.module.css';
 
@@ -103,7 +103,7 @@ export default class InsertModeSelector extends PureComponent {
                         title={`${i18nRegistry.translate('Neos.Neos:Main:insert')} ${i18nRegistry.translate('above')}`}
                     >
                         <ResourceIcon source={createAboveIcon} className={style.iconAlignment}/>
-                        <I18n id="Neos.Neos.Ui:Main:above" fallback="Above"/>
+                        {translate('Neos.Neos.Ui:Main:above', 'Above')}
                     </Button>
                     <Button
                         id={MODE_AFTER}
@@ -114,7 +114,7 @@ export default class InsertModeSelector extends PureComponent {
                         title={`${i18nRegistry.translate('Neos.Neos:Main:insert')} ${i18nRegistry.translate('below')}`}
                     >
                         <ResourceIcon source={createBelowIcon} className={style.iconAlignment}/>
-                        <I18n id="Neos.Neos.Ui:Main:below" fallback="Below"/>
+                        {translate('Neos.Neos.Ui:Main:below', 'Below')}
                     </Button>
                     <Button
                         id={MODE_INTO}
@@ -125,7 +125,7 @@ export default class InsertModeSelector extends PureComponent {
                         title={`${i18nRegistry.translate('Neos.Neos:Main:insert')} ${i18nRegistry.translate('into')}`}
                     >
                         <ResourceIcon source={createInsideIcon} className={style.iconAlignment}/>
-                        <I18n id="Neos.Neos.Ui:Main:inside" fallback="Inside"/>
+                        {translate('Neos.Neos.Ui:Main:inside', 'Inside')}
                     </Button>
                 </ButtonGroup>
             </div>

--- a/packages/neos-ui-containers/src/InsertModeSelector/index.js
+++ b/packages/neos-ui-containers/src/InsertModeSelector/index.js
@@ -100,7 +100,7 @@ export default class InsertModeSelector extends PureComponent {
                         disabled={!enableAlongsideModes}
                         style="lighter"
                         size="small"
-                        title={`${i18nRegistry.translate('Neos.Neos:Main:insert')} ${i18nRegistry.translate('above')}`}
+                        title={`${translate('Neos.Neos:Main:insert')} ${i18nRegistry.translate('above')}`}
                     >
                         <ResourceIcon source={createAboveIcon} className={style.iconAlignment}/>
                         {translate('Neos.Neos.Ui:Main:above', 'Above')}
@@ -111,7 +111,7 @@ export default class InsertModeSelector extends PureComponent {
                         disabled={!enableAlongsideModes}
                         style="lighter"
                         size="small"
-                        title={`${i18nRegistry.translate('Neos.Neos:Main:insert')} ${i18nRegistry.translate('below')}`}
+                        title={`${translate('Neos.Neos:Main:insert')} ${i18nRegistry.translate('below')}`}
                     >
                         <ResourceIcon source={createBelowIcon} className={style.iconAlignment}/>
                         {translate('Neos.Neos.Ui:Main:below', 'Below')}
@@ -122,7 +122,7 @@ export default class InsertModeSelector extends PureComponent {
                         disabled={!enableIntoMode}
                         style="lighter"
                         size="small"
-                        title={`${i18nRegistry.translate('Neos.Neos:Main:insert')} ${i18nRegistry.translate('into')}`}
+                        title={`${translate('Neos.Neos:Main:insert')} ${i18nRegistry.translate('into')}`}
                     >
                         <ResourceIcon source={createInsideIcon} className={style.iconAlignment}/>
                         {translate('Neos.Neos.Ui:Main:inside', 'Inside')}

--- a/packages/neos-ui-containers/src/InsertModeSelector/index.js
+++ b/packages/neos-ui-containers/src/InsertModeSelector/index.js
@@ -2,7 +2,6 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 
 import {ButtonGroup, Button, ResourceIcon} from '@neos-project/react-ui-components';
-import {neos} from '@neos-project/neos-ui-decorators';
 import I18n, {translate} from '@neos-project/neos-ui-i18n';
 
 import style from './style.module.css';
@@ -38,17 +37,12 @@ const calculatePreferredInitialMode = props => {
     return null;
 };
 
-@neos(globalRegistry => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}))
 export default class InsertModeSelector extends PureComponent {
     static propTypes = {
         mode: PropTypes.string,
         enableAlongsideModes: PropTypes.bool.isRequired,
         enableIntoMode: PropTypes.bool.isRequired,
-        onSelect: PropTypes.func.isRequired,
-
-        i18nRegistry: PropTypes.object.isRequired
+        onSelect: PropTypes.func.isRequired
     };
 
     options = [];
@@ -83,7 +77,7 @@ export default class InsertModeSelector extends PureComponent {
     }
 
     render() {
-        const {mode, enableIntoMode, enableAlongsideModes, i18nRegistry} = this.props;
+        const {mode, enableIntoMode, enableAlongsideModes} = this.props;
 
         if (!mode) {
             return null;
@@ -100,7 +94,7 @@ export default class InsertModeSelector extends PureComponent {
                         disabled={!enableAlongsideModes}
                         style="lighter"
                         size="small"
-                        title={`${translate('Neos.Neos:Main:insert')} ${i18nRegistry.translate('above')}`}
+                        title={`${translate('Neos.Neos:Main:insert')} ${translate('Neos.Neos:Main:above')}`}
                     >
                         <ResourceIcon source={createAboveIcon} className={style.iconAlignment}/>
                         {translate('Neos.Neos.Ui:Main:above', 'Above')}
@@ -111,7 +105,7 @@ export default class InsertModeSelector extends PureComponent {
                         disabled={!enableAlongsideModes}
                         style="lighter"
                         size="small"
-                        title={`${translate('Neos.Neos:Main:insert')} ${i18nRegistry.translate('below')}`}
+                        title={`${translate('Neos.Neos:Main:insert')} ${translate('Neos.Neos:Main:below')}`}
                     >
                         <ResourceIcon source={createBelowIcon} className={style.iconAlignment}/>
                         {translate('Neos.Neos.Ui:Main:below', 'Below')}
@@ -122,7 +116,7 @@ export default class InsertModeSelector extends PureComponent {
                         disabled={!enableIntoMode}
                         style="lighter"
                         size="small"
-                        title={`${translate('Neos.Neos:Main:insert')} ${i18nRegistry.translate('into')}`}
+                        title={`${translate('Neos.Neos:Main:insert')} ${translate('Neos.Neos:Main:into')}`}
                     >
                         <ResourceIcon source={createInsideIcon} className={style.iconAlignment}/>
                         {translate('Neos.Neos.Ui:Main:inside', 'Inside')}

--- a/packages/neos-ui-containers/src/InsertModeSelector/index.js
+++ b/packages/neos-ui-containers/src/InsertModeSelector/index.js
@@ -2,7 +2,7 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 
 import {ButtonGroup, Button, ResourceIcon} from '@neos-project/react-ui-components';
-import I18n, {translate} from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 import style from './style.module.css';
 
@@ -86,7 +86,7 @@ export default class InsertModeSelector extends PureComponent {
         return (
             <div className={style.root}>
                 <span className={style.label}>
-                    <I18n id="Neos.Neos:Main:insertMode"/>&nbsp;
+                    {translate('Neos.Neos:Main:insertMode')}&nbsp;
                 </span>
                 <ButtonGroup value={mode} onSelect={this.handleSelect} className={style.buttonGroup}>
                     <Button

--- a/packages/neos-ui-editors/src/Editors/AssetEditor/Components/Controls/index.js
+++ b/packages/neos-ui-editors/src/Editors/AssetEditor/Components/Controls/index.js
@@ -2,16 +2,12 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import style from './style.module.css';
 import IconButton from '@neos-project/react-ui-components/src/IconButton/';
-import {neos} from '@neos-project/neos-ui-decorators';
+import {translate} from '@neos-project/neos-ui-i18n';
 
-@neos(globalRegistry => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}))
 export default class Controls extends PureComponent {
     static propTypes = {
         onChooseFromMedia: PropTypes.func.isRequired,
         onChooseFromLocalFileSystem: PropTypes.func.isRequired,
-        i18nRegistry: PropTypes.object.isRequired,
         isUploadEnabled: PropTypes.bool.isRequired,
         isMediaBrowserEnabled: PropTypes.bool.isRequired
     };
@@ -26,7 +22,7 @@ export default class Controls extends PureComponent {
                     style="lighter"
                     onClick={disabled ? null : this.props.onChooseFromMedia}
                     className={style.button}
-                    title={this.props.i18nRegistry.translate('Neos.Neos:Main:media')}
+                    title={translate('Neos.Neos:Main:media')}
                     disabled={disabled}
                     />}
                 {isUploadEnabled && <IconButton
@@ -35,7 +31,7 @@ export default class Controls extends PureComponent {
                     style="lighter"
                     onClick={disabled ? null : this.props.onChooseFromLocalFileSystem}
                     className={style.button}
-                    title={this.props.i18nRegistry.translate('Neos.Media.Browser:Main:chooseFile')}
+                    title={translate('Neos.Media.Browser:Main:chooseFile')}
                     disabled={disabled}
                     />}
             </div>

--- a/packages/neos-ui-editors/src/Editors/AssetEditor/index.js
+++ b/packages/neos-ui-editors/src/Editors/AssetEditor/index.js
@@ -11,6 +11,7 @@ import {selectors} from '@neos-project/neos-ui-redux-store';
 import AssetOption from '../../Library/AssetOption';
 import {AssetUpload} from '../../Library/index';
 import backend from '@neos-project/neos-ui-backend-connector';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 const DEFAULT_FEATURES = {
     mediaBrowser: true,
@@ -267,7 +268,7 @@ export default class AssetEditor extends PureComponent {
         return (
             <SelectBox
                 optionValueField="identifier"
-                loadingLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:loading')}
+                loadingLabel={translate('Neos.Neos:Main:loading')}
                 displaySearchBox={this.isFeatureEnabled('mediaBrowser')}
                 ListPreviewElement={AssetOption}
                 placeholder={this.props.i18nRegistry.translate(this.props.placeholder)}
@@ -279,8 +280,8 @@ export default class AssetEditor extends PureComponent {
                 showDropDownToggle={false}
                 allowEmpty={true}
                 onSearchTermChange={this.handleSearchTermChange}
-                noMatchesFoundLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}
-                searchBoxLeftToTypeLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
+                noMatchesFoundLabel={translate('Neos.Neos:Main:noMatchesFound')}
+                searchBoxLeftToTypeLabel={translate('Neos.Neos:Main:searchBoxLeftToType')}
                 threshold={this.props?.options?.threshold}
                 disabled={disabled}
             />
@@ -294,7 +295,7 @@ export default class AssetEditor extends PureComponent {
             <MultiSelectBox
                 dndType={dndTypes.MULTISELECT}
                 optionValueField="identifier"
-                loadingLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:loading')}
+                loadingLabel={translate('Neos.Neos:Main:loading')}
                 displaySearchBox={this.isFeatureEnabled('mediaBrowser')}
                 ListPreviewElement={AssetOption}
                 placeholder={this.props.i18nRegistry.translate(this.props.placeholder)}
@@ -305,8 +306,8 @@ export default class AssetEditor extends PureComponent {
                 searchOptions={this.state.searchOptions}
                 showDropDownToggle={false}
                 onSearchTermChange={this.handleSearchTermChange}
-                noMatchesFoundLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}
-                searchBoxLeftToTypeLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
+                noMatchesFoundLabel={translate('Neos.Neos:Main:noMatchesFound')}
+                searchBoxLeftToTypeLabel={translate('Neos.Neos:Main:searchBoxLeftToType')}
                 threshold={this.props?.options?.threshold}
                 disabled={disabled}
             />

--- a/packages/neos-ui-editors/src/Editors/DateTime/index.js
+++ b/packages/neos-ui-editors/src/Editors/DateTime/index.js
@@ -5,6 +5,7 @@ import moment from 'moment';
 import {neos} from '@neos-project/neos-ui-decorators';
 import convertPhpDateFormatToMoment, {has24HourFormat, hasDateFormat, hasTimeFormat} from './helpers';
 import {connect} from 'react-redux';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 @neos(globalRegistry => ({
     i18nRegistry: globalRegistry.get('i18n')
@@ -61,7 +62,7 @@ class DateTime extends PureComponent {
                 timeOnly={!hasDateFormat(options.format)}
                 is24Hour={hasTimeFormat(options.format) && has24HourFormat(options.format)}
                 placeholder={i18nRegistry.translate(options?.placeholder || 'Neos.Neos:Main:content.inspector.editors.dateTimeEditor.noDateSet')}
-                todayLabel={i18nRegistry.translate('content.inspector.editors.dateTimeEditor.today', 'Today', {}, 'Neos.Neos', 'Main')}
+                todayLabel={translate('Neos.Neos:Main:content.inspector.editors.dateTimeEditor.today', 'Today')}
                 locale={interfaceLanguage}
                 disabled={options.disabled}
                 timeConstraints={timeConstraints}

--- a/packages/neos-ui-editors/src/Editors/Image/Components/Controls/index.js
+++ b/packages/neos-ui-editors/src/Editors/Image/Components/Controls/index.js
@@ -2,11 +2,8 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import style from './style.module.css';
 import IconButton from '@neos-project/react-ui-components/src/IconButton/';
-import {neos} from '@neos-project/neos-ui-decorators';
+import {translate} from '@neos-project/neos-ui-i18n';
 
-@neos(globalRegistry => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}))
 export default class Controls extends PureComponent {
     static propTypes = {
         onChooseFromMedia: PropTypes.func.isRequired,
@@ -16,9 +13,7 @@ export default class Controls extends PureComponent {
         disabled: PropTypes.bool,
 
         isUploadEnabled: PropTypes.bool.isRequired,
-        isMediaBrowserEnabled: PropTypes.bool.isRequired,
-
-        i18nRegistry: PropTypes.object.isRequired
+        isMediaBrowserEnabled: PropTypes.bool.isRequired
     };
 
     render() {
@@ -37,7 +32,6 @@ export default class Controls extends PureComponent {
             isUploadEnabled,
             isMediaBrowserEnabled,
             onRemove,
-            i18nRegistry,
             disabled
         } = this.props;
 
@@ -54,7 +48,7 @@ export default class Controls extends PureComponent {
                     style="lighter"
                     onClick={handleChooseFromMedia()}
                     className={style.button}
-                    title={i18nRegistry.translate('Neos.Neos:Main:media')}
+                    title={translate('Neos.Neos:Main:media')}
                     disabled={disabled}
                     />
                 }
@@ -65,7 +59,7 @@ export default class Controls extends PureComponent {
                     style="lighter"
                     onClick={handleChooseFromLocalFileSystem()}
                     className={style.button}
-                    title={i18nRegistry.translate('Neos.Media.Browser:Main:chooseFile')}
+                    title={translate('Neos.Media.Browser:Main:chooseFile')}
                     disabled={disabled}
                     />
                 }
@@ -76,14 +70,14 @@ export default class Controls extends PureComponent {
                     onClick={handleRemove()}
                     disabled={!onRemove || disabled}
                     className={style.button}
-                    title={i18nRegistry.translate('Neos.Neos:Main:remove')}
+                    title={translate('Neos.Neos:Main:remove')}
                     />
             </span>
         );
     }
 
     renderisCropperVisibleButton() {
-        const {onCrop, i18nRegistry, disabled} = this.props;
+        const {onCrop, disabled} = this.props;
 
         const handleCrop = () => disabled ? null : onCrop;
 
@@ -95,7 +89,7 @@ export default class Controls extends PureComponent {
                     style="lighter"
                     className={style.cropButton}
                     onClick={handleCrop()}
-                    title={i18nRegistry.translate('Neos.Neos:Main:crop')}
+                    title={translate('Neos.Neos:Main:crop')}
                     disabled={disabled}
                     />
             );

--- a/packages/neos-ui-editors/src/Editors/Image/Components/ResizeControls/index.js
+++ b/packages/neos-ui-editors/src/Editors/Image/Components/ResizeControls/index.js
@@ -49,7 +49,7 @@ const ResizeControls = props => {
     return (
         <div>
             <div className={style.resizeControls__item}>
-                <div className={style.resizeControls__label}>{translate('width', 'Width')}:</div>
+                <div className={style.resizeControls__label}>{translate('Neos.Neos:Main:width', 'Width')}:</div>
                 <div className={style.resizeControls}>
                     <span className={style.resizeControls__before}>
                         <CheckBox
@@ -74,7 +74,7 @@ const ResizeControls = props => {
                 </div>
             </div>
             <div>
-                <div className={style.resizeControls__label}>{translate('height', 'Height')}:</div>
+                <div className={style.resizeControls__label}>{translate('Neos.Neos:Main:height', 'Height')}:</div>
                 <div className={style.resizeControls}>
                     <span className={style.resizeControls__before}>
                         <CheckBox

--- a/packages/neos-ui-editors/src/Editors/Image/Components/ResizeControls/index.js
+++ b/packages/neos-ui-editors/src/Editors/Image/Components/ResizeControls/index.js
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {TextInput, CheckBox} from '@neos-project/react-ui-components';
-import I18n from '@neos-project/neos-ui-i18n';
 
 import style from './style.module.css';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 const buildResizeAdjustment = (width, height) => ({
     allowUpScaling: null,
@@ -49,7 +49,7 @@ const ResizeControls = props => {
     return (
         <div>
             <div className={style.resizeControls__item}>
-                <div className={style.resizeControls__label}><I18n id="width" fallback="Width"/>:</div>
+                <div className={style.resizeControls__label}>{translate('width', 'Width')}:</div>
                 <div className={style.resizeControls}>
                     <span className={style.resizeControls__before}>
                         <CheckBox
@@ -74,7 +74,7 @@ const ResizeControls = props => {
                 </div>
             </div>
             <div>
-                <div className={style.resizeControls__label}><I18n id="height" fallback="Height"/>:</div>
+                <div className={style.resizeControls__label}>{translate('height', 'Height')}:</div>
                 <div className={style.resizeControls}>
                     <span className={style.resizeControls__before}>
                         <CheckBox

--- a/packages/neos-ui-editors/src/Editors/Range/index.js
+++ b/packages/neos-ui-editors/src/Editors/Range/index.js
@@ -1,19 +1,13 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import {neos} from '@neos-project/neos-ui-decorators';
 import style from './style.module.css';
+import {translate} from '@neos-project/neos-ui-i18n';
 
-@neos(globalRegistry => {
-    return {
-        i18nRegistry: globalRegistry.get('i18n')
-    };
-})
 class RangeEditor extends PureComponent {
     static propTypes = {
         value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         commit: PropTypes.func.isRequired,
-        i18nRegistry: PropTypes.object.isRequired,
         options: PropTypes.shape({
             min: PropTypes.number,
             max: PropTypes.number,
@@ -89,12 +83,12 @@ class RangeEditor extends PureComponent {
                     disabled={options.disabled}
                 />
                 <div className={style.rangeEditorValue}>
-                    <span title={this.props.i18nRegistry.translate('Neos.Neos.Ui:Main:rangeEditorMinimum')}>
+                    <span title={translate('Neos.Neos.Ui:Main:rangeEditorMinimum')}>
                         {options.minLabel ? options.minLabel : options.min + options.unit}
                     </span>
                     <span>
                         <input
-                            title={this.props.i18nRegistry.translate('Neos.Neos.Ui:Main:rangeEditorCurrentValue')}
+                            title={translate('Neos.Neos.Ui:Main:rangeEditorCurrentValue')}
                             type="text"
                             onKeyPress={this.onKeyPress}
                             onChange={this.handleChange}
@@ -104,7 +98,7 @@ class RangeEditor extends PureComponent {
                         />
                         {options.unit}
                     </span>
-                    <span title={this.props.i18nRegistry.translate('Neos.Neos.Ui:Main:rangeEditorMaximum')}>
+                    <span title={translate('Neos.Neos.Ui:Main:rangeEditorMaximum')}>
                         {options.maxLabel ? options.maxLabel : options.max + options.unit}
                     </span>
                 </div>

--- a/packages/neos-ui-editors/src/Editors/Reference/index.js
+++ b/packages/neos-ui-editors/src/Editors/Reference/index.js
@@ -9,6 +9,7 @@ import {connect} from 'react-redux';
 import {actions} from '@neos-project/neos-ui-redux-store';
 
 import {sanitizeOptions} from '../../Library';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 @connect((state) => ({
     creationDialogIsOpen: state?.ui?.nodeCreationDialog?.isOpen,
@@ -60,16 +61,16 @@ export default class ReferenceEditor extends PureComponent {
             optionValueField="identifier"
             displaySearchBox={true}
             ListPreviewElement={NodeOption}
-            createNewLabel={i18nRegistry.translate('Neos.Neos:Main:createNew')}
-            noMatchesFoundLabel={i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}
-            searchBoxLeftToTypeLabel={i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
+            createNewLabel={translate('Neos.Neos:Main:createNew')}
+            noMatchesFoundLabel={translate('Neos.Neos:Main:noMatchesFound')}
+            searchBoxLeftToTypeLabel={translate('Neos.Neos:Main:searchBoxLeftToType')}
             placeholder={i18nRegistry.translate(this.props.placeholder)}
             threshold={threshold}
             options={sanitizeOptions(options)}
             value={value}
             onValueChange={this.handleValueChange}
             onHeaderClick={() => this.handleClick(options[0].uri)}
-            loadingLabel={i18nRegistry.translate('Neos.Neos:Main:loading')}
+            loadingLabel={translate('Neos.Neos:Main:loading')}
             displayLoadingIndicator={displayLoadingIndicator}
             showDropDownToggle={false}
             allowEmpty={true}

--- a/packages/neos-ui-editors/src/Editors/References/index.js
+++ b/packages/neos-ui-editors/src/Editors/References/index.js
@@ -8,6 +8,7 @@ import {dndTypes} from '@neos-project/neos-ui-constants';
 import {neos} from '@neos-project/neos-ui-decorators';
 import {connect} from 'react-redux';
 import {actions} from '@neos-project/neos-ui-redux-store';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 import {sanitizeOptions} from '../../Library';
 
@@ -59,14 +60,14 @@ export default class ReferencesEditor extends PureComponent {
             className={className}
             dndType={dndTypes.MULTISELECT}
             optionValueField="identifier"
-            loadingLabel={i18nRegistry.translate('Neos.Neos:Main:loading')}
+            loadingLabel={translate('Neos.Neos:Main:loading')}
             displaySearchBox={true}
             ListPreviewElement={NodeOption}
-            createNewLabel={i18nRegistry.translate('Neos.Neos:Main:createNew')}
+            createNewLabel={translate('Neos.Neos:Main:createNew')}
             placeholder={i18nRegistry.translate(placeholder)}
             threshold={threshold}
-            noMatchesFoundLabel={i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}
-            searchBoxLeftToTypeLabel={i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
+            noMatchesFoundLabel={translate('Neos.Neos:Main:noMatchesFound')}
+            searchBoxLeftToTypeLabel={translate('Neos.Neos:Main:searchBoxLeftToType')}
             options={sanitizeOptions(options)}
             values={value}
             onValuesChange={this.handleValueChange}

--- a/packages/neos-ui-editors/src/Editors/SelectBox/DataSourceBasedSelectBoxEditor.js
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/DataSourceBasedSelectBoxEditor.js
@@ -7,6 +7,7 @@ import {neos} from '@neos-project/neos-ui-decorators';
 import {shouldDisplaySearchBox, searchOptions, processSelectBoxOptions} from './selectBoxHelpers';
 import {createSelectBoxValueStringFromPossiblyStrangeNodePropertyValue} from './createSelectBoxValueStringFromPossiblyStrangeNodePropertyValue';
 import PreviewOption from '../../Library/PreviewOption';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 const getDataLoaderOptionsForProps = props => ({
     contextNodePath: props.focusedNodePath,
@@ -152,8 +153,8 @@ export default class DataSourceBasedSelectBoxEditor extends PureComponent {
                 displaySearchBox={shouldDisplaySearchBox(options, processedSelectBoxOptions)}
                 searchOptions={searchOptions(this.state.searchTerm, processedSelectBoxOptions)}
                 onSearchTermChange={this.handleSearchTermChange}
-                noMatchesFoundLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}
-                searchBoxLeftToTypeLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
+                noMatchesFoundLabel={translate('Neos.Neos:Main:noMatchesFound')}
+                searchBoxLeftToTypeLabel={translate('Neos.Neos:Main:searchBoxLeftToType')}
                 threshold={options.threshold}
                 disabled={options.disabled}
             />);
@@ -172,8 +173,8 @@ export default class DataSourceBasedSelectBoxEditor extends PureComponent {
             allowEmpty={options.allowEmpty}
             displaySearchBox={shouldDisplaySearchBox(options, processedSelectBoxOptions)}
             onSearchTermChange={this.handleSearchTermChange}
-            noMatchesFoundLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}
-            searchBoxLeftToTypeLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
+            noMatchesFoundLabel={translate('Neos.Neos:Main:noMatchesFound')}
+            searchBoxLeftToTypeLabel={translate('Neos.Neos:Main:searchBoxLeftToType')}
             threshold={options.threshold}
             disabled={options.disabled}
         />);

--- a/packages/neos-ui-editors/src/Editors/SelectBox/DataSourceBasedSelectBoxEditor.js
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/DataSourceBasedSelectBoxEditor.js
@@ -137,7 +137,7 @@ export default class DataSourceBasedSelectBoxEditor extends PureComponent {
 
         // Placeholder text must be unescaped in case html entities were used
         const placeholder = options && options.placeholder && i18nRegistry.translate(unescape(options.placeholder));
-        const loadingLabel = i18nRegistry.translate('loading', 'Loading', [], 'Neos.Neos', 'Main');
+        const loadingLabel = translate('Neos.Neos:Main:loading', 'Loading');
 
         if (options.multiple) {
             return (<MultiSelectBox

--- a/packages/neos-ui-editors/src/Editors/SelectBox/SimpleSelectBoxEditor.js
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/SimpleSelectBoxEditor.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {SelectBox, MultiSelectBox} from '@neos-project/react-ui-components';
 import {neos} from '@neos-project/neos-ui-decorators';
 import {shouldDisplaySearchBox, searchOptions, processSelectBoxOptions} from './selectBoxHelpers';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 @neos(globalRegistry => ({
     i18nRegistry: globalRegistry.get('i18n')
@@ -69,8 +70,8 @@ export default class SimpleSelectBoxEditor extends PureComponent {
                 displaySearchBox={shouldDisplaySearchBox(options, processedSelectBoxOptions)}
                 searchOptions={searchOptions(this.state.searchTerm, processedSelectBoxOptions)}
                 onSearchTermChange={this.handleSearchTermChange}
-                noMatchesFoundLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}
-                searchBoxLeftToTypeLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
+                noMatchesFoundLabel={translate('Neos.Neos:Main:noMatchesFound')}
+                searchBoxLeftToTypeLabel={translate('Neos.Neos:Main:searchBoxLeftToType')}
                 threshold={options.threshold}
                 disabled={options.disabled}
             />);
@@ -86,8 +87,8 @@ export default class SimpleSelectBoxEditor extends PureComponent {
             allowEmpty={allowEmpty}
             displaySearchBox={shouldDisplaySearchBox(options, processedSelectBoxOptions)}
             onSearchTermChange={this.handleSearchTermChange}
-            noMatchesFoundLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}
-            searchBoxLeftToTypeLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
+            noMatchesFoundLabel={translate('Neos.Neos:Main:noMatchesFound')}
+            searchBoxLeftToTypeLabel={translate('Neos.Neos:Main:searchBoxLeftToType')}
             threshold={options.threshold}
             disabled={options.disabled}
         />);

--- a/packages/neos-ui-editors/src/Editors/SelectBox/index.spec.js
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/index.spec.js
@@ -6,6 +6,7 @@ import TestBackend from 'react-dnd-test-backend';
 import {DndProvider as DragDropContextProvider} from 'react-dnd';
 import SelectBoxEditor from './index.js';
 import {WrapWithMockGlobalRegistry, MockDataSourceDataLoader} from '../../_lib/testUtils';
+import {setupI18n} from "@neos-project/neos-ui-i18n";
 
 const optionValues = {
     foo: {
@@ -40,6 +41,10 @@ const multiselectLabels = component =>
     component.find('MultiSelectBox_ListPreviewSortable').find('ListPreviewElement').map(node => node.text());
 
 const commit = () => {};
+
+beforeAll(() => {
+    setupI18n('en-US', 'one,other', {});
+});
 
 test(`SelectBox > single, no dataSource, no preselected value`, () => {
     const expectedDropdownElementLabels = ['fooLabel', 'barLabel'];

--- a/packages/neos-ui-editors/src/Editors/SelectBox/index.spec.js
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/index.spec.js
@@ -6,7 +6,7 @@ import TestBackend from 'react-dnd-test-backend';
 import {DndProvider as DragDropContextProvider} from 'react-dnd';
 import SelectBoxEditor from './index.js';
 import {WrapWithMockGlobalRegistry, MockDataSourceDataLoader} from '../../_lib/testUtils';
-import {setupI18n} from "@neos-project/neos-ui-i18n";
+import {setupI18n} from '@neos-project/neos-ui-i18n';
 
 const optionValues = {
     foo: {

--- a/packages/neos-ui-editors/src/Editors/SelectBox/selectBoxHelpers.spec.ts
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/selectBoxHelpers.spec.ts
@@ -1,6 +1,6 @@
 import {processSelectBoxOptions} from './selectBoxHelpers';
 import type {I18nRegistry} from '@neos-project/neos-ui-i18n';
-import {setupI18n} from "@neos-project/neos-ui-i18n";
+import {setupI18n} from '@neos-project/neos-ui-i18n';
 
 const fakeI18NRegistry = {
     translate: (id) => id ?? ''

--- a/packages/neos-ui-editors/src/Editors/SelectBox/selectBoxHelpers.spec.ts
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/selectBoxHelpers.spec.ts
@@ -1,9 +1,14 @@
 import {processSelectBoxOptions} from './selectBoxHelpers';
 import type {I18nRegistry} from '@neos-project/neos-ui-i18n';
+import {setupI18n} from "@neos-project/neos-ui-i18n";
 
 const fakeI18NRegistry = {
     translate: (id) => id ?? ''
 } as I18nRegistry;
+
+beforeAll(() => {
+    setupI18n('en-US', 'one,other', {});
+});
 
 describe('processSelectBoxOptions', () => {
     it('transforms an associative array with labels to list of objects', () => {
@@ -75,7 +80,7 @@ describe('processSelectBoxOptions', () => {
             'key1': {label: 'Key 1'}
         }, 'oldValue');
 
-        expect(processOptions).toEqual([{value: 'key1', label: 'Key 1'}, {value: 'oldValue', label: 'Neos.Neos.Ui:Main:invalidValue: "oldValue"', icon: 'exclamation-triangle'}]);
+        expect(processOptions).toEqual([{value: 'key1', label: 'Key 1'}, {value: 'oldValue', label: 'Invalid value: "oldValue"', icon: 'exclamation-triangle'}]);
     });
 
     it('creates missing options for unmatched additional array value', () => {
@@ -83,7 +88,7 @@ describe('processSelectBoxOptions', () => {
             'key1': {label: 'Key 1'}
         }, ['oldValue', 'key1']);
 
-        expect(processOptions).toEqual([{value: 'key1', label: 'Key 1'}, {value: 'oldValue', label: 'Neos.Neos.Ui:Main:invalidValue: "oldValue"', icon: 'exclamation-triangle'}]);
+        expect(processOptions).toEqual([{value: 'key1', label: 'Key 1'}, {value: 'oldValue', label: 'Invalid value: "oldValue"', icon: 'exclamation-triangle'}]);
     });
 
     it('creates missing options for unmatched additional multiple array values', () => {
@@ -97,8 +102,8 @@ describe('processSelectBoxOptions', () => {
             {value: 'key1', label: 'Key 1'},
             {value: 'key2', label: 'Key 2'},
             {value: 'key3', label: 'Key 3'},
-            {value: 'oldValue', label: 'Neos.Neos.Ui:Main:invalidValue: "oldValue"', icon: 'exclamation-triangle'},
-            {value: 'oldValue2', label: 'Neos.Neos.Ui:Main:invalidValue: "oldValue2"', icon: 'exclamation-triangle'}
+            {value: 'oldValue', label: 'Invalid value: "oldValue"', icon: 'exclamation-triangle'},
+            {value: 'oldValue2', label: 'Invalid value: "oldValue2"', icon: 'exclamation-triangle'}
         ]);
     });
 

--- a/packages/neos-ui-editors/src/Editors/SelectBox/selectBoxHelpers.ts
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/selectBoxHelpers.ts
@@ -1,5 +1,6 @@
 import type {I18nRegistry} from '@neos-project/neos-ui-i18n';
 import {isNil} from '@neos-project/utils-helpers';
+import {translate} from '@neos-project/neos-ui-i18n';
 import {
     createSelectBoxValueStringFromPossiblyStrangeNodePropertyValue
 } from './createSelectBoxValueStringFromPossiblyStrangeNodePropertyValue';
@@ -77,7 +78,7 @@ export const processSelectBoxOptions = (i18nRegistry: I18nRegistry, selectBoxOpt
         // Mismatch detected. Thus we add an option to the schema so the value is displayable: https://github.com/neos/neos-ui/issues/3520
         processedSelectBoxOptions.push({
             value: singleValue,
-            label: `${i18nRegistry.translate('Neos.Neos.Ui:Main:invalidValue')}: "${singleValue}"`,
+            label: `${translate('Neos.Neos.Ui:Main:invalidValue', 'Invalid value')}: "${singleValue}"`,
             icon: 'exclamation-triangle'
         });
     }

--- a/packages/neos-ui-editors/src/Editors/UriPathSegment/index.js
+++ b/packages/neos-ui-editors/src/Editors/UriPathSegment/index.js
@@ -7,6 +7,7 @@ import {neos} from '@neos-project/neos-ui-decorators';
 import {selectors} from '@neos-project/neos-ui-redux-store';
 import {TextInput, IconButton} from '@neos-project/react-ui-components';
 import style from './style.module.css';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 const defaultOptions = {
     autoFocus: false,
@@ -117,9 +118,7 @@ export default class UriPathSegment extends PureComponent {
                             disabled={this.state.isBusy}
                             style="neutral"
                             hoverStyle="clean"
-                            title={i18nRegistry.translate(
-                                'Neos.Neos.Ui:Main:syncUriPathSegment'
-                            )}
+                            title={translate('Neos.Neos.Ui:Main:syncUriPathSegment')}
                         />
                     </div>
                 ) : null}

--- a/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/index.js
+++ b/packages/neos-ui-editors/src/SecondaryEditors/ImageCropper/index.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import ReactCrop from 'react-image-crop';
 
 import {Icon, IconButton, TextInput} from '@neos-project/react-ui-components';
-import {neos} from '@neos-project/neos-ui-decorators';
 
 import AspectRatioDropDown from './AspectRatioDropDown/index';
 import CropConfiguration, {CustomAspectRatioOption, LockedAspectRatioStrategy} from './model.js';
@@ -11,6 +10,7 @@ import dummyImage from '../../Editors/Image/resource/dummy-image.dataurl.svg';
 import style from './style.module.css';
 
 import './react_crop.vanilla-css';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 /**
  * Calculates the greatest common divisor for given numbers a, b
@@ -70,9 +70,6 @@ class AspectRatioItem extends PureComponent {
     }
 }
 
-@neos(globalRegistry => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}))
 export default class ImageCropper extends PureComponent {
     state = {
         cropConfiguration: CropConfiguration.fromNeosConfiguration(
@@ -84,8 +81,7 @@ export default class ImageCropper extends PureComponent {
     static propTypes = {
         onComplete: PropTypes.func.isRequired,
         sourceImage: PropTypes.object.isRequired,
-        options: PropTypes.object,
-        i18nRegistry: PropTypes.object.isRequired
+        options: PropTypes.object
     };
 
     componentDidMount() {
@@ -181,7 +177,7 @@ export default class ImageCropper extends PureComponent {
         const {cropConfiguration} = this.state;
         const aspectRatioLocked = cropConfiguration.aspectRatioStrategy instanceof LockedAspectRatioStrategy;
         const allowCustomRatios = cropConfiguration.aspectRatioOptions.some(option => option instanceof CustomAspectRatioOption);
-        const {sourceImage, i18nRegistry} = this.props;
+        const {sourceImage} = this.props;
         const src = sourceImage.previewUri || dummyImage;
 
         const toolbarRef = el => {
@@ -207,7 +203,7 @@ export default class ImageCropper extends PureComponent {
                     </div>
 
                     {!aspectRatioLocked && <AspectRatioDropDown
-                        placeholder={`${i18nRegistry.translate('Neos.Neos:Main:imageCropper__aspect-ratio-placeholder')}`}
+                        placeholder={`${translate('Neos.Neos:Main:imageCropper__aspect-ratio-placeholder')}`}
                         current={cropConfiguration.aspectRatioStrategy}
                         allowCustomRatios={allowCustomRatios}
                         options={cropConfiguration.aspectRatioOptions}

--- a/packages/neos-ui-error/src/container/FatalErrorView/FatalErrorView.tsx
+++ b/packages/neos-ui-error/src/container/FatalErrorView/FatalErrorView.tsx
@@ -34,8 +34,8 @@ const CopyTechnicalDetailsButton = (props: { error: null | AnyError }) => {
 
     return <Button onClick={copyErrorDetails} isActive={hasCopied}>
         {!hasCopied
-            ? translate('Neos.Neos.Ui:Main:errorBoundary.copyTechnicalDetails', '')
-            : translate('Neos.Neos.Ui:Main:errorBoundary.technicalDetailsCopied', '')
+            ? translate('Neos.Neos.Ui:Main:errorBoundary.copyTechnicalDetails')
+            : translate('Neos.Neos.Ui:Main:errorBoundary.technicalDetailsCopied')
         }
         &nbsp; <Icon icon="copy" size="sm"/>
     </Button>;
@@ -54,7 +54,7 @@ const ReloadNeosUiButton = () => {
     };
 
     return <Button onClick={reload}>
-        {translate('Neos.Neos.Ui:Main:errorBoundary.reloadUi', '')}
+        {translate('Neos.Neos.Ui:Main:errorBoundary.reloadUi')}
         &nbsp; <Icon icon="redo" size="sm" spin={isReloading}/>
     </Button>;
 };
@@ -63,11 +63,11 @@ export const FatalErrorView = (props: { error: AnyError }) => {
     return <div className={styles.container}>
         <div>
             <Logo />
-            <h1 className={styles.title}>{translate('Neos.Neos.Ui:Main:errorBoundary.title', '')}</h1>
-            <p>{translate('Neos.Neos.Ui:Main:errorBoundary.description', '')}</p>
+            <h1 className={styles.title}>{translate('Neos.Neos.Ui:Main:errorBoundary.title')}</h1>
+            <p>{translate('Neos.Neos.Ui:Main:errorBoundary.description')}</p>
 
             <ErrorView error={props.error} />
-            <p>{translate('Neos.Neos.Ui:Main:errorBoundary.footer', '')}</p>
+            <p>{translate('Neos.Neos.Ui:Main:errorBoundary.footer')}</p>
 
             <div className={styles.buttonGroup}>
                 <ReloadNeosUiButton />

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/AddNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/AddNode/index.js
@@ -1,7 +1,7 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-
+import {translate} from '@neos-project/neos-ui-i18n';
 import {selectors, actions} from '@neos-project/neos-ui-redux-store';
 import {Button, Icon} from '@neos-project/react-ui-components';
 import {InsertPosition} from '@neos-project/neos-ts-interfaces';
@@ -38,8 +38,7 @@ export default class AddNode extends PureComponent {
         className: PropTypes.string,
         insertPosition: PropTypes.string,
         commenceNodeCreation: PropTypes.func.isRequired,
-        isAllowedToAddChildOrSiblingNodes: PropTypes.bool,
-        i18nRegistry: PropTypes.object.isRequired
+        isAllowedToAddChildOrSiblingNodes: PropTypes.bool
     };
 
     handleCommenceNodeCreation = () => {
@@ -54,7 +53,7 @@ export default class AddNode extends PureComponent {
     }
 
     render() {
-        const {isAllowedToAddChildOrSiblingNodes, i18nRegistry, className, insertPosition} = this.props;
+        const {isAllowedToAddChildOrSiblingNodes, className, insertPosition} = this.props;
         const insertPositionIcon = insertPosition === InsertPosition.BEFORE
             ? 'arrow-up' : (insertPosition === InsertPosition.AFTER ? 'arrow-down' : 'arrow-right');
 
@@ -64,7 +63,7 @@ export default class AddNode extends PureComponent {
                 className={className}
                 disabled={!isAllowedToAddChildOrSiblingNodes}
                 onClick={this.handleCommenceNodeCreation}
-                title={i18nRegistry.translate('createNew')}
+                title={translate('Neos.Neos:Main:createNew')}
                 size="small"
                 style="brand"
             >

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/CopySelectedNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/CopySelectedNode/index.js
@@ -1,7 +1,7 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-
+import {translate} from '@neos-project/neos-ui-i18n';
 import {Icon, Button} from '@neos-project/react-ui-components';
 
 import {actions} from '@neos-project/neos-ui-redux-store';
@@ -26,7 +26,7 @@ export default class CopySelectedNode extends PureComponent {
     }
 
     render() {
-        const {destructiveOperationsAreDisabled, className, isCopied, i18nRegistry} = this.props;
+        const {destructiveOperationsAreDisabled, className, isCopied} = this.props;
 
         return (
             <Button
@@ -38,7 +38,7 @@ export default class CopySelectedNode extends PureComponent {
                 hoverStyle="brand"
                 style="transparent"
                 size="small"
-                title={i18nRegistry.translate('copy')}
+                title={translate('Neos.Neos:Main:copy')}
             >
                 {i18nRegistry.translate('copy')}
                 <Icon icon="far copy" />

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/CopySelectedNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/CopySelectedNode/index.js
@@ -40,7 +40,7 @@ export default class CopySelectedNode extends PureComponent {
                 size="small"
                 title={translate('Neos.Neos:Main:copy')}
             >
-                {i18nRegistry.translate('copy')}
+                {translate('Neos.Neos:Main:copy')}
                 <Icon icon="far copy" />
             </Button>
         );

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/CutSelectedNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/CutSelectedNode/index.js
@@ -1,7 +1,7 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-
+import {translate} from '@neos-project/neos-ui-i18n';
 import {Icon, Button} from '@neos-project/react-ui-components';
 
 import {actions} from '@neos-project/neos-ui-redux-store';
@@ -16,8 +16,7 @@ export default class CutSelectedNode extends PureComponent {
         destructiveOperationsAreDisabled: PropTypes.bool.isRequired,
         isCut: PropTypes.bool.isRequired,
         canBeEdited: PropTypes.bool.isRequired,
-        cutNode: PropTypes.func.isRequired,
-        i18nRegistry: PropTypes.object.isRequired
+        cutNode: PropTypes.func.isRequired
     };
 
     handleCutSelectedNodeClick = () => {
@@ -31,8 +30,7 @@ export default class CutSelectedNode extends PureComponent {
             destructiveOperationsAreDisabled,
             isCut,
             className,
-            canBeEdited,
-            i18nRegistry
+            canBeEdited
         } = this.props;
 
         return (
@@ -45,9 +43,9 @@ export default class CutSelectedNode extends PureComponent {
                 hoverStyle="brand"
                 style="transparent"
                 size="small"
-                title={i18nRegistry.translate('cut')}
+                title={translate('Neos.Neos:Main:cut')}
             >
-                {i18nRegistry.translate('cut')}
+                {translate('Neos.Neos:Main:cut')}
                 <Icon icon="cut" />
             </Button>
         );

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/DeleteSelectedNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/DeleteSelectedNode/index.js
@@ -1,7 +1,7 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-
+import {translate} from '@neos-project/neos-ui-i18n';
 import {Icon, Button} from '@neos-project/react-ui-components';
 
 import {actions} from '@neos-project/neos-ui-redux-store';
@@ -16,8 +16,7 @@ export default class DeleteSelectedNode extends PureComponent {
         destructiveOperationsAreDisabled: PropTypes.bool.isRequired,
         canBeDeleted: PropTypes.bool.isRequired,
         canBeEdited: PropTypes.bool.isRequired,
-        commenceNodeRemoval: PropTypes.func.isRequired,
-        i18nRegistry: PropTypes.object.isRequired
+        commenceNodeRemoval: PropTypes.func.isRequired
     };
 
     handleDeleteSelectedNodeClick = () => {
@@ -29,7 +28,7 @@ export default class DeleteSelectedNode extends PureComponent {
     }
 
     render() {
-        const {className, destructiveOperationsAreDisabled, canBeDeleted, canBeEdited, i18nRegistry} = this.props;
+        const {className, destructiveOperationsAreDisabled, canBeDeleted, canBeEdited} = this.props;
 
         return (
             <Button
@@ -40,9 +39,9 @@ export default class DeleteSelectedNode extends PureComponent {
                 hoverStyle="brand"
                 style="transparent"
                 size="small"
-                title={i18nRegistry.translate('delete')}
+                title={translate('Neos.Neos:Main:delete')}
             >
-                {i18nRegistry.translate('delete')}
+                {translate('Neos.Neos:Main:delete')}
                 <Icon icon="trash-alt" />
             </Button>
         );

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/HideSelectedNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/HideSelectedNode/index.js
@@ -1,7 +1,7 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-
+import {translate} from '@neos-project/neos-ui-i18n';
 import {Button, Icon} from '@neos-project/react-ui-components';
 
 import {selectors, actions} from '@neos-project/neos-ui-redux-store';
@@ -20,8 +20,7 @@ export default class HideSelectedNode extends PureComponent {
         showNode: PropTypes.func.isRequired,
         destructiveOperationsAreDisabled: PropTypes.bool.isRequired,
         canBeEdited: PropTypes.bool.isRequired,
-        visibilityCanBeToggled: PropTypes.bool.isRequired,
-        i18nRegistry: PropTypes.object.isRequired
+        visibilityCanBeToggled: PropTypes.bool.isRequired
     };
 
     handleHideNode = () => {
@@ -41,7 +40,7 @@ export default class HideSelectedNode extends PureComponent {
     }
 
     render() {
-        const {className, node, destructiveOperationsAreDisabled, canBeEdited, visibilityCanBeToggled, i18nRegistry} = this.props;
+        const {className, node, destructiveOperationsAreDisabled, canBeEdited, visibilityCanBeToggled} = this.props;
         const isHidden = node?.properties?._hidden;
 
         return (
@@ -54,9 +53,9 @@ export default class HideSelectedNode extends PureComponent {
                 hoverStyle="brand"
                 style="transparent"
                 size="small"
-                title={i18nRegistry.translate(isHidden ? 'unhide' : 'hide')}
+                title={isHidden ? translate('Neos.Neos:Main:unhide') : translate('Neos.Neos:Main:hide')}
             >
-                {i18nRegistry.translate(isHidden ? 'unhide' : 'hide')}
+                {isHidden ? translate('Neos.Neos:Main:unhide') : translate('Neos.Neos:Main:hide')}
                 <Icon
                     icon={isHidden ? 'eye' : 'eye-slash'}
                 />

--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/PasteClipBoardNode/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/Buttons/PasteClipBoardNode/index.js
@@ -2,6 +2,7 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {neos} from '@neos-project/neos-ui-decorators';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 import {selectors, actions} from '@neos-project/neos-ui-redux-store';
 import {InsertPosition} from '@neos-project/neos-ts-interfaces';
@@ -36,8 +37,7 @@ export default class PasteClipBoardNode extends PureComponent {
         fusionPath: PropTypes.string,
         insertPosition: PropTypes.string,
 
-        pasteNode: PropTypes.func.isRequired,
-        i18nRegistry: PropTypes.object.isRequired
+        pasteNode: PropTypes.func.isRequired
     };
 
     handlePasteButtonClick = () => {
@@ -46,7 +46,7 @@ export default class PasteClipBoardNode extends PureComponent {
     }
 
     render() {
-        const {className, canBePasted, i18nRegistry, insertPosition} = this.props;
+        const {className, canBePasted, insertPosition} = this.props;
 
         // FIXME: Also hide/disable button if insertPosition is invalid for the current node
         if (!canBePasted) {
@@ -61,7 +61,7 @@ export default class PasteClipBoardNode extends PureComponent {
                 id="neos-InlineToolbar-PaseClipBoardNode"
                 className={className}
                 onClick={this.handlePasteButtonClick}
-                title={i18nRegistry.translate('paste')}
+                title={translate('Neos.Neos:Main:paste')}
                 size="small"
                 style="brand"
             >

--- a/packages/neos-ui-i18n/src/translate.spec.ts
+++ b/packages/neos-ui-i18n/src/translate.spec.ts
@@ -30,6 +30,7 @@ describe('translate', () => {
         });
 
         it('returns the address if no fallback is specified', () => {
+            // @ts-expect-error for Neos Ui development we only allow translations from Neos or the Ui as package and lint via typescript
             expect(translate('Unknown.Package:UnknownSource:unknown.trans-unit.id'))
                 .toBe('Unknown.Package:UnknownSource:unknown.trans-unit.id');
         });

--- a/packages/neos-ui-i18n/src/translate.spec.ts
+++ b/packages/neos-ui-i18n/src/translate.spec.ts
@@ -21,8 +21,10 @@ describe('translate', () => {
         });
 
         it('returns given fallback', () => {
+            // @ts-expect-error for Neos Ui development we only allow translations from Neos or the Ui as package and lint via typescript
             expect(translate('Unknown.Package:UnknownSource:unknown.trans-unit.id', 'This is the fallback'))
                 .toBe('This is the fallback');
+            // @ts-expect-error for Neos Ui development we only allow translations from Neos or the Ui as package and lint via typescript
             expect(translate('Unknown.Package:UnknownSource:unknown.trans-unit.id', 'This is another fallback'))
                 .toBe('This is another fallback');
         });
@@ -33,38 +35,49 @@ describe('translate', () => {
         });
 
         it('returns given "other" form of fallback when quantity = 0', () => {
+            // @ts-expect-error for Neos Ui development we only allow translations from Neos or the Ui as package and lint via typescript
             expect(translate('Unknown.Package:UnknownSource:unknown.trans-unit.id', ['Singular Fallback', 'Plural Fallback'], [], 0))
                 .toBe('Plural Fallback');
         });
 
         it('returns given "one" form of fallback when quantity = 1', () => {
+            // @ts-expect-error for Neos Ui development we only allow translations from Neos or the Ui as package and lint via typescript
             expect(translate('Unknown.Package:UnknownSource:unknown.trans-unit.id', ['Singular Fallback', 'Plural Fallback'], [], 1))
                 .toBe('Singular Fallback');
         });
 
         it('returns given "other" form of fallback when quantity > 1', () => {
+            // @ts-expect-error for Neos Ui development we only allow translations from Neos or the Ui as package and lint via typescript
             expect(translate('Unknown.Package:UnknownSource:unknown.trans-unit.id', ['Singular Fallback', 'Plural Fallback'], [], 2))
                 .toBe('Plural Fallback');
+            // @ts-expect-error for Neos Ui development we only allow translations from Neos or the Ui as package and lint via typescript
             expect(translate('Unknown.Package:UnknownSource:unknown.trans-unit.id', ['Singular Fallback', 'Plural Fallback'], [], 42))
                 .toBe('Plural Fallback');
+            // @ts-expect-error for Neos Ui development we only allow translations from Neos or the Ui as package and lint via typescript
             expect(translate('Unknown.Package:UnknownSource:unknown.trans-unit.id', ['Singular Fallback', 'Plural Fallback'], [], 24227))
                 .toBe('Plural Fallback');
         });
 
         it('substitutes numerical parameters in fallback string', () => {
+            // @ts-expect-error for Neos Ui development we only allow translations from Neos or the Ui as package and lint via typescript
             expect(translate('Unknown.Package:UnknownSource:unknown.trans-unit.id', 'This is {0} fallback with {1} parameters.', ['a', 'a few']))
                 .toBe('This is a fallback with a few parameters.');
+            // @ts-expect-error for Neos Ui development we only allow translations from Neos or the Ui as package and lint via typescript
             expect(translate('Unknown.Package:UnknownSource:unknown.trans-unit.id', ['This is a fallback with {0} parameter.', 'This is a fallback with {0} parameters.'], ['just one'], 1))
                 .toBe('This is a fallback with just one parameter.');
+            // @ts-expect-error for Neos Ui development we only allow translations from Neos or the Ui as package and lint via typescript
             expect(translate('Unknown.Package:UnknownSource:unknown.trans-unit.id', ['This is a fallback with {0} parameter.', 'This is a fallback with {0} parameters.'], ['one or more'], 2))
                 .toBe('This is a fallback with one or more parameters.');
         });
 
         it('substitutes named parameters in fallback string', () => {
+            // @ts-expect-error for Neos Ui development we only allow translations from Neos or the Ui as package and lint via typescript
             expect(translate('Unknown.Package:UnknownSource:unknown.trans-unit.id', 'This is {foo} fallback with {bar} parameters.', {foo: 'one', bar: 'a couple of'}))
                 .toBe('This is one fallback with a couple of parameters.');
+            // @ts-expect-error for Neos Ui development we only allow translations from Neos or the Ui as package and lint via typescript
             expect(translate('Unknown.Package:UnknownSource:unknown.trans-unit.id', ['This is a fallback with {foo} parameter.', 'This is a fallback with {foo} parameters.'], {foo: 'just one'}, 1))
                 .toBe('This is a fallback with just one parameter.');
+            // @ts-expect-error for Neos Ui development we only allow translations from Neos or the Ui as package and lint via typescript
             expect(translate('Unknown.Package:UnknownSource:unknown.trans-unit.id', ['This is a fallback with {foo} parameter.', 'This is a fallback with {foo} parameters.'], {foo: 'one or more'}, 2))
                 .toBe('This is a fallback with one or more parameters.');
         });

--- a/packages/neos-ui-i18n/src/translate.ts
+++ b/packages/neos-ui-i18n/src/translate.ts
@@ -35,7 +35,7 @@ import {substitutePlaceholders} from './registry';
  * @param {quantity} [quantity] The key of the package in which to look for the translation file
  */
 export function translate(
-    fullyQualifiedTranslationAddressAsString: string,
+    fullyQualifiedTranslationAddressAsString: `${('Neos.Neos.Ui'|'Neos.Neos')}:${string}:${string}`,
     fallback: string | [string, string] = '',
     parameters: Parameters = [],
     quantity: number = 0

--- a/packages/neos-ui-link-editor-core/src/application/Dialog/Dialog.tsx
+++ b/packages/neos-ui-link-editor-core/src/application/Dialog/Dialog.tsx
@@ -148,7 +148,7 @@ const LinkEditorDialog: React.FC<{
             autoFocus={true}
             actions={[
                 <Button onClick={dismiss}>
-                    {translate('Neos.Neos.Ui:LinkEditor.Main:dialog.action.cancel', '')}
+                    {translate('Neos.Neos.Ui:LinkEditor.Main:dialog.action.cancel')}
                 </Button>,
                 <Button
                     id="neos-LinkEditor-submit"
@@ -158,8 +158,8 @@ const LinkEditorDialog: React.FC<{
                     onClick={handleSubmit}
                 >
                     {initialValue === null
-                        ? translate('Neos.Neos.Ui:LinkEditor.Main:dialog.action.create', '')
-                        : translate('Neos.Neos.Ui:LinkEditor.Main:dialog.action.update', '')}
+                        ? translate('Neos.Neos.Ui:LinkEditor.Main:dialog.action.create')
+                        : translate('Neos.Neos.Ui:LinkEditor.Main:dialog.action.update')}
                 </Button>
             ]}
         >

--- a/packages/neos-ui-link-editor-core/src/application/Dialog/LinkOptions/index.tsx
+++ b/packages/neos-ui-link-editor-core/src/application/Dialog/LinkOptions/index.tsx
@@ -27,13 +27,13 @@ export const LinkOptions: React.FC<{
             {props.enabledLinkOptions.includes('title') ? (
                 <div>
                     <Label htmlFor="neos-LinkEditor-Options-title">
-                        {translate('Neos.Neos.Ui:LinkEditor.Main:options.label.title', '')}
+                        {translate('Neos.Neos.Ui:LinkEditor.Main:options.label.title')}
                     </Label>
                     <TextInput
                         id="neos-LinkEditor-Options-title"
                         type="text"
                         value={formOptions?.title ?? ''}
-                        placeholder={translate('Neos.Neos.Ui:LinkEditor.Main:options.placeholder.title', '')}
+                        placeholder={translate('Neos.Neos.Ui:LinkEditor.Main:options.placeholder.title')}
                         onChange={setTitle}
                     />
                 </div>
@@ -43,19 +43,19 @@ export const LinkOptions: React.FC<{
                     {props.enabledLinkOptions.includes('targetBlank') ? (
                         <Label className={style.checkboxLabel}>
                             <CheckBox onChange={setTargetBlank} isChecked={formOptions?.targetBlank ?? false}/>
-                            {translate('Neos.Neos.Ui:LinkEditor.Main:options.label.targetBlank', '')}
+                            {translate('Neos.Neos.Ui:LinkEditor.Main:options.label.targetBlank')}
                         </Label>
                     ) : null}
                     {props.enabledLinkOptions.includes('relNofollow') ? (
                         <Label className={style.checkboxLabel}>
                             <CheckBox onChange={setRelNofollow} isChecked={formOptions?.relNofollow ?? false}/>
-                            {translate('Neos.Neos.Ui:LinkEditor.Main:options.label.relNofollow', '')}
+                            {translate('Neos.Neos.Ui:LinkEditor.Main:options.label.relNofollow')}
                         </Label>
                     ) : null}
                     {props.enabledLinkOptions.includes('download') ? (
                         <Label className={style.checkboxLabel}>
                             <CheckBox onChange={setDownload} isChecked={formOptions?.download ?? false}/>
-                            {translate('Neos.Neos.Ui:LinkEditor.Main:options.label.download', '')}
+                            {translate('Neos.Neos.Ui:LinkEditor.Main:options.label.download')}
                         </Label>
                     ) : null}
                 </div>

--- a/packages/neos-ui-link-editor-core/src/application/LinkTypes/Asset/Asset.tsx
+++ b/packages/neos-ui-link-editor-core/src/application/LinkTypes/Asset/Asset.tsx
@@ -28,7 +28,7 @@ const validateModel = (values: AssetLinkModel): AssetLinkModel => ({
         warning: (
             !values.anchor?.value ? undefined : (
                 (values.anchor.value.startsWith(' ') || values.anchor.value.endsWith(' ')) ? (
-                    translate('Neos.Neos.Ui:LinkEditor.Asset:anchor.validation.leadingOrTrailingSpace', '')
+                    translate('Neos.Neos.Ui:LinkEditor.Asset:anchor.validation.leadingOrTrailingSpace')
                 ) : undefined
             )
         )
@@ -40,7 +40,7 @@ export const Asset: ILinkType<AssetLinkModel> = {
 
     icon: 'camera',
 
-    getTitle: () => translate('Neos.Neos.Ui:LinkEditor.Asset:title', ''),
+    getTitle: () => translate('Neos.Neos.Ui:LinkEditor.Asset:title'),
 
     isSuitableFor,
 
@@ -83,7 +83,7 @@ export const Asset: ILinkType<AssetLinkModel> = {
             return (
                 <IconCard
                     icon="spinner"
-                    title={translate('Neos.Neos.Ui:LinkEditor.Asset:loadingPreview', '')}
+                    title={translate('Neos.Neos.Ui:LinkEditor.Asset:loadingPreview')}
                     subTitle={`asset://${model.identifier}`}
                 />
             );
@@ -121,13 +121,13 @@ export const Asset: ILinkType<AssetLinkModel> = {
         return (
             <div>
                 <Label htmlFor="neos-LinkEditor-Asset-anchor">
-                    {translate('Neos.Neos.Ui:LinkEditor.Asset:anchor.label', '')}
+                    {translate('Neos.Neos.Ui:LinkEditor.Asset:anchor.label')}
                 </Label>
                 <TextInput
                     id="neos-LinkEditor-Asset-anchor"
                     type="text"
                     value={model?.anchor?.value ?? ''}
-                    placeholder={translate('Neos.Neos.Ui:LinkEditor.Asset:anchor.placeholder', '')}
+                    placeholder={translate('Neos.Neos.Ui:LinkEditor.Asset:anchor.placeholder')}
                     onChange={setAnchor}
                 />
                 {model?.anchor?.warning ? (

--- a/packages/neos-ui-link-editor-core/src/application/LinkTypes/MailTo/MailTo.tsx
+++ b/packages/neos-ui-link-editor-core/src/application/LinkTypes/MailTo/MailTo.tsx
@@ -18,11 +18,11 @@ type FormValue<T> = {
 
 const validateRecipient = (recipient: string) => {
     if (!recipient) {
-        return translate('Neos.Neos.Ui:LinkEditor.MailTo:recipient.validation.required', '');
+        return translate('Neos.Neos.Ui:LinkEditor.MailTo:recipient.validation.required');
     }
     if (!isEmail.validate(recipient)) {
         // we use the library isemail here, but we only require some kind of soft email validation - anything can be an email if it wants to be :) Thus we only emit warnings. Could be a simple regex too.
-        return translate('Neos.Neos.Ui:LinkEditor.MailTo:recipient.validation.email', '');
+        return translate('Neos.Neos.Ui:LinkEditor.MailTo:recipient.validation.email');
     }
     return undefined;
 }
@@ -30,7 +30,7 @@ const validateRecipient = (recipient: string) => {
 const validateCc = (cc: string) => {
     if (cc) {
         if (!cc.split(',').every(value => isEmail.validate(value.trim()))) {
-            return translate('Neos.Neos.Ui:LinkEditor.MailTo:cc.validation.emaillist', '');
+            return translate('Neos.Neos.Ui:LinkEditor.MailTo:cc.validation.emaillist');
         }
     }
     return undefined;
@@ -39,7 +39,7 @@ const validateCc = (cc: string) => {
 const validateBcc = (cc: string) => {
     if (cc) {
         if (!cc.split(',').every(value => isEmail.validate(value.trim()))) {
-            return translate('Neos.Neos.Ui:LinkEditor.MailTo:bcc.validation.emaillist', '');
+            return translate('Neos.Neos.Ui:LinkEditor.MailTo:bcc.validation.emaillist');
         }
     }
     return undefined;
@@ -83,7 +83,7 @@ export const MailTo: ILinkType<MailToLinkModel, MailToOptions> = {
 
     icon: 'envelope',
 
-    getTitle: () => translate('Neos.Neos.Ui:LinkEditor.MailTo:title', ''),
+    getTitle: () => translate('Neos.Neos.Ui:LinkEditor.MailTo:title'),
 
     isSuitableFor,
 
@@ -205,7 +205,7 @@ export const MailTo: ILinkType<MailToLinkModel, MailToOptions> = {
         return (
             <Layout.Stack>
                 <div>
-                    <Label htmlFor="neos-LinkEditor-MailTo-recipient">{translate('Neos.Neos.Ui:LinkEditor.MailTo:recipient.label', '')}</Label>
+                    <Label htmlFor="neos-LinkEditor-MailTo-recipient">{translate('Neos.Neos.Ui:LinkEditor.MailTo:recipient.label')}</Label>
                     <TextInput
                         id="neos-LinkEditor-MailTo-recipient"
                         value={email?.recipient?.value ?? ''}
@@ -218,7 +218,7 @@ export const MailTo: ILinkType<MailToLinkModel, MailToOptions> = {
 
                 {options.enabledFields?.subject !== false ? (
                     <div>
-                        <Label htmlFor="neos-LinkEditor-MailTo-subject">{translate('Neos.Neos.Ui:LinkEditor.MailTo:subject.label', '')}</Label>
+                        <Label htmlFor="neos-LinkEditor-MailTo-subject">{translate('Neos.Neos.Ui:LinkEditor.MailTo:subject.label')}</Label>
                         <TextInput
                             id="neos-LinkEditor-MailTo-subject"
                             value={email?.subject?.value ?? ''}
@@ -231,12 +231,12 @@ export const MailTo: ILinkType<MailToLinkModel, MailToOptions> = {
                 ) : null}
                 {options.enabledFields?.cc !== false ? (
                     <div>
-                        <Label htmlFor="neos-LinkEditor-MailTo-cc">{translate('Neos.Neos.Ui:LinkEditor.MailTo:cc.label', '')}</Label>
+                        <Label htmlFor="neos-LinkEditor-MailTo-cc">{translate('Neos.Neos.Ui:LinkEditor.MailTo:cc.label')}</Label>
                         <TextInput
                             id="neos-LinkEditor-MailTo-cc"
                             value={email?.cc?.value ?? ''}
                             onChange={setCc}
-                            placeholder={translate('Neos.Neos.Ui:LinkEditor.MailTo:cc.placeholder', '')}
+                            placeholder={translate('Neos.Neos.Ui:LinkEditor.MailTo:cc.placeholder')}
                         />
                         {email?.cc?.warning ? (
                             <Tooltip renderInline asWarning>{email?.cc.warning}</Tooltip>
@@ -245,12 +245,12 @@ export const MailTo: ILinkType<MailToLinkModel, MailToOptions> = {
                 ) : null}
                 {options.enabledFields?.bcc !== false ? (
                     <div>
-                        <Label htmlFor="neos-LinkEditor-MailTo-bcc">{translate('Neos.Neos.Ui:LinkEditor.MailTo:bcc.label', '')}</Label>
+                        <Label htmlFor="neos-LinkEditor-MailTo-bcc">{translate('Neos.Neos.Ui:LinkEditor.MailTo:bcc.label')}</Label>
                         <TextInput
                             id="neos-LinkEditor-MailTo-bcc"
                             value={email?.bcc?.value ?? ''}
                             onChange={setBcc}
-                            placeholder={translate('Neos.Neos.Ui:LinkEditor.MailTo:bcc.placeholder', '')}
+                            placeholder={translate('Neos.Neos.Ui:LinkEditor.MailTo:bcc.placeholder')}
                         />
                         {email?.bcc?.warning ? (
                             <Tooltip renderInline asWarning>{email?.bcc.warning}</Tooltip>
@@ -259,7 +259,7 @@ export const MailTo: ILinkType<MailToLinkModel, MailToOptions> = {
                 ) : null}
                 {options.enabledFields?.body !== false ? (
                     <div>
-                        <Label htmlFor="neos-LinkEditor-MailTo-body">{translate('Neos.Neos.Ui:LinkEditor.MailTo:body.label', '')}</Label>
+                        <Label htmlFor="neos-LinkEditor-MailTo-body">{translate('Neos.Neos.Ui:LinkEditor.MailTo:body.label')}</Label>
                         <TextArea
                             id="neos-LinkEditor-MailTo-body"
                             value={email?.body?.value ?? ''}

--- a/packages/neos-ui-link-editor-core/src/application/LinkTypes/Node/Node.tsx
+++ b/packages/neos-ui-link-editor-core/src/application/LinkTypes/Node/Node.tsx
@@ -40,7 +40,7 @@ const validateModel = (values: NodeLinkModel): NodeLinkModel => ({
         warning: (
             !values.anchor?.value ? undefined : (
                 (values.anchor.value.startsWith(' ') || values.anchor.value.endsWith(' ')) ? (
-                    translate('Neos.Neos.Ui:LinkEditor.Node:anchor.validation.leadingOrTrailingSpace', '')
+                    translate('Neos.Neos.Ui:LinkEditor.Node:anchor.validation.leadingOrTrailingSpace')
                 ) : undefined
             )
         )
@@ -84,7 +84,7 @@ const NodePreview: React.FC<{ nodeId: string, anchor?: string }> = (props) => {
         return (
             <IconCard
                 icon="spinner"
-                title={translate('Neos.Neos.Ui:LinkEditor.Node:loadingPreview', '')}
+                title={translate('Neos.Neos.Ui:LinkEditor.Node:loadingPreview')}
                 subTitle={`node://${props.nodeId}`}
             />
         );
@@ -94,7 +94,7 @@ const NodePreview: React.FC<{ nodeId: string, anchor?: string }> = (props) => {
         <IconCard
             icon={fetch__nodeSummary.value?.icon ?? 'ban'}
             title={<>
-                {fetch__nodeSummary.value?.label ?? translate('Neos.Neos.Ui:LinkEditor.Node:labelOfNonExistingNode', '')}
+                {fetch__nodeSummary.value?.label ?? translate('Neos.Neos.Ui:LinkEditor.Node:labelOfNonExistingNode')}
                 {props.anchor ? <i> #{props.anchor}</i> : ''}
             </>}
             subTitle={breadcrumbs ?? `node://${props.nodeId}`}
@@ -109,7 +109,7 @@ export const Node: ILinkType<NodeLinkModel, NodeLinkOptions> = {
 
     icon: 'file',
 
-    getTitle: () => translate('Neos.Neos.Ui:LinkEditor.Node:title', ''),
+    getTitle: () => translate('Neos.Neos.Ui:LinkEditor.Node:title'),
 
     isSuitableFor,
 
@@ -209,13 +209,13 @@ export const Node: ILinkType<NodeLinkModel, NodeLinkOptions> = {
         return (
             <div>
                 <Label htmlFor="neos-LinkEditor-Node-anchor">
-                    {translate('Neos.Neos.Ui:LinkEditor.Node:anchor.label', '')}
+                    {translate('Neos.Neos.Ui:LinkEditor.Node:anchor.label')}
                 </Label>
                 <TextInput
                     id="neos-LinkEditor-Node-anchor"
                     type="text"
                     value={model?.anchor?.value ?? ''}
-                    placeholder={translate('Neos.Neos.Ui:LinkEditor.Node:anchor.placeholder', '')}
+                    placeholder={translate('Neos.Neos.Ui:LinkEditor.Node:anchor.placeholder')}
                     onChange={setAnchor}
                 />
                 {model?.anchor?.warning ? (

--- a/packages/neos-ui-link-editor-core/src/application/LinkTypes/Phone/Phone.tsx
+++ b/packages/neos-ui-link-editor-core/src/application/LinkTypes/Phone/Phone.tsx
@@ -23,7 +23,7 @@ const validateModel = (model: PhoneLinkModel): PhoneLinkModel => ({
     ...model,
     phoneNumber: {
         ...model.phoneNumber,
-        warning: !model.phoneNumber.value ? translate('Neos.Neos.Ui:LinkEditor.Phone:phoneNumber.validation.required', '') : (!VALID_PHONE_NUMBER.test(model.phoneNumber.value) ? translate('Neos.Neos.Ui:LinkEditor.Phone:phoneNumber.validation.numbersOnly', '') : undefined)
+        warning: !model.phoneNumber.value ? translate('Neos.Neos.Ui:LinkEditor.Phone:phoneNumber.validation.required') : (!VALID_PHONE_NUMBER.test(model.phoneNumber.value) ? translate('Neos.Neos.Ui:LinkEditor.Phone:phoneNumber.validation.numbersOnly') : undefined)
     }
 });
 
@@ -32,7 +32,7 @@ export const Phone: ILinkType<PhoneLinkModel> = {
 
     icon: 'phone-alt',
 
-    getTitle: () => translate('Neos.Neos.Ui:LinkEditor.Phone:title', ''),
+    getTitle: () => translate('Neos.Neos.Ui:LinkEditor.Phone:title'),
 
     isSuitableFor,
 
@@ -87,13 +87,13 @@ export const Phone: ILinkType<PhoneLinkModel> = {
         return (
             <div>
                 <Label htmlFor="neos-LinkEditor-Phone-number">
-                    {translate('Neos.Neos.Ui:LinkEditor.Phone:phoneNumber.label', '')}
+                    {translate('Neos.Neos.Ui:LinkEditor.Phone:phoneNumber.label')}
                 </Label>
                 <TextInput
                     id="neos-LinkEditor-Phone-number"
                     value={model?.phoneNumber?.value ?? ''}
                     onChange={setPhoneNumber}
-                    placeholder={translate('Neos.Neos.Ui:LinkEditor.Phone:phoneNumber.placeholder', '')}
+                    placeholder={translate('Neos.Neos.Ui:LinkEditor.Phone:phoneNumber.placeholder')}
                 />
                 {model?.phoneNumber?.warning ? (
                     <Tooltip renderInline asWarning>{model.phoneNumber.warning}</Tooltip>

--- a/packages/neos-ui-link-editor-core/src/application/LinkTypes/Web/Web.tsx
+++ b/packages/neos-ui-link-editor-core/src/application/LinkTypes/Web/Web.tsx
@@ -23,8 +23,8 @@ const formattingOptionForLinkWithoutHttpsProtocol = (href: string) => {
     }
     // looks like domain
     return {
-        group: translate('Neos.Neos.Ui:LinkEditor.Web:href.formatOptions', ''),
-        label: translate('Neos.Neos.Ui:LinkEditor.Web:href.formatAsHttp', ''),
+        group: translate('Neos.Neos.Ui:LinkEditor.Web:href.formatOptions'),
+        label: translate('Neos.Neos.Ui:LinkEditor.Web:href.formatAsHttp'),
         value: `https://${href}`
     };
 };
@@ -37,17 +37,17 @@ const validateModel = (values: WebLinkModel): WebLinkModel => ({
             !values.href?.value ? undefined : (
                 // eslint-disable-next-line no-script-url
                 values.href.value.includes('javascript:') ? (
-                    translate('Neos.Neos.Ui:LinkEditor.Web:href.validation.javascriptSchema', '')
+                    translate('Neos.Neos.Ui:LinkEditor.Web:href.validation.javascriptSchema')
                 ) : values.href.value.startsWith('node://') ? (
-                    translate('Neos.Neos.Ui:LinkEditor.Web:href.validation.nodeSchema', '')
+                    translate('Neos.Neos.Ui:LinkEditor.Web:href.validation.nodeSchema')
                 ) : values.href.value.startsWith('asset://') ? (
-                    translate('Neos.Neos.Ui:LinkEditor.Web:href.validation.assetSchema', '')
+                    translate('Neos.Neos.Ui:LinkEditor.Web:href.validation.assetSchema')
                 ) : values.href.value.startsWith('tel:') ? (
-                    translate('Neos.Neos.Ui:LinkEditor.Web:href.validation.telSchema', '')
+                    translate('Neos.Neos.Ui:LinkEditor.Web:href.validation.telSchema')
                 ) : values.href.value.startsWith('mailto:') ? (
-                    translate('Neos.Neos.Ui:LinkEditor.Web:href.validation.telSchema', '')
+                    translate('Neos.Neos.Ui:LinkEditor.Web:href.validation.telSchema')
                 ) : (values.href.value.startsWith(' ') || values.href.value.endsWith(' ')) ? (
-                    translate('Neos.Neos.Ui:LinkEditor.Web:href.validation.leadingOrTrailingSpace', '')
+                    translate('Neos.Neos.Ui:LinkEditor.Web:href.validation.leadingOrTrailingSpace')
                 ) : undefined
             )
         )
@@ -59,7 +59,7 @@ export const Web: ILinkType<WebLinkModel> = {
 
     icon: 'globe',
 
-    getTitle: () => translate('Neos.Neos.Ui:LinkEditor.Web:title', ''),
+    getTitle: () => translate('Neos.Neos.Ui:LinkEditor.Web:title'),
 
     isSuitableFor,
 
@@ -110,7 +110,7 @@ export const Web: ILinkType<WebLinkModel> = {
         return (
             <div>
                 <Label htmlFor="neos-LinkEditor-Web-href">
-                    {translate('Neos.Neos.Ui:LinkEditor.Web:label.link', '')}
+                    {translate('Neos.Neos.Ui:LinkEditor.Web:label.link')}
                 </Label>
                 <div>
                     <SelectBox
@@ -122,7 +122,7 @@ export const Web: ILinkType<WebLinkModel> = {
                         placeholderIcon={'link'}
                         onValueChange={setHref}
                         threshold={0}
-                        placeholder={translate('Neos.Neos.Ui:LinkEditor.Web:href.placeholder', '')}
+                        placeholder={translate('Neos.Neos.Ui:LinkEditor.Web:href.placeholder')}
                         displaySearchBox={true}
                         showDropDownToggle={false}
                         allowEmpty={false}

--- a/packages/neos-ui-link-editor-custom-node-tree/src/application/SelectNodeTypeFilter.tsx
+++ b/packages/neos-ui-link-editor-custom-node-tree/src/application/SelectNodeTypeFilter.tsx
@@ -66,7 +66,7 @@ export const SelectNodeTypeFilter: React.FC<Props> = (props) => {
     return (
         <SelectBox
             disabled={fetch__options.error}
-            placeholder={translate('Neos.Neos:Main:filter', '')}
+            placeholder={translate('Neos.Neos:Main:filter')}
             placeholderIcon={'filter'}
             onValueChange={props.onChange}
             allowEmpty={true}
@@ -76,8 +76,8 @@ export const SelectNodeTypeFilter: React.FC<Props> = (props) => {
             searchTerm={filterTerm}
             onSearchTermChange={setFilterTerm}
             threshold={0}
-            noMatchesFoundLabel={translate('Neos.Neos:Main:noMatchesFound', '')}
-            searchBoxLeftToTypeLabel={translate('Neos.Neos:Main:searchBoxLeftToType', '')}
+            noMatchesFoundLabel={translate('Neos.Neos:Main:noMatchesFound')}
+            searchBoxLeftToTypeLabel={translate('Neos.Neos:Main:searchBoxLeftToType')}
         />
     );
 };

--- a/packages/neos-ui-link-editor-custom-node-tree/src/presentation/SearchInput/index.tsx
+++ b/packages/neos-ui-link-editor-custom-node-tree/src/presentation/SearchInput/index.tsx
@@ -30,7 +30,7 @@ export const SearchInput: React.FC<Props> = props => {
                 className={styles.textInput}
                 type="search"
                 value={props.value}
-                placeholder={translate('Neos.Neos:Main:search', '')}
+                placeholder={translate('Neos.Neos:Main:search')}
                 onChange={props.onChange}
             />
             {props.value && (

--- a/packages/neos-ui-link-editor-inspector/src/InspectorEditor.tsx
+++ b/packages/neos-ui-link-editor-inspector/src/InspectorEditor.tsx
@@ -124,7 +124,7 @@ export const createInspectorEditor = (dataType: LinkDataType, editor: IEditor) =
         return (
             <Button id={props.id} disabled={props.options?.disabled} onClick={editLink}>
                 <Icon icon="link" padded="right"/>
-                {translate('Neos.Neos.Ui:LinkEditor.Main:inspector.create', '')}
+                {translate('Neos.Neos.Ui:LinkEditor.Main:inspector.create')}
             </Button>
         );
     }
@@ -174,7 +174,7 @@ const InspectorEditorWithLinkType: React.FC<{
                 <ErrorView error={error} />
             ) : (
                 <SeamlessButton
-                    title={translate('Neos.Neos.Ui:LinkEditor.Main:inspector.edit', '')}
+                    title={translate('Neos.Neos.Ui:LinkEditor.Main:inspector.edit')}
                     onClick={props.editLink}
                 >
                     <Preview

--- a/packages/neos-ui-sagas/src/Publish/index.ts
+++ b/packages/neos-ui-sagas/src/Publish/index.ts
@@ -52,8 +52,7 @@ const PUBLISH_SUCCESS_TRANSLATIONS = {
         id: 'Neos.Neos.Ui:PublishingDialog:publish.document.success.message',
         fallback: '{numberOfChanges} change(s) in document "{scopeTitle}" were sucessfully published to workspace "{targetWorkspaceName}".'
     }
-
-}
+} as const;
 
 export function * watchPublishing({routes}: {routes: Routes}) {
     const {endpoints} = backend.get();

--- a/packages/neos-ui-sagas/src/UI/Impersonate/index.js
+++ b/packages/neos-ui-sagas/src/UI/Impersonate/index.js
@@ -3,19 +3,13 @@ import {call, takeEvery} from 'redux-saga/effects';
 import {actionTypes} from '@neos-project/neos-ui-redux-store';
 import backend from '@neos-project/neos-ui-backend-connector';
 import {showFlashMessage} from '@neos-project/neos-ui-error';
+import {translate} from '@neos-project/neos-ui-i18n';
 
-export function * impersonateRestore({globalRegistry, routes}) {
+export function * impersonateRestore({routes}) {
     const {impersonateRestore} = backend.get().endpoints;
-    const i18nRegistry = globalRegistry.get('i18n');
 
     yield takeEvery(actionTypes.User.Impersonate.RESTORE, function * restore(action) {
-        const errorMessage = i18nRegistry.translate(
-            'impersonate.error.restoreUser',
-            'Could not switch back to the original user.',
-            {},
-            'Neos.Neos',
-            'Main'
-        );
+        const errorMessage = translate('Neos.Neos:Main:impersonate.error.restoreUser', 'Could not switch back to the original user.');
 
         try {
             const feedback = yield call(impersonateRestore, action.payload);
@@ -23,16 +17,7 @@ export function * impersonateRestore({globalRegistry, routes}) {
             const user = feedback?.impersonate?.accountIdentifier;
             const status = feedback?.status;
 
-            const restoreMessage = i18nRegistry.translate(
-                'impersonate.success.restoreUser',
-                'Switched back from {0} to the orginal user {1}.',
-                {
-                    0: user,
-                    1: originUser
-                },
-                'Neos.Neos',
-                'Main'
-            );
+            const restoreMessage = translate('Neos.Neos:Main:impersonate.success.restoreUser', 'Switched back from {0} to the orginal user {1}.', {0: user, 1: originUser});
 
             if (status) {
                 showFlashMessage({

--- a/packages/neos-ui-validators/src/Count/index.spec.js
+++ b/packages/neos-ui-validators/src/Count/index.spec.js
@@ -1,4 +1,9 @@
 import countValidator from './index';
+import {setupI18n} from "@neos-project/neos-ui-i18n";
+
+beforeAll(() => {
+    setupI18n('en-US', 'one,other', {});
+});
 
 test('2 element object should be valid for min:0 max: 10', () => {
     const validatorOptions = {

--- a/packages/neos-ui-validators/src/Count/index.spec.js
+++ b/packages/neos-ui-validators/src/Count/index.spec.js
@@ -1,5 +1,5 @@
 import countValidator from './index';
-import {setupI18n} from "@neos-project/neos-ui-i18n";
+import {setupI18n} from '@neos-project/neos-ui-i18n';
 
 beforeAll(() => {
     setupI18n('en-US', 'one,other', {});

--- a/packages/neos-ui-validators/src/Count/index.tsx
+++ b/packages/neos-ui-validators/src/Count/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import I18n from '@neos-project/neos-ui-i18n';
+import I18n, {translate} from '@neos-project/neos-ui-i18n';
 import logger from '@neos-project/utils-logger';
 
 /**
@@ -28,7 +28,7 @@ const Count = (value: any, validatorOptions: CountOptions) => {
     }
 
     if (typeof value !== 'object' || value === null) {
-        return <I18n id="content.inspector.validators.countValidator.notCountable"/>;
+        return translate('Neos.Neos:Main:content.inspector.validators.countValidator.notCountable', '');
     }
 
     const {length} = Object.keys(value);

--- a/packages/neos-ui-validators/src/Count/index.tsx
+++ b/packages/neos-ui-validators/src/Count/index.tsx
@@ -28,7 +28,7 @@ const Count = (value: any, validatorOptions: CountOptions) => {
     }
 
     if (typeof value !== 'object' || value === null) {
-        return translate('Neos.Neos:Main:content.inspector.validators.countValidator.notCountable', '');
+        return translate('Neos.Neos:Main:content.inspector.validators.countValidator.notCountable');
     }
 
     const {length} = Object.keys(value);

--- a/packages/neos-ui-validators/src/NumberRange/index.spec.js
+++ b/packages/neos-ui-validators/src/NumberRange/index.spec.js
@@ -1,5 +1,5 @@
 import numberRangeValidator from './index';
-import {setupI18n} from "@neos-project/neos-ui-i18n";
+import {setupI18n} from '@neos-project/neos-ui-i18n';
 
 beforeAll(() => {
     setupI18n('en-US', 'one,other', {});

--- a/packages/neos-ui-validators/src/NumberRange/index.spec.js
+++ b/packages/neos-ui-validators/src/NumberRange/index.spec.js
@@ -1,4 +1,9 @@
 import numberRangeValidator from './index';
+import {setupI18n} from "@neos-project/neos-ui-i18n";
+
+beforeAll(() => {
+    setupI18n('en-US', 'one,other', {});
+});
 
 test('0 for min: 0 max: 10 should be valid', () => {
     const validatorOptions = {

--- a/packages/neos-ui-validators/src/NumberRange/index.tsx
+++ b/packages/neos-ui-validators/src/NumberRange/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import I18n from '@neos-project/neos-ui-i18n';
+import I18n, {translate} from '@neos-project/neos-ui-i18n';
 import logger from '@neos-project/utils-logger';
 
 /**
@@ -33,7 +33,7 @@ const NumberRange = (value: any, validatorOptions: NumberRangeOptions) => {
     }
 
     if (value.length > 0 && !Number.isSafeInteger(number)) {
-        return <I18n id="content.inspector.validators.numberRangeValidator.validNumberExpected"/>;
+        return translate('Neos.Neos:Main:content.inspector.validators.numberRangeValidator.validNumberExpected', '');
     }
     if (number < minimum || number > maximum) {
         const label = validatorOptions?.validationErrorMessage ?? 'content.inspector.validators.numberRangeValidator.numberShouldBeInRange';

--- a/packages/neos-ui-validators/src/NumberRange/index.tsx
+++ b/packages/neos-ui-validators/src/NumberRange/index.tsx
@@ -33,7 +33,7 @@ const NumberRange = (value: any, validatorOptions: NumberRangeOptions) => {
     }
 
     if (value.length > 0 && !Number.isSafeInteger(number)) {
-        return translate('Neos.Neos:Main:content.inspector.validators.numberRangeValidator.validNumberExpected', '');
+        return translate('Neos.Neos:Main:content.inspector.validators.numberRangeValidator.validNumberExpected');
     }
     if (number < minimum || number > maximum) {
         const label = validatorOptions?.validationErrorMessage ?? 'content.inspector.validators.numberRangeValidator.numberShouldBeInRange';

--- a/packages/neos-ui-validators/src/StringLength/index.spec.js
+++ b/packages/neos-ui-validators/src/StringLength/index.spec.js
@@ -1,4 +1,16 @@
 import stringLengthValidator from './index';
+import {setupI18n} from '@neos-project/neos-ui-i18n';
+
+beforeAll(() => {
+    setupI18n('en-US', 'one,other', {
+        'Neos_Neos': {
+            'Main': {
+                'content.inspector.validators.stringLength.smallerThanMinimum': 'This field must contain at least {minimum} characters.',
+                'content.inspector.validators.stringLength.greaterThanMaximum': 'This text may not exceed {maximum} characters.'
+            }
+        }
+    });
+});
 
 test('"123" should be valid for min: 0 max: 10', () => {
     const validatorOptions = {

--- a/packages/neos-ui-validators/src/StringLength/index.tsx
+++ b/packages/neos-ui-validators/src/StringLength/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import I18n from '@neos-project/neos-ui-i18n';
+import I18n, {translate} from '@neos-project/neos-ui-i18n';
 import logger from '@neos-project/utils-logger';
 
 /**
@@ -43,9 +43,9 @@ const StringLength = (value: any, validatorOptions: StringLengthOptions) => {
             return <I18n id={label} params={{minimum, maximum}}/>;
         }
         if (minimum > 0) {
-            return <I18n id="content.inspector.validators.stringLength.smallerThanMinimum" params={{minimum}}/>;
+            return translate('Neos.Neos:Main:content.inspector.validators.stringLength.smallerThanMinimum', '', {minimum});
         }
-        return <I18n id="content.inspector.validators.stringLength.greaterThanMaximum" params={{maximum}}/>;
+        return translate('Neos.Neos:Main:content.inspector.validators.stringLength.greaterThanMaximum', '', {maximum});
     }
     return null;
 };

--- a/packages/neos-ui-views/src/Data/DataLoader/index.js
+++ b/packages/neos-ui-views/src/Data/DataLoader/index.js
@@ -5,9 +5,9 @@ import {neos} from '@neos-project/neos-ui-decorators';
 import {selectors} from '@neos-project/neos-ui-redux-store';
 import Widget from '../../Widget/index';
 import Icon from '@neos-project/react-ui-components/src/Icon/';
-import I18n from '@neos-project/neos-ui-i18n';
 import style from './style.module.css';
 import isEqual from 'lodash.isequal';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 /*
  * This HOC is responsible for fetching data for Data views and wraping
@@ -91,7 +91,7 @@ export default () => WrappedComponent => {
             }
 
             if (!this.state.data) {
-                return (<div><I18n id="Neos.Neos:Main:loading"/></div>);
+                return (<div>{translate('Neos.Neos:Main:loading')}</div>);
             }
 
             return (<WrappedComponent data={this.state.data} {...this.props}/>);

--- a/packages/neos-ui-views/src/NodeInfoView/index.js
+++ b/packages/neos-ui-views/src/NodeInfoView/index.js
@@ -1,26 +1,21 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-import {neos} from '@neos-project/neos-ui-decorators';
 import {selectors} from '@neos-project/neos-ui-redux-store';
 import {IconButton} from '@neos-project/react-ui-components';
 import {showFlashMessage} from '@neos-project/neos-ui-error';
 import style from './style.module.css';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 @connect(state => ({
     focusedNodeContextPath: selectors.CR.Nodes.focusedNodePathSelector(state),
     getNodeByContextPath: selectors.CR.Nodes.nodeByContextPath(state)
 }))
-@neos(globalRegistry => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}))
 export default class NodeInfoView extends PureComponent {
     static propTypes = {
         commit: PropTypes.func.isRequired,
         focusedNodeContextPath: PropTypes.string,
-        getNodeByContextPath: PropTypes.func.isRequired,
-
-        i18nRegistry: PropTypes.object.isRequired
+        getNodeByContextPath: PropTypes.func.isRequired
     }
 
     nodeTypeNameRef = React.createRef();
@@ -45,7 +40,7 @@ export default class NodeInfoView extends PureComponent {
     }
 
     render() {
-        const {focusedNodeContextPath, getNodeByContextPath, i18nRegistry} = this.props;
+        const {focusedNodeContextPath, getNodeByContextPath} = this.props;
 
         const node = getNodeByContextPath(focusedNodeContextPath);
         const properties = {
@@ -64,34 +59,34 @@ export default class NodeInfoView extends PureComponent {
         return (
             <ul className={style.nodeInfoView}>
                 <li className={style.nodeInfoView__item} title={new Date(properties.created).toLocaleString()}>
-                    <div className={style.nodeInfoView__title}>{i18nRegistry.translate('created', 'Created', {}, 'Neos.Neos')}</div>
+                    <div className={style.nodeInfoView__title}>{translate('Neos.Neos:Main:created', 'Created')}</div>
                     <NodeInfoViewContent>{new Date(properties.created).toLocaleString()}</NodeInfoViewContent>
                 </li>
                 <li className={style.nodeInfoView__item} title={new Date(properties.lastModification).toLocaleString()}>
-                    <div className={style.nodeInfoView__title}>{i18nRegistry.translate('lastModification', 'Last modification', {}, 'Neos.Neos')}</div>
-                    <NodeInfoViewContent>{properties.lastModification ? new Date(properties.lastModification).toLocaleString() : i18nRegistry.translate('unavailable', 'unavailable', {}, 'Neos.Neos')}</NodeInfoViewContent>
+                    <div className={style.nodeInfoView__title}>{translate('Neos.Neos:Main:lastModification', 'Last modification')}</div>
+                    <NodeInfoViewContent>{properties.lastModification ? new Date(properties.lastModification).toLocaleString() : translate('Neos.Neos:Main:unavailable', 'unavailable')}</NodeInfoViewContent>
                 </li>
                 <li className={style.nodeInfoView__item} title={new Date(properties.lastPublication).toLocaleString()}>
-                    <div className={style.nodeInfoView__title}>{i18nRegistry.translate('lastPublication', 'Last publication', {}, 'Neos.Neos')}</div>
-                    <NodeInfoViewContent>{properties.lastPublication ? new Date(properties.lastPublication).toLocaleString() : i18nRegistry.translate('unavailable', 'unavailable', {}, 'Neos.Neos')}</NodeInfoViewContent>
+                    <div className={style.nodeInfoView__title}>{translate('Neos.Neos:Main:lastPublication', 'Last publication')}</div>
+                    <NodeInfoViewContent>{properties.lastPublication ? new Date(properties.lastPublication).toLocaleString() : translate('Neos.Neos:Main:unavailable', 'unavailable')}</NodeInfoViewContent>
                 </li>
                 <li className={style.nodeInfoView__item} title={properties.identifier}>
-                    <div className={style.nodeInfoView__title}>{i18nRegistry.translate('identifier', 'Identifier', {}, 'Neos.Neos')}</div>
+                    <div className={style.nodeInfoView__title}>{translate('Neos.Neos:Main:identifier', 'Identifier')}</div>
                     <NodeInfoViewContent>{properties.identifier}</NodeInfoViewContent>
                 </li>
                 <li className={style.nodeInfoView__item} title={properties.nodeAddress}>
-                    <div className={style.nodeInfoView__title}>{i18nRegistry.translate('nodeAddress', 'Node Address', {}, 'Neos.Neos')}</div>
+                    <div className={style.nodeInfoView__title}>{translate('Neos.Neos:Main:nodeAddress', 'Node Address')}</div>
                     <NodeInfoViewContent>{properties.nodeAddress}</NodeInfoViewContent>
                 </li>
                 {properties.name ? (
                     <li className={style.nodeInfoView__item} title={properties.name}>
-                        <div className={style.nodeInfoView__title}>{i18nRegistry.translate('name', 'Name', {}, 'Neos.Neos')}</div>
-                        <NodeInfoViewContent>{properties.name ?? i18nRegistry.translate('unavailable', 'unavailable', {}, 'Neos.Neos')}</NodeInfoViewContent>
+                        <div className={style.nodeInfoView__title}>{translate('Neos.Neos:Main:name', 'Name')}</div>
+                        <NodeInfoViewContent>{properties.name ?? translate('Neos.Neos:Main:unavailable', 'unavailable')}</NodeInfoViewContent>
                     </li>
                 ) : ''}
                 <li className={style.nodeInfoView__item} title={nodeType}>
                     <div
-                        className={style.nodeInfoView__title}>{i18nRegistry.translate('type', 'Type', {}, 'Neos.Neos')}</div>
+                        className={style.nodeInfoView__title}>{translate('Neos.Neos:Main:type', 'Type')}</div>
                     <textarea ref={this.nodeTypeNameRef} className={style.nodeInfoView__nodeTypeTextarea} value={nodeType} readOnly></textarea>
                     <NodeInfoViewContent>
                         <span dangerouslySetInnerHTML={{__html: wrappingNodeTypeName}}></span>
@@ -99,7 +94,7 @@ export default class NodeInfoView extends PureComponent {
                     <IconButton
                         className={style.nodeInfoView__copyButton}
                         icon="copy"
-                        title={i18nRegistry.translate('copyNodeTypeNameToClipboard', 'Copy node type to clipboard', {}, 'Neos.Neos.Ui')}
+                        title={translate('Neos.Neos.Ui:Main:copyNodeTypeNameToClipboard', 'Copy node type to clipboard')}
                         onClick={this.copyNodeToClipboard}
                     />
                 </li>

--- a/packages/neos-ui/src/Containers/Drawer/UserDropDown/RestoreButtonItem.js
+++ b/packages/neos-ui/src/Containers/Drawer/UserDropDown/RestoreButtonItem.js
@@ -2,10 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {Icon} from '@neos-project/react-ui-components';
-import {neos} from '@neos-project/neos-ui-decorators';
 import {connect} from 'react-redux';
 import {actions} from '@neos-project/neos-ui-redux-store';
-import I18n from '@neos-project/neos-ui-i18n';
+import I18n, {translate} from '@neos-project/neos-ui-i18n';
 
 import buttonTheme from './style.module.css';
 
@@ -17,25 +16,15 @@ import buttonTheme from './style.module.css';
         impersonateRestore: actions.User.Impersonate.restore
     }
 )
-@neos(globalRegistry => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}))
 export default class RestoreButtonItem extends React.PureComponent {
     static propTypes = {
         originUser: PropTypes.object,
-        impersonateRestore: PropTypes.func.isRequired,
-        i18nRegistry: PropTypes.object.isRequired
+        impersonateRestore: PropTypes.func.isRequired
     };
 
     render() {
-        const {originUser, i18nRegistry, impersonateRestore} = this.props;
-        const title = i18nRegistry.translate(
-            'impersonate.title.restoreUserButton',
-            'Switch back to the orginal user account',
-            {},
-            'Neos.Neos',
-            'Main'
-        );
+        const {originUser, impersonateRestore} = this.props;
+        const title = translate('Neos.Neos:Main:impersonate.title.restoreUserButton', 'Switch back to the orginal user account',);
 
         return (originUser ? (
             <li className={buttonTheme.dropDown__item}>

--- a/packages/neos-ui/src/Containers/Drawer/UserDropDown/RestoreButtonItem.js
+++ b/packages/neos-ui/src/Containers/Drawer/UserDropDown/RestoreButtonItem.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import {Icon} from '@neos-project/react-ui-components';
 import {connect} from 'react-redux';
 import {actions} from '@neos-project/neos-ui-redux-store';
-import I18n, {translate} from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 import buttonTheme from './style.module.css';
 
@@ -39,13 +39,7 @@ export default class RestoreButtonItem extends React.PureComponent {
                         aria-hidden="true"
                         className={buttonTheme.dropDown__itemIcon}
                     />
-                    <I18n
-                        id="impersonate.label.restoreUserButton"
-                        sourceName="Main"
-                        packageKey="Neos.Neos"
-                        fallback={`Back to user "${originUser.fullName}"`}
-                        params={{0: originUser.fullName}}
-                    />
+                    {translate('Neos.Neos:Main:impersonate.label.restoreUserButton', 'Back to user "{0}"', {0: originUser.fullName})}
                 </button>
             </li>
         ) : null);

--- a/packages/neos-ui/src/Containers/Drawer/UserDropDown/index.js
+++ b/packages/neos-ui/src/Containers/Drawer/UserDropDown/index.js
@@ -8,7 +8,7 @@ import UserImage from './UserImage';
 import RestoreButtonItem from './RestoreButtonItem';
 import {fetchWithErrorHandling} from '@neos-project/neos-ui-backend-connector';
 
-import I18n from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 import style from './style.module.css';
 @connect(state => ({
@@ -37,7 +37,7 @@ export default class UserDropDown extends PureComponent {
                         <li className={style.dropDown__item}>
                             <a title="User Settings" href={userSettingsUri}>
                                 <Icon icon="wrench" aria-hidden="true" className={style.dropDown__itemIcon}/>
-                                <I18n id="userSettings.label" sourceName="Modules" packageKey="Neos.Neos" fallback="User Settings"/>
+                                {translate('Neos.Neos:Modules:userSettings.label', 'User Settings')}
                             </a>
                         </li>
                         <li className={style.dropDown__item}>
@@ -45,7 +45,7 @@ export default class UserDropDown extends PureComponent {
                                 <input type="hidden" name="__csrfToken" value={csrfToken}/>
                                 <button onClick={e => e.stopPropagation()} type="submit" name="" value="logout">
                                     <Icon icon="sign-out-alt" aria-hidden="true" className={style.dropDown__itemIcon}/>
-                                    <I18n id="logout" sourceName="Main" packageKey="Neos.Neos" fallback="Logout"/>
+                                    {translate('Neos.Neos:Main:logout', 'Logout')}
                                 </button>
                             </form>
                         </li>

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
@@ -13,6 +13,7 @@ import {PageTreeNode, ContentTreeNode} from './Node/index';
 
 import style from './style.module.css';
 import {neos} from '@neos-project/neos-ui-decorators';
+import {translate} from '@neos-project/neos-ui-i18n';
 import {getConfiguration} from '@neos-project/neos-ui-configuration';
 
 const ConnectedDragLayer = connect((state, {currentlyDraggedNodes}) => {
@@ -36,8 +37,7 @@ export default class NodeTree extends PureComponent {
         setActiveContentCanvasContextPath: PropTypes.func,
         moveNodes: PropTypes.func,
         allCollapsibleNodes: PropTypes.object,
-        loadingDepth: PropTypes.number,
-        i18nRegistry: PropTypes.object.isRequired
+        loadingDepth: PropTypes.number
     };
 
     state = {
@@ -132,7 +132,7 @@ export default class NodeTree extends PureComponent {
     }
 
     render() {
-        const {rootNode, ChildRenderer, i18nRegistry} = this.props;
+        const {rootNode, ChildRenderer} = this.props;
         if (!rootNode) {
             return (
                 <div className={style.loader}>
@@ -150,7 +150,7 @@ export default class NodeTree extends PureComponent {
                 <button
                     onClick={this.handleCollapseAll}
                     className={style.collapseAll}
-                    title={i18nRegistry.translate('Neos.Neos.Ui:Main:collapseAll')}
+                    title={translate('Neos.Neos.Ui:Main:collapseAll')}
                 >
                     <Icon className={style.collapseAllIcon} icon="compress-alt"/>
                 </button>
@@ -178,12 +178,11 @@ export default class NodeTree extends PureComponent {
     }
 }
 
-const withNodeTypeRegistryAndI18nRegistry = neos(globalRegistry => ({
-    nodeTypesRegistry: globalRegistry.get('@neos-project/neos-ui-contentrepository'),
-    i18nRegistry: globalRegistry.get('i18n')
+const withNodeTypeRegistry = neos(globalRegistry => ({
+    nodeTypesRegistry: globalRegistry.get('@neos-project/neos-ui-contentrepository')
 }));
 
-export const PageTree = withNodeTypeRegistryAndI18nRegistry(connect(
+export const PageTree = withNodeTypeRegistry(connect(
     (state, {nodeTypesRegistry}) => {
         const documentNodesSelector = selectors.CR.Nodes.makeGetCollapsibleDocumentNodes(nodeTypesRegistry);
         return ({
@@ -208,7 +207,7 @@ export const PageTree = withNodeTypeRegistryAndI18nRegistry(connect(
     }
 )(NodeTree));
 
-export const ContentTree = withNodeTypeRegistryAndI18nRegistry(connect(
+export const ContentTree = withNodeTypeRegistry(connect(
     (state, {nodeTypesRegistry}) => {
         const contentNodesSelector = selectors.CR.Nodes.makeGetCollapsibleContentNodes(nodeTypesRegistry);
         return ({

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/NodeTreeFilter/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/NodeTreeFilter/index.js
@@ -5,6 +5,7 @@ import {neos} from '@neos-project/neos-ui-decorators';
 import {SelectBox} from '@neos-project/react-ui-components';
 
 import {searchOptions} from '@neos-project/neos-ui-editors/src/Editors/SelectBox/selectBoxHelpers.js';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 import style from './style.module.css';
 import {getConfiguration} from '@neos-project/neos-ui-configuration';
@@ -70,8 +71,8 @@ export default class NodeTreeFilter extends PureComponent {
                     searchTerm={this.state.filterTerm}
                     onSearchTermChange={this.handleFilterTermChange}
                     threshold={0}
-                    noMatchesFoundLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}
-                    searchBoxLeftToTypeLabel={this.props.i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
+                    noMatchesFoundLabel={translate('Neos.Neos:Main:noMatchesFound')}
+                    searchBoxLeftToTypeLabel={translate('Neos.Neos:Main:searchBoxLeftToType')}
                     />
             </div>
         );

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/NodeTreeFilter/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/NodeTreeFilter/index.js
@@ -33,7 +33,7 @@ export default class NodeTreeFilter extends PureComponent {
 
     render() {
         const {i18nRegistry, nodeTypesRegistry, onChange, value} = this.props;
-        const label = i18nRegistry.translate('filter', 'Filter', {}, 'Neos.Neos', 'Main');
+        const label = translate('Neos.Neos:Main:filter', 'Filter');
 
         const presets = getConfiguration(configuration => configuration?.nodeTree?.presets);
         let options = Object.keys(presets)

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeSearchBar/index.js
@@ -4,7 +4,7 @@ import {connect} from 'react-redux';
 import debounce from 'lodash.debounce';
 import mergeClassNames from 'classnames';
 
-import {neos} from '@neos-project/neos-ui-decorators';
+import {translate} from '@neos-project/neos-ui-i18n';
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 
 import {IconButton} from '@neos-project/react-ui-components';
@@ -14,10 +14,6 @@ import style from './style.module.css';
 
 const searchDelay = 300;
 
-@neos(globalRegistry => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}))
-
 @connect(state => ({
     isSearchBarVisible: state?.ui?.leftSideBar?.searchBar?.isVisible
 }), {
@@ -26,7 +22,6 @@ const searchDelay = 300;
 
 class NodeTreeSearchBar extends PureComponent {
     static propTypes = {
-        i18nRegistry: PropTypes.object.isRequired,
         rootNode: PropTypes.object,
         commenceSearch: PropTypes.func.isRequired,
         isSearchBarVisible: PropTypes.bool.isRequired,
@@ -83,9 +78,9 @@ class NodeTreeSearchBar extends PureComponent {
     }
 
     render() {
-        const {i18nRegistry, isSearchBarVisible} = this.props;
+        const {isSearchBarVisible} = this.props;
         const {searchValue, searchFocused, filterNodeType} = this.state;
-        const searchLabel = i18nRegistry.translate('search', 'Search', {}, 'Neos.Neos', 'Main');
+        const searchLabel = translate('Neos.Neos:Main:search', 'Search');
 
         const searchToggleClassName = mergeClassNames({
             [style.searchToggleButton]: true,

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/AddNode/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/AddNode/index.js
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-
+import {translate} from '@neos-project/neos-ui-i18n';
 import IconButton from '@neos-project/react-ui-components/src/IconButton/';
 
 export default class AddNode extends PureComponent {
@@ -9,8 +9,7 @@ export default class AddNode extends PureComponent {
         id: PropTypes.string,
         onClick: PropTypes.func.isRequired,
         focusedNodeContextPath: PropTypes.string,
-        disabled: PropTypes.bool.isRequired,
-        i18nRegistry: PropTypes.object.isRequired
+        disabled: PropTypes.bool.isRequired
     };
 
     handleClick = () => {
@@ -20,7 +19,7 @@ export default class AddNode extends PureComponent {
     }
 
     render() {
-        const {focusedNodeContextPath, disabled, className, id, i18nRegistry} = this.props;
+        const {focusedNodeContextPath, disabled, className, id} = this.props;
 
         return (
             <span>
@@ -31,7 +30,7 @@ export default class AddNode extends PureComponent {
                     icon="plus"
                     onClick={this.handleClick}
                     hoverStyle="brand"
-                    title={i18nRegistry.translate('createNew')}
+                    title={translate('Neos.Neos:Main:createNew')}
                     />
             </span>
         );

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/CopySelectedNode/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/CopySelectedNode/index.js
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-
+import {translate} from '@neos-project/neos-ui-i18n';
 import IconButton from '@neos-project/react-ui-components/src/IconButton/';
 
 export default class CopySelectedNode extends PureComponent {
@@ -15,9 +15,7 @@ export default class CopySelectedNode extends PureComponent {
 
         disabled: PropTypes.bool,
 
-        isActive: PropTypes.bool,
-
-        i18nRegistry: PropTypes.object.isRequired
+        isActive: PropTypes.bool
     };
 
     handleClick = () => {
@@ -31,8 +29,7 @@ export default class CopySelectedNode extends PureComponent {
             className,
             id,
             disabled,
-            isActive,
-            i18nRegistry
+            isActive
         } = this.props;
 
         return (
@@ -44,7 +41,7 @@ export default class CopySelectedNode extends PureComponent {
                 onClick={this.handleClick}
                 icon="far copy"
                 hoverStyle="brand"
-                title={i18nRegistry.translate('copy')}
+                title={translate('Neos.Neos:Main:copy')}
                 />
         );
     }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/CutSelectedNode/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/CutSelectedNode/index.js
@@ -1,6 +1,7 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import IconButton from '@neos-project/react-ui-components/src/IconButton/';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 export default class CutSelectedNode extends PureComponent {
     static propTypes = {
@@ -11,8 +12,7 @@ export default class CutSelectedNode extends PureComponent {
         disabled: PropTypes.bool.isRequired,
         isActive: PropTypes.bool.isRequired,
 
-        onClick: PropTypes.func.isRequired,
-        i18nRegistry: PropTypes.object.isRequired
+        onClick: PropTypes.func.isRequired
     };
 
     handleClick = () => {
@@ -22,7 +22,7 @@ export default class CutSelectedNode extends PureComponent {
     }
 
     render() {
-        const {className, id, disabled, isActive, i18nRegistry} = this.props;
+        const {className, id, disabled, isActive} = this.props;
 
         return (
             <IconButton
@@ -33,7 +33,7 @@ export default class CutSelectedNode extends PureComponent {
                 onClick={this.handleClick}
                 icon="cut"
                 hoverStyle="brand"
-                title={i18nRegistry.translate('cut')}
+                title={translate('Neos.Neos:Main:cut')}
                 />
         );
     }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/DeleteSelectedNode/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/DeleteSelectedNode/index.js
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-
+import {translate} from '@neos-project/neos-ui-i18n';
 import IconButton from '@neos-project/react-ui-components/src/IconButton/';
 
 export default class DeleteSelectedNode extends PureComponent {
@@ -11,9 +11,7 @@ export default class DeleteSelectedNode extends PureComponent {
         focusedNodeContextPath: PropTypes.string,
         disabled: PropTypes.bool.isRequired,
 
-        onClick: PropTypes.func.isRequired,
-
-        i18nRegistry: PropTypes.object.isRequired
+        onClick: PropTypes.func.isRequired
     };
 
     handleClick = () => {
@@ -23,7 +21,7 @@ export default class DeleteSelectedNode extends PureComponent {
     }
 
     render() {
-        const {className, id, disabled, i18nRegistry} = this.props;
+        const {className, id, disabled} = this.props;
 
         return (
             <IconButton
@@ -33,7 +31,7 @@ export default class DeleteSelectedNode extends PureComponent {
                 onClick={this.handleClick}
                 icon="trash-alt"
                 hoverStyle="brand"
-                title={i18nRegistry.translate('delete')}
+                title={translate('Neos.Neos:Main:delete')}
                 />
         );
     }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/HideSelectedNode/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/HideSelectedNode/index.js
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-
+import {translate} from '@neos-project/neos-ui-i18n';
 import IconButton from '@neos-project/react-ui-components/src/IconButton/';
 
 export default class HideSelectedNode extends PureComponent {
@@ -11,12 +11,11 @@ export default class HideSelectedNode extends PureComponent {
         disabled: PropTypes.bool.isRequired,
         isHidden: PropTypes.bool.isRequired,
 
-        onClick: PropTypes.func.isRequired,
-        i18nRegistry: PropTypes.object.isRequired
+        onClick: PropTypes.func.isRequired
     };
 
     render() {
-        const {className, id, disabled, isHidden, i18nRegistry, onClick} = this.props;
+        const {className, id, disabled, isHidden, onClick} = this.props;
 
         return (
             <IconButton
@@ -27,7 +26,7 @@ export default class HideSelectedNode extends PureComponent {
                 onClick={onClick}
                 icon="eye-slash"
                 hoverStyle="brand"
-                title={i18nRegistry.translate('hideUnhide')}
+                title={translate('Neos.Neos:Main:hideUnhide')}
                 />
         );
     }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/PasteClipBoardNode/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/PasteClipBoardNode/index.js
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-
+import {translate} from '@neos-project/neos-ui-i18n';
 import IconButton from '@neos-project/react-ui-components/src/IconButton/';
 
 export default class PasteClipBoardNode extends PureComponent {
@@ -11,8 +11,7 @@ export default class PasteClipBoardNode extends PureComponent {
         focusedNodeContextPath: PropTypes.string,
         disabled: PropTypes.bool.isRequired,
 
-        onClick: PropTypes.func.isRequired,
-        i18nRegistry: PropTypes.object.isRequired
+        onClick: PropTypes.func.isRequired
     };
 
     handleClick = () => {
@@ -25,8 +24,7 @@ export default class PasteClipBoardNode extends PureComponent {
         const {
             className,
             id,
-            disabled,
-            i18nRegistry
+            disabled
         } = this.props;
 
         return (
@@ -37,7 +35,7 @@ export default class PasteClipBoardNode extends PureComponent {
                 icon="paste"
                 onClick={this.handleClick}
                 hoverStyle="brand"
-                title={i18nRegistry.translate('paste')}
+                title={translate('Neos.Neos:Main:paste')}
                 />
         );
     }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/RefreshPageTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/RefreshPageTree/index.js
@@ -1,6 +1,7 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import mergeClassNames from 'classnames';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 import IconButton from '@neos-project/react-ui-components/src/IconButton/';
 import style from './style.module.css';
@@ -13,9 +14,7 @@ export default class RefreshPageTree extends PureComponent {
 
         isLoading: PropTypes.bool.isRequired,
 
-        onClick: PropTypes.func.isRequired,
-
-        i18nRegistry: PropTypes.object.isRequired
+        onClick: PropTypes.func.isRequired
     };
 
     handleClick = () => {
@@ -25,7 +24,7 @@ export default class RefreshPageTree extends PureComponent {
     }
 
     render() {
-        const {isLoading, className, id, i18nRegistry} = this.props;
+        const {isLoading, className, id} = this.props;
         const finalClassName = mergeClassNames({
             [style.spinning]: isLoading,
             [className]: className && className.length
@@ -39,7 +38,7 @@ export default class RefreshPageTree extends PureComponent {
                 onClick={this.handleClick}
                 icon="sync"
                 hoverStyle="brand"
-                title={i18nRegistry.translate('refresh')}
+                title={translate('Neos.Neos:Main:refresh')}
                 />
         );
     }

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/ToggleContentTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/ToggleContentTree/index.js
@@ -1,5 +1,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 import IconButton from '@neos-project/react-ui-components/src/IconButton/';
 import style from './style.module.css';
@@ -12,9 +13,7 @@ export default class ToggleContentTree extends PureComponent {
 
         isPanelOpen: PropTypes.bool.isRequired,
 
-        onClick: PropTypes.func.isRequired,
-
-        i18nRegistry: PropTypes.object.isRequired
+        onClick: PropTypes.func.isRequired
     };
 
     handleClick = () => {
@@ -24,7 +23,7 @@ export default class ToggleContentTree extends PureComponent {
     }
 
     render() {
-        const {id, isPanelOpen, i18nRegistry} = this.props;
+        const {id, isPanelOpen} = this.props;
 
         return (
             <div role="button" className={style.toggle} onClick={this.handleClick}>
@@ -33,10 +32,10 @@ export default class ToggleContentTree extends PureComponent {
                     className={style.toggleBtn}
                     icon={isPanelOpen ? 'chevron-circle-down' : 'chevron-circle-up'}
                     hoverStyle="clean"
-                    aria-label={i18nRegistry.translate('Neos.Neos:Main:toggleContentTree', 'Toggle content tree')}
+                    aria-label={translate('Neos.Neos:Main:toggleContentTree', 'Toggle content tree')}
                     />
                 <span className={style.toggleLabel}>
-                    {i18nRegistry.translate('Neos.Neos:Main:contentTree', 'Content Tree')}
+                    {translate('Neos.Neos:Main:contentTree', 'Content Tree')}
                 </span>
             </div>
         );

--- a/packages/neos-ui/src/Containers/LeftSideBar/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/index.js
@@ -2,6 +2,7 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import mergeClassNames from 'classnames';
 import {connect} from 'react-redux';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 
@@ -11,8 +12,7 @@ import {neos} from '@neos-project/neos-ui-decorators';
 import style from './style.module.css';
 
 @neos(globalRegistry => ({
-    containerRegistry: globalRegistry.get('containers'),
-    i18nRegistry: globalRegistry.get('i18n')
+    containerRegistry: globalRegistry.get('containers')
 }))
 @connect(state => ({
     isHidden: state?.ui?.leftSideBar?.isHidden,
@@ -26,7 +26,6 @@ import style from './style.module.css';
 export default class LeftSideBar extends PureComponent {
     static propTypes = {
         containerRegistry: PropTypes.object.isRequired,
-        i18nRegistry: PropTypes.object.isRequired,
 
         isHidden: PropTypes.bool.isRequired,
         isHiddenContentTree: PropTypes.bool.isRequired,
@@ -40,7 +39,7 @@ export default class LeftSideBar extends PureComponent {
     }
 
     render() {
-        const {isHidden, isFullScreen, isHiddenContentTree, containerRegistry, i18nRegistry} = this.props;
+        const {isHidden, isFullScreen, isHiddenContentTree, containerRegistry} = this.props;
 
         const classNames = mergeClassNames({
             [style.leftSideBar]: true,
@@ -69,7 +68,7 @@ export default class LeftSideBar extends PureComponent {
                 icon={toggleIcon}
                 className={style.leftSideBar__toggleBtn}
                 hoverStyle="clean"
-                title={i18nRegistry.translate('Neos.Neos:Main:navigate')}
+                title={translate('Neos.Neos:Main:navigate')}
                 />
         );
 
@@ -77,7 +76,7 @@ export default class LeftSideBar extends PureComponent {
             <React.Fragment>
                 <div role="button" className={style.leftSideBar__header} onClick={this.handleToggle}>
                     {toggle}
-                    {!isHidden && !isFullScreen && i18nRegistry.translate('Neos.Neos:Main:documentTree', 'Document Tree')}
+                    {!isHidden && !isFullScreen && translate('Neos.Neos:Main:documentTree', 'Document Tree')}
                 </div>
                 <SideBar
                     position="left"

--- a/packages/neos-ui/src/Containers/Modals/DeleteNode/index.js
+++ b/packages/neos-ui/src/Containers/Modals/DeleteNode/index.js
@@ -6,6 +6,7 @@ import {Button, Dialog, Icon} from '@neos-project/react-ui-components';
 
 import {selectors, actions} from '@neos-project/neos-ui-redux-store';
 import {neos} from '@neos-project/neos-ui-decorators';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 import style from './style.module.css';
 
@@ -51,7 +52,7 @@ export default class DeleteNodeModal extends PureComponent {
             const nodeType = node?.nodeType;
             const nodeTypeLabel = nodeTypesRegistry.get(nodeType)?.ui?.label || 'Neos.Neos:Main:node';
             const nodeTypeLabelText = i18nRegistry.translate(nodeTypeLabel, 'Node')
-            const deleteLabel = i18nRegistry.translate('delete', 'Delete')
+            const deleteLabel = translate('Neos.Neos:Main:delete', 'Delete')
             return (
                 <div className={style.modalTitleContainer}>
                     <Icon icon="exclamation-triangle"/>
@@ -84,7 +85,7 @@ export default class DeleteNodeModal extends PureComponent {
     }
 
     renderAbort() {
-        const abortLabel = this.props.i18nRegistry.translate('cancel', 'Cancel')
+        const abortLabel = translate('Neos.Neos:Main:cancel', 'Cancel')
         return (
             <Button
                 id="neos-DeleteNodeModal-Cancel"
@@ -99,7 +100,7 @@ export default class DeleteNodeModal extends PureComponent {
     }
 
     renderConfirm() {
-        const confirmationLabel = this.props.i18nRegistry.translate('deleteConfirm', 'Confirm')
+        const confirmationLabel = translate('Neos.Neos:Main:deleteConfirm', 'Confirm')
         return (
             <Button
                 id="neos-DeleteNodeModal-Confirm"
@@ -147,7 +148,7 @@ export default class DeleteNodeModal extends PureComponent {
                 >
                 <div className={style.modalContents}>
                     <p>
-                        {i18nRegistry.translate('content.navigate.deleteNodeDialog.header')}
+                        {translate('Neos.Neos:Main:content.navigate.deleteNodeDialog.header')}
                         &nbsp; {nodesToBeDeletedContextPaths.length > 1 ? `${nodesToBeDeletedContextPaths.length} ${i18nRegistry.translate('nodes', 'nodes', {}, 'Neos.Neos.Ui', 'Main')}` : `"$${node?.label}"`}?
                     </p>
                     {warnings.length > 0 ? <hr /> : ''}

--- a/packages/neos-ui/src/Containers/Modals/DeleteNode/index.js
+++ b/packages/neos-ui/src/Containers/Modals/DeleteNode/index.js
@@ -149,7 +149,7 @@ export default class DeleteNodeModal extends PureComponent {
                 <div className={style.modalContents}>
                     <p>
                         {translate('Neos.Neos:Main:content.navigate.deleteNodeDialog.header')}
-                        &nbsp; {nodesToBeDeletedContextPaths.length > 1 ? `${nodesToBeDeletedContextPaths.length} ${i18nRegistry.translate('nodes', 'nodes', {}, 'Neos.Neos.Ui', 'Main')}` : `"$${node?.label}"`}?
+                        &nbsp; {nodesToBeDeletedContextPaths.length > 1 ? `${nodesToBeDeletedContextPaths.length} ${translate('Neos.Neos.Ui:Main:nodes', 'nodes')}` : `"$${node?.label}"`}?
                     </p>
                     {warnings.length > 0 ? <hr /> : ''}
                     {warnings.map((warning, index) => <p key={index}>

--- a/packages/neos-ui/src/Containers/Modals/DeleteNode/index.js
+++ b/packages/neos-ui/src/Containers/Modals/DeleteNode/index.js
@@ -67,13 +67,7 @@ export default class DeleteNodeModal extends PureComponent {
             );
         }
 
-        const deleteMultipleNodesLabel = i18nRegistry.translate(
-            'deleteXNodes',
-            'Delete multiple nodes',
-            {amount: nodesToBeDeletedContextPaths.length},
-            'Neos.Neos.Ui',
-            'Main'
-        )
+        const deleteMultipleNodesLabel = translate('Neos.Neos.Ui:Main:deleteXNodes', 'Delete multiple nodes', {amount: nodesToBeDeletedContextPaths.length})
         return (
             <div>
                 <Icon icon="exclamation-triangle"/>

--- a/packages/neos-ui/src/Containers/Modals/InsertMode/index.js
+++ b/packages/neos-ui/src/Containers/Modals/InsertMode/index.js
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import {neos} from '@neos-project/neos-ui-decorators';
 
 import {Button, Dialog, Icon} from '@neos-project/react-ui-components';
-import I18n, {translate} from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 import {InsertModeSelector} from '@neos-project/neos-ui-containers';
 
@@ -81,41 +81,22 @@ export default class InsertModeModal extends PureComponent {
 
     renderTitle() {
         const {subjectContextPaths, referenceContextPath, operationType} = this.props;
+        const parameters = {
+            source: this.renderNodeLabel(subjectContextPaths),
+            target: this.renderNodeLabel([referenceContextPath])
+        };
 
+        let label = '';
+        if (operationType === actionTypes.CR.Nodes.COPY) {
+            label = translate('Neos.Neos:Main:copy__from__to--title', '', parameters);
+        } else if (operationType === actionTypes.CR.Nodes.CUT || operationType === actionTypes.CR.Nodes.MOVE) {
+            label = translate('Neos.Neos:Main:move__from__to--title', '', parameters);
+        }
         return (
             <div>
                 <Icon icon="clipboard"/>
                 <span className={style.modalTitle}>
-                    {operationType === actionTypes.CR.Nodes.COPY &&
-                        <I18n
-                            key="copy"
-                            id="Neos.Neos:Main:copy__from__to--title"
-                            params={{
-                                source: this.renderNodeLabel(subjectContextPaths),
-                                target: this.renderNodeLabel([referenceContextPath])
-                            }}
-                            />
-                    }
-                    {operationType === actionTypes.CR.Nodes.CUT &&
-                        <I18n
-                            key="move"
-                            id="Neos.Neos:Main:move__from__to--title"
-                            params={{
-                                source: this.renderNodeLabel(subjectContextPaths),
-                                target: this.renderNodeLabel([referenceContextPath])
-                            }}
-                            />
-                    }
-                    {operationType === actionTypes.CR.Nodes.MOVE &&
-                        <I18n
-                            key="move"
-                            id="Neos.Neos:Main:move__from__to--title"
-                            params={{
-                                source: this.renderNodeLabel(subjectContextPaths),
-                                target: this.renderNodeLabel([referenceContextPath])
-                            }}
-                            />
-                    }
+                    {label}
                 </span>
             </div>
         );
@@ -173,13 +154,7 @@ export default class InsertModeModal extends PureComponent {
                 >
                 <div className={style.modalContents}>
                     <p>
-                        <I18n
-                            id="Neos.Neos:Main:copy__from__to--description"
-                            params={{
-                                source: this.renderNodeLabel(subjectContextPaths),
-                                target: this.renderNodeLabel([referenceContextPath])
-                            }}
-                            />
+                        {translate('Neos.Neos:Main:copy__from__to--description', '', {source: this.renderNodeLabel(subjectContextPaths), target: this.renderNodeLabel([referenceContextPath])})}
                     </p>
                     <InsertModeSelector
                         mode={this.state.mode}

--- a/packages/neos-ui/src/Containers/Modals/InsertMode/index.js
+++ b/packages/neos-ui/src/Containers/Modals/InsertMode/index.js
@@ -68,7 +68,7 @@ export default class InsertModeModal extends PureComponent {
     renderNodeLabel(contextPaths) {
         const {getNodeByContextPath, nodeTypesRegistry, i18nRegistry} = this.props;
         if (contextPaths.length > 1) {
-            return `${contextPaths.length} ${i18nRegistry.translate('nodes', 'nodes', {}, 'Neos.Neos.Ui', 'Main')}`;
+            return `${contextPaths.length} ${translate('Neos.Neos.Ui:Main:nodes', 'nodes')}`;
         }
         const contextPath = contextPaths[0];
         const node = getNodeByContextPath(contextPath);

--- a/packages/neos-ui/src/Containers/Modals/InsertMode/index.js
+++ b/packages/neos-ui/src/Containers/Modals/InsertMode/index.js
@@ -130,7 +130,7 @@ export default class InsertModeModal extends PureComponent {
                 hoverStyle="brand"
                 onClick={this.handleCancel}
                 >
-                <I18n id="Neos.Neos:Main:cancel" fallback="Cancel"/>
+                {translate('Neos.Neos:Main:cancel', 'Cancel')}
             </Button>
         );
     }
@@ -145,7 +145,7 @@ export default class InsertModeModal extends PureComponent {
                 onClick={this.handleApply}
                 className={style.applyBtn}
                 >
-                <I18n id="Neos.Neos:Main:apply" fallback="Apply"/>
+                {translate('Neos.Neos:Main:apply', 'Apply')}
             </Button>
         );
     }

--- a/packages/neos-ui/src/Containers/Modals/InsertMode/index.js
+++ b/packages/neos-ui/src/Containers/Modals/InsertMode/index.js
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import {neos} from '@neos-project/neos-ui-decorators';
 
 import {Button, Dialog, Icon} from '@neos-project/react-ui-components';
-import I18n from '@neos-project/neos-ui-i18n';
+import I18n, {translate} from '@neos-project/neos-ui-i18n';
 
 import {InsertModeSelector} from '@neos-project/neos-ui-containers';
 

--- a/packages/neos-ui/src/Containers/Modals/KeyboardShortcutModal/index.js
+++ b/packages/neos-ui/src/Containers/Modals/KeyboardShortcutModal/index.js
@@ -4,7 +4,7 @@ import {connect} from 'react-redux';
 
 import {neos} from '@neos-project/neos-ui-decorators';
 import {actions} from '@neos-project/neos-ui-redux-store';
-import I18n from '@neos-project/neos-ui-i18n';
+import I18n, {translate} from '@neos-project/neos-ui-i18n';
 
 import {Dialog, Button} from '@neos-project/react-ui-components';
 import style from './style.module.css';
@@ -41,7 +41,7 @@ class KeyboardShortcutModal extends PureComponent {
                 hoverStyle="brand"
                 onClick={() => this.props.close()}
                 >
-                <I18n id="Neos.Neos:Main:close" fallback="Close"/>
+                {translate('Neos.Neos:Main:close', 'Close')}
             </Button>
         );
     }

--- a/packages/neos-ui/src/Containers/Modals/KeyboardShortcutModal/index.js
+++ b/packages/neos-ui/src/Containers/Modals/KeyboardShortcutModal/index.js
@@ -4,7 +4,7 @@ import {connect} from 'react-redux';
 
 import {neos} from '@neos-project/neos-ui-decorators';
 import {actions} from '@neos-project/neos-ui-redux-store';
-import I18n, {translate} from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 import {Dialog, Button} from '@neos-project/react-ui-components';
 import style from './style.module.css';
@@ -26,7 +26,7 @@ class KeyboardShortcutModal extends PureComponent {
     renderShortcut = ({id, description, keys}) => (
         <div key={id} className={style.keyboardShortcut}>
             <div className={style.keyboardShortcut__label}>
-                <I18n id={`Neos.Neos.Ui:Main:Shortcut__${id}`} fallback={description} />
+                {translate(`Neos.Neos.Ui:Main:Shortcut__${id}`, description)}
             </div>
             <div className={style.keyboardShortcut__keys}>{keys}</div>
         </div>
@@ -52,12 +52,12 @@ class KeyboardShortcutModal extends PureComponent {
         return (
             <Dialog
                 actions={[this.renderCloseAction()]}
-                title={<I18n fallback="Keyboard Shortcuts" />}
+                title="Keyboard Shortcuts"
                 isOpen={isOpen}
                 onRequestClose={() => close()}
                 >
                 <div className={style.keyboardShortcutIntroText}>
-                    <I18n id={`Neos.Neos.Ui:Main:Shortcut__Introduction`} fallback={''} />
+                    {translate('Neos.Neos.Ui:Main:Shortcut__Introduction')}
                 </div>
                 <div className={style.keyboardShortcutList}>
                     {hotkeyRegistry.getAllAsList().map(key => this.renderShortcut(key))}

--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
@@ -220,7 +220,7 @@ export default class NodeCreationDialog extends PureComponent {
 
         return (
             <span>
-                <I18n fallback="Create new" id="createNew"/>&nbsp;
+                {translate('Neos.Neos:Main:createNew', 'Create new')}&nbsp;
                 <I18n id={label} fallback={label}/>
             </span>
         );

--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
@@ -10,7 +10,7 @@ import validate from '@neos-project/neos-ui-validators';
 import preprocessNodeConfiguration from '../../../preprocessNodeConfiguration';
 
 import {Icon, Button, Dialog} from '@neos-project/react-ui-components';
-import I18n from '@neos-project/neos-ui-i18n';
+import I18n, {translate} from '@neos-project/neos-ui-i18n';
 import EditorEnvelope from '@neos-project/neos-ui-editors/src/EditorEnvelope/index';
 
 import style from './style.module.css';
@@ -210,7 +210,7 @@ export default class NodeCreationDialog extends PureComponent {
                 hoverStyle="brand"
                 onClick={this.handleBack}
             >
-                <I18n id="Neos.Neos:Main:back" fallback="Back"/>
+                {translate('Neos.Neos:Main:back', 'Back')}
             </Button>
         );
     }
@@ -238,7 +238,7 @@ export default class NodeCreationDialog extends PureComponent {
                 disabled={validationErrors && isDirty}
             >
                 <Icon icon="plus-square" className={style.buttonIcon}/>
-                <I18n id="Neos.Neos:Main:createNew" fallback="Create"/>
+                {translate('Neos.Neos:Main:createNew', 'Create')}
             </Button>
         );
     }

--- a/packages/neos-ui/src/Containers/Modals/NodeVariantCreationDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/NodeVariantCreationDialog/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
 import {Button, Dialog} from '@neos-project/react-ui-components';
-import I18n, {translate} from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 import {selectors, actions} from '@neos-project/neos-ui-redux-store';
 import {neos} from '@neos-project/neos-ui-decorators';
@@ -147,14 +147,16 @@ export default class NodeVariantCreationDialog extends PureComponent {
                 >
                 <div className={style.modalContents}>
                     <div>
-                        <I18n id="Neos.Neos:Main:content.dimension.createDialog.nodeTypeDoesNotExistInDimension" fallback="TODO" params={i18nParams}/>
+                        {translate('Neos.Neos:Main:content.dimension.createDialog.nodeTypeDoesNotExistInDimension', '', i18nParams)}
                     </div>
 
                     <div>
-                        <I18n id="Neos.Neos:Main:content.dimension.createDialog.createEmptyOrCopy" fallback="TODO" params={i18nParams}/>
+                        {translate('Neos.Neos:Main:content.dimension.createDialog.createEmptyOrCopy', '', i18nParams)}
                     </div>
                     {numberOfParentNodesToBeCreated > 0 ?
-                        <div><I18n id="Neos.Neos:Main:content.dimension.createDialog.existingAncestorDocuments" fallback="TODO" params={{numberOfNodesMissingInRootline: numberOfParentNodesToBeCreated}}/></div> : null
+                        <div>
+                            {translate('Neos.Neos:Main:content.dimension.createDialog.existingAncestorDocuments', '', {numberOfNodesMissingInRootline: numberOfParentNodesToBeCreated})}
+                        </div> : null
                     }
                 </div>
             </Dialog>

--- a/packages/neos-ui/src/Containers/Modals/NodeVariantCreationDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/NodeVariantCreationDialog/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
 import {Button, Dialog} from '@neos-project/react-ui-components';
-import I18n from '@neos-project/neos-ui-i18n';
+import I18n, {translate} from '@neos-project/neos-ui-i18n';
 
 import {selectors, actions} from '@neos-project/neos-ui-redux-store';
 import {neos} from '@neos-project/neos-ui-decorators';
@@ -63,7 +63,7 @@ export default class NodeVariantCreationDialog extends PureComponent {
         return (
             <div>
                 <span className={style.modalTitle}>
-                    <I18n id="Neos.Neos:Main:content.dimension.createDialog.header" fallback="Start with an empty or pre-filled document?"/>
+                    {translate('Neos.Neos:Main:content.dimension.createDialog.header', 'Start with an empty or pre-filled document?')}
                 </span>
             </div>
         );
@@ -77,7 +77,7 @@ export default class NodeVariantCreationDialog extends PureComponent {
                 hoverStyle="brand"
                 onClick={this.handleAbort}
                 >
-                <I18n id="Neos.Neos:Main:cancel" fallback="Cancel"/>
+                {translate('Neos.Neos:Main:cancel', 'Cancel')}
             </Button>
         );
     }
@@ -91,7 +91,7 @@ export default class NodeVariantCreationDialog extends PureComponent {
                 hoverStyle="brand"
                 onClick={this.handleCreateEmpty}
                 >
-                <I18n id="Neos.Neos:Main:content.dimension.createDialog.createEmpty" fallback="Create empty"/>
+                {translate('Neos.Neos:Main:content.dimension.createDialog.createEmpty', 'Create empty')}
             </Button>
         );
     }
@@ -105,7 +105,7 @@ export default class NodeVariantCreationDialog extends PureComponent {
                 hoverStyle="brand"
                 onClick={this.handleCreateAndCopy}
                 >
-                <I18n id="Neos.Neos:Main:content.dimension.createDialog.createAndCopy" fallback="Create and copy"/>
+                {translate('Neos.Neos:Main:content.dimension.createDialog.createAndCopy', 'Create and copy')}
             </Button>
         );
     }

--- a/packages/neos-ui/src/Containers/Modals/PublishingDialog/ConfirmationDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/PublishingDialog/ConfirmationDialog.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 
 import {Button, Dialog, Icon} from '@neos-project/react-ui-components';
-import I18n from '@neos-project/neos-ui-i18n';
+import I18n, {translate} from '@neos-project/neos-ui-i18n';
 import {PublishingMode, PublishingPhase, PublishingScope} from '@neos-project/neos-ui-redux-store/src/CR/Publishing';
 
 import {Diagram} from './Diagram';
@@ -29,13 +29,11 @@ const ConfirmationDialogVariants = {
             label: {
                 title: {
                     id: 'Neos.Neos.Ui:PublishingDialog:publish.all.confirmation.title',
-                    fallback: (props: { scopeTitle: string; }) =>
-                        `Publish all changes in workspace "${props.scopeTitle}"`
+                    fallback: 'Publish all changes in workspace "{scopeTitle}"'
                 },
                 message: {
                     id: 'Neos.Neos.Ui:PublishingDialog:publish.all.confirmation.message',
-                    fallback: (props: { numberOfChanges: number; scopeTitle: string; targetWorkspaceName: null | string; }) =>
-                        `Are you sure that you want to publish all ${props.numberOfChanges} change(s) in workspace "${props.scopeTitle}" to workspace "${props.targetWorkspaceName}"? Be careful: This cannot be undone!`
+                    fallback: 'Are you sure that you want to publish all {numberOfChanges} change(s) in workspace "{scopeTitle}"  to workspace "{targetWorkspaceName}"? Be careful: This cannot be undone!'
                 },
                 cancel: {
                     id: 'Neos.Neos.Ui:PublishingDialog:publish.all.confirmation.cancel',
@@ -51,13 +49,11 @@ const ConfirmationDialogVariants = {
             label: {
                 title: {
                     id: 'Neos.Neos.Ui:PublishingDialog:publish.site.confirmation.title',
-                    fallback: (props: { scopeTitle: string; }) =>
-                        `Publish all changes in site "${props.scopeTitle}"`
+                    fallback: 'Publish all changes in site "{scopeTitle}"'
                 },
                 message: {
                     id: 'Neos.Neos.Ui:PublishingDialog:publish.site.confirmation.message',
-                    fallback: (props: { numberOfChanges: number; scopeTitle: string; sourceWorkspaceName: string; targetWorkspaceName: null | string; }) =>
-                        `Are you sure that you want to publish all ${props.numberOfChanges} change(s) in site "${props.scopeTitle}" from workspace "${props.sourceWorkspaceName}" to workspace "${props.targetWorkspaceName}"? Be careful: This cannot be undone!`
+                    fallback: 'Are you sure that you want to publish all {numberOfChanges} change(s) in site "{scopeTitle}" from workspace "{sourceWorkspaceName}" to workspace "{targetWorkspaceName}"? Be careful: This cannot be undone!'
                 },
                 cancel: {
                     id: 'Neos.Neos.Ui:PublishingDialog:publish.site.confirmation.cancel',
@@ -74,13 +70,11 @@ const ConfirmationDialogVariants = {
             label: {
                 title: {
                     id: 'Neos.Neos.Ui:PublishingDialog:publish.document.confirmation.title',
-                    fallback: (props: { scopeTitle: string; }) =>
-                        `Publish all changes in document "${props.scopeTitle}"`
+                    fallback: 'Publish all changes in document "{scopeTitle}"'
                 },
                 message: {
                     id: 'Neos.Neos.Ui:PublishingDialog:publish.document.confirmation.message',
-                    fallback: (props: { numberOfChanges: number; scopeTitle: string; sourceWorkspaceName: string; targetWorkspaceName: null | string; }) =>
-                        `Are you sure that you want to publish all ${props.numberOfChanges} change(s) in document "${props.scopeTitle}" from workspace "${props.sourceWorkspaceName}" to workspace "${props.targetWorkspaceName}"? Be careful: This cannot be undone!`
+                    fallback: 'Are you sure that you want to publish all {numberOfChanges} change(s) in document "{scopeTitle}" from workspace "{sourceWorkspaceName}" to workspace "{targetWorkspaceName}"? Be careful: This cannot be undone!'
                 },
                 cancel: {
                     id: 'Neos.Neos.Ui:PublishingDialog:publish.document.confirmation.cancel',
@@ -104,13 +98,11 @@ const ConfirmationDialogVariants = {
             label: {
                 title: {
                     id: 'Neos.Neos.Ui:PublishingDialog:discard.all.confirmation.title',
-                    fallback: (props: { scopeTitle: string; }) =>
-                        `Discard all changes in workspace "${props.scopeTitle}"`
+                    fallback: 'Discard all changes in workspace "{scopeTitle}"'
                 },
                 message: {
                     id: 'Neos.Neos.Ui:PublishingDialog:discard.all.confirmation.message',
-                    fallback: (props: { numberOfChanges: number; scopeTitle: string; }) =>
-                        `Are you sure that you want to discard all ${props.numberOfChanges} change(s) in workspace "${props.scopeTitle}"? Be careful: This cannot be undone!`
+                    fallback: 'Are you sure that you want to discard all {numberOfChanges} change(s) in workspace "{scopeTitle}"? Be careful: This cannot be undone!'
                 },
                 cancel: {
                     id: 'Neos.Neos.Ui:PublishingDialog:discard.all.confirmation.cancel',
@@ -126,13 +118,11 @@ const ConfirmationDialogVariants = {
             label: {
                 title: {
                     id: 'Neos.Neos.Ui:PublishingDialog:discard.site.confirmation.title',
-                    fallback: (props: { scopeTitle: string; }) =>
-                        `Discard all changes in site "${props.scopeTitle}"`
+                    fallback: 'Discard all changes in site "{scopeTitle}"'
                 },
                 message: {
                     id: 'Neos.Neos.Ui:PublishingDialog:discard.site.confirmation.message',
-                    fallback: (props: { numberOfChanges: number; scopeTitle: string; sourceWorkspaceName: string; }) =>
-                        `Are you sure that you want to discard all ${props.numberOfChanges} change(s) in site "${props.scopeTitle}" from workspace "${props.sourceWorkspaceName}"? Be careful: This cannot be undone!`
+                    fallback: 'Are you sure that you want to discard all {numberOfChanges} change(s) in site "{scopeTitle}" from workspace "{sourceWorkspaceName}"? Be careful: This cannot be undone!'
                 },
                 cancel: {
                     id: 'Neos.Neos.Ui:PublishingDialog:discard.site.confirmation.cancel',
@@ -148,13 +138,11 @@ const ConfirmationDialogVariants = {
             label: {
                 title: {
                     id: 'Neos.Neos.Ui:PublishingDialog:discard.document.confirmation.title',
-                    fallback: (props: { scopeTitle: string; }) =>
-                        `Discard all changes in document "${props.scopeTitle}"`
+                    fallback: 'Discard all changes in document "{scopeTitle}"'
                 },
                 message: {
                     id: 'Neos.Neos.Ui:PublishingDialog:discard.document.confirmation.message',
-                    fallback: (props: { numberOfChanges: number; scopeTitle: string; sourceWorkspaceName: string; }) =>
-                        `Are you sure that you want to discard all ${props.numberOfChanges} change(s) in document "${props.scopeTitle}" from workspace "${props.sourceWorkspaceName}"? Be careful: This cannot be undone!`
+                    fallback: 'Are you sure that you want to discard all {numberOfChanges} change(s) in document "{scopeTitle}" from workspace "{sourceWorkspaceName}"? Be careful: This cannot be undone!'
                 },
                 cancel: {
                     id: 'Neos.Neos.Ui:PublishingDialog:discard.document.confirmation.cancel',
@@ -209,11 +197,7 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = (props) => 
             title={<div>
                 <Icon icon={variant.icon.title} />
                 <span className={style.modalTitle}>
-                    <I18n
-                        id={variant[props.scope].label.title.id}
-                        params={props}
-                        fallback={variant[props.scope].label.title.fallback(props)}
-                        />
+                    {translate(variant[props.scope].label.title.id, variant[props.scope].label.title.fallback, props as any)}
                 </span>
             </div>}
             onRequestClose={props.onAbort}
@@ -230,11 +214,7 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = (props) => 
                     targetWorkspaceName={props.targetWorkspaceName}
                     numberOfChanges={props.numberOfChanges}
                     />
-                <I18n
-                    id={variant[props.scope].label.message.id}
-                    params={props}
-                    fallback={variant[props.scope].label.message.fallback(props)}
-                    />
+                {translate(variant[props.scope].label.message.id, variant[props.scope].label.message.fallback, props as any)}
             </div>
         </Dialog>
     );

--- a/packages/neos-ui/src/Containers/Modals/PublishingDialog/ConfirmationDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/PublishingDialog/ConfirmationDialog.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 
 import {Button, Dialog, Icon} from '@neos-project/react-ui-components';
-import I18n, {translate} from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 import {PublishingMode, PublishingPhase, PublishingScope} from '@neos-project/neos-ui-redux-store/src/CR/Publishing';
 
 import {Diagram} from './Diagram';
@@ -181,7 +181,7 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = (props) => 
                     hoverStyle="brand"
                     onClick={props.onAbort}
                 >
-                    <I18n {...variant[props.scope].label.cancel} />
+                    {translate(variant[props.scope].label.cancel.id, variant[props.scope].label.cancel.fallback)}
                 </Button>,
                 <Button
                     id={`${variant.id}-Confirm`}
@@ -191,7 +191,7 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = (props) => 
                     onClick={props.onConfirm}
                 >
                     <Icon icon={variant.icon.confirm} className={style.buttonIcon} />
-                    <I18n {...variant[props.scope].label.confirm} />
+                    {translate(variant[props.scope].label.confirm.id, variant[props.scope].label.confirm.fallback)}
                 </Button>
             ]}
             title={<div>

--- a/packages/neos-ui/src/Containers/Modals/PublishingDialog/ProcessIndicator.tsx
+++ b/packages/neos-ui/src/Containers/Modals/PublishingDialog/ProcessIndicator.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 
 import {Dialog, Icon} from '@neos-project/react-ui-components';
-import I18n from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 import {PublishingMode, PublishingPhase, PublishingScope} from '@neos-project/neos-ui-redux-store/src/CR/Publishing';
 
 import {Diagram} from './Diagram';
@@ -23,13 +23,11 @@ const ProcessIndicatorVariants = {
             label: {
                 title: {
                     id: 'Neos.Neos.Ui:PublishingDialog:publish.all.process.title',
-                    fallback: (props: { scopeTitle: string; }) =>
-                        `Publishing all changes in workspace "${props.scopeTitle}"...`
+                    fallback: 'Publishing all changes in workspace "{scopeTitle}"...'
                 },
                 message: {
                     id: 'Neos.Neos.Ui:PublishingDialog:publish.all.process.message',
-                    fallback: (props: { numberOfChanges: number; }) =>
-                        `Please wait while ${props.numberOfChanges} change(s) are being published. This may take a while.`
+                    fallback: 'Please wait while {numberOfChanges} change(s) are being published. This may take a while.'
                 }
             }
         },
@@ -37,13 +35,11 @@ const ProcessIndicatorVariants = {
             label: {
                 title: {
                     id: 'Neos.Neos.Ui:PublishingDialog:publish.site.process.title',
-                    fallback: (props: { scopeTitle: string; }) =>
-                        `Publishing all changes in site "${props.scopeTitle}"...`
+                    fallback: 'Publishing all changes in site "{scopeTitle}"...'
                 },
                 message: {
                     id: 'Neos.Neos.Ui:PublishingDialog:publish.site.process.message',
-                    fallback: (props: { numberOfChanges: number; }) =>
-                        `Please wait while ${props.numberOfChanges} change(s) are being published. This may take a while.`
+                    fallback: 'Please wait while {numberOfChanges} change(s) are being published. This may take a while.'
                 }
             }
         },
@@ -51,13 +47,11 @@ const ProcessIndicatorVariants = {
             label: {
                 title: {
                     id: 'Neos.Neos.Ui:PublishingDialog:publish.document.process.title',
-                    fallback: (props: { scopeTitle: string; }) =>
-                        `Publishing all changes in document "${props.scopeTitle}"...`
+                    fallback: 'Publishing all changes in document "{scopeTitle}"...'
                 },
                 message: {
                     id: 'Neos.Neos.Ui:PublishingDialog:publish.document.process.message',
-                    fallback: (props: { numberOfChanges: number; }) =>
-                        `Please wait while ${props.numberOfChanges} change(s) are being published. This may take a while.`
+                    fallback: 'Please wait while {numberOfChanges} change(s) are being published. This may take a while.'
                 }
             }
         }
@@ -68,13 +62,11 @@ const ProcessIndicatorVariants = {
             label: {
                 title: {
                     id: 'Neos.Neos.Ui:PublishingDialog:discard.all.process.title',
-                    fallback: (props: { scopeTitle: string; }) =>
-                        `Discarding all changes in workspace "${props.scopeTitle}"...`
+                    fallback: 'Discarding all changes in workspace "{scopeTitle}"...'
                 },
                 message: {
                     id: 'Neos.Neos.Ui:PublishingDialog:discard.all.process.message',
-                    fallback: (props: { numberOfChanges: number; }) =>
-                        `Please wait while ${props.numberOfChanges} change(s) are being discarded. This may take a while.`
+                    fallback: 'Please wait while {numberOfChanges} change(s) are being discarded. This may take a while.'
                 }
             }
         },
@@ -82,13 +74,11 @@ const ProcessIndicatorVariants = {
             label: {
                 title: {
                     id: 'Neos.Neos.Ui:PublishingDialog:discard.site.process.title',
-                    fallback: (props: { scopeTitle: string; }) =>
-                        `Discarding all changes in site "${props.scopeTitle}"...`
+                    fallback: 'Discarding all changes in site "{scopeTitle}"...'
                 },
                 message: {
                     id: 'Neos.Neos.Ui:PublishingDialog:discard.site.process.message',
-                    fallback: (props: { numberOfChanges: number; }) =>
-                        `Please wait while ${props.numberOfChanges} change(s) are being discarded. This may take a while.`
+                    fallback: 'Please wait while {numberOfChanges} change(s) are being discarded. This may take a while.'
                 }
             }
         },
@@ -96,13 +86,11 @@ const ProcessIndicatorVariants = {
             label: {
                 title: {
                     id: 'Neos.Neos.Ui:PublishingDialog:discard.document.process.title',
-                    fallback: (props: { scopeTitle: string; }) =>
-                        `Discarding all changes in document "${props.scopeTitle}"...`
+                    fallback: 'Discarding all changes in document "{scopeTitle}"...'
                 },
                 message: {
                     id: 'Neos.Neos.Ui:PublishingDialog:discard.document.process.message',
-                    fallback: (props: { numberOfChanges: number; }) =>
-                        `Please wait while ${props.numberOfChanges} change(s) are being discarded. This may take a while.`
+                    fallback: 'Please wait while {numberOfChanges} change(s) are being discarded. This may take a while.'
                 }
             }
         }
@@ -126,11 +114,7 @@ export const ProcessIndicator: React.FC<{
                 <div>
                     <Icon icon="refresh" spin />
                     <span className={style.modalTitle}>
-                        <I18n
-                            id={variant[props.scope].label.title.id}
-                            params={props}
-                            fallback={variant[props.scope].label.title.fallback(props)}
-                            />
+                        {translate(variant[props.scope].label.title.id, variant[props.scope].label.title.fallback, props as any)}
                     </span>
                 </div>
             }
@@ -148,11 +132,7 @@ export const ProcessIndicator: React.FC<{
                     targetWorkspaceName={props.targetWorkspaceName}
                     numberOfChanges={props.numberOfChanges}
                 />
-                <I18n
-                    id={variant[props.scope].label.message.id}
-                    params={props}
-                    fallback={variant[props.scope].label.message.fallback(props)}
-                    />
+                {translate(variant[props.scope].label.message.id, variant[props.scope].label.message.fallback, props as any)}
             </div>
         </Dialog>
     );

--- a/packages/neos-ui/src/Containers/Modals/PublishingDialog/ResultDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/PublishingDialog/ResultDialog.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 
 import {Button, Dialog, Icon} from '@neos-project/react-ui-components';
-import I18n from '@neos-project/neos-ui-i18n';
+import I18n, {translate} from '@neos-project/neos-ui-i18n';
 import {PublishingMode, PublishingPhase, PublishingScope} from '@neos-project/neos-ui-redux-store/src/CR/Publishing';
 import {AnyError, ErrorView} from '@neos-project/neos-ui-error';
 
@@ -28,13 +28,11 @@ const ResultDialogVariants = {
                 label: {
                     title: {
                         id: 'Neos.Neos.Ui:PublishingDialog:publish.all.success.title',
-                        fallback: (props: { scopeTitle: string; }) =>
-                            `All changes in workspace "${props.scopeTitle}" were published`
+                        fallback: 'All changes in workspace "{scopeTitle}" were published'
                     },
                     message: {
                         id: 'Neos.Neos.Ui:PublishingDialog:publish.all.success.message',
-                        fallback: (props: { numberOfChanges: number; scopeTitle: string; targetWorkspaceName: null | string; }) =>
-                            `All ${props.numberOfChanges} change(s) in workspace "${props.scopeTitle}" were sucessfully published to workspace "${props.targetWorkspaceName}".`
+                        fallback: 'All {numberOfChanges} change(s) in workspace "{scopeTitle}" were sucessfully published to workspace "{targetWorkspaceName}".'
                     },
                     acknowledge: {
                         id: 'Neos.Neos.Ui:PublishingDialog:publish.all.success.acknowledge',
@@ -46,13 +44,11 @@ const ResultDialogVariants = {
                 label: {
                     title: {
                         id: 'Neos.Neos.Ui:PublishingDialog:publish.site.success.title',
-                        fallback: (props: { scopeTitle: string; }) =>
-                            `Changes in site "${props.scopeTitle}" were published`
+                        fallback: 'Changes in site "{scopeTitle}" were published'
                     },
                     message: {
                         id: 'Neos.Neos.Ui:PublishingDialog:publish.site.success.message',
-                        fallback: (props: { numberOfChanges: number; scopeTitle: string; targetWorkspaceName: null | string; }) =>
-                            `${props.numberOfChanges} change(s) in site "${props.scopeTitle}" were sucessfully published to workspace "${props.targetWorkspaceName}".`
+                        fallback: '{numberOfChanges} change(s) in site "{scopeTitle}" were sucessfully published to workspace "{targetWorkspaceName}".'
                     },
                     acknowledge: {
                         id: 'Neos.Neos.Ui:PublishingDialog:publish.site.success.acknowledge',
@@ -65,13 +61,11 @@ const ResultDialogVariants = {
                 label: {
                     title: {
                         id: 'Neos.Neos.Ui:PublishingDialog:publish.document.success.title',
-                        fallback: (props: { scopeTitle: string; }) =>
-                            `Changes in document "${props.scopeTitle}" were published`
+                        fallback: 'Changes in document "{scopeTitle}" were published'
                     },
                     message: {
                         id: 'Neos.Neos.Ui:PublishingDialog:publish.document.success.message',
-                        fallback: (props: { numberOfChanges: number; scopeTitle: string; targetWorkspaceName: null | string; }) =>
-                            `${props.numberOfChanges} change(s) in document "${props.scopeTitle}" were sucessfully published to workspace "${props.targetWorkspaceName}".`
+                        fallback: '{numberOfChanges} change(s) in document "{scopeTitle}" were sucessfully published to workspace "{targetWorkspaceName}".'
                     },
                     acknowledge: {
                         id: 'Neos.Neos.Ui:PublishingDialog:publish.document.success.acknowledge',
@@ -87,8 +81,7 @@ const ResultDialogVariants = {
                 label: {
                     title: {
                         id: 'Neos.Neos.Ui:PublishingDialog:publish.all.error.title',
-                        fallback: (props: { scopeTitle: string; }) =>
-                            `Changes in workspace "${props.scopeTitle}" could not be published`
+                        fallback: 'Changes in workspace "{scopeTitle}" could not be published'
                     },
                     retry: {
                         id: 'Neos.Neos.Ui:PublishingDialog:publish.all.error.retry',
@@ -104,8 +97,7 @@ const ResultDialogVariants = {
                 label: {
                     title: {
                         id: 'Neos.Neos.Ui:PublishingDialog:publish.site.error.title',
-                        fallback: (props: { scopeTitle: string; }) =>
-                            `Changes in site "${props.scopeTitle}" could not be published`
+                        fallback: 'Changes in site "{scopeTitle}" could not be published'
                     },
                     retry: {
                         id: 'Neos.Neos.Ui:PublishingDialog:publish.site.error.retry',
@@ -121,8 +113,7 @@ const ResultDialogVariants = {
                 label: {
                     title: {
                         id: 'Neos.Neos.Ui:PublishingDialog:publish.document.error.title',
-                        fallback: (props: { scopeTitle: string; }) =>
-                            `Changes in document "${props.scopeTitle}" could not be published`
+                        fallback: 'Changes in document "{scopeTitle}" could not be published'
                     },
                     retry: {
                         id: 'Neos.Neos.Ui:PublishingDialog:publish.document.error.retry',
@@ -145,13 +136,11 @@ const ResultDialogVariants = {
                 label: {
                     title: {
                         id: 'Neos.Neos.Ui:PublishingDialog:discard.all.success.title',
-                        fallback: (props: { scopeTitle: string; }) =>
-                            `All changes in workspace "${props.scopeTitle}" were discarded`
+                        fallback: 'All changes in workspace "{scopeTitle}" were discarded'
                     },
                     message: {
                         id: 'Neos.Neos.Ui:PublishingDialog:discard.all.success.message',
-                        fallback: (props: { numberOfChanges: number; scopeTitle: string; }) =>
-                            `All ${props.numberOfChanges} change(s) in workspace "${props.scopeTitle}" were sucessfully discarded.`
+                        fallback: 'All {numberOfChanges} change(s) in workspace "{scopeTitle}" were sucessfully discarded.'
                     },
                     acknowledge: {
                         id: 'Neos.Neos.Ui:PublishingDialog:discard.all.success.acknowledge',
@@ -163,13 +152,11 @@ const ResultDialogVariants = {
                 label: {
                     title: {
                         id: 'Neos.Neos.Ui:PublishingDialog:discard.site.success.title',
-                        fallback: (props: { scopeTitle: string; }) =>
-                            `Changes in site "${props.scopeTitle}" were discarded`
+                        fallback: 'Changes in site "{scopeTitle}" were discarded'
                     },
                     message: {
                         id: 'Neos.Neos.Ui:PublishingDialog:discard.site.success.message',
-                        fallback: (props: { numberOfChanges: number; scopeTitle: string; }) =>
-                            `${props.numberOfChanges} change(s) in site "${props.scopeTitle}" were sucessfully discarded.`
+                        fallback: '{numberOfChanges} change(s) in site "{scopeTitle}" were sucessfully discarded.'
                     },
                     acknowledge: {
                         id: 'Neos.Neos.Ui:PublishingDialog:discard.site.success.acknowledge',
@@ -181,13 +168,11 @@ const ResultDialogVariants = {
                 label: {
                     title: {
                         id: 'Neos.Neos.Ui:PublishingDialog:discard.document.success.title',
-                        fallback: (props: { scopeTitle: string; }) =>
-                            `Changes in document "${props.scopeTitle}" were discarded`
+                        fallback: 'Changes in document "{scopeTitle}" were discarded'
                     },
                     message: {
                         id: 'Neos.Neos.Ui:PublishingDialog:discard.document.success.message',
-                        fallback: (props: { numberOfChanges: number; scopeTitle: string; }) =>
-                            `${props.numberOfChanges} change(s) in document "${props.scopeTitle}" were sucessfully discarded.`
+                        fallback: '{numberOfChanges} change(s) in document "{scopeTitle}" were sucessfully discarded.'
                     },
                     acknowledge: {
                         id: 'Neos.Neos.Ui:PublishingDialog:discard.document.success.acknowledge',
@@ -203,8 +188,7 @@ const ResultDialogVariants = {
                 label: {
                     title: {
                         id: 'Neos.Neos.Ui:PublishingDialog:discard.all.error.title',
-                        fallback: (props: { scopeTitle: string; }) =>
-                            `Changes in workspace "${props.scopeTitle}" could not be discarded`
+                        fallback: 'Changes in workspace "{scopeTitle}" could not be discarded'
                     },
                     acknowledge: {
                         id: 'Neos.Neos.Ui:PublishingDialog:discard.all.error.acknowledge',
@@ -220,8 +204,7 @@ const ResultDialogVariants = {
                 label: {
                     title: {
                         id: 'Neos.Neos.Ui:PublishingDialog:discard.site.error.title',
-                        fallback: (props: { scopeTitle: string; }) =>
-                            `Changes in site "${props.scopeTitle}" could not be discarded`
+                        fallback: 'Changes in site "{scopeTitle}" could not be discarded'
                     },
                     acknowledge: {
                         id: 'Neos.Neos.Ui:PublishingDialog:discard.site.error.acknowledge',
@@ -237,8 +220,7 @@ const ResultDialogVariants = {
                 label: {
                     title: {
                         id: 'Neos.Neos.Ui:PublishingDialog:discard.document.error.title',
-                        fallback: (props: { scopeTitle: string; }) =>
-                            `Changes in document "${props.scopeTitle}" could not be discarded`
+                        fallback: 'Changes in document "{scopeTitle}" could not be discarded'
                     },
                     acknowledge: {
                         id: 'Neos.Neos.Ui:PublishingDialog:discard.document.error.acknowledge',
@@ -312,11 +294,7 @@ export const ResultDialog: React.FC<{
                 <div>
                     <Icon icon={variant[props.result.phase].icon} />
                     <span className={style.modalTitle}>
-                        <I18n
-                            id={variant[props.result.phase][props.scope].label.title.id}
-                            params={props}
-                            fallback={variant[props.result.phase][props.scope].label.title.fallback(props)}
-                            />
+                        {translate(variant[props.result.phase][props.scope].label.title.id, variant[props.result.phase][props.scope].label.title.fallback, props as any)}
                     </span>
                 </div>
             }
@@ -337,13 +315,7 @@ export const ResultDialog: React.FC<{
                     />
                 {props.result.phase === PublishingPhase.ERROR
                     ? (<ErrorView error={props.result.error} />)
-                    : (
-                        <I18n
-                            id={variant[props.result.phase][props.scope].label.message.id}
-                            params={props}
-                            fallback={variant[props.result.phase][props.scope].label.message.fallback(props)}
-                            />
-                    )
+                    : translate(variant[props.result.phase][props.scope].label.message.id, variant[props.result.phase][props.scope].label.message.fallback, props as any)
                 }
             </div>
         </Dialog>

--- a/packages/neos-ui/src/Containers/Modals/PublishingDialog/ResultDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/PublishingDialog/ResultDialog.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 
 import {Button, Dialog, Icon} from '@neos-project/react-ui-components';
-import I18n, {translate} from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 import {PublishingMode, PublishingPhase, PublishingScope} from '@neos-project/neos-ui-redux-store/src/CR/Publishing';
 import {AnyError, ErrorView} from '@neos-project/neos-ui-error';
 
@@ -266,7 +266,7 @@ export const ResultDialog: React.FC<{
                     hoverStyle="brand"
                     onClick={props.onAcknowledge}
                 >
-                    <I18n {...variant[props.result.phase][props.scope].label.acknowledge} />
+                    {translate(variant[props.result.phase][props.scope].label.acknowledge.id, variant[props.result.phase][props.scope].label.acknowledge.fallback)}
                 </Button>,
                 <Button
                     id={`${variant.id}-Retry`}
@@ -276,7 +276,7 @@ export const ResultDialog: React.FC<{
                     onClick={props.onRetry}
                 >
                     <Icon icon="refresh" className={style.buttonIcon} />
-                    <I18n {...variant[props.result.phase][props.scope].label.retry} />
+                    {translate(variant[props.result.phase][props.scope].label.retry.id, variant[props.result.phase][props.scope].label.retry.fallback)}
                 </Button>
             ] : [
                 <Button
@@ -287,7 +287,7 @@ export const ResultDialog: React.FC<{
                     onClick={props.onAcknowledge}
                 >
                     <Icon icon="check" className={style.buttonIcon} />
-                    <I18n {...variant[props.result.phase][props.scope].label.acknowledge} />
+                    {translate(variant[props.result.phase][props.scope].label.acknowledge.id, variant[props.result.phase][props.scope].label.acknowledge.fallback)}
                 </Button>
             ]}
             title={

--- a/packages/neos-ui/src/Containers/Modals/ReloginDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/ReloginDialog/index.js
@@ -2,7 +2,6 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
-import {neos} from '@neos-project/neos-ui-decorators';
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import backend from '@neos-project/neos-ui-backend-connector';
 import fetchWithErrorHandling from '@neos-project/neos-ui-backend-connector/src/FetchWithErrorHandling/index';
@@ -11,9 +10,6 @@ import {Button, Dialog, TextInput, Tooltip} from '@neos-project/react-ui-compone
 import {translate} from '@neos-project/neos-ui-i18n';
 import style from './style.module.css';
 
-@neos(globalRegistry => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}))
 @connect(state => ({
     authenticationTimeout: selectors.System.authenticationTimeout(state)
 }), {
@@ -30,7 +26,6 @@ export default class ReloginDialog extends PureComponent {
     state = {...this.defaultState};
 
     static propTypes = {
-        i18nRegistry: PropTypes.object.isRequired,
         authenticationTimeout: PropTypes.bool.isRequired,
         reauthenticationSucceeded: PropTypes.func.isRequired
     };
@@ -53,7 +48,7 @@ export default class ReloginDialog extends PureComponent {
                 this.setState(this.defaultState);
             } else {
                 this.setState({
-                    message: this.props.i18nRegistry.translate('Neos.Neos:Main:wrongCredentials', 'The entered username or password was wrong'),
+                    message: translate('Neos.Neos:Main:wrongCredentials', 'The entered username or password was wrong'),
                     isLoading: false
                 });
             }
@@ -61,7 +56,7 @@ export default class ReloginDialog extends PureComponent {
     };
 
     render() {
-        const {authenticationTimeout, i18nRegistry} = this.props;
+        const {authenticationTimeout} = this.props;
 
         if (!authenticationTimeout) {
             return null;
@@ -80,7 +75,7 @@ export default class ReloginDialog extends PureComponent {
                         containerClassName={style.inputFieldWrapper}
                         value={this.state.username}
                         name="__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][username]"
-                        placeholder={i18nRegistry.translate('Neos.Neos:Main:username', 'Username')}
+                        placeholder={translate('Neos.Neos:Main:username', 'Username')}
                         onChange={this.handleUsernameChange}
                         onEnterKey={this.handleTryLogin}
                         setFocus={true}
@@ -91,7 +86,7 @@ export default class ReloginDialog extends PureComponent {
                         containerClassName={style.inputFieldWrapper}
                         value={this.state.password}
                         name="__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][password]"
-                        placeholder={i18nRegistry.translate('Neos.Neos:Main:password', 'Password')}
+                        placeholder={translate('Neos.Neos:Main:password', 'Password')}
                         onChange={this.handlePasswordChange}
                         onEnterKey={this.handleTryLogin}
                         />

--- a/packages/neos-ui/src/Containers/Modals/ReloginDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/ReloginDialog/index.js
@@ -8,7 +8,7 @@ import backend from '@neos-project/neos-ui-backend-connector';
 import fetchWithErrorHandling from '@neos-project/neos-ui-backend-connector/src/FetchWithErrorHandling/index';
 
 import {Button, Dialog, TextInput, Tooltip} from '@neos-project/react-ui-components';
-import I18n from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 import style from './style.module.css';
 
 @neos(globalRegistry => ({
@@ -69,7 +69,7 @@ export default class ReloginDialog extends PureComponent {
 
         return (
             <Dialog
-                title={<I18n id="Neos.Neos:Main:login.expired" fallback="Your login has expired. Please log in again."/>}
+                title={translate('Neos.Neos:Main:login.expired', 'Your login has expired. Please log in again.')}
                 style="narrow"
                 isOpen
                 id="neos-ReloginDialog"
@@ -103,9 +103,9 @@ export default class ReloginDialog extends PureComponent {
                         disabled={this.state.isLoading}
                         className={style.loginButton}
                         >
-                        {this.state.isLoading ?
-                            <I18n id="Neos.Neos:Main:authenticating" fallback="Authenticating"/> :
-                            <I18n id="Neos.Neos:Main:login" fallback="Login"/>
+                        {this.state.isLoading
+                            ? translate('Neos.Neos:Main:authenticating', 'Authenticating')
+                            : translate('Neos.Neos:Main:login', 'Login')
                         }
 
                     </Button>

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
@@ -196,15 +196,15 @@ export default class SelectNodeType extends PureComponent {
 
         const nodeTypeLabel = nodeTypesRegistry.get(referenceNodeType)?.ui?.label
         const nodeTypeLabelText = i18nRegistry.translate(nodeTypeLabel, 'Node')
-        const addLabel = i18nRegistry.translate('Neos.Neos.Ui:Main:add', 'Add')
+        const addLabel = translate('Neos.Neos.Ui:Main:add', 'Add')
         const insertModeLabel = (function () {
             switch (insertMode) {
                 case 'into':
-                    return i18nRegistry.translate('Neos.Neos.Ui:Main:InsertModeTitleInto', 'inside');
+                    return translate('Neos.Neos.Ui:Main:InsertModeTitleInto', 'inside');
                 case 'before':
-                    return i18nRegistry.translate('Neos.Neos.Ui:Main:InsertModeTitleBefore', 'above');
+                    return translate('Neos.Neos.Ui:Main:InsertModeTitleBefore', 'above');
                 case 'after':
-                    return i18nRegistry.translate('Neos.Neos.Ui:Main:InsertModeTitleAfter', 'below');
+                    return translate('Neos.Neos.Ui:Main:InsertModeTitleAfter', 'below');
                 default:
                     return 'to';
             }

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/index.js
@@ -8,7 +8,7 @@ import {neos} from '@neos-project/neos-ui-decorators';
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 
 import {Button, Dialog} from '@neos-project/react-ui-components';
-import I18n from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 import {InsertModeSelector} from '@neos-project/neos-ui-containers';
 import NodeTypeGroupPanel from './nodeTypeGroupPanel';
@@ -185,7 +185,7 @@ export default class SelectNodeType extends PureComponent {
                 hoverStyle="brand"
                 onClick={this.handleCancel}
                 >
-                <I18n id="Neos.Neos:Main:cancel" fallback="Cancel"/>
+                {translate('Neos.Neos:Main:cancel', 'Cancel')}
             </Button>
         );
     }

--- a/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeFilter.js
+++ b/packages/neos-ui/src/Containers/Modals/SelectNodeType/nodeTypeFilter.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {TextInput, IconButton, Icon} from '@neos-project/react-ui-components';
-import {neos} from '@neos-project/neos-ui-decorators';
+import {translate} from '@neos-project/neos-ui-i18n';
 import style from './style.module.css';
 
-const NodeTypeFilter = ({onChange, onEnterKey, filterSearchTerm, i18nRegistry}) => {
+const NodeTypeFilter = ({onChange, onEnterKey, filterSearchTerm}) => {
     const handleResetFilter = () => {
         onChange('');
     };
@@ -17,7 +17,7 @@ const NodeTypeFilter = ({onChange, onEnterKey, filterSearchTerm, i18nRegistry}) 
         onEnterKey();
     };
 
-    const label = i18nRegistry.translate('filter', 'Filter', {}, 'Neos.Neos', 'Main');
+    const label = translate('Neos.Neos:Main:filter', 'Filter');
 
     return (
         <div className={style.nodeTypeDialogHeader__filter}>
@@ -47,10 +47,7 @@ const NodeTypeFilter = ({onChange, onEnterKey, filterSearchTerm, i18nRegistry}) 
 NodeTypeFilter.propTypes = {
     onChange: PropTypes.func.isRequired,
     onEnterKey: PropTypes.func.isRequired,
-    filterSearchTerm: PropTypes.string,
-    i18nRegistry: PropTypes.object.isRequired
+    filterSearchTerm: PropTypes.string
 };
 
-export default neos(globalRegistry => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}))(NodeTypeFilter);
+export default NodeTypeFilter;

--- a/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ConfirmationDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ConfirmationDialog.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 
 import {WorkspaceName} from '@neos-project/neos-ts-interfaces';
-import I18n, {translate} from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 import {Button, Dialog, Icon} from '@neos-project/react-ui-components';
 import {SyncingPhase} from '@neos-project/neos-ui-redux-store/src/CR/Syncing';
 
@@ -52,11 +52,7 @@ export const ConfirmationDialog: React.FC<{
             title={
                 <div className={style.modalTitle}>
                     <WorkspaceSyncIcon onDarkBackground />
-                    <I18n
-                        id="Neos.Neos.Ui:SyncWorkspaceDialog:confirmation.title"
-                        fallback={`Synchronize workspace "${props.workspaceName}" with "${props.baseWorkspaceName}"`}
-                        params={props}
-                        />
+                    {translate('Neos.Neos.Ui:SyncWorkspaceDialog:confirmation.title', 'Synchronize workspace "{workspaceName}" with "{baseWorkspaceName}"', props as any)}
                 </div>
             }
             onRequestClose={props.onCancel}
@@ -72,11 +68,7 @@ export const ConfirmationDialog: React.FC<{
                     baseWorkspaceName={props.baseWorkspaceName}
                     phase={SyncingPhase.START}
                     />
-                <I18n
-                    id="Neos.Neos.Ui:SyncWorkspaceDialog:confirmation.message"
-                    fallback={`Workspace "${props.baseWorkspaceName}" has been modified. You need to synchronize your workspace "${props.workspaceName}" with it in order to see those changes and avoid conflicts. Do you wish to proceed?`}
-                    params={props}
-                    />
+                {translate('Neos.Neos.Ui:SyncWorkspaceDialog:confirmation.message', 'Workspace "{baseWorkspaceName}" has been modified. You need to synchronize your workspace "{workspaceName}" with it in order to see those changes and avoid conflicts. Do you wish to proceed?', props as any)}
             </div>
         </Dialog>
     );

--- a/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ConfirmationDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ConfirmationDialog.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 
 import {WorkspaceName} from '@neos-project/neos-ts-interfaces';
-import I18n from '@neos-project/neos-ui-i18n';
+import I18n, {translate} from '@neos-project/neos-ui-i18n';
 import {Button, Dialog, Icon} from '@neos-project/react-ui-components';
 import {SyncingPhase} from '@neos-project/neos-ui-redux-store/src/CR/Syncing';
 
@@ -35,10 +35,7 @@ export const ConfirmationDialog: React.FC<{
                     hoverStyle="brand"
                     onClick={props.onCancel}
                     >
-                    <I18n
-                        id="Neos.Neos.Ui:SyncWorkspaceDialog:confirmation.cancel"
-                        fallback="No, cancel"
-                        />
+                    {translate('Neos.Neos.Ui:SyncWorkspaceDialog:confirmation.cancel', 'No, cancel')}
                 </Button>,
                 <Button
                     id="neos-SyncWorkspace-Confirm"
@@ -49,10 +46,7 @@ export const ConfirmationDialog: React.FC<{
                     className={style.button}
                     >
                     <Icon icon="sync" className={style.icon} />
-                    <I18n
-                        id="Neos.Neos.Ui:SyncWorkspaceDialog:confirmation.confirm"
-                        fallback="Yes, synchronize now"
-                        />
+                    {translate('Neos.Neos.Ui:SyncWorkspaceDialog:confirmation.confirm', 'Yes, synchronize now')}
                 </Button>
             ]}
             title={

--- a/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ConflictList.tsx
+++ b/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ConflictList.tsx
@@ -9,7 +9,7 @@
  */
 import React from 'react';
 
-import I18n, {I18nRegistry} from '@neos-project/neos-ui-i18n';
+import I18n, {I18nRegistry, translate} from '@neos-project/neos-ui-i18n';
 import {Icon} from '@neos-project/react-ui-components';
 import {Conflict, ReasonForConflict} from '@neos-project/neos-ui-redux-store/src/CR/Syncing';
 import {TypeOfChange} from '@neos-project/neos-ui-redux-store/src/CR/Workspaces';
@@ -38,32 +38,28 @@ const VARIANTS_BY_TYPE_OF_CHANGE = {
         icon: 'pencil',
         label: {
             id: 'Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.typeOfChange.NODE_HAS_BEEN_CHANGED.label',
-            fallback: (props: { label: string }) =>
-                `"${props.label}" has been edited.`
+            fallback: '"{label}" has been edited.'
         }
     },
     [TypeOfChange.NODE_HAS_BEEN_CREATED]: {
         icon: 'plus',
         label: {
             id: 'Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.typeOfChange.NODE_HAS_BEEN_CREATED.label',
-            fallback: (props: { label: string }) =>
-                `"${props.label}" has been created.`
+            fallback: '"{label}" has been created.'
         }
     },
     [TypeOfChange.NODE_HAS_BEEN_DELETED]: {
         icon: 'times',
         label: {
             id: 'Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.typeOfChange.NODE_HAS_BEEN_DELETED.label',
-            fallback: (props: { label: string }) =>
-                `"${props.label}" has been deleted.`
+            fallback: '"{label}" has been deleted.'
         }
     },
     [TypeOfChange.NODE_HAS_BEEN_MOVED]: {
         icon: 'long-arrow-right',
         label: {
             id: 'Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.typeOfChange.NODE_HAS_BEEN_MOVED.label',
-            fallback: (props: { label: string }) =>
-                `"${props.label}" has been moved.`
+            fallback: '"{label}" has been moved.'
         }
     }
 } as const;
@@ -73,8 +69,7 @@ const VARIANTS_BY_REASON_FOR_CONFLICT = {
         icon: 'times',
         label: {
             id: 'Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.reasonForConflict.NODE_HAS_BEEN_DELETED.label',
-            fallback: (props: { label: string }) =>
-                `"${props.label}" or one of its ancestor nodes has been deleted.`
+            fallback: '"{label}" or one of its ancestor nodes has been deleted.'
         }
     }
 } as const;
@@ -159,15 +154,7 @@ const ConflictItem: React.FC<{
                                     className={style.conflict__changeIcon}
                                     icon={changeVariant.icon}
                                     />
-                                <I18n
-                                    id={changeVariant.label.id}
-                                    fallback={changeVariant.label.fallback({
-                                        label: affectedNode.label
-                                    })}
-                                    params={{
-                                        label: affectedNode.label
-                                    }}
-                                    />
+                                {translate(changeVariant.label.id, changeVariant.label.fallback, {label: affectedNode.label})}
                             </dd>
                         ) : (
                             <dd className={style.conflict__descriptionList__description}>
@@ -189,15 +176,7 @@ const ConflictItem: React.FC<{
                         {reasonVariant ? (
                             <dd className={style.conflict__descriptionList__description}>
                                 <Icon icon={reasonVariant.icon} />
-                                <I18n
-                                    id={reasonVariant.label.id}
-                                    fallback={reasonVariant.label.fallback({
-                                        label: affectedNode.label
-                                    })}
-                                    params={{
-                                        label: affectedNode.label
-                                    }}
-                                    />
+                                {translate(reasonVariant.label.id, reasonVariant.label.fallback, {label: affectedNode.label})}
                             </dd>
                         ) : (
                             <dd className={style.conflict__descriptionList__description}>

--- a/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ConflictList.tsx
+++ b/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ConflictList.tsx
@@ -9,7 +9,7 @@
  */
 import React from 'react';
 
-import I18n, {I18nRegistry, translate} from '@neos-project/neos-ui-i18n';
+import {I18nRegistry, translate} from '@neos-project/neos-ui-i18n';
 import {Icon} from '@neos-project/react-ui-components';
 import {Conflict, ReasonForConflict} from '@neos-project/neos-ui-redux-store/src/CR/Syncing';
 import {TypeOfChange} from '@neos-project/neos-ui-redux-store/src/CR/Workspaces';
@@ -121,10 +121,7 @@ const ConflictItem: React.FC<{
                 <dl className={style.conflict__descriptionList}>
                     <div className={style.conflict__descriptionList__group}>
                         <dt className={style.conflict__descriptionList__title}>
-                            <I18n
-                                id="Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.affectedSite.label"
-                                fallback="Affected Site"
-                                />
+                            {translate('Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.affectedSite.label', 'Affected Site')}
                         </dt>
                         <dd className={style.conflict__descriptionList__description}>
                             <Node {...affectedSite} />
@@ -132,10 +129,7 @@ const ConflictItem: React.FC<{
                     </div>
                     <div className={style.conflict__descriptionList__group}>
                         <dt className={style.conflict__descriptionList__title}>
-                            <I18n
-                                id="Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.affectedDocument.label"
-                                fallback="Affected Document"
-                                />
+                            {translate('Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.affectedDocument.label', 'Affected Document')}
                         </dt>
                         <dd className={style.conflict__descriptionList__description}>
                             <Node {...affectedDocument} />
@@ -143,10 +137,7 @@ const ConflictItem: React.FC<{
                     </div>
                     <div className={style.conflict__descriptionList__group}>
                         <dt className={style.conflict__descriptionList__title}>
-                            <I18n
-                                id="Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.typeOfChange.label"
-                                fallback="What was changed?"
-                                />
+                            {translate('Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.typeOfChange.label', 'What was changed?')}
                         </dt>
                         {changeVariant ? (
                             <dd className={style.conflict__descriptionList__description}>
@@ -158,20 +149,14 @@ const ConflictItem: React.FC<{
                             </dd>
                         ) : (
                             <dd className={style.conflict__descriptionList__description}>
-                                <I18n
-                                    id="Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.typeOfChange.unknownMessage"
-                                    fallback="Sorry, but there is no available information on this change."
-                                    />
+                                {translate('Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.typeOfChange.unknownMessage', 'Sorry, but there is no available information on this change.')}
                             </dd>
                         )}
 
                     </div>
                     <div className={style.conflict__descriptionList__group}>
                         <dt className={style.conflict__descriptionList__title}>
-                            <I18n
-                                id="Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.reasonForConflict.label"
-                                fallback="Why is there a conflict?"
-                                />
+                            {translate('Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.reasonForConflict.label', 'Why is there a conflict?')}
                         </dt>
                         {reasonVariant ? (
                             <dd className={style.conflict__descriptionList__description}>
@@ -180,10 +165,7 @@ const ConflictItem: React.FC<{
                             </dd>
                         ) : (
                             <dd className={style.conflict__descriptionList__description}>
-                                <I18n
-                                    id="Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.reasonForConflict.unknownMessage"
-                                    fallback="Sorry, but there is no available information on the reason for this conflict."
-                                    />
+                                {translate('Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.reasonForConflict.unknownMessage', 'Sorry, but there is no available information on the reason for this conflict.')}
                             </dd>
                         )}
                     </div>
@@ -209,11 +191,6 @@ const Node: React.FC<{
                 icon={VARIANTS_BY_TYPE_OF_CHANGE[props.typeOfChange].icon}
                 />
         ) : null}
-        {props.label ?? (
-            <I18n
-                id="Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.unknownNode"
-                fallback="Unknown Node"
-                />
-        )}
+        {props.label ?? translate('Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.unknownNode', 'Unknown Node')}
     </span>
 );

--- a/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ConflictList.tsx
+++ b/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ConflictList.tsx
@@ -9,7 +9,7 @@
  */
 import React from 'react';
 
-import {I18nRegistry, translate} from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 import {Icon} from '@neos-project/react-ui-components';
 import {Conflict, ReasonForConflict} from '@neos-project/neos-ui-redux-store/src/CR/Syncing';
 import {TypeOfChange} from '@neos-project/neos-ui-redux-store/src/CR/Workspaces';
@@ -18,7 +18,6 @@ import style from './style.module.css';
 
 export const ConflictList: React.FC<{
     conflicts: Conflict[];
-    i18n: I18nRegistry;
 }> = (props) => {
     return (
         <ul className={style.conflictList}>
@@ -26,7 +25,6 @@ export const ConflictList: React.FC<{
                 <ConflictItem
                     key={conflict.key}
                     conflict={conflict}
-                    i18n={props.i18n}
                     />
             ))}
         </ul>
@@ -76,7 +74,6 @@ const VARIANTS_BY_REASON_FOR_CONFLICT = {
 
 const ConflictItem: React.FC<{
     conflict: Conflict;
-    i18n: I18nRegistry;
 }> = (props) => {
     const changeVariant = props.conflict.typeOfChange === null
         ? null
@@ -86,24 +83,15 @@ const ConflictItem: React.FC<{
         : VARIANTS_BY_REASON_FOR_CONFLICT[props.conflict.reasonForConflict];
     const affectedNode = props.conflict.affectedNode ?? {
         icon: 'question',
-        label: props.i18n.translate(
-            'Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.unknownNode',
-            'Unknown Node'
-        )
+        label: translate('Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.unknownNode', 'Unknown Node')
     };
     const affectedDocument = props.conflict.affectedDocument ?? {
         icon: 'question',
-        label: props.i18n.translate(
-            'Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.unknownDocument',
-            'Unknown Document'
-        )
+        label: translate('Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.unknownDocument', 'Unknown Document')
     };
     const affectedSite = props.conflict.affectedSite ?? {
         icon: 'question',
-        label: props.i18n.translate(
-            'Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.unknownSite',
-            'Unknown Site'
-        )
+        label: translate('Neos.Neos.Ui:SyncWorkspaceDialog:conflictList.unknownSite', 'Unknown Site')
     };
 
     return (

--- a/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ProcessIndicator.tsx
+++ b/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ProcessIndicator.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 
 import {Dialog, Icon} from '@neos-project/react-ui-components';
-import I18n from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 import {SyncingPhase} from '@neos-project/neos-ui-redux-store/src/CR/Syncing';
 
 import {Diagram} from './Diagram';
@@ -26,11 +26,7 @@ export const ProcessIndicator: React.FC<{
             title={
                 <div className={style.modalTitle}>
                     <Icon icon="refresh" spin />
-                    <I18n
-                        id="Neos.Neos.Ui:SyncWorkspaceDialog:process.title"
-                        params={props}
-                        fallback={`Synchronizing workspace "${props.workspaceName}"...`}
-                        />
+                    {translate('Neos.Neos.Ui:SyncWorkspaceDialog:process.title', 'Synchronizing workspace "{workspaceName}"...', props as any)}
                 </div>
             }
             type={undefined as any}
@@ -46,11 +42,7 @@ export const ProcessIndicator: React.FC<{
                     workspaceName={props.workspaceName}
                     baseWorkspaceName={props.baseWorkspaceName}
                     />
-                <I18n
-                    id="Neos.Neos.Ui:SyncWorkspaceDialog:process.message"
-                    params={props}
-                    fallback={`Please wait, while workspace "${props.workspaceName}" is being synchronized with recent changes in workspace "${props.baseWorkspaceName}". This may take a while.`}
-                    />
+                {translate('Neos.Neos.Ui:SyncWorkspaceDialog:process.message', 'Please wait, while workspace "{workspaceName}" is being synchronized with recent changes in workspace "{baseWorkspaceName}". This may take a while.', props as any)}
             </div>
         </Dialog>
     );

--- a/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ResolutionStrategyConfirmationDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ResolutionStrategyConfirmationDialog.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 
 import {WorkspaceName} from '@neos-project/neos-ts-interfaces';
-import I18n, {I18nRegistry, translate} from '@neos-project/neos-ui-i18n';
+import {I18nRegistry, translate} from '@neos-project/neos-ui-i18n';
 import {Button, Dialog, Icon} from '@neos-project/react-ui-components';
 import {PublishingPhase} from '@neos-project/neos-ui-redux-store/src/CR/Publishing';
 import {Conflict, ResolutionStrategy} from '@neos-project/neos-ui-redux-store/src/CR/Syncing';
@@ -75,11 +75,7 @@ const ForceConfirmationDialog: React.FC<{
             title={
                 <div className={style.modalTitle}>
                     <WorkspaceSyncIcon hasProblem onDarkBackground />
-                    <I18n
-                        id="Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.FORCE.confirmation.title"
-                        fallback={`Drop conflicting changes in workspace "${props.workspaceName}"`}
-                        params={props}
-                        />
+                    {translate('Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.FORCE.confirmation.title', 'Drop conflicting changes in workspace "{workspaceName}"', props as any)}
                 </div>
             }
             onRequestClose={props.onCancelConflictResolution}
@@ -134,11 +130,7 @@ const DiscardAllConfirmationDialog: React.FC<{
             title={
                 <div className={style.modalTitle}>
                     <WorkspaceSyncIcon hasProblem onDarkBackground />
-                    <I18n
-                        id="Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.DISCARD_ALL.confirmation.title"
-                        fallback={`Discard all changes in workspace "${props.workspaceName}"`}
-                        params={props}
-                        />
+                    {translate('Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.DISCARD_ALL.confirmation.title', 'Discard all changes in workspace "{workspaceName}"', props as any)}
                 </div>
             }
             onRequestClose={props.onCancelConflictResolution}
@@ -155,11 +147,7 @@ const DiscardAllConfirmationDialog: React.FC<{
                     targetWorkspaceName={null}
                     phase={PublishingPhase.START}
                     />
-                <I18n
-                    id="Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.DISCARD_ALL.confirmation.message"
-                    fallback={`You are about to discard all ${props.totalNumberOfChangesInWorkspace} change(s) in workspace "${props.workspaceName}". This includes all changes on other sites. Do you wish to proceed? Be careful: This cannot be undone!`}
-                    params={{numberOfChanges: props.totalNumberOfChangesInWorkspace, workspaceName: props.workspaceName}}
-                    />
+                {translate('Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.DISCARD_ALL.confirmation.message', 'You are about to discard all {numberOfChanges} change(s) in workspace "{workspaceName}". This includes all changes on other sites. Do you wish to proceed? Be careful: This cannot be undone!', {numberOfChanges: props.totalNumberOfChangesInWorkspace, workspaceName: props.workspaceName})}
             </div>
         </Dialog>
     );

--- a/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ResolutionStrategyConfirmationDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ResolutionStrategyConfirmationDialog.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 
 import {WorkspaceName} from '@neos-project/neos-ts-interfaces';
-import I18n, {I18nRegistry} from '@neos-project/neos-ui-i18n';
+import I18n, {I18nRegistry, translate} from '@neos-project/neos-ui-i18n';
 import {Button, Dialog, Icon} from '@neos-project/react-ui-components';
 import {PublishingPhase} from '@neos-project/neos-ui-redux-store/src/CR/Publishing';
 import {Conflict, ResolutionStrategy} from '@neos-project/neos-ui-redux-store/src/CR/Syncing';
@@ -58,10 +58,7 @@ const ForceConfirmationDialog: React.FC<{
                     hoverStyle="brand"
                     onClick={props.onCancelConflictResolution}
                     >
-                    <I18n
-                        id="Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.FORCE.confirmation.cancel"
-                        fallback="No, cancel"
-                        />
+                    {translate('Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.FORCE.confirmation.cancel', 'No, cancel')}
                 </Button>,
                 <Button
                     id="neos-ResolutionStrategyConfirmation-Confirm"
@@ -72,10 +69,7 @@ const ForceConfirmationDialog: React.FC<{
                     className={style.button}
                     >
                     <Icon icon="chevron-right" className={style.icon} />
-                    <I18n
-                        id="Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.FORCE.confirmation.confirm"
-                        fallback="Yes, drop those changes"
-                        />
+                    {translate('Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.FORCE.confirmation.confirm', 'Yes, drop those changes')}
                 </Button>
             ]}
             title={
@@ -96,18 +90,12 @@ const ForceConfirmationDialog: React.FC<{
             style={undefined as any}
         >
             <div className={style.modalContents}>
-                <I18n
-                    id="Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.FORCE.confirmation.conflicts.label"
-                    fallback="You are about to drop the following changes:"
-                    />
+                {translate('Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.FORCE.confirmation.conflicts.label', 'You are about to drop the following changes:')}
                 <ConflictList
                     conflicts={props.conflicts}
                     i18n={props.i18n}
                     />
-                <I18n
-                    id="Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.FORCE.confirmation.message"
-                    fallback="Do you wish to proceed? Be careful: This cannot be undone!"
-                    />
+                {translate('Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.FORCE.confirmation.message', 'Do you wish to proceed? Be careful: This cannot be undone!')}
             </div>
         </Dialog>
     );
@@ -129,10 +117,7 @@ const DiscardAllConfirmationDialog: React.FC<{
                     hoverStyle="brand"
                     onClick={props.onCancelConflictResolution}
                     >
-                    <I18n
-                        id="Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.DISCARD_ALL.confirmation.cancel"
-                        fallback="No, cancel"
-                        />
+                    {translate('Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.DISCARD_ALL.confirmation.cancel', 'No, cancel')}
                 </Button>,
                 <Button
                     id="neos-ResolutionStrategyConfirmation-Confirm"
@@ -143,10 +128,7 @@ const DiscardAllConfirmationDialog: React.FC<{
                     className={style.button}
                     >
                     <Icon icon="trash" className={style.icon} />
-                    <I18n
-                        id="Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.DISCARD_ALL.confirmation.confirm"
-                        fallback="Yes, discard everything"
-                        />
+                    {translate('Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.DISCARD_ALL.confirmation.confirm', 'Yes, discard everything')}
                 </Button>
             ]}
             title={

--- a/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ResolutionStrategyConfirmationDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ResolutionStrategyConfirmationDialog.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 
 import {WorkspaceName} from '@neos-project/neos-ts-interfaces';
-import {I18nRegistry, translate} from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 import {Button, Dialog, Icon} from '@neos-project/react-ui-components';
 import {PublishingPhase} from '@neos-project/neos-ui-redux-store/src/CR/Publishing';
 import {Conflict, ResolutionStrategy} from '@neos-project/neos-ui-redux-store/src/CR/Syncing';
@@ -27,7 +27,6 @@ export const ResolutionStrategyConfirmationDialog: React.FC<{
     baseWorkspaceName: WorkspaceName;
     strategy: ResolutionStrategy;
     conflicts: Conflict[];
-    i18n: I18nRegistry;
     onCancelConflictResolution: () => void;
     onConfirmResolutionStrategy: () => void;
 }> = (props) => {
@@ -44,7 +43,6 @@ const ForceConfirmationDialog: React.FC<{
     workspaceName: WorkspaceName;
     baseWorkspaceName: WorkspaceName;
     conflicts: Conflict[];
-    i18n: I18nRegistry;
     onCancelConflictResolution: () => void;
     onConfirmResolutionStrategy: () => void;
 }> = (props) => {
@@ -89,7 +87,6 @@ const ForceConfirmationDialog: React.FC<{
                 {translate('Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.FORCE.confirmation.conflicts.label', 'You are about to drop the following changes:')}
                 <ConflictList
                     conflicts={props.conflicts}
-                    i18n={props.i18n}
                     />
                 {translate('Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.FORCE.confirmation.message', 'Do you wish to proceed? Be careful: This cannot be undone!')}
             </div>

--- a/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ResolutionStrategySelectionDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ResolutionStrategySelectionDialog.tsx
@@ -111,10 +111,7 @@ export const ResolutionStrategySelectionDialog: React.FC<{
                     hoverStyle="brand"
                     onClick={props.onCancel}
                     >
-                    <I18n
-                        id="Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.selection.cancel"
-                        fallback="Cancel Synchronization"
-                        />
+                    {translate('Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.selection.cancel', 'Cancel Synchronization')}
                 </Button>,
                 <Button
                     id="neos-SelectResolutionStrategy-Accept"
@@ -124,10 +121,7 @@ export const ResolutionStrategySelectionDialog: React.FC<{
                     onClick={handleConfirm}
                     className={style.button}
                     >
-                    <I18n
-                        id="Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.selection.accept"
-                        fallback="Accept choice and continue"
-                        />
+                    {translate('Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.selection.accept', 'Accept choice and continue')}
                     <Icon icon="chevron-right" className={style.icon} />
                 </Button>
             ]}
@@ -172,10 +166,7 @@ export const ResolutionStrategySelectionDialog: React.FC<{
                         i18n={props.i18n}
                         />
                 </details>
-                <I18n
-                    id="Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.selection.prompt"
-                    fallback="In order to proceed, you need to decide what to do with the conflicting changes:"
-                    />
+                {translate('Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.selection.prompt', 'In order to proceed, you need to decide what to do with the conflicting changes:')}
                 <SelectBox
                     id="neos-SelectResolutionStrategy-SelectBox"
                     options={options}

--- a/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ResolutionStrategySelectionDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ResolutionStrategySelectionDialog.tsx
@@ -9,7 +9,7 @@
  */
 import React from 'react';
 
-import {I18nRegistry, translate} from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 import {WorkspaceName} from '@neos-project/neos-ts-interfaces';
 import {Button, Dialog, Icon, SelectBox, SelectBox_Option_MultiLineWithThumbnail} from '@neos-project/react-ui-components';
 import {Conflict, ResolutionStrategy, SyncingPhase} from '@neos-project/neos-ui-redux-store/src/CR/Syncing';
@@ -63,7 +63,6 @@ export const ResolutionStrategySelectionDialog: React.FC<{
     baseWorkspaceName: WorkspaceName;
     conflicts: Conflict[];
     defaultStrategy: null | ResolutionStrategy;
-    i18n: I18nRegistry;
     onCancel: () => void;
     onSelectResolutionStrategy: (strategy: ResolutionStrategy) => void;
 }> = (props) => {
@@ -93,7 +92,7 @@ export const ResolutionStrategySelectionDialog: React.FC<{
                     )
                 };
             })
-    }, [props.i18n, props.workspaceName]);
+    }, [props.workspaceName]);
     const handleSelectResolutionStrategy = React.useCallback((value: string) => {
         setSelectedResolutionStrategy(parseInt(value, 10));
     }, []);
@@ -151,7 +150,6 @@ export const ResolutionStrategySelectionDialog: React.FC<{
                     </summary>
                     <ConflictList
                         conflicts={props.conflicts}
-                        i18n={props.i18n}
                         />
                 </details>
                 {translate('Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.selection.prompt', 'In order to proceed, you need to decide what to do with the conflicting changes:')}

--- a/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ResolutionStrategySelectionDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ResolutionStrategySelectionDialog.tsx
@@ -9,7 +9,7 @@
  */
 import React from 'react';
 
-import I18n, {I18nRegistry} from '@neos-project/neos-ui-i18n';
+import I18n, {I18nRegistry, translate} from '@neos-project/neos-ui-i18n';
 import {WorkspaceName} from '@neos-project/neos-ts-interfaces';
 import {Button, Dialog, Icon, SelectBox, SelectBox_Option_MultiLineWithThumbnail} from '@neos-project/react-ui-components';
 import {Conflict, ResolutionStrategy, SyncingPhase} from '@neos-project/neos-ui-redux-store/src/CR/Syncing';
@@ -26,7 +26,7 @@ const VARIANTS_BY_RESOLUTION_STRATEGY = {
         labels: {
             label: {
                 id: 'Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.selection.option.FORCE.label',
-                fallback: () => 'Drop conflicting changes'
+                fallback: 'Drop conflicting changes'
             },
             description: {
                 id: 'Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.selection.option.FORCE.description',
@@ -39,8 +39,7 @@ const VARIANTS_BY_RESOLUTION_STRATEGY = {
         labels: {
             label: {
                 id: 'Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.selection.option.DISCARD_ALL.label',
-                fallback: (props: {workspaceName: WorkspaceName}) =>
-                    `Discard workspace "${props.workspaceName}"`
+                fallback: 'Discard workspace "{workspaceName}"'
             },
             description: {
                 id: 'Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.selection.option.DISCARD_ALL.description',
@@ -83,12 +82,12 @@ export const ResolutionStrategySelectionDialog: React.FC<{
                 return {
                     value: String(value),
                     icon: variant.icon,
-                    label: props.i18n.translate(
+                    label: translate(
                         variant.labels.label.id,
-                        variant.labels.label.fallback(params),
+                        variant.labels.label.fallback,
                         params
                     ),
-                    description: props.i18n.translate(
+                    description: translate(
                         variant.labels.description.id,
                         variant.labels.description.fallback
                     )

--- a/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ResolutionStrategySelectionDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ResolutionStrategySelectionDialog.tsx
@@ -9,7 +9,7 @@
  */
 import React from 'react';
 
-import I18n, {I18nRegistry, translate} from '@neos-project/neos-ui-i18n';
+import {I18nRegistry, translate} from '@neos-project/neos-ui-i18n';
 import {WorkspaceName} from '@neos-project/neos-ts-interfaces';
 import {Button, Dialog, Icon, SelectBox, SelectBox_Option_MultiLineWithThumbnail} from '@neos-project/react-ui-components';
 import {Conflict, ResolutionStrategy, SyncingPhase} from '@neos-project/neos-ui-redux-store/src/CR/Syncing';
@@ -128,11 +128,7 @@ export const ResolutionStrategySelectionDialog: React.FC<{
             title={
                 <div className={style.modalTitle}>
                     <WorkspaceSyncIcon hasProblem onDarkBackground />
-                    <I18n
-                        id="Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.selection.title"
-                        fallback={`Conflicts between workspace "${props.workspaceName}" and "${props.baseWorkspaceName}"`}
-                        params={props}
-                        />
+                    {translate('Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.selection.title', 'Conflicts between workspace "{workspaceName}" and "{baseWorkspaceName}"', props as any)}
                 </div>
             }
             onRequestClose={props.onCancel}
@@ -148,18 +144,10 @@ export const ResolutionStrategySelectionDialog: React.FC<{
                     baseWorkspaceName={props.baseWorkspaceName}
                     phase={SyncingPhase.CONFLICT}
                     />
-                <I18n
-                    id="Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.selection.message"
-                    fallback={`Workspace "${props.baseWorkspaceName}" contains modifications that are in conflict with the changes in workspace "${props.workspaceName}".`}
-                    params={props}
-                    />
+                {translate('Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.selection.message', 'Workspace "{baseWorkspaceName}" contains modifications that are in conflict with the changes in workspace "{workspaceName}".', props as any)}
                 <details className={style.details}>
                     <summary className={style.summary}>
-                        <I18n
-                            id="Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.selection.summary"
-                            fallback={`Show information about ${props.conflicts.length} conflict(s)`}
-                            params={{numberOfConflicts: props.conflicts.length}}
-                            />
+                        {translate('Neos.Neos.Ui:SyncWorkspaceDialog:resolutionStrategy.selection.summary', 'Show information about {numberOfConflicts} conflict(s)', {numberOfConflicts: props.conflicts.length})}
                     </summary>
                     <ConflictList
                         conflicts={props.conflicts}

--- a/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ResultDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ResultDialog.tsx
@@ -9,7 +9,7 @@
  */
 import React from 'react';
 
-import I18n, {translate} from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 import {Button, Dialog, Icon} from '@neos-project/react-ui-components';
 import {AnyError, ErrorView} from '@neos-project/neos-ui-error';
 
@@ -76,10 +76,7 @@ export const ResultDialog: React.FC<{
                     onClick={props.onAcknowledge}
                     className={style.button}
                 >
-                    <I18n
-                        id="Neos.Neos.Ui:SyncWorkspaceDialog:error.acknowledge"
-                        fallback="Cancel"
-                        />
+                    {translate('Neos.Neos.Ui:SyncWorkspaceDialog:error.acknowledge', 'Cancel')}
                 </Button>,
                 <Button
                     id="neos-SyncWorkspace-Retry"
@@ -90,10 +87,7 @@ export const ResultDialog: React.FC<{
                     className={style.button}
                 >
                     <Icon icon="refresh" className={style.icon} />
-                    <I18n
-                        id="Neos.Neos.Ui:SyncWorkspaceDialog:error.retry"
-                        fallback="Try again"
-                        />
+                    {translate('Neos.Neos.Ui:SyncWorkspaceDialog:error.retry', 'Try again')}
                 </Button>
             ] : [
                 <Button
@@ -105,10 +99,7 @@ export const ResultDialog: React.FC<{
                     className={style.button}
                 >
                     <Icon icon="check" className={style.icon} />
-                    <I18n
-                        id="Neos.Neos.Ui:SyncWorkspaceDialog:success.acknowledge"
-                        fallback="OK"
-                        />
+                    {translate('Neos.Neos.Ui:SyncWorkspaceDialog:success.acknowledge', 'OK')}
                 </Button>
             ]}
             title={

--- a/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ResultDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/ResultDialog.tsx
@@ -9,7 +9,7 @@
  */
 import React from 'react';
 
-import I18n from '@neos-project/neos-ui-i18n';
+import I18n, {translate} from '@neos-project/neos-ui-i18n';
 import {Button, Dialog, Icon} from '@neos-project/react-ui-components';
 import {AnyError, ErrorView} from '@neos-project/neos-ui-error';
 
@@ -17,7 +17,6 @@ import {Diagram} from './Diagram';
 
 import style from './style.module.css';
 import {SyncingPhase} from '@neos-project/neos-ui-redux-store/src/CR/Syncing';
-import {WorkspaceName} from '@neos-project/neos-ts-interfaces';
 
 const VARIANTS_BY_SYNCING_PHASE = {
     [SyncingPhase.SUCCESS]: {
@@ -26,13 +25,11 @@ const VARIANTS_BY_SYNCING_PHASE = {
         label: {
             title: {
                 id: 'Neos.Neos.Ui:SyncWorkspaceDialog:success.title',
-                fallback: (props: { workspaceName: WorkspaceName; }) =>
-                    `Workspace "${props.workspaceName}" is up-to-date`
+                fallback: 'Workspace "{workspaceName}" is up-to-date'
             },
             message: {
                 id: 'Neos.Neos.Ui:SyncWorkspaceDialog:success.message',
-                fallback: (props: { workspaceName: WorkspaceName; baseWorkspaceName: WorkspaceName; }) =>
-                    `Workspace "${props.workspaceName}" has been successfully synchronized with all recent changes in workspace "${props.baseWorkspaceName}".`
+                fallback: 'Workspace "{workspaceName}" has been successfully synchronized with all recent changes in workspace "{baseWorkspaceName}".'
             }
         }
     },
@@ -42,13 +39,11 @@ const VARIANTS_BY_SYNCING_PHASE = {
         label: {
             title: {
                 id: 'Neos.Neos.Ui:SyncWorkspaceDialog:error.title',
-                fallback: (props: { workspaceName: WorkspaceName; }) =>
-                    `Workspace "${props.workspaceName}" could not be synchronized`
+                fallback: 'Workspace "{workspaceName}" could not be synchronized'
             },
             message: {
                 id: 'Neos.Neos.Ui:SyncWorkspaceDialog:error.message',
-                fallback: (props: { workspaceName: WorkspaceName; baseWorkspaceName: WorkspaceName; }) =>
-                    `Workspace "${props.workspaceName}" could not be synchronized with the recent changes in workspace "${props.baseWorkspaceName}".`
+                fallback: 'Workspace "{workspaceName}" could not be synchronized with the recent changes in workspace "{baseWorkspaceName}".'
             }
         }
     }
@@ -119,11 +114,7 @@ export const ResultDialog: React.FC<{
             title={
                 <div className={style.modalTitle}>
                     <Icon icon={variant.icon} />
-                    <I18n
-                        id={variant.label.title.id}
-                        fallback={variant.label.title.fallback(props)}
-                        params={props}
-                        />
+                    {translate(variant.label.title.id, variant.label.title.fallback, props as any)}
                 </div>
             }
             onRequestClose={props.onAcknowledge}
@@ -142,13 +133,7 @@ export const ResultDialog: React.FC<{
                     />
                 {props.result.phase === SyncingPhase.ERROR
                     ? (<ErrorView error={props.result.error} />)
-                    : (
-                        <I18n
-                            id={variant.label.message.id}
-                            params={props}
-                            fallback={variant.label.message.fallback(props)}
-                            />
-                    )
+                    : translate(variant.label.message.id, variant.label.message.fallback, props as any)
                 }
             </div>
         </Dialog>

--- a/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/SyncWorkspaceDialog.tsx
+++ b/packages/neos-ui/src/Containers/Modals/SyncWorkspaceDialog/SyncWorkspaceDialog.tsx
@@ -11,11 +11,9 @@ import React from 'react';
 // @ts-ignore
 import {connect} from 'react-redux';
 
-import {neos} from '@neos-project/neos-ui-decorators';
 import {selectors, actions} from '@neos-project/neos-ui-redux-store';
 import {GlobalState} from '@neos-project/neos-ui-redux-store';
 import type {WorkspaceName} from '@neos-project/neos-ts-interfaces';
-import type {I18nRegistry} from '@neos-project/neos-ui-i18n';
 import {ResolutionStrategy, SyncingPhase, State as SyncingState} from '@neos-project/neos-ui-redux-store/src/CR/Syncing';
 
 import {ConfirmationDialog} from './ConfirmationDialog';
@@ -49,14 +47,6 @@ const withReduxState = connect((state: GlobalState): SyncWorkspaceDialogPropsFro
     acknowledge: actions.CR.Syncing.acknowledge
 });
 
-type SyncWorkspaceDialogPropsFromNeosGlobals = {
-    i18nRegistry: I18nRegistry;
-};
-
-const withNeosGlobals = neos((globalRegistry): SyncWorkspaceDialogPropsFromNeosGlobals => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}));
-
 type SyncWorkspaceDialogHandlers = {
     confirm: () => void;
     cancel: () => void;
@@ -69,7 +59,6 @@ type SyncWorkspaceDialogHandlers = {
 
 type SyncWorkspaceDialogProps =
     & SyncWorkspaceDialogPropsFromReduxState
-    & SyncWorkspaceDialogPropsFromNeosGlobals
     & SyncWorkspaceDialogHandlers;
 
 const SyncWorkspaceDialog: React.FC<SyncWorkspaceDialogProps> = (props) => {
@@ -119,7 +108,6 @@ const SyncWorkspaceDialog: React.FC<SyncWorkspaceDialogProps> = (props) => {
                     baseWorkspaceName={props.baseWorkspaceName}
                     conflicts={props.syncingState.process.conflicts}
                     defaultStrategy={props.syncingState.process.strategy}
-                    i18n={props.i18nRegistry}
                     onCancel={handleCancel}
                     onSelectResolutionStrategy={handleSelectResolutionStrategy}
                     />
@@ -132,7 +120,6 @@ const SyncWorkspaceDialog: React.FC<SyncWorkspaceDialogProps> = (props) => {
                     totalNumberOfChangesInWorkspace={props.totalNumberOfChangesInWorkspace}
                     strategy={props.syncingState.process.strategy}
                     conflicts={props.syncingState.process.conflicts}
-                    i18n={props.i18nRegistry}
                     onCancelConflictResolution={handleCancelConflictResolution}
                     onConfirmResolutionStrategy={handleConfirmResolutionStrategy}
                     />
@@ -153,4 +140,4 @@ const SyncWorkspaceDialog: React.FC<SyncWorkspaceDialogProps> = (props) => {
     }
 };
 
-export default withReduxState(withNeosGlobals(SyncWorkspaceDialog as any));
+export default withReduxState(SyncWorkspaceDialog as any);

--- a/packages/neos-ui/src/Containers/Modals/UnappliedChangesDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/UnappliedChangesDialog/index.js
@@ -6,7 +6,7 @@ import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {neos} from '@neos-project/neos-ui-decorators';
 
 import {Icon, Dialog, Button} from '@neos-project/react-ui-components';
-import I18n, {translate} from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 import style from './style.module.css';
 
@@ -85,7 +85,7 @@ export default class UnappliedChangesDialog extends PureComponent {
                 className={`${style.button} ${style.discardButton}`}
                 >
                 <Icon icon="ban" className={style.buttonIcon}/>
-                <I18n id="Neos.Neos:Main:content.inspector.unappliedChangesDialog.button.danger"/>
+                {translate('Neos.Neos:Main:content.inspector.unappliedChangesDialog.button.danger')}
             </Button>
         );
     }
@@ -100,7 +100,7 @@ export default class UnappliedChangesDialog extends PureComponent {
                 onClick={this.handleResume}
                 className={`${style.button} ${style.resumeButton}`}
                 >
-                <I18n id="Neos.Neos:Main:content.inspector.unappliedChangesDialog.button.default"/>
+                {translate('Neos.Neos:Main:content.inspector.unappliedChangesDialog.button.default')}
             </Button>
         );
     }
@@ -119,7 +119,7 @@ export default class UnappliedChangesDialog extends PureComponent {
                 className={`${style.button} ${style.publishButton}`}
                 >
                 <Icon icon="check" className={style.buttonIcon}/>
-                <I18n id="Neos.Neos:Main:content.inspector.unappliedChangesDialog.button.success"/>
+                {translate('Neos.Neos:Main:content.inspector.unappliedChangesDialog.button.success')}
             </Button>
         );
     }

--- a/packages/neos-ui/src/Containers/Modals/UnappliedChangesDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/UnappliedChangesDialog/index.js
@@ -6,7 +6,7 @@ import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {neos} from '@neos-project/neos-ui-decorators';
 
 import {Icon, Dialog, Button} from '@neos-project/react-ui-components';
-import I18n from '@neos-project/neos-ui-i18n';
+import I18n, {translate} from '@neos-project/neos-ui-i18n';
 
 import style from './style.module.css';
 
@@ -64,10 +64,7 @@ export default class UnappliedChangesDialog extends PureComponent {
             <div>
                 <Icon icon="exclamation-triangle"/>
                 <span className={style.modalTitle}>
-                    <I18n
-                        id="Neos.Neos:Main:content.inspector.unappliedChangesDialog.header"
-                        fallback="You still have changes. What do you want to do with them?"
-                        />
+                    {translate('Neos.Neos:Main:content.inspector.unappliedChangesDialog.header', 'You still have changes. What do you want to do with them?')}
                 </span>
             </div>
 
@@ -143,10 +140,7 @@ export default class UnappliedChangesDialog extends PureComponent {
                 id="neos-UnappliedChangesDialog"
                 >
                 <div className={style.modalContents}>
-                    <I18n
-                        id="Neos.Neos:Main:content.inspector.unappliedChangesDialog.header"
-                        fallback="You still have changes. What do you want to do with them?"
-                        />
+                    {translate('Neos.Neos:Main:content.inspector.unappliedChangesDialog.header', 'You still have changes. What do you want to do with them?')}
                 </div>
             </Dialog>
         );

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelector.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelector.js
@@ -5,15 +5,12 @@ import style from './style.module.css';
 
 import mapValues from 'lodash.mapvalues';
 import sortBy from 'lodash.sortby';
-import {neos} from '@neos-project/neos-ui-decorators';
+import {translate} from '@neos-project/neos-ui-i18n';
 import DimensionSelectorOption from './DimensionSelectorOption';
 
 const searchOptions = (searchTerm, processedSelectBoxOptions) =>
     processedSelectBoxOptions.filter(option => option.label && option.label.toLowerCase().indexOf(searchTerm.toLowerCase()) !== -1);
 
-@neos(globalRegistry => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}))
 export default class DimensionSelector extends PureComponent {
     static propTypes = {
         icon: PropTypes.string,
@@ -23,9 +20,7 @@ export default class DimensionSelector extends PureComponent {
         dimensionName: PropTypes.string.isRequired,
         isLoading: PropTypes.bool,
         onSelect: PropTypes.func.isRequired,
-        showDropDownHeaderIcon: PropTypes.bool,
-
-        i18nRegistry: PropTypes.object.isRequired
+        showDropDownHeaderIcon: PropTypes.bool
     };
 
     state = {
@@ -36,7 +31,6 @@ export default class DimensionSelector extends PureComponent {
         const {
             activePreset,
             isLoading,
-            i18nRegistry,
             dimensionName,
             onSelect,
             presets,
@@ -74,8 +68,8 @@ export default class DimensionSelector extends PureComponent {
                 displaySearchBox={false} // TODO reenable `sortedPresetOptions.length >= 10` but see https://github.com/neos/neos-ui/issues/3495
                 searchOptions={searchOptions(this.state.searchTerm, sortedPresetOptions)}
                 onSearchTermChange={this.handleSearchTermChange}
-                noMatchesFoundLabel={i18nRegistry.translate('Neos.Neos:Main:noMatchesFound')}
-                searchBoxLeftToTypeLabel={i18nRegistry.translate('Neos.Neos:Main:searchBoxLeftToType')}
+                noMatchesFoundLabel={translate('Neos.Neos:Main:noMatchesFound')}
+                searchBoxLeftToTypeLabel={translate('Neos.Neos:Main:searchBoxLeftToType')}
                 threshold={0}
                 ListPreviewElement={DimensionSelectorOption}
                 className={style.dimensionSwitcherDropDown}

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelectorOption.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelectorOption.js
@@ -41,8 +41,8 @@ export default class DimensionSelectorOption extends PureComponent {
             );
         }
         option.title = option.disallowed
-            ? translate('Neos.Neos.Ui:Main:dimensions.combinationNotAllowed', '')
-            : translate('Neos.Neos.Ui:Main:dimensions.doesNotExistsInDimension', '')
+            ? translate('Neos.Neos.Ui:Main:dimensions.combinationNotAllowed')
+            : translate('Neos.Neos.Ui:Main:dimensions.doesNotExistsInDimension')
 
         return (
             // eslint-disable-next-line camelcase

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelectorOption.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/DimensionSelectorOption.js
@@ -4,11 +4,7 @@ import style from './style.module.css';
 // eslint-disable-next-line camelcase
 import SelectBox_Option_SingleLine from '@neos-project/react-ui-components/src/SelectBox_Option_SingleLine/index';
 import mergeClassNames from 'classnames';
-import {neos} from '@neos-project/neos-ui-decorators';
-
-@neos(globalRegistry => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}))
+import {translate} from '@neos-project/neos-ui-i18n';
 
 export default class DimensionSelectorOption extends PureComponent {
     static propTypes = {
@@ -17,12 +13,11 @@ export default class DimensionSelectorOption extends PureComponent {
             disallowed: PropTypes.bool,
             covered: PropTypes.bool,
             url: PropTypes.string
-        }),
-        i18nRegistry: PropTypes.object.isRequired
+        })
     };
 
     render() {
-        const {option, i18nRegistry} = this.props;
+        const {option} = this.props;
         const className = mergeClassNames({
             [style.disallowed]: option.disallowed,
             [style.notCovered]: !option.covered
@@ -45,9 +40,9 @@ export default class DimensionSelectorOption extends PureComponent {
                 />
             );
         }
-        option.title = option.disallowed ?
-            i18nRegistry.translate('Neos.Neos.Ui:Main:dimensions.combinationNotAllowed') :
-            i18nRegistry.translate('Neos.Neos.Ui:Main:dimensions.doesNotExistsInDimension')
+        option.title = option.disallowed
+            ? translate('Neos.Neos.Ui:Main:dimensions.combinationNotAllowed', '')
+            : translate('Neos.Neos.Ui:Main:dimensions.doesNotExistsInDimension', '')
 
         return (
             // eslint-disable-next-line camelcase

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/index.js
@@ -6,7 +6,7 @@ import style from './style.module.css';
 import backend from '@neos-project/neos-ui-backend-connector';
 import mapValues from 'lodash.mapvalues';
 import {selectors, actions} from '@neos-project/neos-ui-redux-store';
-import I18n from '@neos-project/neos-ui-i18n';
+import I18n, {translate} from '@neos-project/neos-ui-i18n';
 import {neos} from '@neos-project/neos-ui-decorators';
 import DimensionSelector from './DimensionSelector';
 
@@ -238,14 +238,14 @@ export default class DimensionSwitcher extends PureComponent {
                                 style="lighter"
                                 className={style.cancelButton}
                             >
-                                <I18n id="Neos.Neos:Main:cancel" fallback="Cancel"/>
+                                {translate('Neos.Neos:Main:cancel', 'Cancel')}
                             </Button>
                             <Button
                                 id="neos-DimensionSwitcher-Apply"
                                 onClick={this.handleApplyPresets}
                                 style="brand"
                             >
-                                <I18n id="Neos.Neos:Main:apply" fallback="Apply"/>
+                                {translate('Neos.Neos:Main:apply', 'Apply')}
                             </Button>
                         </div>}
                     </DropDown.Contents>

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/EditPreviewDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/EditPreviewDropDown/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
 import {neos} from '@neos-project/neos-ui-decorators';
-import I18n from '@neos-project/neos-ui-i18n';
+import I18n, {translate} from '@neos-project/neos-ui-i18n';
 
 import style from './style.module.css';
 import {actions, selectors} from '@neos-project/neos-ui-redux-store/src';
@@ -16,14 +16,10 @@ import {getConfiguration} from '@neos-project/neos-ui-configuration';
 }), {
     setEditPreviewMode: actions.UI.EditPreviewMode.set
 })
-@neos(globalRegistry => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}))
 export default class EditPreviewModeDropDown extends PureComponent {
     static propTypes = {
         editPreviewMode: PropTypes.string.isRequired,
         setEditPreviewMode: PropTypes.func.isRequired,
-        i18nRegistry: PropTypes.object.isRequired
     };
 
     handleEditPreviewModeClick = memoize(mode => () => {
@@ -45,8 +41,7 @@ export default class EditPreviewModeDropDown extends PureComponent {
 
     render() {
         const {
-            editPreviewMode,
-            i18nRegistry
+            editPreviewMode
         } = this.props;
 
         const editPreviewModes = getConfiguration(configuration => configuration.editPreviewModes);
@@ -73,7 +68,7 @@ export default class EditPreviewModeDropDown extends PureComponent {
                     </DropDown.Header>
                     <DropDown.Contents className={style.dropDown__contents}>
                         <div className={style.dropDown__groupHeader}>
-                            <Icon className={style.dropDown__btnIcon} icon={'pencil'}/> {i18nRegistry.translate('content.components.editPreviewPanel.modes', 'Editing Modes')}
+                            <Icon className={style.dropDown__btnIcon} icon={'pencil'}/> {translate('Neos.Neos:Main:content.components.editPreviewPanel.modes', 'Editing Modes')}
                         </div>
                         <ul>
                             {editingModes.map(editingMode => (
@@ -91,7 +86,7 @@ export default class EditPreviewModeDropDown extends PureComponent {
                         {previewModes.length > 0 && (
                             <>
                                 <div className={style.dropDown__groupHeader}>
-                                    <Icon className={style.dropDown__btnIcon} icon={'eye'}/> {i18nRegistry.translate('content.components.editPreviewPanel.previewCentral', 'Preview Central')}
+                                    <Icon className={style.dropDown__btnIcon} icon={'eye'}/> {translate('Neos.Neos:Main:content.components.editPreviewPanel.previewCentral', 'Preview Central')}
                                 </div>
                                 <ul>
                                     {previewModes.map(previewMode => (

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/EditPreviewDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/EditPreviewDropDown/index.js
@@ -2,7 +2,6 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
-import {neos} from '@neos-project/neos-ui-decorators';
 import I18n, {translate} from '@neos-project/neos-ui-i18n';
 
 import style from './style.module.css';
@@ -19,7 +18,7 @@ import {getConfiguration} from '@neos-project/neos-ui-configuration';
 export default class EditPreviewModeDropDown extends PureComponent {
     static propTypes = {
         editPreviewMode: PropTypes.string.isRequired,
-        setEditPreviewMode: PropTypes.func.isRequired,
+        setEditPreviewMode: PropTypes.func.isRequired
     };
 
     handleEditPreviewModeClick = memoize(mode => () => {

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/MenuToggler/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/MenuToggler/index.js
@@ -5,13 +5,9 @@ import mergeClassNames from 'classnames';
 
 import Button from '@neos-project/react-ui-components/src/Button/';
 import {actions} from '@neos-project/neos-ui-redux-store';
-import {neos} from '@neos-project/neos-ui-decorators';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 import style from './style.module.css';
-
-@neos(globalRegistry => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}))
 
 @connect(state => ({
     isMenuHidden: state?.ui?.drawer?.isHidden
@@ -20,8 +16,6 @@ import style from './style.module.css';
 })
 export default class MenuToggler extends PureComponent {
     static propTypes = {
-        i18nRegistry: PropTypes.object.isRequired,
-
         className: PropTypes.string,
         isMenuHidden: PropTypes.bool.isRequired,
         toggleDrawer: PropTypes.func.isRequired
@@ -34,7 +28,7 @@ export default class MenuToggler extends PureComponent {
     }
 
     render() {
-        const {className, isMenuHidden, i18nRegistry} = this.props;
+        const {className, isMenuHidden} = this.props;
         const isMenuVisible = !isMenuHidden;
         const classNames = mergeClassNames({
             [style.menuToggler]: true,
@@ -53,7 +47,7 @@ export default class MenuToggler extends PureComponent {
                 hoverStyle="clean"
                 isFocused={isMenuVisible}
                 onClick={this.handleToggle}
-                title={i18nRegistry.translate('Neos.Neos:Main:toggleMenu', 'Toggle menu')}
+                title={translate('Neos.Neos:Main:toggleMenu', 'Toggle menu')}
                 aria-label="Menu"
                 aria-controls="navigation"
                 aria-expanded={isMenuHidden ? 'false' : 'true'}

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/WorkspaceSelector/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/WorkspaceSelector/index.js
@@ -1,21 +1,16 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 import SelectBox from '@neos-project/react-ui-components/src/SelectBox/';
-import {neos} from '@neos-project/neos-ui-decorators';
 import style from './style.module.css';
-
-@neos(globalRegistry => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}))
 
 export default class WorkspaceSelector extends PureComponent {
     static propTypes = {
         baseWorkspace: PropTypes.string.isRequired,
         allowedWorkspaces: PropTypes.object.isRequired,
         changeBaseWorkspaceAction: PropTypes.func.isRequired,
-        changingWorkspaceAllowed: PropTypes.bool,
-        i18nRegistry: PropTypes.object.isRequired
+        changingWorkspaceAllowed: PropTypes.bool
     };
 
     static contextTypes = {
@@ -23,7 +18,7 @@ export default class WorkspaceSelector extends PureComponent {
     };
 
     render() {
-        const {allowedWorkspaces, baseWorkspace, changeBaseWorkspaceAction, changingWorkspaceAllowed, i18nRegistry} = this.props;
+        const {allowedWorkspaces, baseWorkspace, changeBaseWorkspaceAction, changingWorkspaceAllowed} = this.props;
 
         const {context} = this;
         const workspacesOptions = Object.keys(allowedWorkspaces).map(i => ({label: allowedWorkspaces[i]?.title, value: allowedWorkspaces[i]?.name}));
@@ -42,8 +37,8 @@ export default class WorkspaceSelector extends PureComponent {
                     value={baseWorkspace}
                     onValueChange={onWorkspaceSelect}
                     /> :
-                <div className={style.notAllowed} title={i18nRegistry.translate('Neos.Neos:Main:content.components.dirtyWorkspaceDialog.dirtyWorkspaceContainsChanges')}>
-                    {baseWorkspaceTitle} – {i18nRegistry.translate('Neos.Neos:Main:content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader')}
+                <div className={style.notAllowed} title={translate('Neos.Neos:Main:content.components.dirtyWorkspaceDialog.dirtyWorkspaceContainsChanges')}>
+                    {baseWorkspaceTitle} – {translate('Neos.Neos:Main:content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader')}
                 </div>
             )}
         </div>);

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -9,7 +9,6 @@ import {Badge, Icon, DropDown} from '@neos-project/react-ui-components';
 import {translate} from '@neos-project/neos-ui-i18n';
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {PublishingMode, PublishingScope} from '@neos-project/neos-ui-redux-store/src/CR/Publishing';
-import {neos} from '@neos-project/neos-ui-decorators';
 
 const {publishableNodesSelector, publishableNodesInDocumentSelector, baseWorkspaceSelector, isWorkspaceReadOnlySelector, personalWorkspaceNameSelector, allowedTargetWorkspacesSelector} = selectors.CR.Workspaces;
 
@@ -30,10 +29,6 @@ import style from './style.module.css';
     changeBaseWorkspaceAction: actions.CR.Workspaces.changeBaseWorkspace,
     start: actions.CR.Publishing.start
 })
-@neos(globalRegistry => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}))
-
 export default class PublishDropDown extends PureComponent {
     static propTypes = {
         isSaving: PropTypes.bool,
@@ -46,8 +41,7 @@ export default class PublishDropDown extends PureComponent {
         neos: PropTypes.object.isRequired,
         start: PropTypes.func.isRequired,
         changeBaseWorkspaceAction: PropTypes.func.isRequired,
-        routes: PropTypes.object,
-        i18nRegistry: PropTypes.object.isRequired
+        routes: PropTypes.object
     };
 
     handlePublishClick = () => {
@@ -79,7 +73,6 @@ export default class PublishDropDown extends PureComponent {
             isWorkspaceReadOnly,
             baseWorkspace,
             changeBaseWorkspaceAction,
-            i18nRegistry,
             neos,
             allowedWorkspaces
         } = this.props;
@@ -119,12 +112,12 @@ export default class PublishDropDown extends PureComponent {
                             iconRest={{spin: true, transform: 'up-8'}}
                             className={dropDownBtnClassName}
                             disabled
-                            aria-label={i18nRegistry.translate('Neos.Neos:Main:showPublishOptions', 'Show publishing options')}
+                            aria-label={translate('Neos.Neos:Main:showPublishOptions', 'Show publishing options')}
                         />
                     ) : (
                         <DropDown.Header
                             className={dropDownBtnClassName}
-                            aria-label={i18nRegistry.translate('Neos.Neos:Main:showPublishOptions', 'Show publishing options')}
+                            aria-label={translate('Neos.Neos:Main:showPublishOptions', 'Show publishing options')}
                         />
                     )}
                     <DropDown.Contents

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -42,7 +42,7 @@ export default class PublishDropDown extends PureComponent {
         baseWorkspace: PropTypes.string.isRequired,
         neos: PropTypes.object.isRequired,
         start: PropTypes.func.isRequired,
-        changeBaseWorkspaceAction: PropTypes.func.isRequired,
+        changeBaseWorkspaceAction: PropTypes.func.isRequired
     };
 
     handlePublishClick = () => {

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -9,6 +9,7 @@ import {Badge, Icon, DropDown} from '@neos-project/react-ui-components';
 import {translate} from '@neos-project/neos-ui-i18n';
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {PublishingMode, PublishingScope} from '@neos-project/neos-ui-redux-store/src/CR/Publishing';
+import {neos} from '@neos-project/neos-ui-decorators';
 
 const {publishableNodesSelector, publishableNodesInDocumentSelector, baseWorkspaceSelector, isWorkspaceReadOnlySelector, personalWorkspaceNameSelector, allowedTargetWorkspacesSelector} = selectors.CR.Workspaces;
 
@@ -29,6 +30,7 @@ import style from './style.module.css';
     changeBaseWorkspaceAction: actions.CR.Workspaces.changeBaseWorkspace,
     start: actions.CR.Publishing.start
 })
+@neos()
 export default class PublishDropDown extends PureComponent {
     static propTypes = {
         isSaving: PropTypes.bool,
@@ -41,7 +43,6 @@ export default class PublishDropDown extends PureComponent {
         neos: PropTypes.object.isRequired,
         start: PropTypes.func.isRequired,
         changeBaseWorkspaceAction: PropTypes.func.isRequired,
-        routes: PropTypes.object
     };
 
     handlePublishClick = () => {

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/PublishDropDown/index.js
@@ -6,7 +6,7 @@ import mergeClassNames from 'classnames';
 
 import {Badge, Icon, DropDown} from '@neos-project/react-ui-components';
 
-import I18n, {translate} from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {PublishingMode, PublishingScope} from '@neos-project/neos-ui-redux-store/src/CR/Publishing';
 import {neos} from '@neos-project/neos-ui-decorators';
@@ -148,7 +148,7 @@ export default class PublishDropDown extends PureComponent {
                                 <div className={style.dropDown__iconWrapper}>
                                     <Icon icon="check-double"/>
                                 </div>
-                                <I18n id="Neos.Neos:Main:publishAll" fallback="Publish All"/>
+                                {translate('Neos.Neos:Main:publishAll', 'Publish All')}
                                 {publishableNodesCount > 0 && <Badge className={style.badge} label={String(publishableNodesCount)}/>}
                             </AbstractButton>
                         </li>
@@ -164,7 +164,7 @@ export default class PublishDropDown extends PureComponent {
                                 <div className={style.dropDown__iconWrapper}>
                                     <Icon icon="ban"/>
                                 </div>
-                                <I18n id="Neos.Neos:Main:discard" fallback="Discard"/>
+                                {translate('Neos.Neos:Main:discard', 'Discard')}
                                 {publishableNodesInDocumentCount > 0 && <Badge className={style.badge} label={String(publishableNodesInDocumentCount)}/>}
                             </AbstractButton>
                         </li>
@@ -178,7 +178,7 @@ export default class PublishDropDown extends PureComponent {
                                 <div className={style.dropDown__iconWrapper}>
                                     <Icon icon="ban"/>
                                 </div>
-                                <I18n id="Neos.Neos:Main:discardAll" fallback="Discard All"/>
+                                {translate('Neos.Neos:Main:discardAll', 'Discard All')}
                                 {publishableNodesCount > 0 && <Badge className={style.badge} label={String(publishableNodesCount)}/>}
                             </AbstractButton>
                         </li>
@@ -187,7 +187,7 @@ export default class PublishDropDown extends PureComponent {
                                 <div className={style.dropDown__iconWrapper}>
                                     <Icon icon="check-circle"/>
                                 </div>
-                                <I18n id="Neos.Neos:Main:reviewChanges" fallback="Review changes"/>
+                                {translate('Neos.Neos:Main:reviewChanges', 'Review changes')}
                             </a>
                         </li>)}
                         <li className={style.dropDown__item}>
@@ -195,7 +195,7 @@ export default class PublishDropDown extends PureComponent {
                                 <div className={style.dropDown__iconWrapper}>
                                     <Icon icon="th-large"/>
                                 </div>
-                                <I18n id="Neos.Neos:Main:workspaces" fallback="Workspaces"/>
+                                {translate('Neos.Neos:Main:workspaces', 'Workspaces')}
                             </a>
                         </li>
                     </DropDown.Contents>

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/WorkspaceSync/WorkspaceSync.tsx
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/WorkspaceSync/WorkspaceSync.tsx
@@ -13,9 +13,8 @@ import {connect} from 'react-redux';
 
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {GlobalState} from '@neos-project/neos-ui-redux-store';
-import {neos} from '@neos-project/neos-ui-decorators';
 import {WorkspaceStatus} from '@neos-project/neos-ts-interfaces';
-import type {I18nRegistry} from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 import {Button} from '@neos-project/react-ui-components';
 
 import {WorkspaceSyncIcon} from './WorkspaceSyncIcon';
@@ -36,17 +35,8 @@ const withReduxState = connect((state: GlobalState): WorkspaceSyncPropsFromRedux
     startSyncing: actions.CR.Syncing.start
 });
 
-type WorkspaceSyncPropsFromNeosGlobals = {
-    i18nRegistry: I18nRegistry;
-};
-
-const withNeosGlobals = neos((globalRegistry): WorkspaceSyncPropsFromNeosGlobals => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}));
-
 type WorkspaceSyncProps =
     & WorkspaceSyncPropsFromReduxState
-    & WorkspaceSyncPropsFromNeosGlobals
     & WorkspaceSyncHandlers;
 
 const WorkspaceSync: React.FC<WorkspaceSyncProps> = (props) => {
@@ -58,9 +48,7 @@ const WorkspaceSync: React.FC<WorkspaceSyncProps> = (props) => {
         return null;
     }
 
-    const buttonTitle = props.i18nRegistry.translate(
-        'syncPersonalWorkSpace',
-        'Synchronize personal workspace', {}, 'Neos.Neos.Ui', 'Main');
+    const buttonTitle = translate('Neos.Neos.Ui:Main:syncPersonalWorkSpace', 'Synchronize personal workspace');
     return (
         <div id="neos-WorkspaceSync" className={style.wrapper}>
             <Button
@@ -77,4 +65,4 @@ const WorkspaceSync: React.FC<WorkspaceSyncProps> = (props) => {
     );
 };
 
-export default withReduxState(withNeosGlobals(WorkspaceSync as any));
+export default withReduxState(WorkspaceSync as any);

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -333,20 +333,20 @@ export default class Inspector extends PureComponent {
         if (focusedContentNodesContextPaths.length > 1) {
             return (
                 <div
-                    title={i18nRegistry.translate('inspectorMutlipleContentNodesSelectedTooltip', 'Select a single document in order to be able to edit its properties', {}, 'Neos.Neos.Ui', 'Main')}
+                    title={translate('Neos.Neos.Ui:Main:inspectorMutlipleContentNodesSelectedTooltip', 'Select a single document in order to be able to edit its properties')}
                     className={style.centeredInspector}
                     >
-                    <div>{focusedContentNodesContextPaths.length} {i18nRegistry.translate('contentElementsSelected', 'content elements selected', {}, 'Neos.Neos.Ui', 'Main')}</div>
+                    <div>{focusedContentNodesContextPaths.length} {translate('Neos.Neos.Ui:Main:contentElementsSelected', 'content elements selected')}</div>
                 </div>
             );
         }
         if (focusedDocumentNodesContextPaths.length > 1) {
             return (
                 <div
-                    title={i18nRegistry.translate('inspectorMutlipleDocumentNodesSelectedTooltip', 'Select a single content element in order to be able to edit its properties', {}, 'Neos.Neos.Ui', 'Main')}
+                    title={translate('Neos.Neos.Ui:Main:inspectorMutlipleDocumentNodesSelectedTooltip', 'Select a single content element in order to be able to edit its properties')}
                     className={style.centeredInspector}
                     >
-                    <div>{focusedDocumentNodesContextPaths.length} {i18nRegistry.translate('documentsSelected', 'documents selected', {}, 'Neos.Neos.Ui', 'Main')}</div>
+                    <div>{focusedDocumentNodesContextPaths.length} {translate('Neos.Neos.Ui:Main:documentsSelected', 'documents selected')}</div>
                 </div>
             );
         }

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -397,20 +397,7 @@ export default class Inspector extends PureComponent {
                             const notifications = validationErrors ?
                                 this.getAmountOfValidationErrors(tab, validationErrors) : 0;
                             const tabLabel = i18nRegistry.translate(tab?.label);
-                            const notificationTooltipLabelPieces = i18nRegistry.translate(
-                                'UI.RightSideBar.tabs.validationErrorTooltip',
-                                '',
-                                {
-                                    tabName: tabLabel,
-                                    amountOfErrors: notifications
-                                },
-                                'Neos.Neos.Ui',
-                                'Main',
-                                notifications
-                            );
-                            // @todo remove that when substitutePlaceholders of I18nRegistry returns strings
-                            const notificationTooltipLabel = Array.isArray(notificationTooltipLabelPieces) ?
-                                notificationTooltipLabelPieces.join('') : notificationTooltipLabelPieces;
+                            const notificationTooltipLabel = translate('Neos.Neos.Ui:Main:UI.RightSideBar.tabs.validationErrorTooltip', {tabName: tabLabel, amountOfErrors: notifications}, notifications);
 
                             return (
                                 <TabPanel

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -6,7 +6,7 @@ import mapValues from 'lodash.mapvalues';
 import {connect} from 'react-redux';
 import debounce from 'lodash.debounce';
 
-import I18n from '@neos-project/neos-ui-i18n';
+import {translate} from '@neos-project/neos-ui-i18n';
 import {Bar, Button, Tabs, Icon, Badge} from '@neos-project/react-ui-components';
 
 import {SecondaryInspector} from '@neos-project/neos-ui-inspector';
@@ -435,10 +435,10 @@ export default class Inspector extends PureComponent {
                 </Tabs>
                 <Bar position="bottom" className={style.actions}>
                     <Button id="neos-Inspector-Discard" style="lighter" disabled={isDiscardDisabled} onClick={this.handleDiscard} className={`${style.button} ${style.discardButton}`}>
-                        <I18n id="Neos.Neos:Main:discard" fallback="discard"/>
+                        {translate('Neos.Neos:Main:discard', 'discard')}
                     </Button>
                     <Button id="neos-Inspector-Apply" style="lighter" disabled={isApplyDisabled || isWorkspaceReadOnly} onClick={this.handleApply} className={`${style.button} ${style.publishButton}`}>
-                        <I18n id="Neos.Neos:Main:apply" fallback="apply"/>
+                        {translate('Neos.Neos:Main:apply', 'apply')}
                     </Button>
                 </Bar>
                 {

--- a/packages/neos-ui/src/Containers/RightSideBar/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/index.js
@@ -5,12 +5,12 @@ import {connect} from 'react-redux';
 import {IconButton, SideBar} from '@neos-project/react-ui-components';
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {neos} from '@neos-project/neos-ui-decorators';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 import style from './style.module.css';
 
 @neos(globalRegistry => ({
-    containerRegistry: globalRegistry.get('containers'),
-    i18nRegistry: globalRegistry.get('i18n')
+    containerRegistry: globalRegistry.get('containers')
 }))
 @connect(state => ({
     isHidden: selectors.UI.RightSideBar.isHidden(state),
@@ -21,7 +21,6 @@ import style from './style.module.css';
 export default class RightSideBar extends PureComponent {
     static propTypes = {
         containerRegistry: PropTypes.object.isRequired,
-        i18nRegistry: PropTypes.object.isRequired,
 
         isHidden: PropTypes.bool.isRequired,
         isFullScreen: PropTypes.bool.isRequired,
@@ -35,7 +34,7 @@ export default class RightSideBar extends PureComponent {
     }
 
     render() {
-        const {isHidden, isFullScreen, containerRegistry, i18nRegistry} = this.props;
+        const {isHidden, isFullScreen, containerRegistry} = this.props;
         const isSideBarHidden = isHidden;
         const classNames = mergeClassNames({
             [style.rightSideBar]: true,
@@ -50,7 +49,7 @@ export default class RightSideBar extends PureComponent {
                 className={style.rightSideBar__toggleBtn}
                 hoverStyle="clean"
                 onClick={this.handleToggle}
-                title={i18nRegistry.translate('Neos.Neos:Main:toggleInspector')}
+                title={translate('Neos.Neos:Main:toggleInspector')}
                 />
         );
 

--- a/packages/neos-ui/src/Containers/SecondaryToolbar/FullScreenButton/index.js
+++ b/packages/neos-ui/src/Containers/SecondaryToolbar/FullScreenButton/index.js
@@ -4,12 +4,9 @@ import {connect} from 'react-redux';
 
 import IconButton from '@neos-project/react-ui-components/src/IconButton/';
 import {actions} from '@neos-project/neos-ui-redux-store';
-import {neos} from '@neos-project/neos-ui-decorators';
 import style from './style.module.css';
+import {translate} from '@neos-project/neos-ui-i18n';
 
-@neos(globalRegistry => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}))
 @connect(state => ({
     isFullScreen: state?.ui?.fullScreen?.isFullScreen
 }), {
@@ -18,28 +15,27 @@ import style from './style.module.css';
 export default class FullScreenButton extends PureComponent {
     static propTypes = {
         toggleFullScreen: PropTypes.func,
-        i18nRegistry: PropTypes.object.isRequired,
         isFullScreen: PropTypes.bool.isRequired
     };
 
     render() {
-        const {toggleFullScreen, i18nRegistry, isFullScreen} = this.props;
+        const {toggleFullScreen, isFullScreen} = this.props;
 
         return isFullScreen ? (
             <IconButton
                 icon="expand"
                 className={style.fullScreenClose}
                 onClick={toggleFullScreen}
-                aria-label={i18nRegistry.translate('Neos.Neos:Main:deactivateFullscreen', 'Deactivate Fullscreen edit mode')}
-                title={i18nRegistry.translate('Neos.Neos:Main:deactivateFullscreen', 'Deactivate Fullscreen edit mode')}
+                aria-label={translate('Neos.Neos:Main:deactivateFullscreen', 'Deactivate Fullscreen edit mode')}
+                title={translate('Neos.Neos:Main:deactivateFullscreen', 'Deactivate Fullscreen edit mode')}
                 />
             ) : (
                 <IconButton
                     id="neos-FullScreenButton"
                     icon="expand"
                     onClick={toggleFullScreen}
-                    aria-label={i18nRegistry.translate('Neos.Neos:Main:activateFullscreen', 'Activate Fullscreen edit mode')}
-                    title={i18nRegistry.translate('Neos.Neos:Main:activateFullscreen', 'Activate Fullscreen edit mode')}
+                    aria-label={translate('Neos.Neos:Main:activateFullscreen', 'Activate Fullscreen edit mode')}
+                    title={translate('Neos.Neos:Main:activateFullscreen', 'Activate Fullscreen edit mode')}
                     />
             );
     }

--- a/packages/neos-ui/src/Containers/SecondaryToolbar/KeyboardShortcutButton/index.js
+++ b/packages/neos-ui/src/Containers/SecondaryToolbar/KeyboardShortcutButton/index.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import IconButton from '@neos-project/react-ui-components/src/IconButton/';
 import {neos} from '@neos-project/neos-ui-decorators';
 import {connect} from 'react-redux';
+import {translate} from '@neos-project/neos-ui-i18n';
 
 import {actions} from '@neos-project/neos-ui-redux-store';
 
 @neos(globalRegistry => ({
-    i18nRegistry: globalRegistry.get('i18n'),
     hotkeyRegistry: globalRegistry.get('hotkeys')
 }))
 @connect(
@@ -16,13 +16,12 @@ import {actions} from '@neos-project/neos-ui-redux-store';
 )
 export default class KeyboardShortcutButton extends PureComponent {
     static propTypes = {
-        i18nRegistry: PropTypes.object.isRequired,
         toggleFullScreen: PropTypes.func,
         hotkeyRegistry: PropTypes.object.isRequired
     };
 
     render() {
-        const {i18nRegistry, open, hotkeyRegistry} = this.props;
+        const {open, hotkeyRegistry} = this.props;
 
         if (hotkeyRegistry._registry === null || hotkeyRegistry._registry.length === 0) {
             return null;
@@ -31,8 +30,8 @@ export default class KeyboardShortcutButton extends PureComponent {
         return (
             <IconButton
                 icon="keyboard"
-                aria-label={i18nRegistry.translate('Neos.Neos:Main:displayKeyboardShortcuts', 'Display Keyboard Shortcuts')}
-                title={i18nRegistry.translate('Neos.Neos:Main:displayKeyboardShortcuts', 'Display Keyboard Shortcuts')}
+                aria-label={translate('Neos.Neos:Main:displayKeyboardShortcuts', 'Display Keyboard Shortcuts')}
+                title={translate('Neos.Neos:Main:displayKeyboardShortcuts', 'Display Keyboard Shortcuts')}
                 onClick={open}
                 />
         );

--- a/packages/neos-ui/src/Containers/SecondaryToolbar/PreviewButton/index.js
+++ b/packages/neos-ui/src/Containers/SecondaryToolbar/PreviewButton/index.js
@@ -5,23 +5,18 @@ import {connect} from 'react-redux';
 import mergeClassNames from 'classnames';
 
 import style from './style.module.css';
-import {neos} from '@neos-project/neos-ui-decorators';
-
-@neos(globalRegistry => ({
-    i18nRegistry: globalRegistry.get('i18n')
-}))
+import {translate} from '@neos-project/neos-ui-i18n';
 
 @connect(state => ({
     previewUrl: state?.ui?.contentCanvas?.previewUrl
 }))
 export default class PreviewButton extends PureComponent {
     static propTypes = {
-        previewUrl: PropTypes.string,
-        i18nRegistry: PropTypes.object.isRequired
+        previewUrl: PropTypes.string
     };
 
     render() {
-        const {previewUrl, i18nRegistry} = this.props;
+        const {previewUrl} = this.props;
 
         const previewButtonClassNames = mergeClassNames({
             [style.secondaryToolbar__buttonLink]: true,
@@ -35,8 +30,8 @@ export default class PreviewButton extends PureComponent {
                     href={previewUrl ? previewUrl : ''}
                     target="neosPreview"
                     className={previewButtonClassNames}
-                    aria-label={i18nRegistry.translate('Neos.Neos:Main:showPreview', 'Show Preview')}
-                    title={i18nRegistry.translate('Neos.Neos:Main:showPreview', 'Show Preview')}
+                    aria-label={translate('Neos.Neos:Main:showPreview', 'Show Preview')}
+                    title={translate('Neos.Neos:Main:showPreview', 'Show Preview')}
                     >
                     <Icon icon="external-link-alt"/>
                 </a>
@@ -48,7 +43,7 @@ export default class PreviewButton extends PureComponent {
                 id="neos-PreviewButton"
                 className={previewButtonClassNames}
                 disabled
-                aria-label={i18nRegistry.translate('Neos.Neos:Main:showPreview', 'Show Preview')}
+                aria-label={translate('Neos.Neos:Main:showPreview', 'Show Preview')}
                 >
                 <Icon icon="external-link-alt"/>
             </button>


### PR DESCRIPTION
Followup to https://github.com/neos/neos-ui/pull/3804 which deprecates the use of the <i18n> component and the i18nRegistry, as this is now a global concept via the `translate` method.

**What I did**

Using various careful regex replacements and manual adjustments, commit by commit the `translate()` method was introduced.

As written here https://github.com/neos/neos-ui/pull/3804#issuecomment-2613992743 the new method does not handle user input gracefully, which is the reason why non static strings are still using the old translation methods to ensure nothing breaks here.

**How I did it**

**How to verify it**

Via the regex

```
translate\('(?!(Neos\.Neos:(Main|Inspector|Modules)|Neos\.Neos\.Ui:(Error|Main|PublishingDialog|SyncWorkspaceDialog)):[a-zA-Z._-]+')
```

All source files can be checked that each call to `translate()` now specifies the translation as fully qualified shorthand string.

Replacing the <i18n> component with a direct call to `translate()` might not always look correct as this leads to a missing `<span />` tag. Those cases have to be identified by eye.

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
