### PR TITLE
BUGFIX: Close creation dialog if back is pressed and a nodetype was preselected

### DIFF
--- a/packages/neos-ui-sagas/src/CR/NodeOperations/addNode.js
+++ b/packages/neos-ui-sagas/src/CR/NodeOperations/addNode.js
@@ -85,6 +85,10 @@ function * nodeCreationWorkflow(context, step = STEP_SELECT_NODETYPE, workflowDa
                 // User asked to go back
                 //
                 if (nextAction.type === actionTypes.UI.NodeCreationDialog.BACK) {
+                    // If the nodetype was preselected, we do not allow going back to the node type selection step
+                    if (context.nodeType) {
+                        return;
+                    }
                     return yield call(nodeCreationWorkflow, context, STEP_SELECT_NODETYPE);
                 }
                 if (nextAction.type === actionTypes.UI.NodeCreationDialog.APPLY) {


### PR DESCRIPTION
This is a follow up of #3981.
When the node creation workflow is manually triggered and a nodetype was given, the back button doesn't do anything as the workflow goes back into the node selection and then immediately proceeds to the configuration step again as the nodetype is already set.
With this change, "back" closes the dialog for this case.
