### PR TITLE
BUGFIX: Translate selectbox group labels

### DIFF
--- a/packages/neos-ui-editors/src/Editors/SelectBox/selectBoxHelpers.ts
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/selectBoxHelpers.ts
@@ -1,9 +1,10 @@
 import {I18nRegistry} from '@neos-project/neos-ts-interfaces';
 import {isNil} from '@neos-project/utils-helpers';
 
-type RawSelectBoxOptions = {value: string, icon?: string; disabled?: boolean; label: string;}[]|{[key: string]: {icon?: string; disabled?: boolean; label: string;}};
+type RawSelectBoxOptions = {value: string, icon?: string; disabled?: boolean; label: string; group?: string;}[]|{[key: string]: {icon?: string; disabled?: boolean; label: string;
+        group?: string;}};
 
-type SelectBoxOptions = {value: string, icon?: string; disabled?: boolean; label: string;}[];
+type SelectBoxOptions = {value: string, icon?: string; disabled?: boolean; label: string; group?: string;}[];
 
 export const shouldDisplaySearchBox = (options: any, processedSelectBoxOptions: SelectBoxOptions) => options.minimumResultsForSearch >= 0 && processedSelectBoxOptions.length >= options.minimumResultsForSearch;
 
@@ -24,6 +25,10 @@ export const processSelectBoxOptions = (i18nRegistry: I18nRegistry, selectBoxOpt
             ...selectBoxOption, // a value in here overrules value based on the key above.
             label: i18nRegistry.translate(selectBoxOption.label)
         };
+
+        if (selectBoxOption.group) {
+            processedSelectBoxOption.group = i18nRegistry.translate(selectBoxOption.group);
+        }
 
         validValues[processedSelectBoxOption.value] = true;
         processedSelectBoxOptions.push(processedSelectBoxOption);


### PR DESCRIPTION
**What I did**

Made it possible to have localised group labels for select box values

**How I did it**

Translate group in addition to the already translated label.
This change needs an additional fix in Neos itself to convert i18n values. But with this change shorthand translation strings already work.

**How to verify it**

![CleanShot 2025-05-20 at 22 05 04@2x](https://github.com/user-attachments/assets/03c47c17-4f09-4b5c-8d5c-3c511165d870)