### PR TITLE
TASK: Replace only (fully obsolete) usage of `getNodeByCoveredDimensionSpacePoint`

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -162,11 +162,10 @@ class BackendController extends ActionController
         if (!$rootNodeAggregate) {
             throw new \RuntimeException(sprintf('No sites root node found in content repository "%s", while fetching site node "%s"', $contentRepository->id->value, $siteDetectionResult->siteNodeName->value), 1724849303);
         }
-        $rootNode = $rootNodeAggregate->getNodeByCoveredDimensionSpacePoint($arbitraryRootDimensionSpacePoint);
 
         $siteNode = $subgraph->findNodeByPath(
             $siteDetectionResult->siteNodeName->toNodeName(),
-            $rootNode->aggregateId
+            $rootNodeAggregate->nodeAggregateId
         );
 
         if (!$nodeAddress) {


### PR DESCRIPTION
see also https://github.com/neos/neos-development-collection/pull/5490

We can use `$rootNodeAggregate->nodeAggregateId` instead directly - LOL

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
