### PR TITLE
TASK: Simplify `make build-subpackages`

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -21,6 +21,10 @@ jobs:
         run: make install-and-verify
       - name: Lint
         run: make lint
+      - name: Run production build
+        run: make build-production
+      - name: Run NPM build of sub-packages
+        run: make build-subpackages
 
   unittests:
     runs-on: ubuntu-latest
@@ -33,7 +37,5 @@ jobs:
           cache: 'yarn'
       - name: Install
         run: make install-and-verify
-      - name: Build
-        run: make build-production
       - name: Test
         run: make test

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -82,7 +82,6 @@ jobs:
       - name: Build for js for e2e
         run: |
           cd "../${{ env.PACKAGE_FOLDER }}"
-          make build-subpackages
           make build-e2e-testing
 
       - name: Cache Composer packages

--- a/Makefile
+++ b/Makefile
@@ -78,10 +78,9 @@ setup: check-requirements install build ## Run a clean setup
 # Builds
 ################################################################################
 
-# Builds the subpackages for standalone use. The test plugin is built last, as it depends on the other packages being finished.
+# Builds the subpackages for standalone use.
 build-subpackages:
-	yarn workspaces foreach --parallel --exclude @neos-project/neos-ui-test-plugin run build
-	yarn workspace @neos-project/neos-ui-test-plugin run build
+	yarn workspaces foreach --parallel run build
 
 ## Runs the development build.
 build:
@@ -98,7 +97,7 @@ build-production:
 
 build-e2e-testing:
 	yarn workspace @neos-project/neos-ui-extensibility run build
-	yarn workspace @neos-project/neos-ui-test-plugin run build
+	yarn workspace @neos-project/neos-ui-test-plugin run build-testing
 	node esbuild.js --production --e2e-testing
 
 ################################################################################

--- a/Tests/IntegrationTests/TestDistribution/DistributionPackages/Neos.TestNodeTypes/Resources/Private/neos-ui-test-plugin/package.json
+++ b/Tests/IntegrationTests/TestDistribution/DistributionPackages/Neos.TestNodeTypes/Resources/Private/neos-ui-test-plugin/package.json
@@ -5,8 +5,9 @@
   "private": true,
   "main": "./src/index.ts",
   "license": "GNU GPLv3",
+  "//": "NOTE: Before 'build-testing' is run the '@neos-project/neos-ui-extensibility' package must be build as this build will reference its dist for actual testing.",
   "scripts": {
-    "build": "node esbuild.js"
+    "build-testing": "node esbuild.js"
   },
   "dependencies": {
     "@neos-project/neos-ui-extensibility": "workspace:*",


### PR DESCRIPTION
Fixup for https://github.com/neos/neos-ui/pull/4044 to solve the ambiguity and of the new testing packages `build` and the dependency order.

Sorry seb for this funky problem <3


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
