### PR TITLE
TASK: Add ability for read-only users to interact with nodes in the preview page and view node data in the inspector

### DIFF
--- a/Classes/Aspects/AugmentationAspect.php
+++ b/Classes/Aspects/AugmentationAspect.php
@@ -22,6 +22,7 @@ use Neos\Fusion\Service\HtmlAugmenter;
 use Neos\Neos\Domain\Service\ContentContext;
 use Neos\Neos\Ui\Domain\Service\UserLocaleService;
 use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
+use Neos\Neos\Ui\Service\NodePolicyService;
 
 /**
  * - Serialize all nodes related to the currently rendered document
@@ -60,6 +61,12 @@ class AugmentationAspect
      * @var \Neos\Flow\Mvc\Controller\ControllerContext
      */
     protected $controllerContext = null;
+
+    /**
+     * @Flow\Inject
+     * @var NodePolicyService
+     */
+    protected $nodePolicyService;
 
     /**
      * @Flow\Before("method(Neos\Neos\Fusion\ContentElementWrappingImplementation->evaluate())")
@@ -145,7 +152,8 @@ class AugmentationAspect
             return $content;
         }
 
-        if ($this->nodeAuthorizationService->isGrantedToEditNode($node) === false) {
+        // TODO: this is where we could use a feature flag
+        if ($this->nodePolicyService->canReadNode($node) === false) {
             return $content;
         }
 

--- a/Classes/Aspects/AugmentationAspect.php
+++ b/Classes/Aspects/AugmentationAspect.php
@@ -152,7 +152,6 @@ class AugmentationAspect
             return $content;
         }
 
-        // TODO: this is where we could use a feature flag
         if ($this->nodePolicyService->canReadNode($node) === false) {
             return $content;
         }

--- a/Classes/Aspects/AugmentationAspect.php
+++ b/Classes/Aspects/AugmentationAspect.php
@@ -152,7 +152,7 @@ class AugmentationAspect
             return $content;
         }
 
-        if ($this->nodePolicyService->canReadNode($node) === false) {
+        if ($this->nodePolicyService->canReadProperties($node) === false) {
             return $content;
         }
 

--- a/Classes/Service/NodePolicyService.php
+++ b/Classes/Service/NodePolicyService.php
@@ -82,6 +82,7 @@ class NodePolicyService
             'disallowedNodeTypes' => $this->getDisallowedNodeTypes($node),
             'canRemove' => $this->canRemoveNode($node),
             'canEdit' => $this->canEditNode($node),
+            'canView' => $this->canReadNode($node),
             'disallowedProperties' => $this->getDisallowedProperties($node)
         ];
     }
@@ -98,6 +99,22 @@ class NodePolicyService
 
         return $this->privilegeManager->isGranted(
             NodeTreePrivilege::class,
+            new NodePrivilegeSubject($node)
+        );
+    }
+
+    /**
+     * @param NodeInterface $node
+     * @return bool
+     */
+    public function canReadNode(NodeInterface $node): bool
+    {
+        if (!isset(self::getUsedPrivilegeClassNames($this->objectManager)[ReadNodePropertyPrivilege::class])) {
+            return true;
+        }
+
+        return $this->privilegeManager->isGranted(
+            ReadNodePropertyPrivilege::class,
             new NodePrivilegeSubject($node)
         );
     }

--- a/Classes/Service/NodePolicyService.php
+++ b/Classes/Service/NodePolicyService.php
@@ -19,6 +19,7 @@ use Neos\ContentRepository\Security\Authorization\Privilege\Node\EditNodePrivile
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\EditNodePropertyPrivilege;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\NodePrivilegeSubject;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\PropertyAwareNodePrivilegeSubject;
+use Neos\ContentRepository\Security\Authorization\Privilege\Node\ReadNodePrivilege;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\RemoveNodePrivilege;
 use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
@@ -82,7 +83,7 @@ class NodePolicyService
             'disallowedNodeTypes' => $this->getDisallowedNodeTypes($node),
             'canRemove' => $this->canRemoveNode($node),
             'canEdit' => $this->canEditNode($node),
-            'canRead' => $this->canReadNode($node),
+            'canReadProperties' => $this->canReadProperties($node),
             'disallowedProperties' => $this->getDisallowedProperties($node)
         ];
     }
@@ -107,14 +108,22 @@ class NodePolicyService
      * @param NodeInterface $node
      * @return bool
      */
