### PR TITLE
Optional parameter $node declared before required parameter

### DIFF
--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -402,14 +402,18 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
 
     /**
      * @param ?NodeInterface $node
-     * @param ControllerContext $controllerContext
+     * @param ?ControllerContext $controllerContext
      * @return string
      * @throws \Neos\Neos\Exception
      */
-    public function uri(?NodeInterface $node = null, ControllerContext $controllerContext)
+    public function uri(?NodeInterface $node = null, ?ControllerContext $controllerContext = null)
     {
         if ($node === null) {
             // This happens when the document node is not published yet
+            return '';
+        }
+        if ($controllerContext === null) {
+            // This happens when the controller context is null
             return '';
         }
 


### PR DESCRIPTION
Solves the problem that occurs when, for example, the backend is called for the first time. In the DOM
`Deprecated: Optional parameter $node declared before required parameter controllerContext is implicitly treated as a required parameter in /tmp/Flow/Development/Cache/Code/Flow_Object_Classes/Neos_Neos_Ui_Fusion_Helper_NodelnfoHelper.php on line 409` is rendered.