### PR TITLE
BUGFIX: Correctly handle empty children for notInlineEditable overlay

### DIFF
--- a/packages/neos-ui-guest-frame/src/initializeContentDomNode.js
+++ b/packages/neos-ui-guest-frame/src/initializeContentDomNode.js
@@ -19,7 +19,7 @@ export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry}
     }
 
     const isHidden = nodes?.[contextPath]?.properties?._hidden;
-    const hasChildren = Boolean(nodes?.[contextPath]?.children);
+    const hasChildren = Boolean(nodes?.[contextPath]?.children?.length);
     const isInlineEditable = nodeTypesRegistry.isInlineEditable(nodes?.[contextPath]?.nodeType);
     const matchesCurrentDimensions = !nodes?.[contextPath]?.matchesCurrentDimensions;
 


### PR DESCRIPTION
Correctly handle empty child-node array when checking if a node can get a not-inline-editable overlay

Resolves #4040 