### PR TITLE
TASK: Followup #3973 (Use preview uris instead of base workspace preview)

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -25,7 +25,6 @@ use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Domain\Service\NodeTypeNameFactory;
 use Neos\Neos\Domain\Service\WorkspacePublishingService;
 use Neos\Neos\Domain\Service\WorkspaceService;
-use Neos\Neos\Domain\SubtreeTagging\NeosSubtreeTag;
 use Neos\Neos\FrontendRouting\NodeUriBuilderFactory;
 use Neos\Neos\FrontendRouting\SiteDetection\SiteDetectionResult;
 use Neos\Neos\Service\UserService;
@@ -289,43 +288,5 @@ class BackendController extends ActionController
                     user: $user,
                 ),
         ]);
-    }
-
-    /**
-     * @throws \Neos\Flow\Mvc\Exception\StopActionException
-     */
-    public function redirectToAction(string $node): void
-    {
-        $this->response->setHttpHeader('Cache-Control', [
-            'no-cache',
-            'no-store'
-        ]);
-
-        $nodeAddress = NodeAddress::fromJsonString($node);
-
-        $contentRepository = $this->contentRepositoryRegistry->get($nodeAddress->contentRepositoryId);
-
-        $nodeInstance = $contentRepository->getContentSubgraph(
-            $nodeAddress->workspaceName,
-            $nodeAddress->dimensionSpacePoint
-        )->findNodeById($nodeAddress->aggregateId);
-
-        $workspace = $contentRepository->findWorkspaceByName($nodeAddress->workspaceName);
-
-        // we always want to redirect to the node in the base workspace unless we are on a root workspace in which case we stay on that (currently that will not happen)
-        $nodeAddressInBaseWorkspace = NodeAddress::create(
-            $nodeAddress->contentRepositoryId,
-            $workspace->baseWorkspaceName ?? $nodeAddress->workspaceName,
-            $nodeAddress->dimensionSpacePoint,
-            $nodeAddress->aggregateId
-        );
-
-        $nodeUriBuilder = $this->nodeUriBuilderFactory->forActionRequest($this->request);
-
-        $this->redirectToUri(
-            !$nodeInstance || $nodeInstance->tags->contain(NeosSubtreeTag::disabled())
-                ? $nodeUriBuilder->previewUriFor($nodeAddressInBaseWorkspace)
-                : $nodeUriBuilder->uriFor($nodeAddressInBaseWorkspace)
-        );
     }
 }

--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -345,18 +345,6 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
             ->previewUriFor($nodeAddress);
     }
 
-    public function createRedirectToNode(Node $node, ActionRequest $actionRequest): string
-    {
-        $nodeAddress = NodeAddress::fromNode($node);
-
-        $uriBuilder = new UriBuilder();
-        $uriBuilder->setRequest($actionRequest);
-        return $uriBuilder
-            ->setCreateAbsoluteUri(true)
-            ->setFormat('html')
-            ->uriFor('redirectTo', ['node' => $nodeAddress->toJson()], 'Backend', 'Neos.Neos.Ui');
-    }
-
     /**
      * @param string ...$nodeTypeStrings
      * @return string[]
@@ -413,7 +401,6 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
         // to control what is used in eel we maintain this list.
         return in_array($methodName, [
             'serializedNodeAddress',
-            'createRedirectToNode',
             'renderNodeWithPropertiesAndChildrenInformation',
             'defaultNodesForBackend',
             'previewUri'

--- a/Configuration/Routes.Backend.yaml
+++ b/Configuration/Routes.Backend.yaml
@@ -5,12 +5,3 @@
     '@controller': 'Backend'
     '@action': 'index'
   appendExceedingArguments: true
-
--
-  name: 'Redirect to frontend URL'
-  uriPattern: 'redirect'
-  defaults:
-    '@controller': 'Backend'
-    '@action': 'redirectTo'
-    '@format': 'html'
-  appendExceedingArguments: true


### PR DESCRIPTION
With https://github.com/neos/neos-ui/pull/3973 we no longer need `createRedirectToNode` and its routing configuration and action controller. This dead internal code has been removed.

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
