### PR TITLE
TASK: Fix test-plugin build in Jenkins release

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -82,8 +82,8 @@ jobs:
       - name: Build for js for e2e
         run: |
           cd "../${{ env.PACKAGE_FOLDER }}"
-          make build-e2e-testing
           make build-subpackages
+          make build-e2e-testing
 
       - name: Cache Composer packages
         uses: actions/cache@v4

--- a/Build/Jenkins/release-neos-ui.sh
+++ b/Build/Jenkins/release-neos-ui.sh
@@ -44,7 +44,6 @@ make install
 # actual release process
 
 # build
-make build-production
 make build-subpackages
 
 # code quality

--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,10 @@ setup: check-requirements install build ## Run a clean setup
 # Builds
 ################################################################################
 
-# Builds the subpackages for standalone use.
+# Builds the subpackages for standalone use. The test plugin is built last, as it depends on the other packages being finished.
 build-subpackages:
-	yarn workspaces foreach --parallel run build
+	yarn workspaces foreach --parallel --exclude @neos-project/neos-ui-test-plugin run build
+	yarn workspace @neos-project/neos-ui-test-plugin run build
 
 ## Runs the development build.
 build:

--- a/packages/neos-ui-extensibility/src/types.d.ts
+++ b/packages/neos-ui-extensibility/src/types.d.ts
@@ -11,9 +11,9 @@ declare module '@neos-project/neos-ui-extensibility' {
     type BootstrapDependencies = {
         // correct store type depends on https://github.com/neos/neos-ui/pull/4010
         store: any;
-        /** @deprecated use "import {getFrontendConfigurationForPackage} from '@neos-project/neos-ui-configuration'" instead */
+        /** @deprecated use `import {getFrontendConfigurationForPackage} from '@neos-project/neos-ui-configuration'` instead */
         frontendConfiguration: Record<string, any>;
-        /** @deprecated use "import {getConfiguration} from '@neos-project/neos-ui-registry'" instead */
+        /** @deprecated use `import {getConfiguration} from '@neos-project/neos-ui-registry'` instead */
         configuration: Configuration;
         routes: Routes;
     };


### PR DESCRIPTION
This changes makes sure, that all normal packages are build first, so that the test-plugin can access their built sources.