### PR TITLE
BUGFIX: Non-scrollable Neos.Neos/Inspector/Editors/RichTextEditor

### DIFF
--- a/packages/neos-ui-editors/src/SecondaryEditors/CKEditorWrap/index.module.css
+++ b/packages/neos-ui-editors/src/SecondaryEditors/CKEditorWrap/index.module.css
@@ -15,4 +15,5 @@
     outline: 0;
     padding: 15px;
     overflow: scroll;
+    height: 0px;
 }

--- a/packages/neos-ui-editors/src/SecondaryEditors/CKEditorWrap/index.module.css
+++ b/packages/neos-ui-editors/src/SecondaryEditors/CKEditorWrap/index.module.css
@@ -15,5 +15,5 @@
     outline: 0;
     padding: 15px;
     overflow: scroll;
-    height: 0px;
+    height: 0;
 }


### PR DESCRIPTION
Fixes the scrolling behavior within Neos.Neos/Inspector/Editors/RichTextEditor

**What I did**

Added a height with 0px value to enable scrolling within `RichTextEditor`.
=> Not sure if there is any better option/way for this fix as i didn't received any feedback in my [issue](https://github.com/neos/neos-ui/issues/3906), but it is working fine for me.

Before:
![before](https://github.com/user-attachments/assets/ef66bc35-0b04-4eb2-ab93-41d83eb786c1)

After (with height of 0px):
![after](https://github.com/user-attachments/assets/7be2da28-0222-430a-87fe-dfea695780e6)

