### PR TITLE
BUGFIX: Prevent duplicate documents in page tree after filtering

### DIFF
--- a/Classes/Fusion/Helper/NodeInfoHelper.php
+++ b/Classes/Fusion/Helper/NodeInfoHelper.php
@@ -269,10 +269,11 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
             $childNodes = $documentChildNodes;
         }
 
-        $mapper = static function (NodeInterface $childNode) {
+        $mapper = function (NodeInterface $childNode) {
             return [
                 'contextPath' => $childNode->getContextPath(),
-                'nodeType' => $childNode->getNodeType()->getName()
+                'nodeType' => $childNode->getNodeType()->getName(),
+                'role' => $childNode->getNodeType()->isOfType($this->documentNodeTypeRole) ? 'document' : 'content',
             ];
         };
 

--- a/packages/neos-ts-interfaces/src/index.ts
+++ b/packages/neos-ts-interfaces/src/index.ts
@@ -44,6 +44,7 @@ export interface ContextProperties {
 export interface NodeChild {
     contextPath: NodeContextPath;
     nodeType: NodeTypeName;
+    role: 'document' | 'content';
 }
 // TODO: for some reason (probably due to immer) I can not use ReadonlyArray here
 export interface NodeChildren extends Array<NodeChild> {}

--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
@@ -463,10 +463,18 @@ export const reducer = (state: State = defaultState, action: InitAction | EditPr
                 if (!newNode) {
                     throw new Error('This error should never be thrown, it\'s a way to fool TypeScript');
                 }
-                const mergedNode: Node = defaultsDeep({}, newNode, draft.byContextPath[contextPath]);
-                // Force overwrite of children
-                if (newNode.isFullyLoaded && newNode.children !== undefined) {
-                    mergedNode.children = newNode.children;
+                const existingNode = draft.byContextPath[contextPath] || {} as Node;
+                const mergedNode: Node = defaultsDeep({}, newNode, existingNode);
+                if (newNode.children !== undefined) {
+                    if (newNode.isFullyLoaded || !existingNode.children) {
+                        mergedNode.children = newNode.children;
+                    } else {
+                        // A non fully loaded node only contains document children, so we need to preserve existing non-document children
+                        mergedNode.children = [
+                            ...existingNode.children.filter(({role}) => role !== 'document'),
+                            ...newNode.children
+                        ];
+                    }
                 }
                 // Force overwrite of matchesCurrentDimensions
                 if (newNode.matchesCurrentDimensions !== undefined) {


### PR DESCRIPTION
Resolves: #4033 by replacing existing document children with new ones sent by the backend instead of merging new and old children.