### PR TITLE
BUGFIX: Skip content childnodes when returning document tree nodes

### DIFF
--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -575,7 +575,8 @@ class BackendServiceController extends ActionController
                 $result = $nodeInfoHelper->renderNodes(
                     array_filter($flowQuery->get()),
                     $this->getControllerContext(),
-                    true
+                    true,
+                    ($finisher['payload'] ?? 'ALL') !== 'PAGE_TREE',
                 );
                 break;
             case 'getForTreeWithParents':
@@ -583,7 +584,8 @@ class BackendServiceController extends ActionController
                 $result = $nodeInfoHelper->renderNodesWithParents(
                     array_filter($flowQuery->get()),
                     $this->getControllerContext(),
-                    $nodeTypeFilter
+                    $nodeTypeFilter,
+                    ($finisher['payload']['usage'] ?? 'ALL') !== 'PAGE_TREE',
                 );
                 break;
         }

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -576,7 +576,7 @@ class BackendServiceController extends ActionController
                     array_filter($flowQuery->get()),
                     $this->getControllerContext(),
                     true,
-                    ($finisher['payload'] ?? 'ALL') !== 'PAGE_TREE',
+                    ($finisher['payload']['usage'] ?? 'ALL') !== 'PAGE_TREE',
                 );
                 break;
             case 'getForTreeWithParents':

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -14,6 +14,7 @@ namespace Neos\Neos\Ui\Fusion\Helper;
 use Neos\ContentRepository\Domain\Model\Node;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
+use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\ContentRepository\Domain\Utility\NodePaths;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
@@ -98,6 +99,12 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
     protected $ignoredNodeTypeRole;
 
     /**
+     * @Flow\Inject
+     * @var NodeTypeManager
+     */
+    protected $nodeTypeManager;
+
+    /**
      * @param NodeInterface $node
      * @param ?ControllerContext $controllerContext
      * @param bool $omitMostPropertiesForTreeState
@@ -107,8 +114,17 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
      */
     public function renderNode(NodeInterface $node, ?ControllerContext $controllerContext = null, $omitMostPropertiesForTreeState = false, $nodeTypeFilterOverride = null)
     {
+        $includedNodeTypes = $this->getIncludedNodeTypes($controllerContext, $nodeTypeFilterOverride);
         return ($omitMostPropertiesForTreeState ?
-            $this->renderNodeWithMinimalPropertiesAndChildrenInformation($node, $controllerContext, $nodeTypeFilterOverride) :
+            $this->renderNodeWithMinimalPropertiesAndChildrenInformation(
+                $node,
+                $controllerContext,
+                $this->buildNodeTypeFilterString(
+                    $includedNodeTypes,
+                    $this->nodeTypeStringsToList($this->ignoredNodeTypeRole)
+                ),
+                $this->shouldIncludeContentChildNodes($includedNodeTypes)
+            ) :
             $this->renderNodeWithPropertiesAndChildrenInformation($node, $controllerContext, $nodeTypeFilterOverride)
         );
     }
@@ -116,10 +132,14 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
     /**
      * @param NodeInterface $node
      * @param ControllerContext|null $controllerContext
-     * @param ?string $nodeTypeFilterOverride
      * @return array|null
      */
