### PR TITLE
BUGFIX: Speed up node tree copy actions

### DIFF
--- a/Classes/Domain/Model/Changes/AbstractCopy.php
+++ b/Classes/Domain/Model/Changes/AbstractCopy.php
@@ -34,7 +34,6 @@ abstract class AbstractCopy extends AbstractStructuralChange
     {
         $updateNodeInfo = new UpdateNodeInfo();
         $updateNodeInfo->setNode($node);
-        $updateNodeInfo->recursive();
         $this->feedbackCollection->add($updateNodeInfo);
         $this->addNodeCreatedFeedback($node);
         parent::finish($node);


### PR DESCRIPTION
Don’t include recursive childnode info in copy action feedback which we don’t need for the node trees to work.

Both trees still work as before. Only difference is that uncollapsing the copied nodes might lazy load deeper nested nodes.

Resolves: #3983

### Testcase:

Copying 4 documents with some content in the Neos.Demo

<img width="794" height="634" alt="CleanShot 2025-08-14 at 15 46 17@2x" src="https://github.com/user-attachments/assets/95be3e29-4175-4aea-8ece-3c1e1ce91d07" />

### Response times

With recursive data: 4.4KB
Without recursive data: 2.5 KB

<img width="382" height="368" alt="CleanShot 2025-08-14 at 15 38 45@2x" src="https://github.com/user-attachments/assets/d3c54b39-31de-472d-8eb4-24bb1cfccd05" />

With more nested data:

<img width="386" height="296" alt="CleanShot 2025-08-14 at 15 51 46@2x" src="https://github.com/user-attachments/assets/bdb6bb0c-ba7f-4048-9fe9-5e0d91d16351" />

### Calls with recursive data

<img width="1858" height="532" alt="CleanShot 2025-08-14 at 15 47 52@2x" src="https://github.com/user-attachments/assets/9bb6a777-9916-4af2-99f9-c46d180c1847" />

### Calls without recursive data

<img width="1814" height="574" alt="CleanShot 2025-08-14 at 15 48 26@2x" src="https://github.com/user-attachments/assets/d2de21c8-eb79-41a0-b12a-7fc0d2af03ed" />
