### PR TITLE
WIP!!! FEATURE: Augment nodes in guestframe with html comments instead of data attributes

### DIFF
--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.js
@@ -45,10 +45,10 @@ export default class NodeToolbar extends PureComponent {
     iframeWindow = getGuestFrameWindow();
 
     updateStickyness = () => {
-        const nodeElement = findNodeInGuestFrame(this.props.contextPath, this.props.fusionPath);
-        if (nodeElement) {
+        const node = findNodeInGuestFrame(this.props.contextPath, this.props.fusionPath);
+        if (node) {
             const {isSticky} = this.state;
-            const {top, bottom} = nodeElement.getBoundingClientRect();
+            const {top, bottom} = node.contentDomNode.getBoundingClientRect();
             const shouldBeSticky = top < 50 && bottom > 0;
 
             if (isSticky !== shouldBeSticky) {
@@ -92,9 +92,9 @@ export default class NodeToolbar extends PureComponent {
     scrollIntoView() {
         // Only scroll into view when triggered from content tree (on focus change)
         if (this.props.shouldScrollIntoView) {
-            const nodeElement = findNodeInGuestFrame(this.props.contextPath, this.props.fusionPath);
-            if (nodeElement && !isElementVisibleInGuestFrame(nodeElement)) {
-                animateScrollToElementInGuestFrame(nodeElement, 100);
+            const node = findNodeInGuestFrame(this.props.contextPath, this.props.fusionPath);
+            if (node?.contentDomNode && !isElementVisibleInGuestFrame(node.contentDomNode)) {
+                animateScrollToElementInGuestFrame(node.contentDomNode, 100);
             }
             this.props.requestScrollIntoView(false);
         }
@@ -132,15 +132,15 @@ export default class NodeToolbar extends PureComponent {
             className: style.toolBar__btnGroup__btn
         };
 
-        const nodeElement = findNodeInGuestFrame(contextPath, fusionPath);
+        const node = findNodeInGuestFrame(contextPath, fusionPath);
 
         // Check if nodeElement exists before accessing its props or if the node toolbar
         // should be invisible e.g. when the workspace is in read only mode
-        if (!nodeElement || !visible) {
+        if (!node || !visible) {
             return null;
         }
 
-        const {top, width, rightAsMeasuredFromRightDocumentBorder} = getAbsolutePositionOfElementInGuestFrame(nodeElement);
+        const {top, width, rightAsMeasuredFromRightDocumentBorder} = getAbsolutePositionOfElementInGuestFrame(node);
 
         // TODO: hardcoded dimensions
         const TOOLBAR_WIDTH = 200;

--- a/packages/neos-ui-guest-frame/src/dom.js
+++ b/packages/neos-ui-guest-frame/src/dom.js
@@ -39,104 +39,254 @@ export const findInGuestFrame = selector =>
 export const findAllInGuestFrame = selector =>
     [].slice.call(getGuestFrameDocument().querySelectorAll(selector));
 
-//
-// Find all DOM nodes that represent CR nodes in the guest frame
-//
-export const findAllNodesInGuestFrame = () =>
-    findAllInGuestFrame('[data-__neos-node-contextpath]');
+/**
+ * @typedef {Object} NodeInGuestFrame
+ * @property {string} nodeAddress
+ * @property {string} fusionPath
+ * @property {Element} dataNode
+ * @property {HTMLElement|null} contentDomNode
+ * @property {Element} endNode
+ */
+const NODE_START_PREFIX = '__NEOS_UI_NODE_START__';
+const NODE_END_PREFIX = '__NEOS_UI_NODE_END__';
+
+/**
+ * Find all DOM nodes that represent CR nodes in the guest frame
+ * @return {Array<NodeInGuestFrame>}
+ */
+export const findAllNodesInGuestFrame = () => {
+    return loadNodesFromComments();
+}
+
+/**
+ *
+ * @param {NodeInGuestFrame} nodeInGuestFrame
+ * @return {Array<Node>}
+ */
+export const getDomNodesForNodeInGuestFrame = (nodeInGuestFrame) => {
+    const {dataNode, nodeAddress} = nodeInGuestFrame;
+    const nodesToRemove = [dataNode];
+    let node = dataNode.nextSibling;
+    while (node) {
+        nodesToRemove.push(node);
+        if (node.nodeType === Node.COMMENT_NODE && node.nodeValue.indexOf(NODE_END_PREFIX + nodeAddress) === 0) {
+            break;
+        }
+        node = node.nextSibling;
+    }
+    return nodesToRemove;
+}
+
+/**
+ * Remove a DOM nodes that represent a CR node in the guest frame
+ * @param {NodeInGuestFrame} nodeInGuestFrame
+ * @return void
+ */
+export const removeNodeInGuestsFrame = (nodeInGuestFrame) => {
+    getDomNodesForNodeInGuestFrame(nodeInGuestFrame).forEach(node => {
+        node.parentNode.removeChild(node);
+    });
+}
+
+/**
+ * @param {string} filter
+ * @param {Element} parentElement
+ * @return {TreeWalker}
+ */
+const loadNodes = (filter, parentElement) => {
+    const document = getGuestFrameDocument();
+    return document.createTreeWalker(
+        parentElement ? parentElement : document.getRootNode(),
+        NodeFilter.SHOW_COMMENT,
+        {
+            acceptNode: (node) => node.nodeValue.indexOf(filter) === 0 ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP,
+        }
+    );
+}
+
+/**
+ * @param {Node} domNode
+ * @return {NodeInGuestFrame|null}
+ */
+const parseNodeFromComment = (domNode) => {
+    // The content dom node can be null if the node encapsulates other nodes without its own markup
+    // TODO: They might still need some sort of rendering for highlighting, so we might need to create a helper dom element somewhere in the body
+    // FIXME: Now there could be multiple nodes in the guest frame that are not encapsulated by a comment node
+    // FIXME: Ignore comment nodes that are not part of the Neos UI
+    let contentDomNode = domNode.nextSibling;
+    if (contentDomNode.nodeType === Node.COMMENT_NODE) {
+        contentDomNode = null;
+    }
+    let endNode = domNode.nextSibling;
+    while (endNode) {
+        if (endNode.nodeType === Node.COMMENT_NODE && endNode.nodeValue.indexOf(NODE_END_PREFIX) === 0) {
+            break;
+        }
+        endNode = endNode.nextSibling;
+    }
+
+    return {
+        ...JSON.parse(domNode.nodeValue.substring(NODE_START_PREFIX.length)),
+        dataNode: domNode,
+        contentDomNode,
+        endNode,
+    };
+}
+
+/**
+ *
+ * @param {string|null} nodeAddress
+ * @param {string|null} fusionPath
+ * @param {Element|null} parentElement
+ * @return {Array<NodeInGuestFrame>}
+ */
+const loadNodesFromComments = (nodeAddress = null, fusionPath = null, parentElement = null) => {
+    const nodeComments = loadNodes(NODE_START_PREFIX, parentElement);
+    const nodes = [];
+    while (nodeComments.nextNode()) {
+        const {currentNode} = nodeComments;
+        const nodeInGuestFrame = parseNodeFromComment(currentNode);
+        if (!nodeInGuestFrame || (nodeAddress && nodeInGuestFrame.nodeAddress !== nodeAddress) || (fusionPath && nodeInGuestFrame.fusionPath !== fusionPath)) {
+            continue;
+        }
+        nodes.push(nodeInGuestFrame);
+    }
+    return nodes;
+}
 
 //
 // Find all DOM nodes that represent CR node properties in the guest frame
+// TODO: Remove?
 //
-export const findAllPropertiesInGuestFrame = () =>
-    findAllInGuestFrame('[data-__neos-property]');
+export const findAllPropertiesInGuestFrame = () => {
+    return findAllInGuestFrame('[data-__neos-property]');
+}
 
-//
-// Find all DOM nodes that represent a particular node property in the guest frame
-//
-export const findAllOccurrencesOfNodePropertyInGuestFrame = (contextPath, propertyName) => findAllInGuestFrame(`[data-__neos-editable-node-contextpath="${CSS.escape(contextPath)}"][data-__neos-property="${CSS.escape(propertyName)}"]`);
+/**
+ * Find all DOM nodes that represent a particular node property in the guest frame
+ * @param {string} nodeAddress
+ * @param {string} propertyName
+ * @return {NodeInGuestFrame|null}
+ */
+export const findAllOccurrencesOfNodePropertyInGuestFrame = (nodeAddress, propertyName) => {
+    findAllInGuestFrame(`[data-__neos-editable-node-contextpath="${CSS.escape(nodeAddress)}"][data-__neos-property="${CSS.escape(propertyName)}"]`);
+};
 
-//
-// Find all DOM nodes that represent CR node properties in the guest frame
-//
-export const findRelativePropertiesInGuestFrame = contentDomNode =>
-    [].slice.call(contentDomNode.querySelectorAll(
-        `[data-__neos-property][data-__neos-editable-node-contextpath="${CSS.escape(contentDomNode.getAttribute('data-__neos-node-contextpath'))}"]`
+/**
+ * Find all DOM nodes that represent CR node properties in the guest frame
+ * @param {NodeInGuestFrame} node
+ * @return {Array<Element>}
+ */
+export const findRelativePropertiesInGuestFrame = (node) => {
+    return [].slice.call(node.contentDomNode.querySelectorAll(
+        `[data-__neos-property][data-__neos-editable-node-contextpath="${CSS.escape(node.nodeAddress)}"]`
     )).concat(...(
-        contentDomNode.hasAttribute('data-__neos-property') ?
-            [contentDomNode] : []
+        node.contentDomNode.hasAttribute('data-__neos-property') ?
+            [node.contentDomNode] : []
     ));
+}
 
-//
-// Find a specific DOM node that represents a CR node in the guest frame
-//
-export const findNodeInGuestFrame = (contextPath, fusionPath) => fusionPath ? findInGuestFrame(
-    `[data-__neos-node-contextpath="${CSS.escape(contextPath)}"][data-__neos-fusion-path="${CSS.escape(fusionPath)}"]`
-) : findInGuestFrame(
-    `[data-__neos-node-contextpath="${CSS.escape(contextPath)}"]`
-);
-
-//
-// Find all DOM nodes that represent a CR node identified by context path and
-// fusion path in the guest frame
-//
-export const findAllOccurrencesOfNodeInGuestFrame = (contextPath, fusionPath) => fusionPath ? findAllInGuestFrame(
-    `[data-__neos-node-contextpath="${CSS.escape(contextPath)}"][data-__neos-fusion-path="${CSS.escape(fusionPath)}"]`
-) : findAllInGuestFrame(
-    `[data-__neos-node-contextpath="${CSS.escape(contextPath)}"]`
-);
-
-//
-// Find all rendered childnodes beneath a given DOM ndoe
-//
-export const findAllChildNodes = el => [].slice.call(el.querySelectorAll('[data-__neos-node-contextpath]'));
-
-//
-// Find the closest DOM node that represents a CR node relative to the given DOM node
-// in the guest frame
-//
-export const closestNodeInGuestFrame = el => {
-    if (!el || !el.dataset) {
-        // el.dataset is not existing for window.document; and we need to prevent this case from happening.
-        return null;
+/**
+ * Find a specific DOM node that represents a CR node in the guest frame
+ * @param {string|null} nodeAddress
+ * @param {string|null} fusionPath
+ * @param {Element|null} parentElement
+ * @return {NodeInGuestFrame|null}
+ */
+export const findNodeInGuestFrame = (nodeAddress = null, fusionPath = null, parentElement = null) => {
+    const nodes = loadNodesFromComments(nodeAddress, fusionPath, parentElement);
+    if (nodes.length > 0) {
+        return nodes[0];
     }
-
-    return el.dataset.__neosNodeContextpath ? el : closestNodeInGuestFrame(el.parentNode);
+    return null;
 };
 
-//
-// Get the context path from the closest DOM node that represents a CR node relative to the
-// given DOM node in the guest frame
-//
+/**
+ * Find all DOM nodes that represent a CR node identified by context path and
+ * fusion path in the guest frame
+ * @param {string} nodeAddress
+ * @param {string} fusionPath
+ * @return {Array<NodeInGuestFrame>}
+ */
+export const findAllOccurrencesOfNodeInGuestFrame = (nodeAddress, fusionPath) => {
+    return loadNodesFromComments(nodeAddress, fusionPath);
+};
+
+/**
+ * Find all rendered child nodes beneath a given DOM node
+ * @param {Element} el
+ * @return {Array<NodeInGuestFrame>}
+ */
+export const findAllChildNodes = (el) => {
+    if (!el) {
+        return [];
+    }
+    return loadNodesFromComments(null, null, el);
+};
+
+/**
+ * Find the closest DOM node that represents a CR node relative to the given DOM node
+ * in the guest frame
+ * @param {Element} el
+ * @return {NodeInGuestFrame|null}
+ */
+export const closestNodeInGuestFrame = (el) => {
+    if (!el) {
+        return null;
+    }
+    // Find nearest comment node that can be converted to a NodeInGuestFrame
+    // FIXME: Ignore comment nodes that are not part of the Neos UI
+    while (el && el.nodeType !== Node.COMMENT_NODE) {
+        if (!el.previousSibling) {
+            break;
+        }
+        el = el.previousSibling;
+        if (el.nodeType === Node.COMMENT_NODE && el.nodeValue.indexOf(NODE_START_PREFIX) === 0) {
+            return parseNodeFromComment(el);
+        }
+    }
+    return closestNodeInGuestFrame(el.parentNode);
+};
+
+/**
+ * Get the context path from the closest DOM node that represents a CR node relative to the
+ * given DOM node in the guest frame
+ * @param {Element} el
+ * @return {string|null}
+ */
 export const closestContextPathInGuestFrame = el => {
-    const dom = closestNodeInGuestFrame(el);
+    const nodeInGuestFrame = closestNodeInGuestFrame(el);
 
-    if (!dom) {
+    if (!nodeInGuestFrame) {
         return null;
     }
 
-    return dom.dataset.__neosNodeContextpath;
+    return nodeInGuestFrame.nodeAddress;
 };
 
-//
-// Add hidden class to a DOM node that represents a CR node
-//
-export const markNodeAsHidden = contextPath => {
-    const domNode = findNodeInGuestFrame(contextPath);
+/**
+ * Add hidden class to a DOM node that represents a CR node
+ * @param {string} nodeAddress
+ * @return {void}
+ */
+export const markNodeAsHidden = nodeAddress => {
+    const domNode = findNodeInGuestFrame(nodeAddress);
 
     if (domNode) {
-        domNode.classList.add(style.markHiddenNodeAsHidden);
+        domNode.contentDomNode.classList.add(style.markHiddenNodeAsHidden);
     }
 };
 
-//
-// Remove hidden class from a DOM node that represents a CR node
-//
-export const markNodeAsVisible = contextPath => {
-    const domNode = findNodeInGuestFrame(contextPath);
+/**
+ * Remove hidden class from a DOM node that represents a CR node
+ * @param {string} nodeAddress
+ * @return {void}
+ */
+export const markNodeAsVisible = nodeAddress => {
+    const domNode = findNodeInGuestFrame(nodeAddress);
 
     if (domNode) {
-        domNode.classList.remove(style.markHiddenNodeAsHidden);
+        domNode.contentDomNode.classList.remove(style.markHiddenNodeAsHidden);
     }
 };
 
@@ -146,6 +296,7 @@ export const markNodeAsVisible = contextPath => {
 // NOTE: If the element is "big enough" (i.e. more than 20 px), we do not render the placeholder either; as then
 // the user will very likely have created his own rendering.
 export const createEmptyContentCollectionPlaceholderIfMissing = collectionDomNode => {
+    // FIXME: Adjust to NodeInGuestFrame
     if (collectionDomNode) {
         const hasChildNodes = Boolean(
             collectionDomNode.querySelector('[data-__neos-node-contextpath]')
@@ -259,9 +410,9 @@ export const clampElementToDocumentDimensions = (elementDimensions, documentDime
 // width and height of the guest frame (i.e. so that it is fully visible).
 //
 export const getAbsolutePositionOfElementInGuestFrame = element => {
-    if (element && element.getBoundingClientRect) {
+    if (element?.contentDomNode?.getBoundingClientRect) {
         const relativeDocumentDimensions = getGuestFrameDocument().documentElement.getBoundingClientRect();
-        const relativeElementDimensions = element.getBoundingClientRect();
+        const relativeElementDimensions = element.contentDomNode.getBoundingClientRect();
 
         return clampElementToDocumentDimensions(relativeElementDimensions, relativeDocumentDimensions);
     }

--- a/packages/neos-ui-guest-frame/src/initializeContentDomNode.js
+++ b/packages/neos-ui-guest-frame/src/initializeContentDomNode.js
@@ -8,20 +8,28 @@ import initializePropertyDomNode from './initializePropertyDomNode';
 
 import style from './style.module.css';
 
-export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry}) => contentDomNode => {
+/**
+ * @param store
+ * @param globalRegistry
+ * @param nodeTypesRegistry
+ * @param inlineEditorRegistry
+ * @return {(function(NodeInGuestFrame): void)|*}
+ * FIXME: Handle multiple content nodes when adding event listeners and classes
+ */
+export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry}) => (node) => {
     const nodes = store.getState().cr.nodes.byContextPath;
-    const contextPath = contentDomNode.getAttribute('data-__neos-node-contextpath');
+    const {contentDomNode, nodeAddress} = node;
 
-    if (!nodes[contextPath]) {
+    if (!nodes[nodeAddress]) {
         // Node is not available in the store yet, so we can't initialize any interaction
-        console.warn(`Node with context path "${contextPath}" is not available in the store yet.`);
+        console.warn(`Node with context path "${nodeAddress}" is not available in the store yet.`);
         return;
     }
 
-    const isHidden = nodes?.[contextPath]?.properties?._hidden;
-    const hasChildren = Boolean(nodes?.[contextPath]?.children);
-    const isInlineEditable = nodeTypesRegistry.isInlineEditable(nodes?.[contextPath]?.nodeType);
-    const matchesCurrentDimensions = !nodes?.[contextPath]?.matchesCurrentDimensions;
+    const isHidden = nodes?.[nodeAddress]?.properties?._hidden;
+    const hasChildren = Boolean(nodes?.[nodeAddress]?.children);
+    const isInlineEditable = nodeTypesRegistry.isInlineEditable(nodes?.[nodeAddress]?.nodeType);
+    const matchesCurrentDimensions = !nodes?.[nodeAddress]?.matchesCurrentDimensions;
 
     if (isHidden) {
         contentDomNode.classList.add(style.markHiddenNodeAsHidden);
@@ -60,7 +68,7 @@ export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry}
         createEmptyContentCollectionPlaceholderIfMissing(contentDomNode);
     }
 
-    findRelativePropertiesInGuestFrame(contentDomNode).forEach(
+    findRelativePropertiesInGuestFrame(node).forEach(
         initializePropertyDomNode({
             store,
             globalRegistry,

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -5,6 +5,7 @@ import {requestIdleCallback} from '@neos-project/utils-helpers';
 
 import initializeContentDomNode from './initializeContentDomNode';
 import {
+    closestNodeInGuestFrame,
     dispatchCustomEvent,
     findAllNodesInGuestFrame,
     findInGuestFrame,
@@ -62,7 +63,7 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
 
     // Load all nodedata for nodes in the guest frame and filter duplicates
     const {q} = yield backend.get();
-    const nodeContextPathsInGuestFrame = findAllNodesInGuestFrame().map(node => node.getAttribute('data-__neos-node-contextpath'));
+    const nodeContextPathsInGuestFrame = findAllNodesInGuestFrame().map(({nodeAddress}) => nodeAddress);
 
     // Filter nodes that are already present in the redux store and duplicates
     const nodesByContextPath = store.getState().cr.nodes.byContextPath;
@@ -124,24 +125,18 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
             domNode.getAttribute &&
             domNode.getAttribute('data-__neos-property')
         );
-        const selectedDomNode = clickPath.find(domNode =>
-            domNode &&
-            domNode.getAttribute &&
-            domNode.getAttribute('data-__neos-node-contextpath')
-        );
+        const selectedDomNode = closestNodeInGuestFrame(event.target);
 
         if (isInsideInlineUi) {
             // Do nothing, everything OK!
         } else if (selectedDomNode) {
-            const contextPath = selectedDomNode.getAttribute('data-__neos-node-contextpath');
-            const fusionPath = selectedDomNode.getAttribute('data-__neos-fusion-path');
             const state = store.getState();
             const focusedNodeContextPath = selectors.CR.Nodes.focusedNodePathSelector(state);
             if (!isInsideEditableProperty) {
                 store.dispatch(actions.UI.ContentCanvas.setCurrentlyEditedPropertyName(''));
             }
-            if (!isInsideEditableProperty || focusedNodeContextPath !== contextPath) {
-                store.dispatch(actions.CR.Nodes.focus(contextPath, fusionPath));
+            if (!isInsideEditableProperty || focusedNodeContextPath !== selectedDomNode.nodeAddress) {
+                store.dispatch(actions.CR.Nodes.focus(selectedDomNode.nodeAddress, selectedDomNode.fusionPath));
             }
         } else {
             store.dispatch(actions.UI.ContentCanvas.setCurrentlyEditedPropertyName(''));
@@ -177,7 +172,7 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
 
         requestIdleCallback(() => {
             // Only of guest frame document did not change in the meantime, we continue initializing the node
-            if (getGuestFrameDocument() === node.ownerDocument) {
+            if (getGuestFrameDocument() === node.contentDomNode.ownerDocument) {
                 initializeCurrentNode(node);
             }
             initializeSubSequentNodes();
@@ -190,7 +185,7 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
     const focusedNode = yield select(selectors.CR.Nodes.focusedNodePathSelector);
     const focusedNodeElement = findNodeInGuestFrame(focusedNode);
     if (focusedNodeElement) {
-        focusedNodeElement.classList.add(style['markActiveNodeAsFocused--focusedNode']);
+        focusedNodeElement.contentDomNode.classList.add(style['markActiveNodeAsFocused--focusedNode']);
         // Request to scroll focused node into view
         yield put(actions.UI.ContentCanvas.requestScrollIntoView(true));
     }
@@ -212,7 +207,7 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
             const nodeElement = findNodeInGuestFrame(contextPath, fusionPath);
 
             if (nodeElement) {
-                nodeElement.classList.add(style['markActiveNodeAsFocused--focusedNode']);
+                nodeElement.contentDomNode.classList.add(style['markActiveNodeAsFocused--focusedNode']);
 
                 const getNodeByContextPathSelector = selectors.CR.Nodes.makeGetNodeByContextPathSelector(contextPath);
                 const node = yield select(getNodeByContextPathSelector);

--- a/packages/neos-ui-sagas/src/CR/NodeOperations/helpers.js
+++ b/packages/neos-ui-sagas/src/CR/NodeOperations/helpers.js
@@ -18,7 +18,7 @@ export const calculateDomAddressesFromMode = (mode, contextNode, fusionPath) => 
         case 'before':
         case 'after': {
             const element = findNodeInGuestFrame(contextNode.contextPath, fusionPath);
-            const parentElement = element ? closestNodeInGuestFrame(element.parentNode) : null;
+            const parentElement = element?.contentDomNode ? closestNodeInGuestFrame(element.contentDomNode.parentNode) : null;
 
             return {
                 siblingDomAddress: {
@@ -26,8 +26,8 @@ export const calculateDomAddressesFromMode = (mode, contextNode, fusionPath) => 
                     fusionPath
                 },
                 parentDomAddress: parentElement ? {
-                    contextPath: parentElement.getAttribute('data-__neos-node-contextpath'),
-                    fusionPath: parentElement.getAttribute('data-__neos-fusion-path')
+                    contextPath: parentElement.nodeAddress,
+                    fusionPath: parentElement.fusionPath
                 } : {
                     contextPath: contextNode.parent,
                     fusionPath: null
@@ -41,8 +41,8 @@ export const calculateDomAddressesFromMode = (mode, contextNode, fusionPath) => 
             return {
                 parentContextPath: contextNode.contextPath,
                 parentDomAddress: {
-                    contextPath: element ? element.getAttribute('data-__neos-node-contextpath') : contextNode.contextPath,
-                    fusionPath: element ? element.getAttribute('data-__neos-fusion-path') : fusionPath
+                    contextPath: element ? element.nodeAddress : contextNode.contextPath,
+                    fusionPath: element ? element.fusionPath : fusionPath
                 }
             };
         }

--- a/packages/neos-ui-sagas/src/UI/Inspector/index.js
+++ b/packages/neos-ui-sagas/src/UI/Inspector/index.js
@@ -101,7 +101,7 @@ function * flushInspector(inspectorRegistry) {
     let focusedNodeFusionPath = state?.cr?.nodes?.focused?.fusionPath;
     if (!focusedNodeFusionPath) {
         const focusedDomNode = findNodeInGuestFrame(focusedNode?.contextPath);
-        focusedNodeFusionPath = focusedDomNode && focusedDomNode.getAttribute('data-__neos-fusion-path');
+        focusedNodeFusionPath = focusedDomNode?.fusionPath;
     }
     const transientInspectorValues = getTransientInspectorValues(state);
     const transientInspectorValuesForFocusedNodes = transientInspectorValues?.[focusedNode?.contextPath];

--- a/packages/neos-ui/src/manifest.js
+++ b/packages/neos-ui/src/manifest.js
@@ -14,7 +14,9 @@ import {
     findAllOccurrencesOfNodeInGuestFrame,
     createEmptyContentCollectionPlaceholderIfMissing,
     findAllChildNodes,
-    dispatchCustomEvent
+    dispatchCustomEvent,
+    removeNodeInGuestsFrame,
+    getDomNodesForNodeInGuestFrame
 } from '@neos-project/neos-ui-guest-frame/src/dom';
 import initializeContentDomNode from '@neos-project/neos-ui-guest-frame/src/initializeContentDomNode';
 
@@ -409,24 +411,24 @@ manifest('main', {}, (globalRegistry, {routes}) => {
     //
     serverFeedbackHandlers.set('Neos.Neos.Ui:RenderContentOutOfBand/Main', (feedbackPayload, {store, globalRegistry}) => {
         const {contextPath, renderedContent, parentDomAddress, siblingDomAddress, mode} = feedbackPayload;
-        const parentElement = parentDomAddress && findNodeInGuestFrame(
+        const parentNode = parentDomAddress && findNodeInGuestFrame(
             parentDomAddress.contextPath,
             parentDomAddress.fusionPath
         );
-        const siblingElement = siblingDomAddress && findNodeInGuestFrame(
+        const siblingNode = siblingDomAddress && findNodeInGuestFrame(
             siblingDomAddress.contextPath,
             siblingDomAddress.fusionPath
         );
 
         // We need to create the new DOM nodes from within the iframe document,
-        // because many frameworkds (e.g. CKE, React) use the following checks
+        // because many frameworks (e.g. CKE, React) use the following checks
         // `obj instanceof obj.ownerDocument.defaultView.Node`
         // which would fail if this node was created in Host
-        const wrapTagName = parentElement.tagName ? parentElement.tagName : 'div';
-        const tempNodeInGuest = getGuestFrameDocument().createElement(wrapTagName);
+        // FIXME: Adjust this code to work with the new comments
+        const tempNodeInGuest = getGuestFrameDocument().createElement('div');
         tempNodeInGuest.innerHTML = renderedContent;
-        const contentElement = tempNodeInGuest
-            .querySelector(`[data-__neos-node-contextpath="${CSS.escape(contextPath)}"]`);
+        const contentElement = findNodeInGuestFrame(contextPath, null, tempNodeInGuest);
+        debugger;
 
         if (!contentElement) {
             console.error(`!!! Content Element (rendered out-of-band) with context path "${contextPath}" not found in returned HTML from server (which you see below) - Reloading the full page!`);
@@ -436,13 +438,14 @@ manifest('main', {}, (globalRegistry, {routes}) => {
             return;
         }
 
-        const fusionPath = contentElement.dataset.__neosFusionPath;
-        // Check if an insertion anchor is defined and use this one for appending the childnode
+        // Check if an insertion anchor is defined and use this one for appending the child node
+        // TODO: Move method to dom.js
         const findInsertionParentByAnchor = () => {
-            let insertionParent = parentElement;
-            const insertionAnchors = parentElement.querySelectorAll('[data-__neos-insertion-anchor]');
+            let insertionParent = parentNode.contentDomNode;
+            // TODO: Make the insertion anchor a html comment
+            const insertionAnchors = parentNode.contentDomNode.querySelectorAll('[data-__neos-insertion-anchor]');
             for (const anchorElement of insertionAnchors) {
-                if (closestNodeInGuestFrame(anchorElement).dataset.__neosNodeContextpath === parentElement.dataset.__neosNodeContextpath) {
+                if (closestNodeInGuestFrame(anchorElement).nodeAddress === parentNode.nodeAddress) {
                     insertionParent = anchorElement;
                     break;
                 }
@@ -453,42 +456,51 @@ manifest('main', {}, (globalRegistry, {routes}) => {
 
         const existingElement = findNodeInGuestFrame(
             contextPath,
-            fusionPath
+            contentElement.fusionPath
         );
 
         // Remove duplicate node in case of move action on the same level
         if (existingElement) {
-            existingElement.remove();
+            removeNodeInGuestsFrame(existingElement);
         }
 
+        // FIXME: Adjust this code to work with the new comments
+        const nodesToInsert = getDomNodesForNodeInGuestFrame(contentElement);
         switch (mode) {
             case 'before':
-                siblingElement.parentNode.insertBefore(contentElement, siblingElement);
+                nodesToInsert.forEach(node => {
+                    siblingNode.dataNode.parentNode.insertBefore(node, siblingNode.dataNode);
+                });
                 break;
 
             case 'after':
-                siblingElement.parentNode.insertBefore(contentElement, siblingElement.nextSibling);
+                nodesToInsert.forEach(node => {
+                    siblingNode.dataNode.parentNode.insertBefore(node, siblingNode.endNode.nextSibling);
+                });
                 break;
 
             case 'into':
             default:
-                insertionParent.appendChild(contentElement);
+                nodesToInsert.forEach((node) => {
+                    insertionParent.appendChild(node);
+                });
                 break;
         }
 
-        const children = findAllChildNodes(contentElement);
+        // FIXME: Make it possible to find all child nodes between the start and end comment nodes of a given node. This is necessary if the node has no contentDomNode
+        const childNodes = findAllChildNodes(contentElement.contentDomNode);
 
         const nodes = Object.assign(
             {[contextPath]: selectors.CR.Nodes.byContextPathSelector(contextPath)(store.getState())},
-            ...children.map(el => {
-                const contextPath = el.getAttribute('data-__neos-node-contextpath');
-                return {[contextPath]: selectors.CR.Nodes.byContextPathSelector(contextPath)(store.getState())};
+            ...childNodes.map(({nodeAddress}) => {
+                return {[nodeAddress]: selectors.CR.Nodes.byContextPathSelector(nodeAddress)(store.getState())};
             })
         );
         const nodeTypesRegistry = globalRegistry.get('@neos-project/neos-ui-contentrepository');
         const inlineEditorRegistry = globalRegistry.get('inlineEditors');
 
-        const emptyContentCollectionOverlay = parentElement.querySelector(`.${style.addEmptyContentCollectionOverlay}`);
+        // TODO: Check if this still works
+        const emptyContentCollectionOverlay = parentNode.querySelector(`.${style.addEmptyContentCollectionOverlay}`);
         if (emptyContentCollectionOverlay && emptyContentCollectionOverlay.parentElement.children.length > 1) {
             emptyContentCollectionOverlay.remove();
         }
@@ -496,7 +508,7 @@ manifest('main', {}, (globalRegistry, {routes}) => {
         //
         // Initialize the newly rendered node and all nodes that came with it
         //
-        [contentElement, ...children].forEach(
+        [contentElement, ...childNodes].forEach(
             initializeContentDomNode({
                 store,
                 globalRegistry,
@@ -505,7 +517,7 @@ manifest('main', {}, (globalRegistry, {routes}) => {
                 nodes
             })
         );
-        store.dispatch(actions.CR.Nodes.focus(contextPath, fusionPath));
+        store.dispatch(actions.CR.Nodes.focus(contextPath, contentElement.fusionPath));
         store.dispatch(actions.UI.ContentCanvas.requestScrollIntoView(true));
 
         dispatchCustomEvent('Neos.NodeCreated', 'Node was created.', {
@@ -519,21 +531,20 @@ manifest('main', {}, (globalRegistry, {routes}) => {
     //
     serverFeedbackHandlers.set('Neos.Neos.Ui:ReloadContentOutOfBand/Main', async (feedbackPayload, {store, globalRegistry}) => {
         const {contextPath, renderedContent, nodeDomAddress} = feedbackPayload;
-        const domNode = nodeDomAddress && findNodeInGuestFrame(
+        const existingNode = nodeDomAddress && findNodeInGuestFrame(
             nodeDomAddress.contextPath,
             nodeDomAddress.fusionPath
         );
 
         // We need to create the new DOM nodes from within the iframe document,
-        // because many frameworkds (e.g. CKE, React) use the following checks
+        // because many frameworks (e.g. CKE, React) use the following checks
         // `obj instanceof obj.ownerDocument.defaultView.Node`
         // which would fail if this node was created in Host
         const tempNodeInGuest = getGuestFrameDocument().createElement('div');
         tempNodeInGuest.innerHTML = renderedContent;
-        const contentElement = tempNodeInGuest
-            .querySelector(`[data-__neos-node-contextpath="${CSS.escape(contextPath)}"]`);
+        const nodeToInsert = findNodeInGuestFrame(contextPath, null, tempNodeInGuest);
 
-        if (!contentElement) {
+        if (!nodeToInsert) {
             console.error(`!!! Content Element (reloaded out-of-band) with context path "${contextPath}" not found in returned HTML from server (which you see below) - Reloading the full page!`);
             console.log(renderedContent);
 
@@ -541,18 +552,16 @@ manifest('main', {}, (globalRegistry, {routes}) => {
             return;
         }
 
-        const fusionPath = contentElement.dataset.__neosFusionPath;
+        // FIXME: Handle multiple content dom nodes
+        existingNode.dataNode.parentElement.replaceChild(nodeToInsert.contentDomNode, existingNode.contentDomNode);
 
-        domNode.parentElement.replaceChild(contentElement, domNode);
-
-        const children = findAllChildNodes(contentElement);
+        const childNodes = findAllChildNodes(nodeToInsert.contentDomNode);
 
         // in case there are foreign referenced nodes, we need to put them into the store:
         const uninitializedReferencedNodes = [];
-        for (const el of children) {
-            const contextPath = el.getAttribute('data-__neos-node-contextpath');
-            if (!selectors.CR.Nodes.byContextPathSelector(contextPath)(store.getState())) {
-                uninitializedReferencedNodes.push(contextPath);
+        for (const childNode of childNodes) {
+            if (!selectors.CR.Nodes.byContextPathSelector(childNode.nodeAddress)(store.getState())) {
+                uninitializedReferencedNodes.push(childNode.nodeAddress);
             }
         }
         if (uninitializedReferencedNodes.length) {
@@ -570,9 +579,8 @@ manifest('main', {}, (globalRegistry, {routes}) => {
 
         const nodes = Object.assign(
             {[contextPath]: selectors.CR.Nodes.byContextPathSelector(contextPath)(store.getState())},
-            ...children.map(el => {
-                const contextPath = el.getAttribute('data-__neos-node-contextpath');
-                return {[contextPath]: selectors.CR.Nodes.byContextPathSelector(contextPath)(store.getState())};
+            ...childNodes.map(({nodeAddress}) => {
+                return {[nodeAddress]: selectors.CR.Nodes.byContextPathSelector(nodeAddress)(store.getState())};
             })
         );
         const nodeTypesRegistry = globalRegistry.get('@neos-project/neos-ui-contentrepository');
@@ -581,7 +589,7 @@ manifest('main', {}, (globalRegistry, {routes}) => {
         //
         // Initialize the newly rendered node and all nodes that came with it
         //
-        [contentElement, ...children].forEach(
+        [nodeToInsert, ...childNodes].forEach(
             initializeContentDomNode({
                 store,
                 globalRegistry,
@@ -590,7 +598,7 @@ manifest('main', {}, (globalRegistry, {routes}) => {
                 nodes
             })
         );
-        store.dispatch(actions.CR.Nodes.focus(contextPath, fusionPath));
+        store.dispatch(actions.CR.Nodes.focus(contextPath, nodeToInsert.fusionPath));
         store.dispatch(actions.UI.ContentCanvas.requestScrollIntoView(true));
     });
 


### PR DESCRIPTION
Relates: #3231

**What I did**

**How I did it**

Instead of a wrapping Dom element or augmenting a nodes markup, the backend creates 2 encapsulating html comments that contain all necessary data and allow interactions with nodes without markup manipulations.

This also needs an adjustment in Neos.Neos, as the wrapping class is still there.

- [x] Wrap content with comments instead of augmenting with data attributes
- [x] Load node addresses from comments
- [x] Make nodes selectable from content tree and in guest frame
- [x] Make nodes without markup work (no highlighting though)
- [x] Nodes are fully inline editable
- [x] OOB rendering reload
- [ ] OOB move/copy (50%, still buggy)
- [ ] Insert new node (untested)
- [ ] Implement node highlighting from host frame like the buttoner
- [ ] Make sure nodes with multiple Dom nodes without a single wrapping Dom element work correctly
- [ ] Check if property augmenter can also be switched to comments (can be also a separate PR)
- [ ] Move augmentation logic from Neos.Neos to Neos.Ui
- [ ] Check if insertion anchor can be a comment (can also be a separate PR)
- [ ] Deprecate `additionalAttributes` in `Neos.Neos:ContentElementWrapping`

**How to verify it**

All manipulations of nodes in the guest frame and access from the host frame still work + e2e tests.
