### PR TITLE
BUGFIX: Remove the height to reduce the size of step 2 of the Creation Dialog

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/style.module.css
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/style.module.css
@@ -1,6 +1,5 @@
 .body {
     display: flex;
-    height: calc(65vh);
 }
 .primaryColumn {
     overflow-y: auto;


### PR DESCRIPTION
Resolves: #3928 

**What I did**
Reduce the height of step 2 of the Creation Dialog.

**How I did it**
Remove the fixed height `height: calc(65vh);` in the styles of NodeCreationDialogue. The Creation Dialog adjusts its height to fit the content.

**How to verify it**

Before:
![Bildschirmfoto 2025-04-17 um 12 01 06](https://github.com/user-attachments/assets/aba922a9-47d6-4517-b01a-78857f6bcd91)

After:
![Bildschirmfoto 2025-04-17 um 12 01 25](https://github.com/user-attachments/assets/d381fe37-eb2d-4560-8211-bcc956dbeac1)


