### PR TITLE
BUGFIX: Allow selecting Flow entites in selectboxeditor without value error

### DIFF
--- a/packages/neos-ui-editors/src/Editors/SelectBox/selectBoxHelpers.spec.ts
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/selectBoxHelpers.spec.ts
@@ -25,7 +25,6 @@ describe('processSelectBoxOptions', () => {
     it('overrules the array key with the explicit value', () => {
         const processOptions = processSelectBoxOptions(fakeI18NRegistry, {
             'key1': {label: 'Key 1'},
-            // @ts-expect-error we declare the typescript types to what we want, but cant influence user input
             'key2': {label: 'Key 2', value: 'key2-overrule'}
         }, null);
 
@@ -44,7 +43,6 @@ describe('processSelectBoxOptions', () => {
     it('omits entries that are invalid and empty', () => {
         let processOptions = processSelectBoxOptions(fakeI18NRegistry, {
             'key1': {label: 'Key 1'},
-            // @ts-expect-error we declare the typescript types to what we want, but cant influence user input
             'key2': null
         }, null);
 
@@ -52,7 +50,6 @@ describe('processSelectBoxOptions', () => {
 
         processOptions = processSelectBoxOptions(fakeI18NRegistry, {
             'key1': {label: 'Key 1'},
-            // @ts-expect-error we declare the typescript types to what we want, but cant influence user input
             'key2': {}
         }, null);
 

--- a/packages/neos-ui-editors/src/Editors/SelectBox/selectBoxHelpers.ts
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/selectBoxHelpers.ts
@@ -1,10 +1,39 @@
 import {I18nRegistry} from '@neos-project/neos-ts-interfaces';
 import {isNil} from '@neos-project/utils-helpers';
+import {
+    createSelectBoxValueStringFromPossiblyStrangeNodePropertyValue
+} from './createSelectBoxValueStringFromPossiblyStrangeNodePropertyValue';
 
-type RawSelectBoxOptions = {value: string, icon?: string; disabled?: boolean; label: string; group?: string;}[]|{[key: string]: {icon?: string; disabled?: boolean; label: string;
-        group?: string;}};
+type SerializedEntity = {
+    __identity: string;
+    [key: string]: string;
+}
 
-type SelectBoxOptions = {value: string, icon?: string; disabled?: boolean; label: string; group?: string;}[];
+type RawSelectBoxOptions = {
+        value: string | SerializedEntity,
+        icon?: string;
+        disabled?: boolean;
+        label: string;
+        group?: string;
+    }[] |
+    {
+        [key: string]: {
+            icon?: string;
+            disabled?: boolean;
+            label: string;
+            group?: string;
+        } | null | Record<string, any>;
+    };
+
+type SelectBoxOption = {
+    value: string,
+    icon ? : string;
+    disabled ? : boolean;
+    label: string;
+    group ? : string;
+}
+
+type SelectBoxOptions = SelectBoxOption[];
 
 export const shouldDisplaySearchBox = (options: any, processedSelectBoxOptions: SelectBoxOptions) => options.minimumResultsForSearch >= 0 && processedSelectBoxOptions.length >= options.minimumResultsForSearch;
 
@@ -20,11 +49,12 @@ export const processSelectBoxOptions = (i18nRegistry: I18nRegistry, selectBoxOpt
             continue;
         }
 
-        const processedSelectBoxOption = {
+        const processedSelectBoxOption: SelectBoxOption = {
             value: key,
             ...selectBoxOption, // a value in here overrules value based on the key above.
             label: i18nRegistry.translate(selectBoxOption.label)
         };
+        processedSelectBoxOption.value = createSelectBoxValueStringFromPossiblyStrangeNodePropertyValue(processedSelectBoxOption.value) as string;
 
         if (selectBoxOption.group) {
             processedSelectBoxOption.group = i18nRegistry.translate(selectBoxOption.group);

--- a/packages/neos-ui-editors/src/Editors/SelectBox/selectBoxHelpers.ts
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/selectBoxHelpers.ts
@@ -27,10 +27,10 @@ type RawSelectBoxOptions = {
 
 type SelectBoxOption = {
     value: string,
-    icon ? : string;
-    disabled ? : boolean;
+    icon?: string;
+    disabled?: boolean;
     label: string;
-    group ? : string;
+    group?: string;
 }
 
 type SelectBoxOptions = SelectBoxOption[];


### PR DESCRIPTION
Resolves: #3963

**How I did it**

Use the entities identity for the value existence check in the preprocessor the same way
as the DataSourceBasedSelectBoxEditor does internally to map the value to an entity.
This is necessary as the value cannot be used as array key.

**How to verify it**

Use example code from
https://gist.github.com/Benjamin-K/cae7debba7349c4e671bec253ee7f00d
