### PR TITLE
BUGFIX: Position Dialog Modals centered and adjust width and height

### DIFF
--- a/packages/react-ui-components/src/Dialog/style.module.css
+++ b/packages/react-ui-components/src/Dialog/style.module.css
@@ -18,9 +18,9 @@
 .dialog__contentsPosition {
     composes: reset from '../reset.module.css';
     position: absolute;
-    top: 20vh;
+    top: 50%;
     left: 50%;
-    transform: translateX(-50%) scale(1);
+    transform: translateY(-50%) translateX(-50%) scale(1);
     background: var(--colors-ContrastDarker);
     box-shadow: 0 20px 40px rgba(0, 0, 0, .4);
     border-radius: 0;
@@ -31,17 +31,17 @@
 .dialog__contents {
     composes: reset from '../reset.module.css';
     position: relative;
-    width: calc(100vw - var(--spacing-GoldenUnit) * 2);
-    max-width: calc(var(--spacing-GoldenUnit) * 16);
+    width: auto;
+    max-width: calc(100vw - var(--spacing-GoldenUnit) * 2);
     border: 2px solid var(--colors-ContrastDark);
     transition: var(--transition-Default) ease max-width;
 
     .dialog--wide & {
-        max-width: calc(var(--spacing-GoldenUnit) * 24);
+        min-width: calc(var(--spacing-GoldenUnit) * 18);
 
         @media(max-width: 576px) {
             max-width: 100vw;
-            width: 100vw;
+            min-width: 100vw;
         }
     }
 
@@ -77,7 +77,8 @@
     padding-right: var(--spacing-GoldenUnit);
 }
 .dialog__body {
-    max-height: calc(65vh);
+    /*todo increase height even further but consider space for title and actions*/
+    max-height: 80vh;
     overflow-y: auto;
 
     @media(max-width: 576px) {

--- a/packages/react-ui-components/src/Dialog/style.module.css
+++ b/packages/react-ui-components/src/Dialog/style.module.css
@@ -1,7 +1,7 @@
 @keyframes slideDialogContents {
     from {
         opacity: 0;
-        transform: translateX(-50%) scale(.9);
+        transform: translate(-50%, -50%) scale(.9);
     }
 }
 
@@ -20,7 +20,7 @@
     position: absolute;
     top: 50%;
     left: 50%;
-    transform: translateY(-50%) translateX(-50%) scale(1);
+    transform: translate(-50%, -50%) scale(1);
     background: var(--colors-ContrastDarker);
     box-shadow: 0 20px 40px rgba(0, 0, 0, .4);
     border-radius: 0;

--- a/packages/react-ui-components/src/Dialog/style.module.css
+++ b/packages/react-ui-components/src/Dialog/style.module.css
@@ -35,6 +35,9 @@
     max-width: calc(100vw - var(--spacing-GoldenUnit) * 2);
     border: 2px solid var(--colors-ContrastDark);
     transition: var(--transition-Default) ease max-width;
+    display: flex;
+    flex-direction: column;
+    max-height: 80vh;
 
     .dialog--wide & {
         min-width: calc(var(--spacing-GoldenUnit) * 18);
@@ -77,13 +80,7 @@
     padding-right: var(--spacing-GoldenUnit);
 }
 .dialog__body {
-    /*todo increase height even further but consider space for title and actions*/
-    max-height: 80vh;
     overflow-y: auto;
-
-    @media(max-width: 576px) {
-        max-height: calc(55vh);
-    }
 }
 .dialog__actions {
     composes: reset from '../reset.module.css';


### PR DESCRIPTION
The dialogs always leave a spacing of 20vh from the top which wastes spaces and looks unbalanced on laptops as below the dialog ends often without gap.

This changes centers the dialogs now on the vertical axis so they are always in center no matter their height. (see small vs. big creation dialog)

Additionally, the default width of "wide" was a little reduced as select boxes and text-fields in the creation dialog grew super wide - much wider than one is used from them in the inspector. This size adjustment will also make the new link editor appear by default in the correct width.

The dialog additionally grows by default and in "wide" mode to fit its contents. This is required when the new link editor shows the asset selection which takes the full width.

For reference the original Archaeopterix employed a hack to archive this which is now merged into the core behaviour:

https://github.com/sitegeist/Sitegeist.Archaeopteryx/blob/2d53b63b483b608dcc062a23bf2af608f27d5445/Neos.Ui/core/src/presentation/Modal.tsx#L7-L34

## Visual comparison

| Before | After |
|--------|--------|
| <img width="1728" height="908" alt="image" src="https://github.com/user-attachments/assets/3ec6f8c3-a8fb-4d9a-afea-7f880d0fdf52" />  | <img width="1728" height="910" alt="image" src="https://github.com/user-attachments/assets/de203c70-32a4-4875-addc-b018508885c8" /> |
| <img width="1728" height="907" alt="image" src="https://github.com/user-attachments/assets/2b9d2f51-b822-4728-b7b6-2b1d743bc002" /> | <img width="1725" height="912" alt="image" src="https://github.com/user-attachments/assets/6b0ae414-8f5a-4a63-99a2-d284c28f1f06" /> |

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
