### PR TITLE
BUGFIX: Resolve PHP 8.0 compatbility regression

### DIFF
--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -454,7 +454,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
         $arguments = UriHelper::parseQueryIntoArguments($sitePreviewUri);
         return (string)UriHelper::uriWithArguments(
             $sitePreviewUri,
-            [...$arguments, 'node' => $node->getContextPath()],
+            array_merge($arguments, ['node' => $node->getContextPath()]),
         );
     }
 


### PR DESCRIPTION
Unpacking arrays with keys is not supported yet with the Neos 8.3 minimal PHP version of 8.0.

Resolves: #4006

DO NOT UPMERGE, as this only affects Neos 8.3 and not 8.4 which has PHP 8.2 as minimal version.
