### PR TITLE
BUGFIX: (CSS): add visual selection of multiple cells in table in ckeditor

### DIFF
--- a/packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/TableStyles.vanilla-css
+++ b/packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/TableStyles.vanilla-css
@@ -136,6 +136,11 @@
 .ck-editor__editable.ck-blurred .ck-widget.ck-widget_selected .ck-widget__selection-handle,.ck-editor__editable.ck-blurred .ck-widget.ck-widget_selected .ck-widget__selection-handle:hover,.ck-editor__editable.ck-blurred .ck-widget.ck-widget_selected:hover .ck-widget__selection-handle,.ck-editor__editable.ck-blurred .ck-widget.ck-widget_selected:hover .ck-widget__selection-handle:hover{
     background:var(--ck-color-widget-blurred-border)
 }
+.ck-editor__editable.ck-editor__nested-editable.ck-editor__editable_selected,
+.ck-editor__editable.ck-editor__nested-editable.ck-editor__nested-editable-focus {
+	border: 2px solid var(--ck-color-focus-border);
+	background-color: var(--ck-color-table-focused-cell-background);
+}
 :root{
     --ck-color-table-focused-cell-background:#f5fafe
 }


### PR DESCRIPTION

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**
Added CSS for selected cells in tables in CSS editor. The CSS is adding blue outlines to selected cells when multiple cells are selected by dragging the mouse.

**How I did it**
Added 2 CSS definitions in  packages/neos-ui-ckeditor5-bindings/src/EditorToolbar/TableStyles.vanilla-css

![Screenshot from 2025-06-21 13-25-32](https://github.com/user-attachments/assets/31e0f810-3acc-4426-91fb-138fa957ac47)

