### PR TITLE
BUGFIX: Use correct color for timed visibility icon

### DIFF
--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -1,16 +1,15 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-
+import moment from 'moment';
+import hashSum from 'hash-sum';
 import flowright from 'lodash.flowright';
+
 import {Tree, Icon} from '@neos-project/react-ui-components';
 import {stripTags, decodeHtml} from '@neos-project/utils-helpers';
-
 import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {isNodeCollapsed} from '@neos-project/neos-ui-redux-store/src/CR/Nodes/helpers';
 import {neos} from '@neos-project/neos-ui-decorators';
-
-import hashSum from 'hash-sum';
 import {urlWithParams} from '@neos-project/utils-helpers/src/urlWithParams';
 
 const getContextPath = node => node?.contextPath;
@@ -172,7 +171,13 @@ export default class Node extends PureComponent {
         const hasTimeableNodeVisibility = node?.properties?._hasTimeableNodeVisibility;
 
         if (hasTimeableNodeVisibility) {
-            const circleColor = isDisabled ? 'error' : 'primaryBlue';
+            const {enableAfterDateTime, disableAfterDateTime} = node.properties;
+
+            let isCurrentlyHidden = isDisabled
+                || (enableAfterDateTime && moment(enableAfterDateTime).isAfter(moment()))
+                || (disableAfterDateTime && moment(disableAfterDateTime).isBefore(moment()));
+
+            const circleColor = isDisabled || isCurrentlyHidden ? 'error' : 'primaryBlue';
 
             return (
                 <span className="fa-layers fa-fw">


### PR DESCRIPTION
**What I did**

This fixes a regression introduced with 43efd9c63709ecf87a029d2636b33b0a935d41f3

Resolves: #3997 

**How I did it**

Readded some of the necessary code from 8.3 and adjusted it to the new visibility property names.

**How to verify it**

<img width="652" height="358" alt="CleanShot 2025-09-29 at 09 22 23@2x" src="https://github.com/user-attachments/assets/acb6bebf-d1c5-42b3-95e1-8fda71f7678d" />
<img width="648" height="404" alt="CleanShot 2025-09-29 at 09 22 12@2x" src="https://github.com/user-attachments/assets/fae67bb0-bec9-4fdb-a7c6-eab9ee0ac784" />
