### PR TITLE
TASK: Auto rebase workspace on backend module opening if necessary

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -13,6 +13,7 @@ namespace Neos\Neos\Ui\Controller;
  */
 
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceStatus;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;
@@ -20,6 +21,7 @@ use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Neos\Domain\Repository\DomainRepository;
 use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Domain\Service\NodeTypeNameFactory;
+use Neos\Neos\Domain\Service\WorkspacePublishingService;
 use Neos\Neos\Domain\Service\WorkspaceService;
 use Neos\Neos\Domain\SubtreeTagging\NeosSubtreeTag;
 use Neos\Neos\FrontendRouting\NodeUriBuilderFactory;
@@ -124,6 +126,12 @@ class BackendController extends ActionController
     protected $workspaceService;
 
     /**
+     * @Flow\Inject
+     * @var WorkspacePublishingService
+     */
+    protected $workspacePublishingService;
+
+    /**
      * Displays the backend interface
      *
      * @param string $node The node that will be displayed on the first tab
@@ -143,6 +151,9 @@ class BackendController extends ActionController
 
         $this->workspaceService->createPersonalWorkspaceForUserIfMissing($siteDetectionResult->contentRepositoryId, $user);
         $workspace = $this->workspaceService->getPersonalWorkspaceForUser($siteDetectionResult->contentRepositoryId, $user->getId());
+        if ($workspace->status === WorkspaceStatus::OUTDATED && !$workspace->hasPublishableChanges()) {
+            $this->workspacePublishingService->rebaseWorkspace($siteDetectionResult->contentRepositoryId, $workspace->workspaceName);
+        }
 
         $contentGraph = $contentRepository->getContentGraph($workspace->workspaceName);
 

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -133,6 +133,12 @@ class BackendController extends ActionController
     protected $workspacePublishingService;
 
     /**
+     * @Flow\InjectConfiguration(path="autoSyncPersonalWorkspaces")
+     * @var bool
+     */
+    protected $autoSyncPersonalWorkspaces;
+
+    /**
      * Displays the backend interface
      *
      * @param string $node The node that will be displayed on the first tab
@@ -152,7 +158,11 @@ class BackendController extends ActionController
 
         $this->workspaceService->createPersonalWorkspaceForUserIfMissing($siteDetectionResult->contentRepositoryId, $user);
         $workspace = $this->workspaceService->getPersonalWorkspaceForUser($siteDetectionResult->contentRepositoryId, $user->getId());
-        if ($workspace->status === WorkspaceStatus::OUTDATED && !$workspace->hasPublishableChanges()) {
+        if (
+            $this->autoSyncPersonalWorkspaces
+            && $workspace->status === WorkspaceStatus::OUTDATED
+            && !$workspace->hasPublishableChanges()
+        ) {
             try {
                 $this->workspacePublishingService->rebaseWorkspace($siteDetectionResult->contentRepositoryId, $workspace->workspaceName);
             } catch (WorkspaceRebaseFailed) {

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -12,6 +12,7 @@ namespace Neos\Neos\Ui\Controller;
  * source code.
  */
 
+use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Exception\WorkspaceRebaseFailed;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceStatus;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
@@ -152,7 +153,12 @@ class BackendController extends ActionController
         $this->workspaceService->createPersonalWorkspaceForUserIfMissing($siteDetectionResult->contentRepositoryId, $user);
         $workspace = $this->workspaceService->getPersonalWorkspaceForUser($siteDetectionResult->contentRepositoryId, $user->getId());
         if ($workspace->status === WorkspaceStatus::OUTDATED && !$workspace->hasPublishableChanges()) {
-            $this->workspacePublishingService->rebaseWorkspace($siteDetectionResult->contentRepositoryId, $workspace->workspaceName);
+            try {
+                $this->workspacePublishingService->rebaseWorkspace($siteDetectionResult->contentRepositoryId, $workspace->workspaceName);
+            } catch (WorkspaceRebaseFailed) {
+                // currently we don't have a way to provide this rebase error directly to the neos ui and have it solved.
+                // instead we ignore it and have the editor trigger it again via the sync button.
+            }
         }
 
         $contentGraph = $contentRepository->getContentGraph($workspace->workspaceName);

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -91,6 +91,11 @@ Neos:
 
           'CR.Nodes.unfocus': 'u n'
 
+      # If enabled, will automatically synchronize (rebase) personal workspaces when used in the UI
+      # (currently: Neos\Neos\Ui\Controller\BackendController::indexAction())
+      # if necessary (outdated) and possible (no own changes)
+      autoSyncPersonalWorkspaces: true
+
       #################################
       # INTERNAL CONFIG (no API)
       #################################


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

Originally there was a `EditorContentStreamZookeeper` which task was it to create the users workspace on login and also always have it rebased on login.
Then it was adjusted to only rebase if really necessary by using the outdated check: https://github.com/neos/neos-development-collection/issues/4728
But because rebases could likely cause exceptions / legacy OUTDATED_CONFLICT state the rebase on login feature was removed: https://github.com/neos/neos-development-collection/commit/dadb444124ac32483f361ace97d065a32ae1ac42
After all the whole service was removed when the workspace creation was moved to the UI's `BackendController` https://github.com/neos/neos-development-collection/commit/7a2e68abaedf25420a88118644e527575381089a 

Now we discussed that as rebasing is a new 9.0 topic we want to avoid the burden for users who only login to see the current state without even having changes, thus we reintroduce the automatic rebase but directly in the `BackendController`, and in difference than before with the get pending changes check which should prevent a rebase exception.

**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
