### PR TITLE
BUGFIX: add CKEditor Heading Plugin for p, pre, blockquote

### DIFF
--- a/packages/neos-ui-ckeditor5-bindings/src/manifest.config.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/manifest.config.js
@@ -133,7 +133,10 @@ export default ckEditorRegistry => {
         || editorOptions?.formatting?.justify
     )));
     config.set('heading', addPlugin(Heading, editorOptions => (
-        editorOptions?.formatting?.h1
+        editorOptions?.formatting?.p
+        || editorOptions?.formatting?.pre
+        || editorOptions?.formatting?.blockquote
+        || editorOptions?.formatting?.h1
         || editorOptions?.formatting?.h2
         || editorOptions?.formatting?.h3
         || editorOptions?.formatting?.h4


### PR DESCRIPTION
This is the MR for 9.0

See #3965
Resolves #3964