### PR TITLE
BUGFIX: add CKEditor Heading Plugin for p, pre, blockquote

### DIFF
--- a/packages/neos-ui-ckeditor5-bindings/src/manifest.config.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/manifest.config.js
@@ -128,6 +128,9 @@ export default ckEditorRegistry => {
         $get('formatting.justify')
     )));
     config.set('heading', addPlugin(Heading, $or(
+        $get('formatting.p'),
+        $get('formatting.pre'),
+        $get('formatting.blockquote'),
         $get('formatting.h1'),
         $get('formatting.h2'),
         $get('formatting.h3'),


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

Added the heading plugin in case of p, pre or blockquote

**How to verify it**

Set formattingOptions
```yaml
p: true
pre: true
blockquote: true
h1: false
h2: false
h3: false
h4: false
h5: false
```
and then test p, pre and blockquote blocks in the inline editing.

<img width="370" height="739" alt="image" src="https://github.com/user-attachments/assets/9db37e4b-1605-4c96-a85b-716c7fa9f29c" />


<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->

Resolves #3964 