### PR TITLE
WIP Neos 10 TASK: Remove legacy `neos.configuration` b/c layer

### DIFF
--- a/packages/neos-ui-configuration/src/frontendConfiguration.ts
+++ b/packages/neos-ui-configuration/src/frontendConfiguration.ts
@@ -1,7 +1,6 @@
 import {getInlinedDataFromBackend} from './bootstrap';
 import {GlobalRegistry, SynchronousRegistry} from '@neos-project/neos-ui-registry';
 import {terminateDueToFatalInitializationError} from '@neos-project/neos-ui-error';
-import {getConfiguration} from './configuration';
 
 const frontendConfiguration = getInlinedDataFromBackend('frontendConfiguration') as Record<string, any>;
 
@@ -57,9 +56,4 @@ export function initializeFrontendConfiguration(globalRegistry: GlobalRegistry) 
             ...value
         });
     });
-
-    /**
-     * @deprecated for legacy compatibility to be removed with Neos 9.1 or later
-     */
-    frontendConfigurationRegistry.set('editPreviewModes', getConfiguration((configuration) => configuration.editPreviewModes))
 }

--- a/packages/neos-ui-decorators/src/neos.tsx
+++ b/packages/neos-ui-decorators/src/neos.tsx
@@ -38,7 +38,6 @@ export default <OwnProps extends {}, InjectedProps extends {}> (mapRegistriesToP
                             return null;
                         }
                         const registriesToPropsMap = mapRegistriesToProps ? mapRegistriesToProps(context.globalRegistry) : {};
