### PR TITLE
TASK: Fix jenkins release build step

### DIFF
--- a/Build/Jenkins/release-neos-ui.sh
+++ b/Build/Jenkins/release-neos-ui.sh
@@ -44,6 +44,7 @@ make install
 # actual release process
 
 # build
+make build-production
 make build-subpackages
 
 # code quality


### PR DESCRIPTION
The first build step was replaced with the subpackage build step in 78c9719e5db7cf6124d3709f99ea0839669d461f, but they rely on each other.