### PR TITLE
BUGFIX: Use preview links consistently

### DIFF
--- a/Classes/Domain/Model/Feedback/Operations/UpdateNodePreviewUrl.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateNodePreviewUrl.php
@@ -111,7 +111,7 @@ class UpdateNodePreviewUrl extends AbstractFeedback
             $contextPath = '';
         } else {
             $nodeInfoHelper = new NodeInfoHelper();
-            $newPreviewUrl = $nodeInfoHelper->createRedirectToNode($this->node, $controllerContext->getRequest());
+            $newPreviewUrl = $nodeInfoHelper->previewUri($this->node, $controllerContext->getRequest());
             $contextPath = NodeAddress::fromNode($this->node)->toJson();
         }
         return [

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -118,7 +118,7 @@ Neos:
         metaData:
           documentNode: '${Neos.Ui.NodeInfo.serializedNodeAddress(documentNode)}'
           siteNode: '${Neos.Ui.NodeInfo.serializedNodeAddress(site)}'
-          previewUrl: '${Neos.Ui.NodeInfo.createRedirectToNode(documentNode, request)}'
+          previewUrl: '${Neos.Ui.NodeInfo.previewUri(documentNode, request)}'
           contentDimensions:
             active: '${Neos.Ui.ContentDimensions.dimensionSpacePointArray(documentNode.dimensionSpacePoint)}'
             allowedPresets: '${Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.dimensionSpacePoint, documentNode.contentRepositoryId)}'


### PR DESCRIPTION
We introduced the redirect links for performance in older Neos versions to prevent resolving routes for Nodes which was quite expensive. The Neos 9 preview links are easy to resolve and we have no need for the redirect links for previews.
This helps keep preview links consistent and always use the previewAction.
