### PR TITLE
BUGFIX: Have base z-index for inspector to make relative z-indices work

### DIFF
--- a/packages/neos-ui/src/Containers/RightSideBar/style.module.css
+++ b/packages/neos-ui/src/Containers/RightSideBar/style.module.css
@@ -6,6 +6,7 @@
     right: unset;
     position: relative;
     background-color: var(--colors-ContrastDarkest);
+    z-index: 1;
 }
 .rightSideBar--isHidden {
     width: 0;


### PR DESCRIPTION
With this change the issue is solved that the help message of properties is in front of the publish dropdown and custom inspector plugins with z-indices caused visual issues with the creation dialog overlay.

Resolves: #3342

Before:

![CleanShot 2025-03-26 at 13 14 11](https://github.com/user-attachments/assets/7a45d064-8696-4e85-a8d2-bcc14eeada11)

After:

![CleanShot 2025-03-26 at 13 14 19@2x](https://github.com/user-attachments/assets/0809e309-8d59-4372-8663-24e4434fbb37)
