### PR TITLE
BUGFIX: add feedback to switch to new document in tree on cut and copy

### DIFF
--- a/Classes/Domain/Model/Changes/AbstractCopy.php
+++ b/Classes/Domain/Model/Changes/AbstractCopy.php
@@ -36,6 +36,7 @@ abstract class AbstractCopy extends AbstractStructuralChange
         $updateNodeInfo->setNode($node);
         $updateNodeInfo->recursive();
         $this->feedbackCollection->add($updateNodeInfo);
+        $this->addNodeCreatedFeedback($this->getSubject());
         parent::finish($node);
     }
 

--- a/Classes/Domain/Model/Changes/AbstractCopy.php
+++ b/Classes/Domain/Model/Changes/AbstractCopy.php
@@ -36,7 +36,7 @@ abstract class AbstractCopy extends AbstractStructuralChange
         $updateNodeInfo->setNode($node);
         $updateNodeInfo->recursive();
         $this->feedbackCollection->add($updateNodeInfo);
-        $this->addNodeCreatedFeedback($this->getSubject());
+        $this->addNodeCreatedFeedback($node);
         parent::finish($node);
     }
 

--- a/Classes/Domain/Model/Changes/AbstractMove.php
+++ b/Classes/Domain/Model/Changes/AbstractMove.php
@@ -17,6 +17,7 @@ use Neos\ContentRepository\Domain\Service as ContentRepository;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\RemoveNode;
 use Neos\Flow\Annotations as Flow;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateNodePath;
+use Neos\Neos\Ui\Domain\Model\Feedback\Operations\Redirect;
 
 abstract class AbstractMove extends AbstractStructuralChange
 {
@@ -40,7 +41,11 @@ abstract class AbstractMove extends AbstractStructuralChange
             $updateNodePath->setNewContextPath($this->getSubject()->getContextPath());
             $this->feedbackCollection->add($updateNodePath);
         }
-
+        if ($this->getSubject()->getNodeType()->isOfType('Neos.Neos:Document')) {
+            $redirect = new Redirect();
+            $redirect->setNode($this->getSubject());
+            $this->feedbackCollection->add($redirect);
+        }
         // $this->getSubject() is the moved node at the NEW location!
         parent::finish($this->getSubject());
     }


### PR DESCRIPTION
see #3917 

**What I did**
When using cut/copy in the document tree, the user is not automatically redirected to the "new" page. 

**How I did it**
To keep it consistent with  all other operations in the content/document tree I added feedback in the operations that will lead to the user being on the new page 


**How to verify it**
When using cut/copy/create in both the document and content tree, the user is always redirected to the "new" node. 
