### PR TITLE
TASK: Optimize cloning in update-neos-ui-compiled.sh

### DIFF
--- a/Build/Jenkins/update-neos-ui-compiled.sh
+++ b/Build/Jenkins/update-neos-ui-compiled.sh
@@ -38,11 +38,7 @@ make clean && make setup
 NEOS_UI_VERSION="${GIT_TAG:-${GIT_BRANCH#*/}-dev}" make build-production
 
 rm -Rf tmp_compiled_pkg
-git clone git@github.com:neos/neos-ui-compiled.git tmp_compiled_pkg
-cd tmp_compiled_pkg
-git checkout "$GIT_BRANCH"
-cd ..
-
+git clone --depth 1 git@github.com:neos/neos-ui-compiled.git --single-branch --branch=${GIT_BRANCH} tmp_compiled_pkg
 
 mkdir -p tmp_compiled_pkg/Resources/Public/Build
 


### PR DESCRIPTION
The script clones `git@github.com:neos/neos-ui-compiled.git` – and that is a **massive** repository. Cloning it uses a lot of space (over 1 GB) and takes long, as the Jenkins log shows (timestamps are elapsed time):

```
00:00:50.125 + git clone git@github.com:neos/neos-ui-compiled.git tmp_compiled_pkg
00:00:50.137 Cloning into 'tmp_compiled_pkg'...
00:21:54.271 + cd tmp_compiled_pkg
00:21:54.272 + git checkout origin/8.4
```

That took… more than 20 minutes! Yikes!

I suggest to do this instead:

```
git clone --depth 1 git@github.com:neos/neos-ui-compiled.git --single-branch --branch=${BRANCH} tmp_compiled_pkg
```

Takes about 10 seconds for me, transfers around 5 MB of data, uses 23 MB of disk space and even saves us the `git checkout`, as the branch is already taken care of.
