### PR TITLE
BUGFIX: Speed up node tree copy actions 9.0 port of #3984

### DIFF
--- a/Classes/Domain/Model/Changes/AbstractStructuralChange.php
+++ b/Classes/Domain/Model/Changes/AbstractStructuralChange.php
@@ -125,7 +125,6 @@ abstract class AbstractStructuralChange extends AbstractChange
     {
         $updateNodeInfo = new UpdateNodeInfo();
         $updateNodeInfo->setNode($node);
-        $updateNodeInfo->recursive();
         $this->feedbackCollection->add($updateNodeInfo);
 
         $parentNode = $this->contentRepositoryRegistry->subgraphForNode($node)

--- a/Classes/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
@@ -41,8 +41,6 @@ class UpdateNodeInfo extends AbstractFeedback
      */
     protected $contentRepositoryRegistry;
 
-    protected bool $isRecursive = false;
-
     protected ?string $baseNodeType = null;
 
     public function setBaseNodeType(?string $baseNodeType): void
@@ -58,14 +56,6 @@ class UpdateNodeInfo extends AbstractFeedback
     public function setNode(Node $node): void
     {
         $this->node = $node;
-    }
-
-    /**
-     * Update node infos recursively
-     */
-    public function recursive(): void
-    {
-        $this->isRecursive = true;
     }
 
     public function getNode(): Node
@@ -103,7 +93,7 @@ class UpdateNodeInfo extends AbstractFeedback
     public function serializePayload(ControllerContext $controllerContext): array
     {
         return [
-            'byContextPath' => $this->serializeNodeRecursively($this->node, $controllerContext->getRequest())
+            'byContextPath' => $this->serializeNode($this->node, $controllerContext->getRequest())
         ];
     }
 
@@ -112,25 +102,13 @@ class UpdateNodeInfo extends AbstractFeedback
      *
      * @return array<string,?array<string,mixed>>
      */
-    private function serializeNodeRecursively(Node $node, ActionRequest $actionRequest): array
+    private function serializeNode(Node $node, ActionRequest $actionRequest): array
     {
-        $contentRepository = $this->contentRepositoryRegistry->get($node->contentRepositoryId);
-
-        $result = [
-            NodeAddress::fromNode($node)->toJson()
-            => $this->nodeInfoHelper->renderNodeWithPropertiesAndChildrenInformation(
+        return [
+            NodeAddress::fromNode($node)->toJson() => $this->nodeInfoHelper->renderNodeWithPropertiesAndChildrenInformation(
                 $node,
                 $actionRequest
             )
         ];
-
-        if ($this->isRecursive === true) {
-            $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
-            foreach ($subgraph->findChildNodes($node->aggregateId, FindChildNodesFilter::create()) as $childNode) {
-                $result = array_merge($result, $this->serializeNodeRecursively($childNode, $actionRequest));
-            }
-        }
-
-        return $result;
     }
 }


### PR DESCRIPTION
See https://github.com/neos/neos-ui/pull/3984

In Neos 9 the `$updateNodeInfo->recursive()` was added to `AbstractStructuralChange` and the `AbstractCopy` was removed.

This change now removes the expensive recursive of `UpdateNodeInfo` as we dont need that for the Ui anymore.

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

9.0 Benchmarks

9 document nodes
Before: 191kb 1,72s
After: 47kb 1,06s


about 6 times 9 document nodes (nested)
Before: 1.18mb  11,47s
After: 294,41kb  6,03s



**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
