### PR TITLE
FEATURE: Add possibility to display warning

### DIFF
--- a/Classes/Domain/Model/Feedback/Messages/Warning.php
+++ b/Classes/Domain/Model/Feedback/Messages/Warning.php
@@ -1,0 +1,42 @@
+<?php
+namespace Neos\Neos\Ui\Domain\Model\Feedback\Messages;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Neos\Ui\Domain\Model\Feedback\AbstractMessageFeedback;
+
+class Warning extends AbstractMessageFeedback
+{
+    /**
+     * @var string
+     */
+    protected $severity = 'Warning';
+
+    /**
+     * Get the type identifier
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return 'Neos.Neos.Ui:Warning';
+    }
+
+    /**
+     * Get the description
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return 'An warning message';
+    }
+}

--- a/packages/neos-ui-redux-store/src/UI/FlashMessages/index.spec.js
+++ b/packages/neos-ui-redux-store/src/UI/FlashMessages/index.spec.js
@@ -47,7 +47,7 @@ test(`The "add" action should throw an error if an invalid "severity" was passed
     const fn = () => reducer(undefined, actions.add('myMessageId', 'myMessage', null));
 
     expect(fn).toThrowError(
-        'Invalid "severity" specified while adding a new FlashMessage. Allowed severities are success error info.'
+        'Invalid "severity" specified while adding a new FlashMessage. Allowed severities are success error info warning.'
     );
 });
 

--- a/packages/neos-ui-redux-store/src/UI/FlashMessages/index.ts
+++ b/packages/neos-ui-redux-store/src/UI/FlashMessages/index.ts
@@ -65,7 +65,7 @@ export const reducer = (state: State = defaultState, action: InitAction | Action
     switch (action.type) {
         case actionTypes.ADD: {
             const message = action.payload;
-            const allowedSeverities = ['success', 'error', 'info'];
+            const allowedSeverities = ['success', 'error', 'info', 'warning'];
             const {id, severity} = message;
             const messageContents = message.message;
 

--- a/packages/neos-ui/src/Containers/FlashMessages/FlashMessage/index.js
+++ b/packages/neos-ui/src/Containers/FlashMessages/FlashMessage/index.js
@@ -33,18 +33,21 @@ export default class FlashMessage extends PureComponent {
         const isSuccess = severity === 'success';
         const isError = severity === 'error';
         const isInfo = severity === 'info';
+        const isWarning = severity === 'warning';
 
         const flashMessageClasses = mergeClassNames({
             [style.flashMessage]: true,
             [style['flashMessage--success']]: isSuccess,
             [style['flashMessage--error']]: isError,
-            [style['flashMessage--info']]: isInfo
+            [style['flashMessage--info']]: isInfo,
+            [style['flashMessage--warning']]: isWarning
         });
 
         const iconName = mergeClassNames({
             check: isSuccess,
             ban: isError,
-            info: isInfo
+            info: isInfo,
+            warning: isWarning
         }) || 'info';
 
         return (

--- a/packages/neos-ui/src/Containers/FlashMessages/FlashMessage/style.module.css
+++ b/packages/neos-ui/src/Containers/FlashMessages/FlashMessage/style.module.css
@@ -26,6 +26,10 @@
     background-color: var(--colors-PrimaryBlue);
 }
 
+.flashMessage--warning {
+    background-color: var(--colors-Warn);
+}
+
 .flashMessage__icon {
     position: absolute;
     left: 0;

--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -196,11 +196,12 @@ manifest('main', {}, (globalRegistry, {routes}) => {
         const {message, severity} = feedbackPayload;
         const timeout = severity.toLowerCase() === 'success' ? 5000 : 0;
         const id = uuid.v4();
-
+        console.log(message);
         store.dispatch(actions.UI.FlashMessages.add(id, message, severity, timeout));
     };
     serverFeedbackHandlers.set('Neos.Neos.Ui:Success/Main', flashMessageFeedbackHandler);
     serverFeedbackHandlers.set('Neos.Neos.Ui:Error/Main', flashMessageFeedbackHandler);
+    serverFeedbackHandlers.set('Neos.Neos.Ui:Warning/Main', flashMessageFeedbackHandler);
     serverFeedbackHandlers.set('Neos.Neos.Ui:Info/Main', feedbackPayload => {
         switch (feedbackPayload.severity) {
             case 'ERROR':

--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -196,7 +196,7 @@ manifest('main', {}, (globalRegistry, {routes}) => {
         const {message, severity} = feedbackPayload;
         const timeout = severity.toLowerCase() === 'success' ? 5000 : 0;
         const id = uuid.v4();
-        console.log(message);
+
         store.dispatch(actions.UI.FlashMessages.add(id, message, severity, timeout));
     };
     serverFeedbackHandlers.set('Neos.Neos.Ui:Success/Main', flashMessageFeedbackHandler);


### PR DESCRIPTION
**What I did**
When extending the Neos UI it would be great to have the possibility to easily show a warning. 
The use case is: When a user sets a Document to 'hidden', I would like to show a message if the page exists as the target for a redirect. 
In FlashMessages there is a Message::SEVERITY_WARNING that can be set, but in the Neos UI, using the Feedback collections, there is only the possibility to display Success, error, and info(which is logged to console). 

It is of course possible to display a message using neos extensibility but I thought it would be nice to have an easy way in the Neos UI and be consistent with the flashMessages.

**How I did it**
I added a new Feedback class "Warning" that will show up as an orange message in the Neos UI 

**How to verify it**
```
$warning = new Warning();
$warning->setMessage('This page exists as a source in redirects.');
$this->feedbackCollection->add($warning);
```
will show up as warning in the UI: 

<img width="526" alt="Bildschirmfoto 2025-03-28 um 08 59 22" src="https://github.com/user-attachments/assets/7b7ec05b-eede-4829-b707-893af4ba9dab" />