-                        /** @deprecated the injected neos.configuration is deprecated please use import {getConfiguration} from '@neos-project/neos-ui-configuration'; instead, can be removed with Neos 9.1 or later */
                         return (
                             <WrappedComponent
                                 neos={buildConfigurationAndGlobalRegistry(context.configuration, context.globalRegistry, context.routes)}

--- a/packages/neos-ui-decorators/src/neos.tsx
+++ b/packages/neos-ui-decorators/src/neos.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
 import {defaultMemoize} from 'reselect';
 import type {GlobalRegistry} from '@neos-project/neos-ui-registry';
-import type {Configuration} from '@neos-project/neos-ui-configuration';
 import type {Routes} from '@neos-project/neos-ui-backend-connector';
 
 // We need to memoize configuration and global registry; otherwise a new object is created at every render; leading to
 // LOADS of unnecessary re-draws.
-const buildConfigurationAndGlobalRegistry = defaultMemoize((configuration: {}, globalRegistry: GlobalRegistry, routes: {}) => ({configuration, globalRegistry, routes}));
+const buildGlobalRegistry = defaultMemoize((globalRegistry: GlobalRegistry, routes: {}) => ({globalRegistry, routes}));
 
 export interface NeosContextInterface {
     globalRegistry: GlobalRegistry;
-    configuration: Configuration;
     routes: Routes;
 }
 
@@ -40,7 +38,7 @@ export default <OwnProps extends {}, InjectedProps extends {}> (mapRegistriesToP
                         const registriesToPropsMap = mapRegistriesToProps ? mapRegistriesToProps(context.globalRegistry) : {};
                         return (
                             <WrappedComponent
-                                neos={buildConfigurationAndGlobalRegistry(context.configuration, context.globalRegistry, context.routes)}
+                                neos={buildGlobalRegistry(context.globalRegistry, context.routes)}
                                 {...this.props}
                                 {...registriesToPropsMap}
                                 />

--- a/packages/neos-ui/src/Containers/Neos/index.js
+++ b/packages/neos-ui/src/Containers/Neos/index.js
@@ -6,15 +6,14 @@ import {NeosContext} from '@neos-project/neos-ui-decorators';
 export default class Neos extends PureComponent {
     static propTypes = {
         globalRegistry: PropTypes.object.isRequired,
-        configuration: PropTypes.object.isRequired,
         routes: PropTypes.object.isRequired,
         children: PropTypes.element.isRequired
     };
 
     render() {
-        const {configuration, globalRegistry, routes} = this.props;
+        const {globalRegistry, routes} = this.props;
         return (
-            <NeosContext.Provider value={{configuration, globalRegistry, routes}}>
+            <NeosContext.Provider value={{globalRegistry, routes}}>
                 {Children.only(this.props.children)}
             </NeosContext.Provider>
         );

--- a/packages/neos-ui/src/Containers/Root.js
+++ b/packages/neos-ui/src/Containers/Root.js
@@ -21,7 +21,7 @@ library.add(fab, fas, far);
 
 class Root extends PureComponent {
     render() {
-        const {store, globalRegistry, configuration, menu, routes} = this.props;
+        const {store, globalRegistry, menu, routes} = this.props;
 
         const containerRegistry = globalRegistry.get('containers');
         const App = containerRegistry.get('App');
@@ -33,7 +33,6 @@ class Root extends PureComponent {
                         <DndProvider backend={HTML5Backend}>
                             <Neos
                                 globalRegistry={globalRegistry}
-                                configuration={configuration}
                                 routes={routes}
                                 >
                                 <App globalRegistry={globalRegistry} menu={menu}/>

--- a/packages/neos-ui/src/index.js
+++ b/packages/neos-ui/src/index.js
@@ -30,7 +30,6 @@ import Root from './Containers/Root';
 import apiExposureMap from './apiExposureMap';
 import DelegatingReducer from './DelegatingReducer';
 import {getGlobalRegistry} from '@neos-project/neos-ui-registry';
-import {allowedTargetWorkspacesSelector} from '@neos-project/neos-ui-redux-store/src/CR/Workspaces/selectors';
 
 const serverState = getInlinedDataFromBackend('initialState');
 const routes = getInlinedDataFromBackend('routes');
@@ -173,16 +172,11 @@ async function loadImpersonateStatus() {
 }
 
 function renderApplication() {
-    /**
-     * @deprecated if accessed via neos.configuration.allowedTargetWorkspaces this information now resides in the redux store see selectors.CR.Workspaces.allowedTargetWorkspacesSelector()
-     */
-    const allowedTargetWorkspaces = allowedTargetWorkspacesSelector(store.getState());
-
     ReactDOM.render(
         <Root
             globalRegistry={globalRegistry}
             menu={menu}
-            configuration={{...configuration, allowedTargetWorkspaces}}
+            configuration={configuration}
             routes={routes}
             store={store}
             />,

--- a/packages/neos-ui/src/index.js
+++ b/packages/neos-ui/src/index.js
@@ -35,7 +35,6 @@ const serverState = getInlinedDataFromBackend('initialState');
 const routes = getInlinedDataFromBackend('routes');
 const menu = getInlinedDataFromBackend('menu');
 
-const configuration = getConfiguration();
 fetchWithErrorHandling.setCsrfToken(csrfToken);
 initializeJsAPI(window, {
     systemEnv,
@@ -92,7 +91,7 @@ async function main() {
 function initializePlugins() {
     manifests
         .map(manifest => manifest[Object.keys(manifest)[0]])
-        .forEach(({bootstrap}) => bootstrap(globalRegistry, {store, frontendConfiguration: getFullPackageFrontendConfiguration(), configuration, routes}));
+        .forEach(({bootstrap}) => bootstrap(globalRegistry, {store, frontendConfiguration: getFullPackageFrontendConfiguration(), configuration: getConfiguration(), routes}));
 }
 
 function initializeAdditionalReduxReducers() {
@@ -101,7 +100,7 @@ function initializeAdditionalReduxReducers() {
 }
 
 function initializeAdditionalReduxSagas() {
-    globalRegistry.get('sagas').getAllAsList().forEach(element => sagaMiddleWare.run(element.saga, {store, globalRegistry, configuration, routes}));
+    globalRegistry.get('sagas').getAllAsList().forEach(element => sagaMiddleWare.run(element.saga, {store, globalRegistry, routes}));
 }
 
 function initializeReduxState() {
@@ -176,7 +175,6 @@ function renderApplication() {
         <Root
             globalRegistry={globalRegistry}
             menu={menu}
-            configuration={configuration}
             routes={routes}
             store={store}
             />,


### PR DESCRIPTION
Either merged into a minor or 10 but yes

Followup to https://github.com/neos/neos-ui/pull/4012

- the `frontendConfiguration` no longer carries the `editPreviewModes` setting
- redux sagas no longer receive the `{configuration}` as parameter
- when using the `@neos()` decorator `neos.configuration` is no longer available
- the state information `configuration.allowedTargetWorkspaces` is no longer stored as configuration but in the redux store via `selectors.CR.Workspaces.allowedTargetWorkspacesSelector()`



**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
