### PR TITLE
TASK: New link editor final final final polish

### DIFF
--- a/Resources/Private/Translations/de/LinkEditor/Main.xlf
+++ b/Resources/Private/Translations/de/LinkEditor/Main.xlf
@@ -17,6 +17,10 @@
                 <source>Edit Link</source>
                 <target>Link editieren</target>
             </trans-unit>
+            <trans-unit id="inspector.delete" xml:space="preserve" approved="yes">
+                <source>Delete Link</source>
+                <target>Link löschen</target>
+            </trans-unit>
             <trans-unit id="inspector.notfound" xml:space="preserve" approved="yes">
                 <source>Could not find an editor suitable for {href}</source>
                 <target>Konnte keinen geeigneten Editor für {href} finden</target>
@@ -32,6 +36,10 @@
                 <target>Link bearbeiten</target>
             </trans-unit>
 
+            <trans-unit id="dialog.action.delete" xml:space="preserve" approved="yes">
+                <source>Delete Link</source>
+                <target>Link löschen</target>
+            </trans-unit>
             <trans-unit id="dialog.action.cancel" xml:space="preserve" approved="yes">
                 <source>Cancel</source>
                 <target>Abbrechen</target>

--- a/Resources/Private/Translations/de/LinkEditor/Main.xlf
+++ b/Resources/Private/Translations/de/LinkEditor/Main.xlf
@@ -75,8 +75,8 @@
                 <target>Nicht folgen (SEO)</target>
             </trans-unit>
             <trans-unit id="options.label.download" xml:space="preserve" approved="yes">
-                <source>Download target</source>
-                <target>Ziel herunterladen</target>
+                <source>Force download</source>
+                <target>Herunterladen erzwingen</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Translations/de/LinkEditor/Phone.xlf
+++ b/Resources/Private/Translations/de/LinkEditor/Phone.xlf
@@ -19,8 +19,8 @@
                 <target>Eine Telefonnummer ist erforderlich</target>
             </trans-unit>
             <trans-unit id="phoneNumber.validation.numbersOnly" xml:space="preserve" approved="yes">
-                <source>Please enter only number values without a leading 0</source>
-                <target>Bitte nur Zahlenwerte ohne führende 0 eingeben</target>
+                <source>Please enter only number values</source>
+                <target>Bitte nur Zahlenwerte eingeben</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Translations/en/LinkEditor/Main.xlf
+++ b/Resources/Private/Translations/en/LinkEditor/Main.xlf
@@ -14,6 +14,9 @@
             <trans-unit id="inspector.edit" xml:space="preserve" approved="yes">
                 <source>Edit Link</source>
             </trans-unit>
+            <trans-unit id="inspector.delete" xml:space="preserve" approved="yes">
+                <source>Delete Link</source>
+            </trans-unit>
             <trans-unit id="inspector.notfound" xml:space="preserve" approved="yes">
                 <source>Could not determine link editor for value {href}</source>
             </trans-unit>
@@ -24,6 +27,9 @@
             </trans-unit>
             <trans-unit id="dialog.title.edit" xml:space="preserve" approved="yes">
                 <source>Edit Link</source>
+            </trans-unit>
+            <trans-unit id="dialog.action.delete" xml:space="preserve" approved="yes">
+                <source>Delete Link</source>
             </trans-unit>
             <trans-unit id="dialog.action.cancel" xml:space="preserve" approved="yes">
                 <source>Cancel</source>

--- a/Resources/Private/Translations/en/LinkEditor/Main.xlf
+++ b/Resources/Private/Translations/en/LinkEditor/Main.xlf
@@ -58,7 +58,7 @@
                 <source>No follow (SEO)</source>
             </trans-unit>
             <trans-unit id="options.label.download" xml:space="preserve" approved="yes">
-                <source>Download target</source>
+                <source>Force download</source>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Translations/en/LinkEditor/Phone.xlf
+++ b/Resources/Private/Translations/en/LinkEditor/Phone.xlf
@@ -15,7 +15,7 @@
                 <source>A phone number is required</source>
             </trans-unit>
             <trans-unit id="phoneNumber.validation.numbersOnly" xml:space="preserve" approved="yes">
-                <source>Please enter only number values without a leading 0</source>
+                <source>Please enter only number values</source>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Translations/fr/LinkEditor/Phone.xlf
+++ b/Resources/Private/Translations/fr/LinkEditor/Phone.xlf
@@ -19,8 +19,8 @@
                 <target>Veuillez sélectionner un code d'appel de pays valide</target>
             </trans-unit>
             <trans-unit id="phoneNumber.validation.numbersOnly" xml:space="preserve" approved="yes">
-                <source>Please enter only number values without a leading 0</source>
-                <target>Veuillez saisir uniquement les valeurs numériques sans le premier 0</target>
+                <source>Please enter only number values</source>
+                <target>Veuillez saisir uniquement les valeurs numériques</target>
             </trans-unit>
         </body>
     </file>

