### PR TITLE
BUGFIX: Adjust dimension space point handling without a node address in backend controller

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -12,6 +12,7 @@ namespace Neos\Neos\Ui\Controller;
  * source code.
  */
 
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Exception\WorkspaceRebaseFailed;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceStatus;
@@ -158,6 +159,7 @@ class BackendController extends ActionController
 
         $this->workspaceService->createPersonalWorkspaceForUserIfMissing($siteDetectionResult->contentRepositoryId, $user);
         $workspace = $this->workspaceService->getPersonalWorkspaceForUser($siteDetectionResult->contentRepositoryId, $user->getId());
+
         if (
             $this->autoSyncPersonalWorkspaces
             && $workspace->status === WorkspaceStatus::OUTDATED
@@ -173,14 +175,6 @@ class BackendController extends ActionController
 
         $contentGraph = $contentRepository->getContentGraph($workspace->workspaceName);
 
-        $rootDimensionSpacePoints = $contentRepository->getVariationGraph()->getRootGeneralizations();
-        $arbitraryRootDimensionSpacePoint = array_shift($rootDimensionSpacePoints);
-
-        $subgraph = $contentRepository->getContentSubgraph(
-            $workspace->workspaceName,
-            $nodeAddress->dimensionSpacePoint ?? $arbitraryRootDimensionSpacePoint,
-        );
-
         // we assume that the ROOT node is always stored in the CR as "physical" node; so it is safe
         // to call the contentGraph here directly.
         $rootNodeAggregate = $contentGraph->findRootNodeAggregateByType(
@@ -190,22 +184,74 @@ class BackendController extends ActionController
             throw new \RuntimeException(sprintf('No sites root node found in content repository "%s", while fetching site node "%s"', $contentRepository->id->value, $siteDetectionResult->siteNodeName->value), 1724849303);
         }
 
-        $siteNode = $subgraph->findNodeByPath(
-            $siteDetectionResult->siteNodeName->toNodeName(),
-            $rootNodeAggregate->nodeAggregateId
-        );
+        $resolvedNodeAddressIsSite = ($nodeAddress === null);
+        if ($nodeAddress === null) {
+            $site = $this->siteRepository->findOneByNodeName($siteDetectionResult->siteNodeName);
+            $defaultDimensionSpacePoint = $site->getConfiguration()->defaultDimensionSpacePoint;
 
-        if ($siteNode === null) {
-            throw new \RuntimeException(sprintf('Site node "%s" not found in content repository "%s" in dimension space point %s and visibility constraints "%s"', $siteDetectionResult->siteNodeName->value, $contentRepository->id->value, $subgraph->getDimensionSpacePoint()->toJson(), join(' | ', $subgraph->getVisibilityConstraints()->excludedSubtreeTags->toStringArray())), 1747474100);
+            $siteNodeAggregate = $contentGraph->findChildNodeAggregateByName(
+                $rootNodeAggregate->nodeAggregateId,
+                $siteDetectionResult->siteNodeName->toNodeName(),
+            );
+
+            if ($siteNodeAggregate === null) {
+                throw new \RuntimeException(sprintf(
+                    'Site node aggregate named "%s" is missing in content repository "%s"',
+                    $siteDetectionResult->siteNodeName->value,
+                    $contentRepository->id->value,
+                ), 1752861981);
+            }
+
+            if ($siteNodeAggregate->coversDimensionSpacePoint($defaultDimensionSpacePoint)) {
+                $nodeAddress = NodeAddress::create(
+                    $siteDetectionResult->contentRepositoryId,
+                    $workspace->workspaceName,
+                    $defaultDimensionSpacePoint,
+                    $siteNodeAggregate->nodeAggregateId,
+                );
+            } else {
+                $rootDimensionSpacePoints = DimensionSpacePointSet::fromArray($contentRepository->getVariationGraph()->getRootGeneralizations());
+                // first, try to use any of the root dimension space points
+                $eligibleDimensionSpacePoints = $rootDimensionSpacePoints->getIntersection(
+                    $siteNodeAggregate->coveredDimensionSpacePoints
+                );
+                // second, try any covered dimension space point
+                if ($eligibleDimensionSpacePoints->isEmpty()) {
+                    $eligibleDimensionSpacePoints = $siteNodeAggregate->coveredDimensionSpacePoints;
+                }
+                if ($eligibleDimensionSpacePoints->isEmpty()) {
+                    throw new \RuntimeException(sprintf(
+                        'Site node aggregate named "%s" is in content repository "%s" does not cover any dimension space points',
+                        $siteDetectionResult->siteNodeName->value,
+                        $contentRepository->id->value,
+                    ), 1752861984);
+                }
+
+                $eligibleDimensionSpacePointsArray = $eligibleDimensionSpacePoints->points;
+                $arbitraryEligibleDimensionSpacePoint = array_shift($eligibleDimensionSpacePointsArray);
+
+                $nodeAddress = NodeAddress::create(
+                    $siteDetectionResult->contentRepositoryId,
+                    $workspace->workspaceName,
+                    $arbitraryEligibleDimensionSpacePoint,
+                    $siteNodeAggregate->nodeAggregateId,
+                );
+            }
         }
 
-        if ($nodeAddress === null) {
-            $documentNode = $siteNode;
+        $subgraph = $contentRepository->getContentSubgraph(
+            $workspace->workspaceName,
+            $nodeAddress->dimensionSpacePoint,
+        );
+
+        $documentNode = $subgraph->findNodeById($nodeAddress->aggregateId);
+        if ($resolvedNodeAddressIsSite) {
+            $siteNode = $documentNode;
         } else {
-            $documentNode = $subgraph->findNodeById($nodeAddress->aggregateId);
-            if ($documentNode === null) {
-                $documentNode = $siteNode;
-            }
+            $siteNode = $subgraph->findNodeByPath(
+                $siteDetectionResult->siteNodeName->toNodeName(),
+                $rootNodeAggregate->nodeAggregateId,
+            );
         }
 
         $this->view->setOption('title', 'Neos CMS');

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -187,7 +187,7 @@ class BackendController extends ActionController
         $resolvedNodeAddressIsSite = ($nodeAddress === null);
         if ($nodeAddress === null) {
             $site = $this->siteRepository->findOneByNodeName($siteDetectionResult->siteNodeName);
-            $defaultDimensionSpacePoint = $site->getConfiguration()->defaultDimensionSpacePoint;
+            $defaultDimensionSpacePoint = $site?->getConfiguration()->defaultDimensionSpacePoint;
 
             $siteNodeAggregate = $contentGraph->findChildNodeAggregateByName(
                 $rootNodeAggregate->nodeAggregateId,
@@ -202,7 +202,7 @@ class BackendController extends ActionController
                 ), 1752861981);
             }
 
-            if ($siteNodeAggregate->coversDimensionSpacePoint($defaultDimensionSpacePoint)) {
+            if ($defaultDimensionSpacePoint && $siteNodeAggregate->coversDimensionSpacePoint($defaultDimensionSpacePoint)) {
                 $nodeAddress = NodeAddress::create(
                     $siteDetectionResult->contentRepositoryId,
                     $workspace->workspaceName,
@@ -219,16 +219,16 @@ class BackendController extends ActionController
                 if ($eligibleDimensionSpacePoints->isEmpty()) {
                     $eligibleDimensionSpacePoints = $siteNodeAggregate->coveredDimensionSpacePoints;
                 }
-                if ($eligibleDimensionSpacePoints->isEmpty()) {
+
+                $eligibleDimensionSpacePointsArray = $eligibleDimensionSpacePoints->points;
+                $arbitraryEligibleDimensionSpacePoint = array_shift($eligibleDimensionSpacePointsArray);
+                if ($arbitraryEligibleDimensionSpacePoint === null) {
                     throw new \RuntimeException(sprintf(
                         'Site node aggregate named "%s" is in content repository "%s" does not cover any dimension space points',
                         $siteDetectionResult->siteNodeName->value,
                         $contentRepository->id->value,
                     ), 1752861984);
                 }
-
-                $eligibleDimensionSpacePointsArray = $eligibleDimensionSpacePoints->points;
-                $arbitraryEligibleDimensionSpacePoint = array_shift($eligibleDimensionSpacePointsArray);
 
                 $nodeAddress = NodeAddress::create(
                     $siteDetectionResult->contentRepositoryId,
@@ -245,6 +245,9 @@ class BackendController extends ActionController
         );
 
         $documentNode = $subgraph->findNodeById($nodeAddress->aggregateId);
+        if ($documentNode === null) {
+            throw new \RuntimeException('Could not resolve document node for node address ' . $nodeAddress->toJson(), 1752862846);
+        }
         if ($resolvedNodeAddressIsSite) {
             $siteNode = $documentNode;
         } else {
@@ -252,6 +255,9 @@ class BackendController extends ActionController
                 $siteDetectionResult->siteNodeName->toNodeName(),
                 $rootNodeAggregate->nodeAggregateId,
             );
+            if ($siteNode === null) {
+                throw new \RuntimeException('Could not resolve site node for name ' . $siteDetectionResult->siteNodeName->value, 1752862879);
+            }
         }
 
         $this->view->setOption('title', 'Neos CMS');


### PR DESCRIPTION
**What I did**

The backend controller now respects Neos' default dimension space point if configured.
It also now prevents using an arbitrary root dimension space point that is not even covered by the requesting site, which previously lead to an exception that could hardly be resolved.

**How I did it**

When no node address is sent to the backend controller, e.g. directly after login, this now checks the requested site node aggregate whether 

1. it covers the default dimension space point configured in Neos; If yes, that is used
2. it covers any of the root dimension space points; If yes, an arbitrary one of those is used
3. it covers any dimension space points at all; If yes, an arbitrary one of those is used

**How to verify it**

* configure a default DSP and verify that one is used
* configure no default DSP and verify that the backend still loads