### PR TITLE
BUGFIX: Prevent constant re-rendering of right sidebar

### DIFF
--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -121,8 +121,12 @@ export default class Inspector extends PureComponent {
         }
     }
 
-    componentDidUpdate() {
-        this.preprocessViewConfigurationDebounced();
+    componentDidUpdate(prevProps) {
+        // Only call the preprocessing if relevant props changed
+        if (prevProps.focusedNode !== this.props.focusedNode ||
+            prevProps.transientValues !== this.props.transientValues) {
+            this.preprocessViewConfigurationDebounced();
+        }
     }
 
     componentWillUnmount() {

--- a/packages/react-ui-components/src/DropDown/contents.tsx
+++ b/packages/react-ui-components/src/DropDown/contents.tsx
@@ -188,6 +188,9 @@ export default class ShallowDropDownContents extends PureComponent<ShallowDropDo
     public readonly state = ShallowDropDownContents.getDerivedStateFromProps(this.props);
 
     public readonly recalculateStyle = () => requestAnimationFrame(() => {
+        if (!this.props.isOpen) {
+            return;
+        }
         this.setState({style: ShallowDropDownContents.getCalculatedStyleFromProps(this.props)});
     })
 


### PR DESCRIPTION
Resolves: #3936

**What I did**

Prevent re-rendering in right sidebar

**How I did it**

Add checks whether props in the inspector actually changed after the props have been post processed.

**How to verify it**

Before: 
![CleanShot 2025-04-02 at 17 20 43@2x](https://github.com/user-attachments/assets/9491876f-133a-430e-be37-6329941bab15)

After:
![CleanShot 2025-04-02 at 17 21 34@2x](https://github.com/user-attachments/assets/8f1b9854-76ea-4412-9b87-463307dfd92f)