--- a/Tests/IntegrationTests/Fixtures/1Dimension/linkEditor.e2e.ts
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/linkEditor.e2e.ts
@@ -498,7 +498,7 @@ test('Can edit property links via inspector and save the change', async t => {
     await t.click(LinkStringProperty.find('[title="Edit Link"]'));
     await t.expect(OpenLinkEditor.withText('Edit Link').exists).ok();
     await t.expect(Selector('#neos-LinkEditor [role="tab"]').withExactText('Asset').getAttribute('aria-selected')).eql('true');
-    await t.expect(Selector('#neos-LinkEditor-Preview span').withExactText('neos_primary.png').exists).ok();
+    await t.expect(Selector('#neos-LinkEditor-Preview span').withExactText('neos_primary.png #my-anchor').exists).ok();
     await t.expect(Selector('#neos-LinkEditor-Preview img').getAttribute('src')).contains('neos_primary-');
 
     subSection('Select web target with anchor and save change');
@@ -640,7 +640,7 @@ test('Can edit property links via inspector and save the change', async t => {
     await t.click(Selector('#neos-LinkEditor button').withExactText('Advanced'));
     await t.click(Selector('#neos-LinkEditor label').withExactText('No follow (SEO)').find('input'))
 
-    await t.click(Selector('#neos-LinkEditor label').withExactText('Download target').find('input'))
+    await t.click(Selector('#neos-LinkEditor label').withExactText('Force download').find('input'))
 
     await t.expect(WarningOrErrorTooltips.exists).notOk();
     await t.click(Selector('#neos-LinkEditor-submit'));

--- a/packages/neos-ui-ckeditor5-bindings/src/manifest.config.ts
+++ b/packages/neos-ui-ckeditor5-bindings/src/manifest.config.ts
@@ -278,6 +278,9 @@ export default (ckEditorRegistry: SynchronousMetaRegistry<unknown>) => {
             icon: IconFontColor,
             items: blockFormattingToolbarItems
         })
+        if (formatting.a) {
+            toolbarItems.push('link');
+        }
 
         // Items in the "More" dropdown of the main toolbar
         const moreToolbarItems = [];
@@ -316,9 +319,6 @@ export default (ckEditorRegistry: SynchronousMetaRegistry<unknown>) => {
         }
         if (formatting.code) {
             balloonToolbarItems.push('code');
-        }
-        if (formatting.a) {
-            toolbarItems.push('link');
         }
         const tableItems = formatting.table ? [
             'tableColumn',

--- a/packages/neos-ui-link-editor-core/src/application/Dialog/AdvancedOptions/index.tsx
+++ b/packages/neos-ui-link-editor-core/src/application/Dialog/AdvancedOptions/index.tsx
@@ -13,7 +13,7 @@ import {Layout} from '../../../presentation';
 export const AdvancedOptions: React.FC<{
     editor: IEditor,
     form$: State<FormValues>
-    initialLinkType?: ILinkType,
+    initialLinkType: ILinkType | null,
     linkType: ILinkType
     model$: State<any>
     options: any

--- a/packages/neos-ui-link-editor-core/src/application/Dialog/AdvancedOptions/index.tsx
+++ b/packages/neos-ui-link-editor-core/src/application/Dialog/AdvancedOptions/index.tsx
@@ -54,25 +54,21 @@ export const AdvancedOptions: React.FC<{
     });
 
     return <div className={style.advanced}>
-        <Button disabled={!enabled} style="lighter" hoverStyle="brand" className={classNames} onClick={toggleOpen}>
+        <div id="neos-LinkEditor-Advanced-popover" popover="auto" className={style.advancedContents}>
+            <Layout.Stack>
+                {AdvancedEditor
+                    ? <AdvancedEditor model$={props.model$} options={props.options} />
+                    : null}
+                <LinkOptions
+                    form$={props.form$}
+                    enabledLinkOptions={enabledLinkOptions}
+                />
+            </Layout.Stack>
+        </div>
+        <Button popovertarget="neos-LinkEditor-Advanced-popover" disabled={!enabled} style="lighter" hoverStyle="brand" className={classNames} onClick={toggleOpen}>
             <Icon icon="cogs" color={isUsed ? 'primaryBlue' : undefined} padded="right"/>
             {translate('Neos.Neos.Ui:LinkEditor.Main:options.title', 'Advanced')}
-            <Icon icon={isOpen ? 'chevron-left' : 'chevron-right'} padded="left"/>
+            <Icon className={style.advancedOpenerIcon} icon="chevron-left" padded="left"/>
         </Button>
-        {
-            isOpen ? (
-                <div className={style.advancedContents}>
-                    <Layout.Stack>
-                        {AdvancedEditor
-                            ? <AdvancedEditor model$={props.model$} options={props.options} />
-                            : null}
-                        <LinkOptions
-                            form$={props.form$}
-                            enabledLinkOptions={enabledLinkOptions}
-                        />
-                    </Layout.Stack>
-                </div>
-            ) : null
-        }
     </div>
 };

--- a/packages/neos-ui-link-editor-core/src/application/Dialog/AdvancedOptions/index.tsx
+++ b/packages/neos-ui-link-editor-core/src/application/Dialog/AdvancedOptions/index.tsx
@@ -47,7 +47,6 @@ export const AdvancedOptions: React.FC<{
 
         <div
             id="neos-LinkEditor-Advanced-popover"
-            // @ts-expect-error FIXME we need to update typescript
             popover="auto"
             className={style.advancedContents}
         >
@@ -62,7 +61,6 @@ export const AdvancedOptions: React.FC<{
             </Layout.Stack>
         </div>
         <Button
-            // @ts-expect-error FIXME we need to update typescript
             popovertarget="neos-LinkEditor-Advanced-popover"
             disabled={!enabled}
             style="lighter"
@@ -71,7 +69,7 @@ export const AdvancedOptions: React.FC<{
         >
             <Icon icon="cogs" color={isUsed ? 'primaryBlue' : undefined} padded="right"/>
             {translate('Neos.Neos.Ui:LinkEditor.Main:options.title', 'Advanced')}
-            <Icon className={style.advancedOpenerIcon} icon="chevron-left" padded="left"/>
+            <Icon className={style.advancedOpenerIcon} icon="chevron-right" padded="left"/>
         </Button>
     </div>;
 };

--- a/packages/neos-ui-link-editor-core/src/application/Dialog/AdvancedOptions/index.tsx
+++ b/packages/neos-ui-link-editor-core/src/application/Dialog/AdvancedOptions/index.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import {IEditor, ILinkType} from '../../../domain';
 import {mapState, State} from '@neos-project/framework-observable'
 import {useLatestState} from '@neos-project/framework-observable-react'
-import mergeClassNames from 'classnames'
 import {Button, Icon} from '@neos-project/react-ui-components'
 import {translate} from '@neos-project/neos-ui-i18n'
 import {LinkOptions} from '../LinkOptions';
@@ -38,26 +37,23 @@ export const AdvancedOptions: React.FC<{
 
     const isUsed = enabled && (formStatus.isOptionSet || Boolean(model && props.linkType.isAdvanced?.(model)));
 
-    const [isOpen, setOpen] = React.useState<boolean>(false);
-
-    const toggleOpen = React.useCallback(() => enabled ? setOpen(openState => !openState) : null, [enabled]);
-
     const {AdvancedEditor} = props.linkType;
 
     if (!enabledLinkOptions.length && !AdvancedEditor) {
         return null;
     }
 
-    const classNames = mergeClassNames({
-        [style.advancedButton]: true,
-        [style.advancedButtonIsOpen]: isOpen
-    });
+    return <div className={style.advancedCorner}>
 
-    return <div className={style.advanced}>
-        <div id="neos-LinkEditor-Advanced-popover" popover="auto" className={style.advancedContents}>
+        <div
+            id="neos-LinkEditor-Advanced-popover"
+            // @ts-expect-error FIXME we need to update typescript
+            popover="auto"
+            className={style.advancedContents}
+        >
             <Layout.Stack>
                 {AdvancedEditor
-                    ? <AdvancedEditor model$={props.model$} options={props.options} />
+                    ? <AdvancedEditor model$={props.model$} options={props.options}/>
                     : null}
                 <LinkOptions
                     form$={props.form$}
@@ -65,10 +61,17 @@ export const AdvancedOptions: React.FC<{
                 />
             </Layout.Stack>
         </div>
-        <Button popovertarget="neos-LinkEditor-Advanced-popover" disabled={!enabled} style="lighter" hoverStyle="brand" className={classNames} onClick={toggleOpen}>
+        <Button
+            // @ts-expect-error FIXME we need to update typescript
+            popovertarget="neos-LinkEditor-Advanced-popover"
+            disabled={!enabled}
+            style="lighter"
+            hoverStyle="brand"
+            className={style.advancedButton}
+        >
             <Icon icon="cogs" color={isUsed ? 'primaryBlue' : undefined} padded="right"/>
             {translate('Neos.Neos.Ui:LinkEditor.Main:options.title', 'Advanced')}
             <Icon className={style.advancedOpenerIcon} icon="chevron-left" padded="left"/>
         </Button>
-    </div>
+    </div>;
 };

--- a/packages/neos-ui-link-editor-core/src/application/Dialog/AdvancedOptions/style.module.css
+++ b/packages/neos-ui-link-editor-core/src/application/Dialog/AdvancedOptions/style.module.css
@@ -1,19 +1,44 @@
-.advanced {
+.advancedCorner {
     position: absolute;
     left: 0;
     bottom: 0;
+
+    /* legacy support for non anchor CSS */
+    display: flex;
+    flex-direction: row-reverse;
+    /* legacy support for non anchor CSS */
 }
 
 .advancedContents {
     background: var(--colors-ContrastDarkest);
-    border: 1px solid var(--colors-ContrastDark);
-    border-bottom: 0;
+    border: 1px solid var(--colors-PrimaryBlue);
     padding: 1rem;
-    position: absolute;
-    left: 0;
-    bottom: 0;
+    margin: 0;
+    inset: auto;
+
     width: max-content;
     min-width: 300px;
+
+    /* legacy support for non anchor CSS */
+    transform: translate(calc(100%), calc(-100% + 40px));
+    /* legacy support for non anchor CSS */
+}
+
+@supports (position-anchor: --neos-LinkEditor-Advanced-anchor) {
+    .advancedContents {
+        position-anchor: --neos-LinkEditor-Advanced-anchor;
+        left: anchor(right);
+        top: anchor(bottom);
+        transform: translateY(-100%);
+    }
+}
+
+.advancedButton {
+    anchor-name: --neos-LinkEditor-Advanced-anchor;
+}
+
+.advancedButton:focus {
+    outline: none;
 }
 
 .advancedContents:popover-open + .advancedButton .advancedOpenerIcon {

--- a/packages/neos-ui-link-editor-core/src/application/Dialog/AdvancedOptions/style.module.css
+++ b/packages/neos-ui-link-editor-core/src/application/Dialog/AdvancedOptions/style.module.css
@@ -10,26 +10,12 @@
     border-bottom: 0;
     padding: 1rem;
     position: absolute;
-    left: 100%;
+    left: 0;
     bottom: 0;
     width: max-content;
     min-width: 300px;
 }
 
-.advancedButton:hover svg {
-    color: currentColor;
-}
-
-.advancedButtonIsOpen {
-    border-right: unset;
-}
-
-.advancedButtonIsOpen::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 100%;
-    bottom: 0;
-    width: 1px;
-    background: var(--colors-ContrastDark);
+.advancedContents:popover-open + .advancedButton .advancedOpenerIcon {
+    transform: rotateY(180deg);
 }

--- a/packages/neos-ui-link-editor-core/src/application/Dialog/Dialog.tsx
+++ b/packages/neos-ui-link-editor-core/src/application/Dialog/Dialog.tsx
@@ -144,7 +144,7 @@ const LinkEditorDialog: React.FC<{
                 ? translate('Neos.Neos.Ui:LinkEditor.Main:dialog.title.create', 'Create Link')
                 : translate('Neos.Neos.Ui:LinkEditor.Main:dialog.title.edit', 'Edit Link')
             }</div>}
-            style="wide"
+            style="auto"
             autoFocus={true}
             actions={[
                 <Button onClick={dismiss}>

--- a/packages/neos-ui-link-editor-core/src/application/Dialog/Dialog.tsx
+++ b/packages/neos-ui-link-editor-core/src/application/Dialog/Dialog.tsx
@@ -44,10 +44,9 @@ const LinkEditorDialog: React.FC<{
 
     const {editorOptions} = useLatestState(editor.state$);
 
-    // todo link type might not be available if disabled but returned here...
-    const initialLinkType = useLinkTypeForHref(initialValue?.href ?? null);
-
     const availableLinkTypes = useSortedAndFilteredLinkTypes(editor);
+
+    const initialLinkType = useLinkTypeForHref(initialValue?.href ?? null, availableLinkTypes);
 
     const {error: initialError, model: initialModel} = React.useMemo(() => {
         if (!initialLinkType || !initialValue) {

--- a/packages/neos-ui-link-editor-core/src/application/Dialog/Dialog.tsx
+++ b/packages/neos-ui-link-editor-core/src/application/Dialog/Dialog.tsx
@@ -167,7 +167,7 @@ const LinkEditorDialog: React.FC<{
             <ErrorBoundary errorFallback={ErrorView}>
                 <Form>
                     {formStatus.isDirty && formStatus.isValid ? (
-                        <Deletable id="neos-LinkEditor-Preview" onDelete={unsetLinkModels}>
+                        <Deletable id="neos-LinkEditor-Preview" onDelete={unsetLinkModels} label={translate('Neos.Neos.Ui:LinkEditor.Main:dialog.action.delete', '')}>
                             <ErrorBoundary errorFallback={ErrorView}>
                                 {
                                     React.createElement(formStatus.activeLinkType.Preview, {
@@ -179,7 +179,7 @@ const LinkEditorDialog: React.FC<{
                         </Deletable>
                     ) : (
                         !formStatus.initialLinkWasDeleted && initialLinkType ? (
-                            <Deletable id="neos-LinkEditor-Preview" onDelete={unsetLinkModels}>
+                            <Deletable id="neos-LinkEditor-Preview" onDelete={unsetLinkModels} label={translate('Neos.Neos.Ui:LinkEditor.Main:dialog.action.delete', '')}>
                                 <ErrorBoundary errorFallback={ErrorView}>
                                     {
                                         initialError ? (

--- a/packages/neos-ui-link-editor-core/src/application/Dialog/Dialog.tsx
+++ b/packages/neos-ui-link-editor-core/src/application/Dialog/Dialog.tsx
@@ -42,6 +42,8 @@ const LinkEditorDialog: React.FC<{
 }> = ({editor, initialValue}) => {
     const {dismiss, apply, unset} = editor.transactions;
 
+    const {editorOptions} = useLatestState(editor.state$);
+
     // todo link type might not be available if disabled but returned here...
     const initialLinkType = useLinkTypeForHref(initialValue?.href ?? null);
 
@@ -72,7 +74,7 @@ const LinkEditorDialog: React.FC<{
     } as FormValues), []);
 
     const formStatus$ = React.useMemo(() => mapState(form$, (form) => {
-        const linkType = availableLinkTypes.find(l => l.id === form.activeLinkTypeId);
+        const linkType = availableLinkTypes.find(linkType => linkType.id === form.activeLinkTypeId);
         if (!linkType) {
             throw Error(`Fatal: Link type ${form.activeLinkTypeId} does no longer exist.`)
         }
@@ -82,7 +84,10 @@ const LinkEditorDialog: React.FC<{
         return {
             isDirty: form.isOptionsDirty || (model ? linkType.isDirty(model) : false),
             isValid: model ? linkType.isValid(model) : false,
-            initialLinkWasDeleted: form.initialLinkWasDeleted
+            initialLinkWasDeleted: form.initialLinkWasDeleted,
+            activeLinkTypeId: form.activeLinkTypeId,
+            activeModel: model,
+            activeLinkType: linkType
         };
     }), []);
 
@@ -113,6 +118,15 @@ const LinkEditorDialog: React.FC<{
         } else {
             console.error('NeosUi LinkEditor: Nothing to do, handleSubmit should not have been invoked.');
         }
+    }, []);
+
+    const unsetLinkModels = React.useCallback(() => {
+        form$.update((values) => ({
+            ...values,
+            options: {},
+            initialLinkWasDeleted: values.initialLinkWasDeleted || Boolean(initialLinkType),
+            linkModels: {}
+        }));
     }, []);
 
     const isAuthenticated = useSelector(state => !state.system?.authenticationTimeout);
@@ -152,47 +166,64 @@ const LinkEditorDialog: React.FC<{
         >
             <ErrorBoundary errorFallback={ErrorView}>
                 <Form>
-                    {(initialValue === null || initialLinkType === null) || formStatus.initialLinkWasDeleted ? (
-                        <DialogWithEmptyValue
-                            form$={form$}
-                            editor={editor}
-                            availableLinkTypes={availableLinkTypes}
-                        />
+                    {formStatus.isDirty && formStatus.isValid ? (
+                        <Deletable id="neos-LinkEditor-Preview" onDelete={unsetLinkModels}>
+                            <ErrorBoundary errorFallback={ErrorView}>
+                                {
+                                    React.createElement(formStatus.activeLinkType.Preview, {
+                                        model: formStatus.activeModel,
+                                        options: editorOptions.linkTypes?.[formStatus.activeLinkTypeId] as any ?? {}
+                                    })
+                                }
+                            </ErrorBoundary>
+                        </Deletable>
                     ) : (
-                        <DialogWithValue
-                            form$={form$}
-                            editor={editor}
-                            initialModel={initialModel}
-                            initialError={initialError}
-                            initialLinkType={initialLinkType}
-                            availableLinkTypes={availableLinkTypes}
-                        />
+                        !formStatus.initialLinkWasDeleted && initialLinkType ? (
+                            <Deletable id="neos-LinkEditor-Preview" onDelete={unsetLinkModels}>
+                                <ErrorBoundary errorFallback={ErrorView}>
+                                    {
+                                        initialError ? (
+                                            <ErrorView error={initialError} />
+                                        ) : (
+                                            React.createElement(initialLinkType.Preview, {
+                                                model: initialModel,
+                                                options: editorOptions.linkTypes?.[initialLinkType.id] as any ?? {}
+                                            })
+                                        )
+                                    }
+                                </ErrorBoundary>
+                            </Deletable>
+                        ) : null
                     )}
+                    <DialogContents
+                        form$={form$}
+                        editor={editor}
+                        initialModel={formStatus.initialLinkWasDeleted ? null : initialModel}
+                        initialLinkType={formStatus.initialLinkWasDeleted ? null : initialLinkType}
+                        availableLinkTypes={availableLinkTypes}
+                    />
                 </Form>
             </ErrorBoundary>
         </Dialog>
     )
 }
 
-const DialogWithEmptyValue: React.FC<{
+const DialogContents: React.FC<{
     form$: State<FormValues>
     editor: IEditor,
+    initialModel: any | null,
+    initialLinkType: ILinkType | null,
     availableLinkTypes: ReadonlyArray<ILinkType>
 }> = props => {
+    const {editorOptions} = useLatestState(props.editor.state$);
+
     const setActiveTab = React.useCallback((linkId) => props.form$.update((values) => ({...values, activeLinkTypeId: linkId})), []);
     const activeTab$ = React.useMemo(() => mapState(props.form$, (form) => form.activeLinkTypeId), []);
     const activeTab = useLatestState(activeTab$);
 
-    const {editorOptions} = useLatestState(props.editor.state$);
-
     const linkModels$ = React.useMemo(() => pickState(props.form$, 'linkModels'), []);
 
-    return (<>
-        <PreviewForLinkType
-            availableLinkTypes={props.availableLinkTypes}
-            editor={props.editor}
-            form$={props.form$}
-        />
+    return (
         <Tabs
             activeTab={activeTab}
             onActiveTabChange={setActiveTab}
@@ -212,156 +243,22 @@ const DialogWithEmptyValue: React.FC<{
                         icon={linkType.icon}
                     >
                         <ErrorBoundary errorFallback={ErrorView}>
-                            <Editor model$={model$} options={options}/>
+                            <Editor
+                                model$={model$}
+                                options={options}
+                            />
+                            <AdvancedOptions
+                                editor={props.editor}
+                                form$={props.form$}
+                                initialLinkType={props.initialLinkType}
+                                linkType={linkType}
+                                model$={model$}
+                                options={options}
+                            />
                         </ErrorBoundary>
-                        <AdvancedOptions
-                            editor={props.editor}
-                            form$={props.form$}
-                            linkType={linkType}
-                            model$={model$}
-                            options={editorOptions.linkTypes?.[linkType.id] as any ?? {}}
-                        />
                     </TabsPanel>
                 )
             })}
         </Tabs>
-    </>);
-}
-
-const DialogWithValue: React.FC<{
-    form$: State<FormValues>
-    editor: IEditor,
-    initialModel: any,
-    initialError: AnyError | null
-    initialLinkType: ILinkType,
-    availableLinkTypes: ReadonlyArray<ILinkType>
-}> = props => {
-    const {editorOptions} = useLatestState(props.editor.state$);
-
-    const setActiveTab = React.useCallback((linkId) => props.form$.update((values) => ({...values, activeLinkTypeId: linkId})), []);
-    const activeTab$ = React.useMemo(() => mapState(props.form$, (form) => form.activeLinkTypeId), []);
-    const activeTab = useLatestState(activeTab$);
-
-    const linkModels$ = React.useMemo(() => pickState(props.form$, 'linkModels'), []);
-
-    const InitialPreview = props.initialLinkType.Preview;
-
-    return (
-        <>
-            <PreviewForLinkType
-                editor={props.editor}
-                initialLinkType={props.initialLinkType}
-                availableLinkTypes={props.availableLinkTypes}
-                form$={props.form$}
-                initialLinkTypePreview={() => (
-                    props.initialError ? (
-                        <ErrorView error={props.initialError}/>
-                    ) : (
-                        <InitialPreview
-                            model={props.initialModel}
-                            options={editorOptions.linkTypes?.[props.initialLinkType.id] as any ?? {}}
-                        />
-                    )
-                )}
-            />
-            <Tabs
-                activeTab={activeTab}
-                onActiveTabChange={setActiveTab}
-                vertical
-            >
-                {props.availableLinkTypes.map((linkType) => {
-                    const {Editor} = linkType;
-                    const model$ = React.useMemo(() => pickState(linkModels$, linkType.id), [linkModels$])
-
-                    return (
-                        <TabsPanel
-                            key={linkType.id}
-                            id={linkType.id}
-                            // menu item props
-                            title={linkType.getTitle()}
-                            icon={linkType.icon}
-                        >
-                            <ErrorBoundary errorFallback={ErrorView}>
-                                <Editor
-                                    model$={model$}
-                                    options={editorOptions.linkTypes?.[linkType.id] as any ?? {}}
-                                />
-                                <AdvancedOptions
-                                    editor={props.editor}
-                                    form$={props.form$}
-                                    initialLinkType={props.initialLinkType}
-                                    linkType={linkType}
-                                    model$={model$}
-                                    options={editorOptions.linkTypes?.[linkType.id] as any ?? {}}
-                                />
-                            </ErrorBoundary>
-                        </TabsPanel>
-                    )
-                })}
-            </Tabs>
-        </>
     );
 }
-
-const PreviewForLinkType: React.FC<{
-    editor: IEditor,
-    availableLinkTypes: ReadonlyArray<ILinkType>
-    initialLinkType?: ILinkType,
-    form$: State<FormValues>
-    initialLinkTypePreview?: () => React.ReactNode
-}> = props => {
-    const {editorOptions} = useLatestState(props.editor.state$);
-
-    const formHeader$ = React.useMemo(() => mapState(props.form$, (form) => {
-        const linkType = props.availableLinkTypes.find(l => l.id === form.activeLinkTypeId);
-        if (!linkType) {
-            throw Error(`Fatal: Link type ${form.activeLinkTypeId} does no longer exist.`)
-        }
-
-        const activeModel = form.linkModels[form.activeLinkTypeId];
-
-        const showPreviewForEditedActiveLink = activeModel && linkType.isDirty(activeModel) && linkType.isValid(activeModel);
-
-        return {
-            activeModel,
-            activeLinkType: linkType, // todo is this a good idea to put this into an observable?
-            showPreviewForEditedActiveLink
-        }
-    }), []);
-
-    const unsetLinkModels = React.useCallback(() => {
-        props.form$.update((values) => ({
-            ...values,
-            options: {},
-            initialLinkWasDeleted: values.initialLinkWasDeleted || Boolean(props.initialLinkType),
-            linkModels: {}
-        }));
-    }, []);
-
-    const formHeader = useLatestState(formHeader$);
-
-    const {Preview} = formHeader.activeLinkType;
-
-    return formHeader.showPreviewForEditedActiveLink ? (
-        <Deletable
-            id={'neos-LinkEditor-Preview'}
-            onDelete={unsetLinkModels}
-        >
-            <ErrorBoundary errorFallback={ErrorView}>
-                <Preview
-                    model={formHeader.activeModel}
-                    options={editorOptions.linkTypes?.[formHeader.activeLinkType.id] as any ?? {}}
-                />
-            </ErrorBoundary>
-        </Deletable>
-    ) : (props.initialLinkTypePreview ? (
-        <Deletable
-            id={'neos-LinkEditor-Preview'}
-            onDelete={unsetLinkModels}
-        >
-            <ErrorBoundary errorFallback={ErrorView}>
-                {props.initialLinkTypePreview()}
-            </ErrorBoundary>
-        </Deletable>
-    ) : null)
-};

--- a/packages/neos-ui-link-editor-core/src/application/LinkTypes/Asset/Asset.tsx
+++ b/packages/neos-ui-link-editor-core/src/application/LinkTypes/Asset/Asset.tsx
@@ -95,7 +95,10 @@ export const Asset: ILinkType<AssetLinkModel> = {
 
         return (
             <ImageCard
-                label={asset.value.label}
+                label={<>
+                    {asset.value.label}
+                    {model.anchor?.value ? <i> #{model.anchor.value}</i> : ''}
+                </>}
                 src={asset.value.preview}
             />
         );

--- a/packages/neos-ui-link-editor-core/src/application/LinkTypes/Node/Node.tsx
+++ b/packages/neos-ui-link-editor-core/src/application/LinkTypes/Node/Node.tsx
@@ -54,7 +54,7 @@ type NodeLinkOptions = {
     allowedNodeTypes?: string[];
 };
 
-const NodePreview: React.FC<{ nodeId: string }> = (props) => {
+const NodePreview: React.FC<{ nodeId: string, anchor?: string }> = (props) => {
     const workspaceName = useSelector(selectors.CR.Workspaces.personalWorkspaceNameSelector);
     const dimensionValues = useSelector(selectors.CR.ContentDimensions.active);
     const fetch__nodeSummary = usePromise(async () => {
@@ -93,9 +93,10 @@ const NodePreview: React.FC<{ nodeId: string }> = (props) => {
     return (
         <IconCard
             icon={fetch__nodeSummary.value?.icon ?? 'ban'}
-            title={
-                fetch__nodeSummary.value?.label ?? translate('Neos.Neos.Ui:LinkEditor.Node:labelOfNonExistingNode', '')
-            }
+            title={<>
+                {fetch__nodeSummary.value?.label ?? translate('Neos.Neos.Ui:LinkEditor.Node:labelOfNonExistingNode', '')}
+                {props.anchor ? <i> #{props.anchor}</i> : ''}
+            </>}
             subTitle={breadcrumbs ?? `node://${props.nodeId}`}
         />
     );
@@ -142,7 +143,7 @@ export const Node: ILinkType<NodeLinkModel, NodeLinkOptions> = {
     }),
 
     Preview: (props: { model: NodeLinkModel }) => {
-        return <NodePreview nodeId={props.model.nodeId!} />;
+        return <NodePreview nodeId={props.model.nodeId!} anchor={props.model.anchor?.value} />;
     },
 
     Editor: ({

--- a/packages/neos-ui-link-editor-core/src/domain/Editor/Editor.ts
+++ b/packages/neos-ui-link-editor-core/src/domain/Editor/Editor.ts
@@ -12,6 +12,7 @@ export interface IEditorState {
             [identifier: string]: {
                 enabled?: boolean;
                 position?: string;
+                [optionKey: string]: any
             }
         }
     }

--- a/packages/neos-ui-link-editor-core/src/domain/Editor/index.ts
+++ b/packages/neos-ui-link-editor-core/src/domain/Editor/index.ts
@@ -2,3 +2,4 @@ export type {IEditor} from './Editor';
 export {
     createEditor
 } from './Editor';
+export {upcastLegacyLinkEditorOptions} from './upcastLegacyLinkEditorOptions';

--- a/packages/neos-ui-link-editor-core/src/domain/Editor/upcastLegacyLinkEditorOptions.spec.ts
+++ b/packages/neos-ui-link-editor-core/src/domain/Editor/upcastLegacyLinkEditorOptions.spec.ts
@@ -3,7 +3,7 @@ import {upcastLegacyLinkEditorOptions} from './upcastLegacyLinkEditorOptions';
 describe('upcastLegacyLinkEditorOptions', () => {
     it('leaves empty case alone', () => {
         expect(
-            upcastLegacyLinkEditorOptions(undefined, {linkTypes: {}})
+            upcastLegacyLinkEditorOptions(undefined)
         ).toStrictEqual(
             {
                 linkTypes: {}
@@ -11,7 +11,7 @@ describe('upcastLegacyLinkEditorOptions', () => {
         );
 
         expect(
-            upcastLegacyLinkEditorOptions({}, {linkTypes: {}})
+            upcastLegacyLinkEditorOptions({})
         ).toStrictEqual(
             {
                 linkTypes: {Node: {}, Asset: {}}
@@ -20,24 +20,10 @@ describe('upcastLegacyLinkEditorOptions', () => {
 
         expect(
             // @ts-ignore
-            upcastLegacyLinkEditorOptions({placeholder: 'unused'}, {linkTypes: {}})
+            upcastLegacyLinkEditorOptions({placeholder: 'unused'})
         ).toStrictEqual(
             {
                 linkTypes: {Node: {}, Asset: {}}
-            }
-        );
-
-        expect(
-            // @ts-ignore
-            upcastLegacyLinkEditorOptions({}, {linkTypes: {Node: {startingPoint: '/<Foo>'}}})
-        ).toStrictEqual(
-            {
-                linkTypes: {
-                    Node: {
-                        startingPoint: '/<Foo>'
-                    },
-                    Asset: {}
-                }
             }
         );
     });
@@ -50,8 +36,7 @@ describe('upcastLegacyLinkEditorOptions', () => {
                     nodeTypes: 'Neos.Neos:Document',
                     assets: false,
                     nodes: true
-                },
-                {linkTypes: {}}
+                }
             )
         ).toStrictEqual(
             {
@@ -69,53 +54,12 @@ describe('upcastLegacyLinkEditorOptions', () => {
         );
     });
 
-    it('ignores legacy things when new syntax overrules', () => {
-        expect(
-            upcastLegacyLinkEditorOptions(
-                {
-                    startingPoint: '/<Foo>',
-                    nodeTypes: 'Neos.Neos:Document',
-                    assets: false,
-                    nodes: true
-                },
-                {linkTypes: {
-                    Node: {
-                        startingPoint: '/<Overruled>',
-                        baseNodeType: 'Neos.Neos:Overruled',
-                        enabled: false,
-                        loadingDepth: 8
-                    },
-                    Asset: {
-                        enabled: true,
-                        position: 'end'
-                    }
-                }}
-            )
-        ).toStrictEqual(
-            {
-                linkTypes: {
-                    Node: {
-                        startingPoint: '/<Overruled>',
-                        baseNodeType: 'Neos.Neos:Overruled',
-                        enabled: false,
-                        loadingDepth: 8
-                    },
-                    Asset: {
-                        enabled: true,
-                        position: 'end'
-                    }
-                }
-            }
-        );
-    });
-
     it('nodeTypes as array', () => {
         expect(
             upcastLegacyLinkEditorOptions(
                 {
                     nodeTypes: ['Neos.Neos:Foo', 'Neos.Neos:Bar']
-                },
-                {linkTypes: {}}
+                }
             )
         ).toStrictEqual(
             {

--- a/packages/neos-ui-link-editor-core/src/domain/Editor/upcastLegacyLinkEditorOptions.spec.ts
+++ b/packages/neos-ui-link-editor-core/src/domain/Editor/upcastLegacyLinkEditorOptions.spec.ts
@@ -1,0 +1,131 @@
+import {upcastLegacyLinkEditorOptions} from './upcastLegacyLinkEditorOptions';
+
+describe('upcastLegacyLinkEditorOptions', () => {
+    it('leaves empty case alone', () => {
+        expect(
+            upcastLegacyLinkEditorOptions(undefined, {linkTypes: {}})
+        ).toStrictEqual(
+            {
+                linkTypes: {}
+            }
+        );
+
+        expect(
+            upcastLegacyLinkEditorOptions({}, {linkTypes: {}})
+        ).toStrictEqual(
+            {
+                linkTypes: {Node: {}, Asset: {}}
+            }
+        );
+
+        expect(
+            // @ts-ignore
+            upcastLegacyLinkEditorOptions({placeholder: 'unused'}, {linkTypes: {}})
+        ).toStrictEqual(
+            {
+                linkTypes: {Node: {}, Asset: {}}
+            }
+        );
+
+        expect(
+            // @ts-ignore
+            upcastLegacyLinkEditorOptions({}, {linkTypes: {Node: {startingPoint: '/<Foo>'}}})
+        ).toStrictEqual(
+            {
+                linkTypes: {
+                    Node: {
+                        startingPoint: '/<Foo>'
+                    },
+                    Asset: {}
+                }
+            }
+        );
+    });
+
+    it('adds legacy things', () => {
+        expect(
+            upcastLegacyLinkEditorOptions(
+                {
+                    startingPoint: '/<Foo>',
+                    nodeTypes: 'Neos.Neos:Document',
+                    assets: false,
+                    nodes: true
+                },
+                {linkTypes: {}}
+            )
+        ).toStrictEqual(
+            {
+                linkTypes: {
+                    Node: {
+                        startingPoint: '/<Foo>',
+                        baseNodeType: 'Neos.Neos:Document',
+                        enabled: true
+                    },
+                    Asset: {
+                        enabled: false
+                    }
+                }
+            }
+        );
+    });
+
+    it('ignores legacy things when new syntax overrules', () => {
+        expect(
+            upcastLegacyLinkEditorOptions(
+                {
+                    startingPoint: '/<Foo>',
+                    nodeTypes: 'Neos.Neos:Document',
+                    assets: false,
+                    nodes: true
+                },
+                {linkTypes: {
+                    Node: {
+                        startingPoint: '/<Overruled>',
+                        baseNodeType: 'Neos.Neos:Overruled',
+                        enabled: false,
+                        loadingDepth: 8
+                    },
+                    Asset: {
+                        enabled: true,
+                        position: 'end'
+                    }
+                }}
+            )
+        ).toStrictEqual(
+            {
+                linkTypes: {
+                    Node: {
+                        startingPoint: '/<Overruled>',
+                        baseNodeType: 'Neos.Neos:Overruled',
+                        enabled: false,
+                        loadingDepth: 8
+                    },
+                    Asset: {
+                        enabled: true,
+                        position: 'end'
+                    }
+                }
+            }
+        );
+    });
+
+    it('nodeTypes as array', () => {
+        expect(
+            upcastLegacyLinkEditorOptions(
+                {
+                    nodeTypes: ['Neos.Neos:Foo', 'Neos.Neos:Bar']
+                },
+                {linkTypes: {}}
+            )
+        ).toStrictEqual(
+            {
+                linkTypes: {
+                    Node: {
+                        baseNodeType: 'Neos.Neos:Foo,Neos.Neos:Bar'
+                    },
+                    Asset: {}
+                }
+            }
+        );
+    });
+});

--- a/packages/neos-ui-link-editor-core/src/domain/Editor/upcastLegacyLinkEditorOptions.ts
+++ b/packages/neos-ui-link-editor-core/src/domain/Editor/upcastLegacyLinkEditorOptions.ts
@@ -11,24 +11,22 @@ type LegacyLinkEditorOptions = {
 /**
  * @deprecated with Neos 9.1 handle legacy root level option
  */
-export const upcastLegacyLinkEditorOptions = (legacyLinkEditorOptions: LegacyLinkEditorOptions|null|undefined, linkEditorOptions: IEditorState['editorOptions']): IEditorState['editorOptions'] => {
+export const upcastLegacyLinkEditorOptions = (legacyLinkEditorOptions: LegacyLinkEditorOptions|null|undefined): IEditorState['editorOptions'] => {
     if (!legacyLinkEditorOptions) {
-        return linkEditorOptions;
+        return {
+            linkTypes: {}
+        }
     }
     return {
-        ...linkEditorOptions,
         linkTypes: {
-            ...linkEditorOptions.linkTypes,
             Node: {
                 ...('nodes' in legacyLinkEditorOptions ? {enabled: Boolean(legacyLinkEditorOptions.nodes)} : {}),
                 ...(typeof legacyLinkEditorOptions.startingPoint === 'string' ? {startingPoint: legacyLinkEditorOptions.startingPoint} : {}),
                 ...(typeof legacyLinkEditorOptions.nodeTypes === 'string' && legacyLinkEditorOptions.nodeTypes ? {baseNodeType: legacyLinkEditorOptions.nodeTypes} : {}),
-                ...(Array.isArray(legacyLinkEditorOptions.nodeTypes) && legacyLinkEditorOptions.nodeTypes.join(',') ? {baseNodeType: legacyLinkEditorOptions.nodeTypes.join(',')} : {}),
-                ...linkEditorOptions.linkTypes?.Node
+                ...(Array.isArray(legacyLinkEditorOptions.nodeTypes) && legacyLinkEditorOptions.nodeTypes.join(',') ? {baseNodeType: legacyLinkEditorOptions.nodeTypes.join(',')} : {})
             },
             Asset: {
-                ...('assets' in legacyLinkEditorOptions ? {enabled: Boolean(legacyLinkEditorOptions.assets)} : {}),
-                ...linkEditorOptions.linkTypes?.Asset
+                ...('assets' in legacyLinkEditorOptions ? {enabled: Boolean(legacyLinkEditorOptions.assets)} : {})
             }
         }
     }

--- a/packages/neos-ui-link-editor-core/src/domain/Editor/upcastLegacyLinkEditorOptions.ts
+++ b/packages/neos-ui-link-editor-core/src/domain/Editor/upcastLegacyLinkEditorOptions.ts
@@ -1,0 +1,35 @@
+import {IEditorState} from './Editor';
+
+type LegacyLinkEditorOptions = {
+    // @deprecated legacy root level options from the old LinkEditor, will be upcast to new `linkTypes` format
+    startingPoint?: string
+    nodeTypes?: string | string[]
+    assets?: boolean
+    nodes?: boolean
+}
+
+/**
+ * @deprecated with Neos 9.1 handle legacy root level option
+ */
+export const upcastLegacyLinkEditorOptions = (legacyLinkEditorOptions: LegacyLinkEditorOptions|null|undefined, linkEditorOptions: IEditorState['editorOptions']): IEditorState['editorOptions'] => {
+    if (!legacyLinkEditorOptions) {
+        return linkEditorOptions;
+    }
+    return {
+        ...linkEditorOptions,
+        linkTypes: {
+            ...linkEditorOptions.linkTypes,
+            Node: {
+                ...('nodes' in legacyLinkEditorOptions ? {enabled: Boolean(legacyLinkEditorOptions.nodes)} : {}),
+                ...(typeof legacyLinkEditorOptions.startingPoint === 'string' ? {startingPoint: legacyLinkEditorOptions.startingPoint} : {}),
+                ...(typeof legacyLinkEditorOptions.nodeTypes === 'string' && legacyLinkEditorOptions.nodeTypes ? {baseNodeType: legacyLinkEditorOptions.nodeTypes} : {}),
+                ...(Array.isArray(legacyLinkEditorOptions.nodeTypes) && legacyLinkEditorOptions.nodeTypes.join(',') ? {baseNodeType: legacyLinkEditorOptions.nodeTypes.join(',')} : {}),
+                ...linkEditorOptions.linkTypes?.Node
+            },
+            Asset: {
+                ...('assets' in legacyLinkEditorOptions ? {enabled: Boolean(legacyLinkEditorOptions.assets)} : {}),
+                ...linkEditorOptions.linkTypes?.Asset
+            }
+        }
+    }
+}

--- a/packages/neos-ui-link-editor-core/src/domain/Link/LinkType.ts
+++ b/packages/neos-ui-link-editor-core/src/domain/Link/LinkType.ts
@@ -45,51 +45,51 @@ export interface ILinkTypeFactoryApi {
     createError: (message: string) => Error
 }
 
-export function useLinkTypes(): ILinkType[] {
-    return getRegistryById('@neos-project/neos-ui-link-editor/link-types')?.getAllAsList() ?? [];
-}
-
-export function useLinkTypeForHref(href: null | string): null | ILinkType {
-    const linkTypes = useLinkTypes();
+export function useLinkTypeForHref(href: null | string, availableLinkTypes: ILinkType[]): null | ILinkType {
     const result = React.useMemo(() => {
         if (href === null) {
             return null;
         }
 
-        for (const linkType of [...linkTypes].reverse()) {
+        for (const linkType of availableLinkTypes) {
             if (linkType.isSuitableFor({href})) {
                 return linkType;
             }
         }
 
         return null;
-    }, [linkTypes, href]);
+    }, [availableLinkTypes, href]);
 
     return result;
 }
 
 export function useSortedAndFilteredLinkTypes(editor: IEditor): ILinkType[] {
-    const linkTypes = useLinkTypes();
+    const linkTypes = getRegistryById('@neos-project/neos-ui-link-editor/link-types')?.getAllAsList() ?? [];
+
     const {editorOptions} = useLatestState(editor.state$);
 
-    const linkTypesAndEditorOptions = linkTypes.map(
-        (linkType) => ({
-            linkType,
-            options: editorOptions.linkTypes?.[linkType.id]
-        })
-    )
+    const result = React.useMemo(() => {
+        const linkTypesAndEditorOptions = linkTypes.map(
+            (linkType) => ({
+                linkType,
+                options: editorOptions.linkTypes?.[linkType.id]
+            })
+        )
 
-    const sortedLinkTypesViaEditorOptionsPosition = positionalArraySorter(
-        linkTypesAndEditorOptions,
-        // badly typed
-        ({options}) => options?.position
-    )
+        const sortedLinkTypesViaEditorOptionsPosition = positionalArraySorter(
+            linkTypesAndEditorOptions,
+            // badly typed
+            ({options}) => options?.position
+        )
 
-    const filteredLinkTypes = sortedLinkTypesViaEditorOptionsPosition.filter(
-        ({options}) => (options && 'enabled' in options) ? options.enabled : true
-    )
+        const filteredLinkTypes = sortedLinkTypesViaEditorOptionsPosition.filter(
+            ({options}) => (options && 'enabled' in options) ? options.enabled : true
+        )
 
-    return filteredLinkTypes.map(
-        ({linkType}) => linkType
-    );
+        return filteredLinkTypes.map(
+            ({linkType}) => linkType
+        );
+    }, [editorOptions]);
+
+    return result;
 }

--- a/packages/neos-ui-link-editor-core/src/domain/Link/index.ts
+++ b/packages/neos-ui-link-editor-core/src/domain/Link/index.ts
@@ -2,7 +2,6 @@ export type {ILink, ILinkOptions} from './Link';
 
 export type {ILinkType} from './LinkType';
 export {
-    useLinkTypes,
     useLinkTypeForHref,
     useSortedAndFilteredLinkTypes
 } from './LinkType';

--- a/packages/neos-ui-link-editor-core/src/domain/index.ts
+++ b/packages/neos-ui-link-editor-core/src/domain/index.ts
@@ -6,5 +6,6 @@ export {
 
 export type {IEditor} from './Editor';
 export {
-    createEditor
+    createEditor,
+    upcastLegacyLinkEditorOptions
 } from './Editor';

--- a/packages/neos-ui-link-editor-core/src/domain/index.ts
+++ b/packages/neos-ui-link-editor-core/src/domain/index.ts
@@ -1,6 +1,5 @@
 export type {ILink, ILinkOptions, ILinkType} from './Link';
 export {
-    useLinkTypes,
     useLinkTypeForHref,
     useSortedAndFilteredLinkTypes
 } from './Link';

--- a/packages/neos-ui-link-editor-core/src/index.ts
+++ b/packages/neos-ui-link-editor-core/src/index.ts
@@ -3,7 +3,8 @@ export {registerLinkTypes, registerDialog} from './application';
 export type {IEditor, ILinkType, ILinkOptions} from './domain';
 export {
     useLinkTypeForHref,
-    createEditor
+    createEditor,
+    upcastLegacyLinkEditorOptions
 } from './domain';
 
 export {Deletable} from './presentation';

--- a/packages/neos-ui-link-editor-core/src/presentation/CardTitle/style.module.css
+++ b/packages/neos-ui-link-editor-core/src/presentation/CardTitle/style.module.css
@@ -10,3 +10,7 @@
     color: #FFF;
     min-width: 0;
 }
+
+.container i {
+    color: #999;
+}

--- a/packages/neos-ui-link-editor-core/src/presentation/Deletable/index.tsx
+++ b/packages/neos-ui-link-editor-core/src/presentation/Deletable/index.tsx
@@ -7,10 +7,11 @@ import mergeClassNames from 'classnames';
 export const Deletable: React.FC<{
     id?: string,
     onDelete(): void,
+    label: string,
     hoverStyle?: 'brand' | 'none',
 }> = props => (
     <div className={mergeClassNames(style.container, {[style.hoverStyleBrand]: props.hoverStyle === 'brand'})} id={props.id}>
         <div>{props.children}</div>
-        <IconButton className={style.styledButton} icon="xmark" hoverStyle="brand" title="Delete Link" onClick={props.onDelete}/>
+        <IconButton className={style.styledButton} icon="xmark" hoverStyle="brand" title={props.label} onClick={props.onDelete}/>
     </div>
 )

--- a/packages/neos-ui-link-editor-core/src/presentation/IconCard/index.tsx
+++ b/packages/neos-ui-link-editor-core/src/presentation/IconCard/index.tsx
@@ -7,7 +7,7 @@ import {CardSubTitle} from '../CardSubTitle';
 
 interface Props {
     icon: string;
-    title: string;
+    title: string | React.ReactNode;
     subTitle?: string;
 }
 

--- a/packages/neos-ui-link-editor-core/src/presentation/ImageCard/index.tsx
+++ b/packages/neos-ui-link-editor-core/src/presentation/ImageCard/index.tsx
@@ -4,7 +4,7 @@ import style from './style.module.css';
 import {CardTitle} from '../CardTitle';
 
 interface Props {
-    label: string
+    label: string | React.ReactNode
     src: string
 }
 

--- a/packages/neos-ui-link-editor-inline/src/LinkUiPlugin.ts
+++ b/packages/neos-ui-link-editor-inline/src/LinkUiPlugin.ts
@@ -17,7 +17,7 @@ import {
     ViewPosition
 } from '@ckeditor/ckeditor5-engine';
 import {DomOptimalPositionOptions} from '@ckeditor/ckeditor5-utils';
-import {IEditor, ILinkOptions} from '@neos-project/neos-ui-link-editor-core';
+import {IEditor, ILinkOptions, upcastLegacyLinkEditorOptions} from '@neos-project/neos-ui-link-editor-core';
 /** @ts-expect-error */
 import {LinkTargetBlankPlugin} from './LinkTargetBlankPlugin';
 /** @ts-expect-error */
@@ -33,11 +33,16 @@ interface NeosEditorOptions {
         relNofollow?: boolean
         targetBlank?: boolean
         download?: boolean
-        // legacy root level option, linkTypes.Node.startingPoint should be used instead
-        startingPoint?: string
+
         linkTypes?: {
             [key: string]: object
         }
+
+        // @deprecated legacy root level options from the old LinkEditor, will be upcast to new `linkTypes` format
+        startingPoint?: string
+        nodeTypes?: string | string[]
+        assets?: boolean
+        nodes?: boolean
     }
 }
 
@@ -90,22 +95,6 @@ export function createLinkUiPlugin(neosLinkEditor: IEditor, neosEditorOptions: N
         }
 
         private async _handleLinkEditing() {
-            const editorOptions = {
-                linkTypes: {
-                    ...neosEditorOptions?.linking?.linkTypes
-                }
-            };
-
-            if (neosEditorOptions?.linking?.startingPoint) {
-                // handle legacy root level option
-                editorOptions.linkTypes.Node = {
-                    ...editorOptions.linkTypes.Node,
-                    startingPoint:
-                        (editorOptions.linkTypes.Node as any).startingPoint
-                        ?? neosEditorOptions.linking.startingPoint
-                };
-            }
-
             const linkCommand: LinkCommand = this.editor.commands.get('link')!;
 
             const link = linkCommand.value ? {
@@ -136,7 +125,18 @@ export function createLinkUiPlugin(neosLinkEditor: IEditor, neosEditorOptions: N
                 enabledLinkOptions.push('download');
             }
 
-            const result = await neosLinkEditor.transactions.editLink(link, enabledLinkOptions, editorOptions);
+            const result = await neosLinkEditor.transactions.editLink(
+                link,
+                enabledLinkOptions,
+                upcastLegacyLinkEditorOptions(
+                    neosEditorOptions?.linking?.linkTypes,
+                    {
+                        linkTypes: {
+                            ...neosEditorOptions?.linking?.linkTypes
+                        }
+                    }
+                )
+            );
 
             if (result.change) {
                 if (result.value === null) {

--- a/packages/neos-ui-link-editor-inline/src/LinkUiPlugin.ts
+++ b/packages/neos-ui-link-editor-inline/src/LinkUiPlugin.ts
@@ -128,14 +128,11 @@ export function createLinkUiPlugin(neosLinkEditor: IEditor, neosEditorOptions: N
             const result = await neosLinkEditor.transactions.editLink(
                 link,
                 enabledLinkOptions,
-                upcastLegacyLinkEditorOptions(
-                    neosEditorOptions?.linking?.linkTypes,
-                    {
-                        linkTypes: {
-                            ...neosEditorOptions?.linking?.linkTypes
-                        }
+                neosEditorOptions?.linking?.linkTypes ? ({
+                    linkTypes: {
+                        ...neosEditorOptions.linking.linkTypes
                     }
-                )
+                }) : upcastLegacyLinkEditorOptions(neosEditorOptions?.linking?.linkTypes)
             );
 
             if (result.change) {

--- a/packages/neos-ui-link-editor-inspector/src/InspectorEditor.tsx
+++ b/packages/neos-ui-link-editor-inspector/src/InspectorEditor.tsx
@@ -4,7 +4,7 @@ import {
     ILinkType,
     useLinkTypeForHref,
     Deletable,
-    IEditor
+    IEditor, upcastLegacyLinkEditorOptions
 } from '@neos-project/neos-ui-link-editor-core';
 import {AnyError, ErrorBoundary, ErrorView} from '@neos-project/neos-ui-error';
 import {ILink, useSortedAndFilteredLinkTypes} from '@neos-project/neos-ui-link-editor-core/src/domain';
@@ -21,12 +21,20 @@ import {DisabledWrap, SeamlessButton} from './presentation';
 export type EditorProps = {
     id?: string
     options?: {
-        linkTypes?: Record<string, unknown>,
+        linkTypes?: {
+            [key: string]: object
+        }
         title?: boolean
         relNofollow?: boolean
         targetBlank?: boolean
         download?: boolean
         disabled?: boolean
+
+        // @deprecated legacy root level options from the old LinkEditor, will be upcast to new `linkTypes` format
+        startingPoint?: string
+        nodeTypes?: string | string[]
+        assets?: boolean
+        nodes?: boolean
     };
     value: any;
     commit(value: any): void;
@@ -77,11 +85,14 @@ export const createInspectorEditor = (dataType: LinkDataType, editor: IEditor) =
         const result = await transactions.editLink(
             serializedLinkToILink(serializedLink),
             enabledLinkOptions,
-            {
-                linkTypes: {
-                    ...props.options?.linkTypes
+            upcastLegacyLinkEditorOptions(
+                props.options?.linkTypes,
+                {
+                    linkTypes: {
+                        ...props.options?.linkTypes
+                    }
                 }
-            }
+            )
         );
 
         if (result.change) {

--- a/packages/neos-ui-link-editor-inspector/src/InspectorEditor.tsx
+++ b/packages/neos-ui-link-editor-inspector/src/InspectorEditor.tsx
@@ -118,7 +118,7 @@ export const createInspectorEditor = (dataType: LinkDataType, editor: IEditor) =
         );
     }
     return (
-        <Deletable id={props.id} onDelete={reset} hoverStyle="brand">
+        <Deletable id={props.id} onDelete={reset} hoverStyle="brand" label={translate('Neos.Neos.Ui:LinkEditor.Main:inspector.delete', '')}>
             <ErrorView error={translate('Neos.Neos.Ui:LinkEditor.Main:inspector.notfound', 'Could not determine link editor for value {href}', {href: JSON.stringify(serializedLink.value)})} />
         </Deletable>
     );
@@ -157,7 +157,7 @@ const InspectorEditorWithLinkType: React.FC<{
     }
 
     return (
-        <Deletable id={props.htmlId} onDelete={props.reset} hoverStyle="brand">
+        <Deletable id={props.htmlId} onDelete={props.reset} hoverStyle="brand" label={translate('Neos.Neos.Ui:LinkEditor.Main:inspector.delete', '')}>
             {error ? (
                 <ErrorView error={error} />
             ) : (

--- a/packages/neos-ui-link-editor-inspector/src/InspectorEditor.tsx
+++ b/packages/neos-ui-link-editor-inspector/src/InspectorEditor.tsx
@@ -16,7 +16,7 @@ import {
     serializedLinkToILink
 } from './serialisation';
 import {translate} from '@neos-project/neos-ui-i18n';
-import {SeamlessButton} from './presentation';
+import {DisabledWrap, SeamlessButton} from './presentation';
 
 export type EditorProps = {
     id?: string
@@ -145,14 +145,15 @@ const InspectorEditorWithLinkType: React.FC<{
     const {Preview} = props.linkType;
 
     if (props.disabled) {
-        // todo add grey overlay like with disabled button and invalid mouse cursor effect
         return error ? (
             <ErrorView error={error} />
         ) : (
-            <Preview
-                model={model}
-                options={props.options}
-            />
+            <DisabledWrap>
+                <Preview
+                    model={model}
+                    options={props.options}
+                />
+            </DisabledWrap>
         )
     }
 

--- a/packages/neos-ui-link-editor-inspector/src/InspectorEditor.tsx
+++ b/packages/neos-ui-link-editor-inspector/src/InspectorEditor.tsx
@@ -7,7 +7,7 @@ import {
     IEditor
 } from '@neos-project/neos-ui-link-editor-core';
 import {AnyError, ErrorBoundary, ErrorView} from '@neos-project/neos-ui-error';
-import {ILink} from '@neos-project/neos-ui-link-editor-core/src/domain';
+import {ILink, useSortedAndFilteredLinkTypes} from '@neos-project/neos-ui-link-editor-core/src/domain';
 import {ILinkOptions} from '@neos-project/neos-ui-link-editor-core/src/domain';
 import {
     convertILinkToSerializedLinkValue,
@@ -39,8 +39,11 @@ export const createInspectorEditor = (dataType: LinkDataType, editor: IEditor) =
 
     const serializedLink = resolveSerializedLinkFromValue(props.value, dataType);
 
+    const availableLinkTypes = useSortedAndFilteredLinkTypes(editor);
+
     const linkType = useLinkTypeForHref(
-        serializedLinkToILink(serializedLink)?.href ?? null
+        serializedLinkToILink(serializedLink)?.href ?? null,
+        availableLinkTypes
     );
 
     const enabledLinkOptions = React.useMemo(() => {

--- a/packages/neos-ui-link-editor-inspector/src/InspectorEditor.tsx
+++ b/packages/neos-ui-link-editor-inspector/src/InspectorEditor.tsx
@@ -85,14 +85,11 @@ export const createInspectorEditor = (dataType: LinkDataType, editor: IEditor) =
         const result = await transactions.editLink(
             serializedLinkToILink(serializedLink),
             enabledLinkOptions,
-            upcastLegacyLinkEditorOptions(
-                props.options?.linkTypes,
-                {
-                    linkTypes: {
-                        ...props.options?.linkTypes
-                    }
+            props.options?.linkTypes ? ({
+                linkTypes: {
+                    ...props.options?.linkTypes
                 }
-            )
+            }) : upcastLegacyLinkEditorOptions(props.options?.linkTypes)
         );
 
         if (result.change) {

--- a/packages/neos-ui-link-editor-inspector/src/presentation/DisabledWrap/index.tsx
+++ b/packages/neos-ui-link-editor-inspector/src/presentation/DisabledWrap/index.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import styles from './style.module.css'
+
+export const DisabledWrap: React.FC = props => {
+    return <div className={styles.disabled}>{props.children}</div>
+}

--- a/packages/neos-ui-link-editor-inspector/src/presentation/DisabledWrap/style.module.css
+++ b/packages/neos-ui-link-editor-inspector/src/presentation/DisabledWrap/style.module.css
@@ -1,0 +1,6 @@
+
+.disabled {
+    opacity: .5;
+    cursor: not-allowed;
+    user-select: none;
+}

--- a/packages/neos-ui-link-editor-inspector/src/presentation/index.tsx
+++ b/packages/neos-ui-link-editor-inspector/src/presentation/index.tsx
@@ -1,2 +1,3 @@
 
+export {DisabledWrap} from './DisabledWrap'
 export {SeamlessButton} from './SeamlessButton'

--- a/packages/react-ui-components/src/Dialog/dialog.spec.tsx
+++ b/packages/react-ui-components/src/Dialog/dialog.spec.tsx
@@ -17,6 +17,7 @@ describe('<Dialog/>', () => {
             'dialog': 'dialogClassName',
             'dialog--narrow': 'narrowClassName',
             'dialog--wide': 'wideClassName',
+            'dialog--auto': 'autoClassName',
             'dialog--jumbo': 'jumboClassName',
             'dialog--success': 'successClassName',
             'dialog--warn': 'warnClassName',

--- a/packages/react-ui-components/src/Dialog/dialog.tsx
+++ b/packages/react-ui-components/src/Dialog/dialog.tsx
@@ -4,7 +4,7 @@ import {createPortal} from 'react-dom';
 import {Dialog, DialogManager} from './DialogManager';
 
 type DialogType = 'success' | 'warn' | 'error';
-type DialogStyle = 'wide' | 'jumbo' | 'narrow';
+type DialogStyle = 'wide' | 'auto' | 'jumbo' | 'narrow';
 
 interface DialogTheme {
     readonly 'dialog': string;
@@ -15,6 +15,7 @@ interface DialogTheme {
     readonly 'dialog__closeBtn': string;
     readonly 'dialog__actions': string;
     readonly 'dialog--wide': string;
+    readonly 'dialog--auto': string;
     readonly 'dialog--jumbo': string;
     readonly 'dialog--narrow': string;
     readonly 'dialog--success': string;
@@ -56,8 +57,9 @@ export interface DialogProps {
 
     /**
      * The `style` prop defines the visual style of the `Dialog`.
+     * Set to "wide" by default.
      */
-    readonly style: DialogStyle;
+    readonly style?: DialogStyle;
 
     /**
      * The contents to be rendered within the Dialog.
@@ -208,7 +210,8 @@ class DialogWithOverlay extends PureComponent<DialogProps> {
         const sectionClassName = mergeClassNames(
             theme!.dialog,
             {
-                [theme!['dialog--wide']]: style === 'wide',
+                [theme!['dialog--wide']]: !style || style === 'wide',
+                [theme!['dialog--auto']]: style === 'auto',
                 [theme!['dialog--jumbo']]: style === 'jumbo',
                 [theme!['dialog--narrow']]: style === 'narrow'
             },

--- a/packages/react-ui-components/src/Dialog/style.module.css
+++ b/packages/react-ui-components/src/Dialog/style.module.css
@@ -7,19 +7,21 @@
 
 .dialog {
     composes: reset from '../reset.module.css';
-    position: fixed;
+    position: absolute;
     top: 0;
     left: 0;
     z-index: var(--zIndex-Dialog);
     width: 100vw;
     height: 100vh;
     background: rgba(0, 0, 0, .8);
-    display: grid;
-    align-items: center;
-    justify-content: center;
 }
 .dialog__contentsPosition {
     composes: reset from '../reset.module.css';
+    margin: auto;
+    position: fixed;
+    inset: 0;
+    width: fit-content;
+    height: fit-content;
     background: var(--colors-ContrastDarker);
     box-shadow: 0 20px 40px rgba(0, 0, 0, .4);
     border-radius: 0;

--- a/packages/react-ui-components/src/Dialog/style.module.css
+++ b/packages/react-ui-components/src/Dialog/style.module.css
@@ -41,6 +41,16 @@
     max-height: 80vh;
 
     .dialog--wide & {
+        max-width: calc(var(--spacing-GoldenUnit) * 24);
+        min-width: calc(var(--spacing-GoldenUnit) * 18);
+
+        @media(max-width: 576px) {
+            max-width: 100vw;
+            width: 100vw;
+        }
+    }
+
+    .dialog--auto & {
         min-width: calc(var(--spacing-GoldenUnit) * 18);
 
         @media(max-width: 576px) {

--- a/packages/react-ui-components/src/Dialog/style.module.css
+++ b/packages/react-ui-components/src/Dialog/style.module.css
@@ -1,7 +1,7 @@
 @keyframes slideDialogContents {
     from {
         opacity: 0;
-        transform: translate(-50%, -50%) scale(.9);
+        transform: scale(.9);
     }
 }
 
@@ -14,13 +14,12 @@
     width: 100vw;
     height: 100vh;
     background: rgba(0, 0, 0, .8);
+    display: grid;
+    align-items: center;
+    justify-content: center;
 }
 .dialog__contentsPosition {
     composes: reset from '../reset.module.css';
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%) scale(1);
     background: var(--colors-ContrastDarker);
     box-shadow: 0 20px 40px rgba(0, 0, 0, .4);
     border-radius: 0;


### PR DESCRIPTION
Just a tiny followup attempting to polish the new link editor (#3996) to absolute shininess ;)

Most importantly we support now `popovers` inside dialogs and thus clickoutside to close for the advanced link options.

<img width="1124" height="760" alt="image" src="https://github.com/user-attachments/assets/a7f698f0-b214-4e6c-a7c1-204c641422d9" />

Getting popovers to work in our dialog was not trivial as `transform translate -50%` trips browsers off (even though the spec allows it). Now we center the dialog via `margin: auto` on all axis. The change https://github.com/neos/neos-ui/pull/4007 is partly readjusted herby as dialog style `wide` does no longer allow to expand to the full width. For more details see commits below.

 - https://github.com/neos/neos-ui/pull/4037/commits/7caa659cfd0f810e76ab1c76f1d93b50ded21e4a (alternative: use flex/grid: https://github.com/neos/neos-ui/pull/4037/commits/75d9daf6dd29361b1839116b502ddc2c0af788ec)
 - https://github.com/neos/neos-ui/pull/4037/commits/2a4802420501b6fe7573d4ec447e86c6f53857c7


Todo:
- [x] solve new mandatory todos from link editor pr (in code)
- [x] fix dialog flex box centering - its now too wide with too much text
- [x] add preview of anchor in node and asset card
- [x] "Force download" and "Herunterladen erzwingen" as label
- [x] Phone validation without leading 0 is wrong label

**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