-    public function renderNodeWithMinimalPropertiesAndChildrenInformation(NodeInterface $node, ?ControllerContext $controllerContext = null, ?string $nodeTypeFilterOverride = null)
+    public function renderNodeWithMinimalPropertiesAndChildrenInformation(
+        NodeInterface $node,
+        ?ControllerContext $controllerContext = null,
+        string $nodeTypeFilter = '',
+        bool $includeContentChildNodes = false
+    )
     {
         if (!$this->nodePolicyService->isNodeTreePrivilegeGranted($node)) {
             return null;
@@ -137,15 +157,9 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
 
         if ($controllerContext !== null) {
             $nodeInfo = array_merge($nodeInfo, $this->getUriInformation($node, $controllerContext));
-            if ($controllerContext->getRequest()->hasArgument('presetBaseNodeType')) {
-                $presetBaseNodeType = $controllerContext->getRequest()->getArgument('presetBaseNodeType');
-            }
         }
 
-        $baseNodeType = $nodeTypeFilterOverride ? $nodeTypeFilterOverride : (isset($presetBaseNodeType) ? $presetBaseNodeType : $this->defaultBaseNodeType);
-        $nodeTypeFilter = $this->buildNodeTypeFilterString($this->nodeTypeStringsToList($baseNodeType), $this->nodeTypeStringsToList($this->ignoredNodeTypeRole));
-
-        $nodeInfo['children'] = $this->renderChildrenInformation($node, $nodeTypeFilter);
+        $nodeInfo['children'] = $this->renderChildrenInformation($node, $nodeTypeFilter, $includeContentChildNodes);
 
         $this->userLocaleService->switchToUILocale(true);
 
@@ -239,12 +253,16 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
      * @param string $nodeTypeFilterString
      * @return array
      */
-    protected function renderChildrenInformation(NodeInterface $node, string $nodeTypeFilterString): array
+    protected function renderChildrenInformation(NodeInterface $node, string $nodeTypeFilterString, bool $includeContentChildNodes = true): array
     {
         $documentChildNodes = $node->getChildNodes($nodeTypeFilterString);
-        // child nodes for content tree, must not include those nodes filtered out by `baseNodeType`
-        $contentChildNodes = $node->getChildNodes($this->buildContentChildNodeFilterString());
-        $childNodes = array_merge($documentChildNodes, $contentChildNodes);
+        if ($includeContentChildNodes) {
+            // child nodes for content tree, must not include those nodes filtered out by `baseNodeType`
+            $contentChildNodes = $node->getChildNodes($this->buildContentChildNodeFilterString());
+            $childNodes = array_merge($documentChildNodes, $contentChildNodes);
+        } else {
+            $childNodes = $documentChildNodes;
+        }
 
         $mapper = static function (NodeInterface $childNode) {
             return [
@@ -262,14 +280,44 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
      * @param bool $omitMostPropertiesForTreeState
      * @return array
      */
-    public function renderNodes(array $nodes, ControllerContext $controllerContext, $omitMostPropertiesForTreeState = false): array
+    public function renderNodes(
+        array $nodes,
+        ControllerContext $controllerContext,
+        $omitMostPropertiesForTreeState = false,
+        bool $includeContentChildNodes = true
+    ): array
     {
-        $methodName = $omitMostPropertiesForTreeState ? 'renderNodeWithMinimalPropertiesAndChildrenInformation' : 'renderNodeWithPropertiesAndChildrenInformation';
-        $mapper = function (NodeInterface $node) use ($controllerContext, $methodName) {
-            return $this->$methodName($node, $controllerContext);
-        };
+        if ($omitMostPropertiesForTreeState) {
+            $includedNodeTypes = $this->getIncludedNodeTypes($controllerContext);
+            $nodeTypeFilterString = $this->buildNodeTypeFilterString(
+                $includedNodeTypes,
+                $this->nodeTypeStringsToList($this->ignoredNodeTypeRole)
+            );
+            $renderedNodes = array_map(function ($node) use ($controllerContext, $includeContentChildNodes, $nodeTypeFilterString) {
+                return $this->renderNodeWithMinimalPropertiesAndChildrenInformation(
+                    $node,
+                    $controllerContext,
+                    $nodeTypeFilterString,
+                    $includeContentChildNodes
+                );
+            }, $nodes);
+        } else {
+            $renderedNodes = array_map(function ($node) use ($controllerContext) {
+                return $this->renderNodeWithPropertiesAndChildrenInformation($node, $controllerContext);
+            }, $nodes);
+        }
 
-        return array_values(array_filter(array_map($mapper, $nodes)));
+        return array_values(array_filter($renderedNodes));
+    }
+
+    protected function getIncludedNodeTypes(?ControllerContext $controllerContext, string $nodeTypeFilterOverride = null): array
+    {
+        if ($controllerContext?->getRequest()->hasArgument('presetBaseNodeType')) {
+            $presetBaseNodeType = $controllerContext?->getRequest()->getArgument('presetBaseNodeType');
+        }
+
+        $baseNodeType = $nodeTypeFilterOverride ?: $presetBaseNodeType ?? $this->defaultBaseNodeType;
+        return $this->nodeTypeStringsToList($baseNodeType);
     }
 
     /**
@@ -278,17 +326,30 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
      * @param null|string $nodeTypeFilter
      * @return array
      */
-    public function renderNodesWithParents(array $nodes, ControllerContext $controllerContext, ?string $nodeTypeFilter = null): array
+    public function renderNodesWithParents(
+        array $nodes,
+        ControllerContext $controllerContext,
+        ?string $nodeTypeFilter = null,
+        bool $includeContentChildNodes = true
+    ): array
     {
         // For search operation we want to include all nodes, not respecting the "baseNodeType" setting
         $baseNodeTypeOverride = $this->documentNodeTypeRole;
         $renderedNodes = [];
+        $includedNodeTypes = $this->getIncludedNodeTypes($controllerContext, $nodeTypeFilter ?? $baseNodeTypeOverride);
+        $excludedNodeTypes = $this->nodeTypeStringsToList($this->ignoredNodeTypeRole);
+        $nodeTypeFilterString = $this->buildNodeTypeFilterString($includedNodeTypes, $excludedNodeTypes);
 
         /** @var NodeInterface $node */
         foreach ($nodes as $node) {
             if (array_key_exists($node->getPath(), $renderedNodes)) {
                 $renderedNodes[$node->getPath()]['matched'] = true;
-            } elseif ($renderedNode = $this->renderNodeWithMinimalPropertiesAndChildrenInformation($node, $controllerContext, $nodeTypeFilter ?? $baseNodeTypeOverride)) {
+            } elseif ($renderedNode = $this->renderNodeWithMinimalPropertiesAndChildrenInformation(
+                $node,
+                $controllerContext,
+                $nodeTypeFilterString,
+                $includeContentChildNodes
+            )) {
                 $renderedNode['matched'] = true;
                 $renderedNodes[$node->getPath()] = $renderedNode;
             } else {
@@ -311,7 +372,12 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
                 if (array_key_exists($parentNode->getPath(), $renderedNodes)) {
                     $renderedNodes[$parentNode->getPath()]['intermediate'] = true;
                 } else {
-                    $renderedParentNode = $this->renderNodeWithMinimalPropertiesAndChildrenInformation($parentNode, $controllerContext, $baseNodeTypeOverride);
+                    $renderedParentNode = $this->renderNodeWithMinimalPropertiesAndChildrenInformation(
+                        $parentNode,
+                        $controllerContext,
+                        $nodeTypeFilterString,
+                        $includeContentChildNodes
+                    );
                     if ($renderedParentNode) {
                         $renderedParentNode['intermediate'] = true;
                         $renderedNodes[$parentNode->getPath()] = $renderedParentNode;

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -372,7 +372,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
                     $renderedParentNode = $this->renderNodeWithMinimalPropertiesAndChildrenInformation(
                         $parentNode,
                         $controllerContext,
-                        $nodeTypeFilterString,
+                        $baseNodeTypeOverride,
                         $includeContentChildNodes
                     );
                     if ($renderedParentNode) {

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -139,8 +139,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
         ?ControllerContext $controllerContext = null,
         string $nodeTypeFilter = '',
         bool $includeContentChildNodes = false
-    )
-    {
+    ) {
         if (!$this->nodePolicyService->isNodeTreePrivilegeGranted($node)) {
             return null;
         }
@@ -285,8 +284,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
         ControllerContext $controllerContext,
         $omitMostPropertiesForTreeState = false,
         bool $includeContentChildNodes = true
-    ): array
-    {
+    ): array {
         if ($omitMostPropertiesForTreeState) {
             $includedNodeTypes = $this->getIncludedNodeTypes($controllerContext);
             $nodeTypeFilterString = $this->buildNodeTypeFilterString(
@@ -331,8 +329,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
         ControllerContext $controllerContext,
         ?string $nodeTypeFilter = null,
         bool $includeContentChildNodes = true
-    ): array
-    {
+    ): array {
         // For search operation we want to include all nodes, not respecting the "baseNodeType" setting
         $baseNodeTypeOverride = $this->documentNodeTypeRole;
         $renderedNodes = [];

--- a/packages/neos-ui-backend-connector/src/FlowQuery/Operations/GetForTree/index.ts
+++ b/packages/neos-ui-backend-connector/src/FlowQuery/Operations/GetForTree/index.ts
@@ -1,4 +1,4 @@
 export default () => (usage: 'ALL' | 'PAGE_TREE' = 'ALL') => ({
     type: 'getForTree',
-    payload: usage
+    payload: {usage}
 });

--- a/packages/neos-ui-backend-connector/src/FlowQuery/Operations/GetForTree/index.ts
+++ b/packages/neos-ui-backend-connector/src/FlowQuery/Operations/GetForTree/index.ts
@@ -1,4 +1,4 @@
-export default () => (index: number | 'ALL' = 'ALL') => ({
+export default () => (usage: 'ALL' | 'PAGE_TREE' = 'ALL') => ({
     type: 'getForTree',
-    payload: index
+    payload: usage
 });

--- a/packages/neos-ui-backend-connector/src/FlowQuery/Operations/GetForTreeWithParents/index.ts
+++ b/packages/neos-ui-backend-connector/src/FlowQuery/Operations/GetForTreeWithParents/index.ts
@@ -1,4 +1,4 @@
-export default () => (nodeTypeFilter = null) => ({
+export default () => (nodeTypeFilter = null, usage: 'ALL' | 'PAGE_TREE' = 'ALL') => ({
     type: 'getForTreeWithParents',
-    payload: {nodeTypeFilter}
+    payload: {nodeTypeFilter, usage}
 });

--- a/packages/neos-ui-sagas/src/CR/NodeOperations/reloadState.js
+++ b/packages/neos-ui-sagas/src/CR/NodeOperations/reloadState.js
@@ -22,14 +22,14 @@ export default function * watchReloadState({configuration}) {
 
         let nodes = [];
         if (isSearch) {
-            nodes = yield q(siteNodeContextPath).search(searchQuery, effectiveFilterNodeType).getForTreeWithParents(effectiveFilterNodeType);
+            nodes = yield q(siteNodeContextPath).search(searchQuery, effectiveFilterNodeType).getForTreeWithParents(effectiveFilterNodeType, 'PAGE_TREE');
         } else {
             nodes = yield q([siteNodeContextPath, documentNodeContextPath]).neosUiDefaultNodes(
                 configuration.nodeTree.presets.default.baseNodeType,
                 configuration.nodeTree.loadingDepth,
                 toggledNodes,
                 clipboardNodesContextPaths
-            ).getForTree();
+            ).getForTree('PAGE_TREE');
         }
 
         const nodeMap = nodes.reduce((nodeMap, node) => {

--- a/packages/neos-ui-sagas/src/UI/PageTree/index.js
+++ b/packages/neos-ui-sagas/src/UI/PageTree/index.js
@@ -37,9 +37,9 @@ export function * watchRequestChildrenForContextPath({configuration}) {
         try {
             const query = q(contextPath);
 
-            parentNodes = yield query.getForTree();
+            parentNodes = yield query.getForTree('PAGE_TREE');
             const {baseNodeType} = configuration.nodeTree.presets.default;
-            childNodes = yield query.neosUiFilteredChildren(baseNodeType).getForTree();
+            childNodes = yield query.neosUiFilteredChildren(baseNodeType).getForTree('PAGE_TREE');
         } catch (err) {
             yield put(actions.UI.PageTree.invalidate(contextPath));
             yield put(actions.UI.FlashMessages.add('loadChildNodesError', err.message, 'error'));
@@ -157,7 +157,7 @@ export function * watchSearch({configuration}) {
             const query = q(contextPath);
 
             if (isSearch) {
-                matchingNodes = yield query.search(searchQuery, effectiveFilterNodeType).getForTreeWithParents(effectiveFilterNodeType);
+                matchingNodes = yield query.search(searchQuery, effectiveFilterNodeType).getForTreeWithParents(effectiveFilterNodeType, 'PAGE_TREE');
             } else {
                 const clipboardNodeContextPath = yield select($get('cr.nodes.clipboard'));
                 const toggledNodes = yield select($get('ui.pageTree.toggled'));
@@ -168,7 +168,7 @@ export function * watchSearch({configuration}) {
                     configuration.nodeTree.loadingDepth,
                     toggledNodes,
                     clipboardNodeContextPath
-                ).getForTree();
+                ).getForTree('PAGE_TREE');
             }
         } catch (err) {
             console.error('Error while executing a tree search: ', err);


### PR DESCRIPTION
**What I did**

Speed up response time for return nodes for the document tree by a factor of up to 5x when uncollapsing a document or searching. With ~200 documents (e.g. Blog folder with many articles) the following results were achieved:

* Uncollapse blog page with ~200 articles: 
  * Response size is reduced from 162 KB to 132 KB -> -19%
  * Response time is reduced from 2.5s to 0.6s -> -75%
* Search in the document tree for the same blog posts (also ~200 results)
  * Response size is reduced from 193 KB to 163 KB -> -16%
  * Response time is reduced from 2s to 0.5s -> -75%

**How I did it**

* Skip content child nodes if we only request document types depending on the clients requested usage
* Don't recalculate nodetype filter for each rendered node

**How to verify it**

* Tests still work
* Node trees behave the same way except that uncollapsing and search are much faster

Resolves: #1508