### PR TITLE
BUGFIX: Update inline hidden state when hidden property is changed via inspector

### DIFF
--- a/Classes/Domain/Model/Changes/Property.php
+++ b/Classes/Domain/Model/Changes/Property.php
@@ -117,7 +117,7 @@ class Property extends AbstractChange
     /**
      * Get the node dom address
      *
-     * @return RenderedNodeDomAddress
+     * @return ?RenderedNodeDomAddress
      */
     public function getNodeDomAddress()
     {
@@ -232,7 +232,9 @@ class Property extends AbstractChange
 
             $reloadIfChangedConfigurationPath = sprintf('properties.%s.ui.reloadIfChanged', $propertyName);
             if (!$this->getIsInline() && $node->getNodeType()->getConfiguration($reloadIfChangedConfigurationPath)) {
-                if ($this->getNodeDomAddress() && $this->getNodeDomAddress()->getFusionPath()
+                if (!$this->getNodeDomAddress()) {
+                    $this->reloadDocument($node);
+                } elseif ($this->getNodeDomAddress()->getFusionPath()
                     && $node->getNodeType()->isOfType('Neos.Neos:Content')
                     && $node->getParent()->getNodeType()->isOfType('Neos.Neos:ContentCollection')
                 ) {

--- a/packages/neos-ui-sagas/src/UI/Inspector/index.js
+++ b/packages/neos-ui-sagas/src/UI/Inspector/index.js
@@ -1,7 +1,7 @@
 import {take, race, put, call, select} from 'redux-saga/effects';
 import {$get} from 'plow-js';
 import escapeRegExp from 'lodash.escaperegexp';
-import {findNodeInGuestFrame} from '@neos-project/neos-ui-guest-frame/src/dom';
+import {findNodeInGuestFrame, markNodeAsHidden, markNodeAsVisible} from '@neos-project/neos-ui-guest-frame/src/dom';
 
 import {actionTypes, actions, selectors} from '@neos-project/neos-ui-redux-store';
 
@@ -152,6 +152,14 @@ function * flushInspector(inspectorRegistry) {
                 const oldUriFragment = oldUri.split('@')[0];
                 const newUriFragment = oldUriFragment.replace(new RegExp(escapeRegExp(oldValue) + '$'), newValue);
                 yield put(actions.CR.Nodes.updateUri(oldUriFragment, newUriFragment));
+            }
+        }
+
+        if (focusedNode && propertyName === '_hidden') {
+            if (value === true) {
+                markNodeAsHidden(focusedNode.contextPath);
+            } else {
+                markNodeAsVisible(focusedNode.contextPath);
             }
         }
     }


### PR DESCRIPTION
This change handles the case that the hidden state is updated in the inspector which didn't update the guest frame.
Also the case is handled that reloadIfChanged is enabled on the hidden property but the ui didn't send a nodeDomAdress and the backend would throw an exception.

Resolves: #3988