### PR TITLE
BUGFIX: Fix the height of CKEditor Wrapper

### DIFF
--- a/packages/neos-ui-editors/src/SecondaryEditors/CKEditorWrap/index.module.css
+++ b/packages/neos-ui-editors/src/SecondaryEditors/CKEditorWrap/index.module.css
@@ -15,5 +15,4 @@
     outline: 0;
     padding: 15px;
     overflow: scroll;
-    height: 0;
 }

--- a/packages/neos-ui-inspector/src/SecondaryInspector/style.module.css
+++ b/packages/neos-ui-inspector/src/SecondaryInspector/style.module.css
@@ -4,6 +4,7 @@
     background: var(--colors-ContrastDarker);
     border: 1px solid var(--colors-ContrastDark);
     border-bottom-width: 0;
+    overflow-y: auto;
 }
 .secondaryInspector--isElevated {
     z-index: var(--zIndex-SecondaryInspectorElevated);


### PR DESCRIPTION
**What I did**
Fix the height of CKEditor Wrapper and SecondaryInspector scroll behaviour

**How I did it**
Remove the height:0; added here: https://github.com/neos/neos-ui/commit/677a6f7483a119d0a7e4b0e78fe80bf6f36286a3
This was added because the scroll within the SecondaryInspector didn't work. But it breaks the height of the CKEditor Wrapper when used in other places. see screenshots.
Instead I added a overflow-y: auto; to the SecondaryInspector itself. 
This fixes the scrolling Issue and acts as a fallback if the editor within doesnt have a overflow-scroll itself.

**How to verify it**

As an example the CKEditor is used in the PAckage Neos Sidekick, this is what happens with the height:0:
![Screenshot 2025-05-26 at 12 41 46](https://github.com/user-attachments/assets/fec00bce-9ca9-4673-a707-c0a27e4b2350)

This is how it looks without the height:0:
![Screenshot 2025-05-26 at 12 33 23](https://github.com/user-attachments/assets/783f1a7b-3d4e-4480-9927-feb0c2c783a7)

To verify the SecondaryInspector scrolling still works you can simply either test the RichTextEditor or the CodeEditor.
