### PR TITLE
BUGFIX: Solve deprecation warnings in PHP 8.3

### DIFF
--- a/Classes/Domain/Service/NodeTreeBuilder.php
+++ b/Classes/Domain/Service/NodeTreeBuilder.php
@@ -224,7 +224,7 @@ class NodeTreeBuilder
         return $result;
     }
 
-    protected function isInRootLine(?NodeInterface $haystack = null, NodeInterface $needle)
+    protected function isInRootLine(?NodeInterface $haystack, NodeInterface $needle)
     {
         if ($haystack === null) {
             return false;

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -406,7 +406,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
      * @return string
      * @throws \Neos\Neos\Exception
      */
-    public function uri(?NodeInterface $node = null, ControllerContext $controllerContext)
+    public function uri(?NodeInterface $node, ControllerContext $controllerContext)
     {
         if ($node === null) {
             // This happens when the document node is not published yet


### PR DESCRIPTION
The fix of PHP8.4 deprecation warnings has introduced new deprecation warnings in PHP 8.3.

https://github.com/neos/neos-ui/pull/3934

```
Deprecated: Optional parameter $haystack declared before required parameter $needle is implicitly treated as a required parameter in /var/www/html/Packages/Application/Neos.Neos.Ui/Classes/Domain/Service/NodeTreeBuilder.php on line 227

Deprecated: Optional parameter $node declared before required parameter $controllerContext is implicitly treated as a required parameter in /var/www/html/Packages/Application/Neos.Neos.Ui/Classes/Fusion/Helper/NodeInfoHelper.php on line 409
```

Both parameter are rather nullable than optional. 