### PR TITLE
BUGFIX: Nested content not editable after copy

### DIFF
--- a/Classes/Domain/Model/Changes/AbstractStructuralChange.php
+++ b/Classes/Domain/Model/Changes/AbstractStructuralChange.php
@@ -178,6 +178,14 @@ abstract class AbstractStructuralChange extends AbstractChange
                 $this->getParentDomAddress()->getFusionPath() &&
                 $this->getParentDomAddress()->getContextPath() === $node->getParent()->getContextPath()
             ) {
+                // Include nested nodedata for with the rendered content as the change usually only contains the updated node
+                if ($node->hasChildNodes()) {
+                    $updateNestedNodeInfo = new UpdateNodeInfo();
+                    $updateNestedNodeInfo->setNode($node);
+                    $updateNestedNodeInfo->recursive();
+                    $this->feedbackCollection->add($updateNestedNodeInfo);
+                }
+
                 $renderContentOutOfBand = new RenderContentOutOfBand();
                 $renderContentOutOfBand->setNode($node);
                 $renderContentOutOfBand->setParentDomAddress($this->getParentDomAddress());

--- a/Classes/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
@@ -118,7 +118,8 @@ class UpdateNodeInfo extends AbstractFeedback
             return false;
         }
 
-        return $this->getNode()->getContextPath() === $feedback->getNode()->getContextPath();
+        return $this->getNode()->getContextPath() === $feedback->getNode()->getContextPath()
+            && $this->isRecursive === $feedback->isRecursive;
     }
 
     /**


### PR DESCRIPTION
This solves a regression introduced with ef118b19d5de7092cd8f3d2f23f55db77bdb98e4 which prevented editing nested copied content after insertion. 

With this change the out-of-band code rendering takes care to include the nested child node data.