### PR TITLE
BUGFIX: Page tree collapse calculation issue

### DIFF
--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
@@ -51,16 +51,16 @@ export default class NodeTree extends PureComponent {
     }
 
     handleCollapseAll = () => {
-        const {collapseAll, allCollapsibleNodes, rootNode, loadingDepth} = this.props
-        let nodeContextPaths = []
-        const collapsedByDefaultNodesContextPaths = []
+        const {collapseAll, allCollapsibleNodes, rootNode, loadingDepth} = this.props;
+        let nodeContextPaths = [];
+        const collapsedByDefaultNodesContextPaths = [];
 
         Object.values(allCollapsibleNodes).forEach(node => {
-            const collapsedByDefault = loadingDepth === 0 ? false : node.depth - rootNode.depth >= loadingDepth
+            const collapsedByDefault = loadingDepth === 0 ? false : node.depth - rootNode.depth >= loadingDepth;
             if (collapsedByDefault) {
-                collapsedByDefaultNodesContextPaths.push(node.contextPath)
+                collapsedByDefaultNodesContextPaths.push(node.contextPath);
             } else {
-                nodeContextPaths.push(node.contextPath)
+                nodeContextPaths.push(node.contextPath);
             }
         });
 

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/index.js
@@ -197,7 +197,7 @@ export const PageTree = withNodeTypeRegistryAndI18nRegistry(connect(
             focusedNodesContextPaths: selectors.UI.PageTree.getAllFocused(state),
             ChildRenderer: PageTreeNode,
             allowOpeningNodesInNewWindow: true,
-            loadingDepth: neos.configuration.structureTree.loadingDepth,
+            loadingDepth: neos.configuration.nodeTree.loadingDepth,
             allCollapsibleNodes: documentNodesSelector(state)
         })
     }, {


### PR DESCRIPTION
The page tree collapse didn't correctly filter the already collapsed nodes and also toggled them as the wrong configuration was used.
