### PR TITLE
BUGFIX: Add parameter name for js/css cachebuster

### DIFF
--- a/Classes/Domain/Service/StyleAndJavascriptInclusionService.php
+++ b/Classes/Domain/Service/StyleAndJavascriptInclusionService.php
@@ -47,6 +47,12 @@ class StyleAndJavascriptInclusionService
     protected $additionalEelDefaultContext;
 
     /**
+     * @Flow\InjectConfiguration(path="resources.cacheBusterParameter")
+     * @var string|null
+     */
+    protected $cacheBusterParameter;
+
+    /**
      * @Flow\InjectConfiguration(path="resources.javascript")
      * @var array
      */
@@ -79,7 +85,7 @@ class StyleAndJavascriptInclusionService
         $result = '';
         foreach ($sortedResources as $element) {
             $resourceExpression = $element['resource'];
-            if (substr($resourceExpression, 0, 2) === '${' && substr($resourceExpression, -1) === '}') {
+            if (str_starts_with($resourceExpression, '${') && str_ends_with($resourceExpression, '}')) {
                 $resourceExpression = Utility::evaluateEelExpression(
                     $resourceExpression,
                     $this->eelEvaluator,
@@ -90,12 +96,14 @@ class StyleAndJavascriptInclusionService
 
             $hash = null;
 
-            if (strpos($resourceExpression, 'resource://') === 0) {
-                // Cache breaker
-                $hash = substr(md5_file($resourceExpression), 0, 8);
+            if (str_starts_with($resourceExpression, 'resource://')) {
+                if ($this->cacheBusterParameter) {
+                    // Calculate cache buster value
+                    $hash = substr(md5_file($resourceExpression), 0, 8);
+                }
                 $resourceExpression = $this->resourceManager->getPublicPackageResourceUriByPath($resourceExpression);
             }
-            $finalUri = $hash ? $resourceExpression . (str_contains($resourceExpression, '?') ? '&' : '?') . $hash : $resourceExpression;
+            $finalUri = $hash ? $resourceExpression . (str_contains($resourceExpression, '?') ? '&' : '?') . $this->cacheBusterParameter . '=' . $hash : $resourceExpression;
             $additionalAttributes = array_merge(
                 // legacy first level 'defer' attribute
                 isset($element['defer']) ? ['defer' => $element['defer']] : [],

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -36,6 +36,8 @@ Neos:
 
       # API: "start 100" and smaller numbers; "no numbers", ...
       resources:
+        # Set to `null` or an empty string, if you provide your own cache buster, e.g. via `flowpack/cachebuster`
+        cacheBusterParameter: 'bust'
 
         javascript:
           'Neos.Neos.UI:Host':


### PR DESCRIPTION
Resolves: #3946

**What I did**

Give cache buster parameter a name to have a key & value pair in the query string

**How I did it**

Add configurable cache buster parameter name 

**How to verify it**

Inspect the Neos backend and check that all JS and CSS files loaded by the Neos.Ui like plugins etc. have the parameter appended with a name and value.
