### PR TITLE
TASK: Revert half backed refactoring of `contextPath` to `nodeAddress`

### DIFF
--- a/Classes/Application/ReloadNodes/MinimalNodeForTree.php
+++ b/Classes/Application/ReloadNodes/MinimalNodeForTree.php
@@ -29,7 +29,7 @@ use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
 final readonly class MinimalNodeForTree implements \JsonSerializable
 {
     /**
-     * @param array{nodeAddress:string}&array<string,mixed> $data
+     * @param array{contextPath:string}&array<string,mixed> $data
      */
     private function __construct(private array $data)
     {
@@ -40,7 +40,7 @@ final readonly class MinimalNodeForTree implements \JsonSerializable
         NodeInfoHelper $nodeInfoHelper,
         ActionRequest $actionRequest
     ): ?self {
-        /** @var null|(array{nodeAddress:string}&array<string,mixed>) $data */
+        /** @var null|(array{contextPath:string}&array<string,mixed>) $data */
         $data = $nodeInfoHelper
             ->renderNodeWithMinimalPropertiesAndChildrenInformation(
                 node: $node,
@@ -52,7 +52,7 @@ final readonly class MinimalNodeForTree implements \JsonSerializable
 
     public function getNodeAddressAsString(): string
     {
-        return $this->data['nodeAddress'];
+        return $this->data['contextPath'];
     }
 
     /**

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -187,8 +187,8 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
         $nodeAddress = NodeAddress::fromNode($node);
 
         return [
+            // todo rename eventually rename to nodeAddress
             'contextPath' => $nodeAddress->toJson(),
-            'nodeAddress' => $nodeAddress->toJson(),
             'name' => $node->name?->value ?? '',
             'identifier' => $node->aggregateId->jsonSerialize(),
             'nodeType' => $node->nodeTypeName->value,

--- a/packages/neos-ui-views/src/NodeInfoView/index.js
+++ b/packages/neos-ui-views/src/NodeInfoView/index.js
@@ -44,7 +44,7 @@ export default class NodeInfoView extends PureComponent {
             created: node?.creationDateTime,
             lastModification: node?.lastModificationDateTime,
             lastPublication: node?.lastPublicationDateTime,
-            nodeAddress: node?.nodeAddress,
+            nodeAddress: node?.contextPath,
             name: node?.name ?? '/'
         };
 
@@ -70,9 +70,9 @@ export default class NodeInfoView extends PureComponent {
                     <div className={style.nodeInfoView__title}>{i18nRegistry.translate('identifier', 'Identifier', {}, 'Neos.Neos')}</div>
                     <NodeInfoViewContent>{properties.identifier}</NodeInfoViewContent>
                 </li>
-                <li className={style.nodeInfoView__item} title={properties.nodeAddress}>
+                <li className={style.nodeInfoView__item} title={properties.contextPath}>
                     <div className={style.nodeInfoView__title}>{i18nRegistry.translate('nodeAddress', 'Node Address', {}, 'Neos.Neos')}</div>
-                    <NodeInfoViewContent>{properties.nodeAddress}</NodeInfoViewContent>
+                    <NodeInfoViewContent>{properties.contextPath}</NodeInfoViewContent>
                 </li>
                 <li className={style.nodeInfoView__item} title={properties.name}>
                     <div className={style.nodeInfoView__title}>{i18nRegistry.translate('name', 'Name', {}, 'Neos.Neos')}</div>


### PR DESCRIPTION
the nodeAddress as property on `node` was introduced via https://github.com/neos/neos-ui/pull/3478 but never really used except in the node info view.

To avoid shipping the same information twice to the ui we for now remove the `nodeAddress` as property again.

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
