### PR TITLE
BUGFIX: Proper error if site node not found in backend

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -199,10 +199,13 @@ class BackendController extends ActionController
             throw new \RuntimeException(sprintf('Site node "%s" not found in content repository "%s" in dimension space point %s and visibility constraints "%s"', $siteDetectionResult->siteNodeName->value, $contentRepository->id->value, $subgraph->getDimensionSpacePoint()->toJson(), join(' | ', $subgraph->getVisibilityConstraints()->excludedSubtreeTags->toStringArray())), 1747474100);
         }
 
-        if (!$nodeAddress) {
-            $node = $siteNode;
+        if ($nodeAddress === null) {
+            $documentNode = $siteNode;
         } else {
-            $node = $subgraph->findNodeById($nodeAddress->aggregateId);
+            $documentNode = $subgraph->findNodeById($nodeAddress->aggregateId);
+            if ($documentNode === null) {
+                $documentNode = $siteNode;
+            }
         }
 
         $this->view->setOption('title', 'Neos CMS');
@@ -229,7 +232,7 @@ class BackendController extends ActionController
             'initialState' =>
                 $this->initialStateProvider->getInitialState(
                     actionRequest: $this->request,
-                    documentNode: $node,
+                    documentNode: $documentNode,
                     site: $siteNode,
                     user: $user,
                 ),

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -195,6 +195,10 @@ class BackendController extends ActionController
             $rootNodeAggregate->nodeAggregateId
         );
 
+        if ($siteNode === null) {
+            throw new \RuntimeException(sprintf('Site node "%s" not found in content repository "%s" in dimension space point %s and visibility constraints "%s"', $siteDetectionResult->siteNodeName->value, $contentRepository->id->value, $subgraph->getDimensionSpacePoint()->toJson(), join(' | ', $subgraph->getVisibilityConstraints()->excludedSubtreeTags->toStringArray())), 1747474100);
+        }
+
         if (!$nodeAddress) {
             $node = $siteNode;
         } else {

--- a/Classes/Domain/InitialData/InitialStateProviderInterface.php
+++ b/Classes/Domain/InitialData/InitialStateProviderInterface.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Neos\Neos\Ui\Domain\InitialData;
 
-use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Neos\Domain\Model\User;
@@ -31,7 +30,7 @@ interface InitialStateProviderInterface
     public function getInitialState(
         ActionRequest $actionRequest,
         ?Node $documentNode,
-        ?Node $site,
+        Node $site,
         User $user,
     ): array;
 }

--- a/Classes/Domain/InitialData/InitialStateProviderInterface.php
+++ b/Classes/Domain/InitialData/InitialStateProviderInterface.php
@@ -29,7 +29,7 @@ interface InitialStateProviderInterface
     /** @return array<mixed> */
     public function getInitialState(
         ActionRequest $actionRequest,
-        ?Node $documentNode,
+        Node $documentNode,
         Node $site,
         User $user,
     ): array;

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -329,9 +329,6 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
         Node $documentNode,
         ActionRequest $actionRequest
     ): array {
-        // does not support multiple CRs here yet
-        $contentRepository = $this->contentRepositoryRegistry->get($site->contentRepositoryId);
-
         return [
             (NodeAddress::fromNode($site)->toJson())
             => $this->renderNodeWithPropertiesAndChildrenInformation($site, $actionRequest),

--- a/Classes/Infrastructure/Configuration/InitialStateProvider.php
+++ b/Classes/Infrastructure/Configuration/InitialStateProvider.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Neos\Neos\Ui\Infrastructure\Configuration;
 
-use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\ActionRequest;
@@ -42,7 +41,7 @@ final class InitialStateProvider implements InitialStateProviderInterface
     public function getInitialState(
         ActionRequest $actionRequest,
         ?Node $documentNode,
-        ?Node $site,
+        Node $site,
         User $user,
     ): array {
         return $this->configurationRenderingService->computeConfiguration(

--- a/Classes/Infrastructure/Configuration/InitialStateProvider.php
+++ b/Classes/Infrastructure/Configuration/InitialStateProvider.php
@@ -40,7 +40,7 @@ final class InitialStateProvider implements InitialStateProviderInterface
 
     public function getInitialState(
         ActionRequest $actionRequest,
-        ?Node $documentNode,
+        Node $documentNode,
         Node $site,
         User $user,
     ): array {


### PR DESCRIPTION
It seems the (internal) contract for providing the UI state requires no site or document node, but this is not true (obviously)
The `defaultNodesForBackend` helper will just crash:

> defaultNodesForBackend(): Argument #1 ($site) must be of type Neos\ContentRepository\Core\Projection\ContentGraph\Node, null given

It is invoked here via YAML - hence we did not detect this null pointer bug:

https://github.com/neos/neos-ui/blob/ebed35152bf480329cb54a18ec40d49fc0076673/Configuration/Settings.yaml#L131

Instead now a pretty error is throw which will also highlight probably its cause:

```
Site node "neosdemo" not found in content repository "default" in dimension space point {"language":"en_US","targetGroup":"private"} and visibility constraints "removed"
```

In my case i had a configuration laying around adding a new dimension `targetGroup` for all sites which was un nice which lead to no nodes being found.
