### PR TITLE
BUGFIX: Use preview links consistently

### DIFF
--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -255,7 +255,7 @@ class BackendServiceController extends ActionController
                 $this->publishingService->publishNode($node, $targetWorkspace);
 
                 if ($node->getNodeType()->isAggregate()) {
-                    $updateNodePreviewUrl = new UpdateNodePreviewUrl();
+                    $updateNodePreviewUrl = new UpdateNodePreviewUrl($this->settings['nextVersionPreviewBehavior'] ?? false);
                     $updateNodePreviewUrl->setNode($node);
                     $this->feedbackCollection->add($updateNodePreviewUrl);
                 }

--- a/Classes/Domain/Model/Feedback/Operations/UpdateNodePreviewUrl.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateNodePreviewUrl.php
@@ -25,6 +25,17 @@ class UpdateNodePreviewUrl extends AbstractFeedback
     protected $node;
 
     /**
+     * @var bool
+     * @deprecated
+     */
+    protected $nextVersionPreviewBehavior;
+
+    public function __construct(bool $nextVersionPreviewBehavior)
+    {
+        $this->nextVersionPreviewBehavior = $nextVersionPreviewBehavior;
+    }
+
+    /**
      * Set the node
      *
      * @param NodeInterface $node
@@ -92,7 +103,11 @@ class UpdateNodePreviewUrl extends AbstractFeedback
             $contextPath = '';
         } else {
             $nodeInfoHelper = new NodeInfoHelper();
-            $newPreviewUrl = $nodeInfoHelper->uri($this->node, $controllerContext);
+            if ($this->nextVersionPreviewBehavior) {
+                $newPreviewUrl = $nodeInfoHelper->uri($this->node, $controllerContext);
+            } else {
+                $newPreviewUrl = $nodeInfoHelper->createRedirectToNode($controllerContext, $this->node);
+            }
             $contextPath = $this->node->getContextPath();
         }
         return [

--- a/Classes/Domain/Model/Feedback/Operations/UpdateNodePreviewUrl.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateNodePreviewUrl.php
@@ -92,7 +92,7 @@ class UpdateNodePreviewUrl extends AbstractFeedback
             $contextPath = '';
         } else {
             $nodeInfoHelper = new NodeInfoHelper();
-            $newPreviewUrl = $nodeInfoHelper->createRedirectToNode($controllerContext, $this->node);
+            $newPreviewUrl = $nodeInfoHelper->uri($this->node, $controllerContext);
             $contextPath = $this->node->getContextPath();
         }
         return [

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -30,7 +30,13 @@ Neos:
         Neos.Neos.Ui: true
 
     Ui:
-
+      # This feature flag changes the preview link button in the backend to operate more in the sense of a preview for
+      # how the current workspace would look like when published. Before it would show the page in the parent workspace,
+      # but without changes applied. The new behavior in combination with preview modes allows seeing what a page might
+      # look like after publishing it. The drawback is that for example the live URL is no longer visible as the preview
+      # never shows the Live workspace. Also editors might be confused by the different behavior. So take care changing
+      # this setting in a pre-existing project.
+      nextVersionPreviewBehavior: false
       splashScreen:
         partial: 'SplashScreen'
 
@@ -114,7 +120,7 @@ Neos:
         metaData:
           documentNode: '${q(documentNode).property("_contextPath")}'
           siteNode: '${q(site).property(''_contextPath'')}'
-          previewUrl: '${Neos.Ui.NodeInfo.uri(documentNode, controllerContext)}'
+          previewUrl: '${Configuration.setting("nextVersionPreviewBehavior") ? Neos.Ui.NodeInfo.uri(documentNode, controllerContext)} : ${Neos.Ui.NodeInfo.createRedirectToNode(controllerContext, documentNode)}'
           contentDimensions:
             active: '${documentNode.context.dimensions}'
             allowedPresets: '${Neos.Ui.Api.emptyArrayToObject(Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.context.dimensions))}'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -114,7 +114,7 @@ Neos:
         metaData:
           documentNode: '${q(documentNode).property("_contextPath")}'
           siteNode: '${q(site).property(''_contextPath'')}'
-          previewUrl: '${Neos.Ui.NodeInfo.createRedirectToNode(controllerContext, documentNode)}'
+          previewUrl: '${Neos.Ui.NodeInfo.uri(documentNode, controllerContext)}'
           contentDimensions:
             active: '${documentNode.context.dimensions}'
             allowedPresets: '${Neos.Ui.Api.emptyArrayToObject(Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.context.dimensions))}'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -120,7 +120,7 @@ Neos:
         metaData:
           documentNode: '${q(documentNode).property("_contextPath")}'
           siteNode: '${q(site).property(''_contextPath'')}'
-          previewUrl: '${Configuration.setting("nextVersionPreviewBehavior") ? Neos.Ui.NodeInfo.uri(documentNode, controllerContext)} : ${Neos.Ui.NodeInfo.createRedirectToNode(controllerContext, documentNode)}'
+          previewUrl: '${Configuration.setting("Neos.Neos.Ui.nextVersionPreviewBehavior") ? Neos.Ui.NodeInfo.uri(documentNode, controllerContext)} : ${Neos.Ui.NodeInfo.createRedirectToNode(controllerContext, documentNode)}'
           contentDimensions:
             active: '${documentNode.context.dimensions}'
             allowedPresets: '${Neos.Ui.Api.emptyArrayToObject(Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.context.dimensions))}'


### PR DESCRIPTION
We introduced the redirect links for performance in older Neos versions to prevent resolving routes for Nodes which was quite expensive. The Neos 9 preview links are easy to resolve and we have no need for the redirect links for previews. This helps keep preview links consistent and always use the previewAction.

These links should always be preview Urls so performance should be fine.

To restore the 8.3 behaviour use

```yaml
Neos.Neos.Ui.nextVersionPreviewBehavior: false
```