-    public function canReadNode(NodeInterface $node): bool
+    public function canReadProperties(NodeInterface $node): bool
     {
-        if (!isset(self::getUsedPrivilegeClassNames($this->objectManager)[ReadNodePropertyPrivilege::class])) {
+        // In our current understanding, this canReadProperties check can NEVER return false under normal
+        // Neos UI circumstances, because we test for ReadNodePrivilege.
+        // if a node should be hidden via ReadNodePrivilege, it is not returned from persistence, thus
+        // you would not be able to get the $node instance.
+        //
+        // We left the method in there nevertheless for:
+        // - if users want to override this via AOP
+        // - if somebody would want to create a new PrivilegeType for it (!! node privilege concept changes with Neos 9 !!)
+        if (!isset(self::getUsedPrivilegeClassNames($this->objectManager)[ReadNodePrivilege::class])) {
             return true;
         }
 
         return $this->privilegeManager->isGranted(
-            ReadNodePropertyPrivilege::class,
+            ReadNodePrivilege::class,
             new NodePrivilegeSubject($node)
         );
     }

--- a/Classes/Service/NodePolicyService.php
+++ b/Classes/Service/NodePolicyService.php
@@ -82,7 +82,7 @@ class NodePolicyService
             'disallowedNodeTypes' => $this->getDisallowedNodeTypes($node),
             'canRemove' => $this->canRemoveNode($node),
             'canEdit' => $this->canEditNode($node),
-            'canView' => $this->canReadNode($node),
+            'canRead' => $this->canReadNode($node),
             'disallowedProperties' => $this->getDisallowedProperties($node)
         ];
     }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   ],
   "require": {
     "neos/neos": "^8.3.0",
-    "neos/neos-ui-compiled": "self.version"
+    "neos/neos-ui-compiled": "8.4.x-dev"
   },
   "autoload": {
     "psr-4": {

--- a/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
@@ -37,12 +37,12 @@ export const bootstrap = _editorConfig => {
 };
 
 export const createEditor = store => async options => {
-    const {propertyDomNode, propertyName, editorOptions, globalRegistry, userPreferences, onChange} = options;
+    const {propertyDomNode, propertyName, editorOptions, globalRegistry, userPreferences, onChange, isReadOnly} = options;
     const ckEditorConfig = editorConfig.configRegistry.getCkeditorConfig({
         editorOptions,
         userPreferences,
         globalRegistry,
-        propertyDomNode
+        propertyDomNode,
     });
 
     class NeosEditor extends DecoupledEditor {
@@ -58,26 +58,34 @@ export const createEditor = store => async options => {
     return NeosEditor
         .create(propertyDomNode, ckEditorConfig)
         .then(editor => {
-            const debouncedOnChange = debounce(() => onChange(cleanupContentBeforeCommit(editor.getData())), 1500, {maxWait: 5000});
-            editor.model.document.on('change:data', debouncedOnChange);
-            editor.ui.focusTracker.on('change:isFocused', event => {
-                if (!event.source.isFocused) {
-                    // when another editor is focused commit all possible pending changes
-                    debouncedOnChange.flush();
-                    return
-                }
+            editor.isReadOnly = isReadOnly;
 
-                currentEditor = editor;
-                editorConfig.setCurrentlyEditedPropertyName(propertyName);
-                handleUserInteractionCallback();
-            });
+            // Set placeholder text as Data if editor is empty because readOnly mode hides the placeholder
+            if (isReadOnly && editor.getData() === '') {
+                editor.setData(ckEditorConfig.placeholder, {doNotFireChange: true});
+            } else {
+                const debouncedOnChange = debounce(() => onChange(cleanupContentBeforeCommit(editor.getData())), 1500, {maxWait: 5000});
+                editor.model.document.on('change:data', debouncedOnChange);
+                editor.ui.focusTracker.on('change:isFocused', event => {
+                    if (!event.source.isFocused) {
+                        // when another editor is focused commit all possible pending changes
+                        debouncedOnChange.flush();
+                        return
+                    }
 
-            editor.keystrokes.set('Ctrl+K', (_, cancel) => {
-                store.dispatch(actions.UI.ContentCanvas.toggleLinkEditor());
-                cancel();
-            });
+                    currentEditor = editor;
+                    editorConfig.setCurrentlyEditedPropertyName(propertyName);
+                    handleUserInteractionCallback();
+                });
 
-            editor.model.document.on('change', () => handleUserInteractionCallback());
+                editor.keystrokes.set('Ctrl+K', (_, cancel) => {
+                    store.dispatch(actions.UI.ContentCanvas.toggleLinkEditor());
+                    cancel();
+                });
+
+                editor.model.document.on('change', () => handleUserInteractionCallback());
+            }
+
             return editor;
         }).catch(e => {
             if (e instanceof TypeError && e.message.match(/Class constructor .* cannot be invoked without 'new'/)) {

--- a/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
@@ -42,7 +42,7 @@ export const createEditor = store => async options => {
         editorOptions,
         userPreferences,
         globalRegistry,
-        propertyDomNode,
+        propertyDomNode
     });
 
     class NeosEditor extends DecoupledEditor {

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -112,9 +112,11 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
 
     const editPreviewMode = $get(['ui', 'editPreviewMode'], state);
     const editPreviewModes = globalRegistry.get('frontendConfiguration').get('editPreviewModes');
-    const isWorkspaceReadOnly = selectors.CR.Workspaces.isWorkspaceReadOnlySelector(state);
     const currentEditMode = editPreviewModes[editPreviewMode];
-    if (!currentEditMode || !currentEditMode.isEditingMode || isWorkspaceReadOnly) {
+
+    // ReadOnly workspaces are handled by ckEditor directly
+    // TODO: this will break other editors, correct?
+    if (!currentEditMode || !currentEditMode.isEditingMode) {
         return;
     }
 

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -115,7 +115,6 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
     const currentEditMode = editPreviewModes[editPreviewMode];
 
     // ReadOnly workspaces are handled by ckEditor directly
-    // TODO: this will break other editors, correct?
     if (!currentEditMode || !currentEditMode.isEditingMode) {
         return;
     }

--- a/packages/neos-ui-guest-frame/src/initializePropertyDomNode.js
+++ b/packages/neos-ui-guest-frame/src/initializePropertyDomNode.js
@@ -4,6 +4,8 @@ import {actions} from '@neos-project/neos-ui-redux-store';
 import {validateElement} from '@neos-project/neos-ui-validators';
 
 import {getGuestFrameWindow, closestContextPathInGuestFrame} from './dom';
+// TODO: this import feels foreign to the rest of neos code, but it feels strange to import the complete selectors object
+import {isWorkspaceReadOnlySelector} from '@neos-project/neos-ui-redux-store/src/CR/Workspaces/selectors';
 
 export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry, nodes}) => propertyDomNode => {
     const guestFrameWindow = getGuestFrameWindow();
@@ -61,6 +63,7 @@ export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry,
         try {
             if (!propertyDomNode.dataset.neosInlineEditorIsInitialized) {
                 const userPreferences = $get('user.preferences', store.getState());
+                const isReadOnly = isWorkspaceReadOnlySelector(store.getState());
 
                 createInlineEditor({
                     propertyDomNode,
@@ -70,10 +73,21 @@ export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry,
                     editorOptions,
                     globalRegistry,
                     userPreferences,
-                    persistChange: change => store.dispatch(
-                        actions.Changes.persistChanges([change])
-                    ),
+                    isReadOnly,
+                    persistChange: change => {
+                        if (isReadOnly) {
+                            return;
+                        }
+
+                        store.dispatch(
+                            actions.Changes.persistChanges([change])
+                        )
+                    },
                     onChange: value => {
+                        if (isReadOnly) {
+                            return;
+                        }
+
                         const validationResult = validateElement(value, $get(['properties', propertyName], nodeType), globalRegistry.get('validators'));
                         // Update inline validation errors
                         store.dispatch(

--- a/packages/neos-ui-guest-frame/src/initializePropertyDomNode.js
+++ b/packages/neos-ui-guest-frame/src/initializePropertyDomNode.js
@@ -1,11 +1,9 @@
 import {$get, $contains} from 'plow-js';
 
-import {actions} from '@neos-project/neos-ui-redux-store';
+import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {validateElement} from '@neos-project/neos-ui-validators';
 
 import {getGuestFrameWindow, closestContextPathInGuestFrame} from './dom';
-// TODO: this import feels foreign to the rest of neos code, but it feels strange to import the complete selectors object
-import {isWorkspaceReadOnlySelector} from '@neos-project/neos-ui-redux-store/src/CR/Workspaces/selectors';
 
 export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry, nodes}) => propertyDomNode => {
     const guestFrameWindow = getGuestFrameWindow();
@@ -63,7 +61,7 @@ export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry,
         try {
             if (!propertyDomNode.dataset.neosInlineEditorIsInitialized) {
                 const userPreferences = $get('user.preferences', store.getState());
-                const isReadOnly = isWorkspaceReadOnlySelector(store.getState());
+                const isWorkspaceReadOnly = selectors.CR.Workspaces.isWorkspaceReadOnlySelector(store.getState());
 
                 createInlineEditor({
                     propertyDomNode,
@@ -73,9 +71,9 @@ export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry,
                     editorOptions,
                     globalRegistry,
                     userPreferences,
-                    isReadOnly,
+                    isReadOnly: isWorkspaceReadOnly,
                     persistChange: change => {
-                        if (isReadOnly) {
+                        if (isWorkspaceReadOnly) {
                             return;
                         }
 
@@ -84,7 +82,7 @@ export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry,
                         )
                     },
                     onChange: value => {
-                        if (isReadOnly) {
+                        if (isWorkspaceReadOnly) {
                             return;
                         }
 

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
@@ -30,7 +30,7 @@ export default class TabPanel extends PureComponent {
             return false;
         }
 
-        return $get(['policy', 'canEdit'], node) && !$contains(item.id, 'policy.disallowedProperties', node);
+        return $get(['policy', 'canView'], node) && !$contains(item.id, 'policy.disallowedProperties', node);
     };
 
     renderTabPanel = groups => {

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
@@ -30,7 +30,7 @@ export default class TabPanel extends PureComponent {
             return false;
         }
 
-        return $get(['policy', 'canRead'], node) && !$contains(item.id, 'policy.disallowedProperties', node);
+        return $get(['policy', 'canReadProperties'], node) && !$contains(item.id, 'policy.disallowedProperties', node);
     };
 
     renderTabPanel = groups => {

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
@@ -30,7 +30,7 @@ export default class TabPanel extends PureComponent {
             return false;
         }
 
-        return $get(['policy', 'canView'], node) && !$contains(item.id, 'policy.disallowedProperties', node);
+        return $get(['policy', 'canRead'], node) && !$contains(item.id, 'policy.disallowedProperties', node);
     };
 
     renderTabPanel = groups => {

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -247,7 +247,7 @@ export default class Inspector extends PureComponent {
             return false;
         }
 
-        return $get(['policy', 'canEdit'], focusedNode) && !$contains(item.id, 'policy.disallowedProperties', focusedNode);
+        return $get(['policy', 'canView'], focusedNode) && !$contains(item.id, 'policy.disallowedProperties', focusedNode);
     };
 
     /**

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -247,7 +247,7 @@ export default class Inspector extends PureComponent {
             return false;
         }
 
-        return $get(['policy', 'canView'], focusedNode) && !$contains(item.id, 'policy.disallowedProperties', focusedNode);
+        return $get(['policy', 'canRead'], focusedNode) && !$contains(item.id, 'policy.disallowedProperties', focusedNode);
     };
 
     /**

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -247,7 +247,7 @@ export default class Inspector extends PureComponent {
             return false;
         }
 
-        return $get(['policy', 'canRead'], focusedNode) && !$contains(item.id, 'policy.disallowedProperties', focusedNode);
+        return $get(['policy', 'canReadProperties'], focusedNode) && !$contains(item.id, 'policy.disallowedProperties', focusedNode);
     };
 
     /**


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**
Previous Behaviour:
- When a view-only user clicks on a node on the preview page nothing happens.
- The user can only select nodes via the content tree (left sidebar)
- The user can not see any node data in the inspector (right sidebar)

Fixed Behaviour:
- The user can interact with nodes on the preview page (highlighting is visible)
- The user can view - but not edit - node data in the inspector (right sidebar)

**How I did it**
- I let the backend send metadata to the client when the user has permission to read (previously it was only sent, when the user had permission to edit).
- I handle the read-only case in CKEditor to prevent the user from editing and throwing errors that way.

This should also apply to read-only workspaces.

> Note: When I tested editing content via circumventing browser behaviour (disabled fields etc) the server responded with an error. This has not been a very thorough test though.

**How to verify it**
- Create a role (e.g. with the Sandstorm.NeosAcl package) that has permission to view but not to edit/create.
- When browsing content the user should be able to click on nodes in the preview page and see their data in the inspector.

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
**BEFORE**
![Screenshot before change](https://github.com/user-attachments/assets/637bd2c8-51ef-4c7d-a42f-7e3dd6e2d829)
**AFTER**
![Screenshot after change](https://github.com/user-attachments/assets/e1e4c832-02c7-49eb-9ec0-ce3204a3b4ee)
