### PR TITLE
BUGFIX: Forward defined insert mode in creation workflow when nodetype is set

### DIFF
--- a/packages/neos-ui-sagas/src/CR/NodeOperations/addNode.js
+++ b/packages/neos-ui-sagas/src/CR/NodeOperations/addNode.js
@@ -30,7 +30,7 @@ function * nodeCreationWorkflow(context, step = STEP_SELECT_NODETYPE, workflowDa
             // If nodeType option is passed, skip selection of nodetype and immediately jump to the next step
             if (nodeType) {
                 yield put(actions.UI.SelectNodeTypeModal.apply(preferredMode, nodeType));
-                return yield call(nodeCreationWorkflow, context, STEP_NODE_CREATION_DIALOG, {preferredMode, nodeType});
+                return yield call(nodeCreationWorkflow, context, STEP_NODE_CREATION_DIALOG, {mode: preferredMode, nodeType});
             }
             const waitForNextAction = yield race([
                 take(actionTypes.UI.SelectNodeTypeModal.CANCEL),


### PR DESCRIPTION
When triggering the node creation workflow and providing a nodetype, the mode ends up being not set due to a typo and the resulting action can lead to an invalid creation action as the default mode is `into` and one might not be allowed to create the same node into itself.
With this patch, the mode is used as provided.