### PR TITLE
BUGFIX: Additional node info view show NodeAddress and hide name if empty

### DIFF
--- a/packages/neos-ui-views/src/NodeInfoView/index.js
+++ b/packages/neos-ui-views/src/NodeInfoView/index.js
@@ -45,7 +45,7 @@ export default class NodeInfoView extends PureComponent {
             lastModification: node?.lastModificationDateTime,
             lastPublication: node?.lastPublicationDateTime,
             nodeAddress: node?.contextPath,
-            name: node?.name ?? '/'
+            name: node?.name
         };
 
         const nodeType = node?.nodeType;
@@ -70,14 +70,16 @@ export default class NodeInfoView extends PureComponent {
                     <div className={style.nodeInfoView__title}>{i18nRegistry.translate('identifier', 'Identifier', {}, 'Neos.Neos')}</div>
                     <NodeInfoViewContent>{properties.identifier}</NodeInfoViewContent>
                 </li>
-                <li className={style.nodeInfoView__item} title={properties.contextPath}>
+                <li className={style.nodeInfoView__item} title={properties.nodeAddress}>
                     <div className={style.nodeInfoView__title}>{i18nRegistry.translate('nodeAddress', 'Node Address', {}, 'Neos.Neos')}</div>
-                    <NodeInfoViewContent>{properties.contextPath}</NodeInfoViewContent>
+                    <NodeInfoViewContent>{properties.nodeAddress}</NodeInfoViewContent>
                 </li>
-                <li className={style.nodeInfoView__item} title={properties.name}>
-                    <div className={style.nodeInfoView__title}>{i18nRegistry.translate('name', 'Name', {}, 'Neos.Neos')}</div>
-                    <NodeInfoViewContent>{properties.name ?? i18nRegistry.translate('unavailable', 'unavailable', {}, 'Neos.Neos')}</NodeInfoViewContent>
-                </li>
+                {properties.name ? (
+                    <li className={style.nodeInfoView__item} title={properties.name}>
+                        <div className={style.nodeInfoView__title}>{i18nRegistry.translate('name', 'Name', {}, 'Neos.Neos')}</div>
+                        <NodeInfoViewContent>{properties.name ?? i18nRegistry.translate('unavailable', 'unavailable', {}, 'Neos.Neos')}</NodeInfoViewContent>
+                    </li>
+                ) : ''}
                 <li className={style.nodeInfoView__item} title={nodeType}>
                     <div
                         className={style.nodeInfoView__title}>{i18nRegistry.translate('type', 'Type', {}, 'Neos.Neos')}</div>

--- a/packages/neos-ui-views/src/NodeInfoView/index.js
+++ b/packages/neos-ui-views/src/NodeInfoView/index.js
@@ -4,6 +4,7 @@ import {connect} from 'react-redux';
 import {neos} from '@neos-project/neos-ui-decorators';
 import {selectors} from '@neos-project/neos-ui-redux-store';
 import {IconButton} from '@neos-project/react-ui-components';
+import {showFlashMessage} from '@neos-project/neos-ui-error';
 import style from './style.module.css';
 
 @connect(state => ({
@@ -29,9 +30,17 @@ export default class NodeInfoView extends PureComponent {
         const result = document.execCommand('copy');
 
         if (result) {
-            this.props.addFlashMessage('copiedToClipboard', 'Copied nodetype to clipboard', 'success');
+            showFlashMessage({
+                id: 'copiedToClipboard',
+                message: 'Copied nodetype to clipboard',
+                severity: 'success'
+            });
         } else {
-            this.props.addFlashMessage('copiedToClipboardFailed', 'Could not copy to clipboard', 'error');
+            showFlashMessage({
+                id: 'copiedToClipboardFailed',
+                message: 'Could not copy to clipboard',
+                severity: 'error'
+            });
         }
     }
 
@@ -83,7 +92,7 @@ export default class NodeInfoView extends PureComponent {
                 <li className={style.nodeInfoView__item} title={nodeType}>
                     <div
                         className={style.nodeInfoView__title}>{i18nRegistry.translate('type', 'Type', {}, 'Neos.Neos')}</div>
-                    <textarea ref={this.nodeTypeNameRef} className={style.nodeInfoView__nodeTypeTextarea}>{nodeType}</textarea>
+                    <textarea ref={this.nodeTypeNameRef} className={style.nodeInfoView__nodeTypeTextarea} value={nodeType} readOnly></textarea>
                     <NodeInfoViewContent>
                         <span dangerouslySetInnerHTML={{__html: wrappingNodeTypeName}}></span>
                     </NodeInfoViewContent>


### PR DESCRIPTION
Regression from https://github.com/neos/neos-ui/pull/3931

| Before | After |
|--------|--------|
| <img width="301" height="435" alt="image" src="https://github.com/user-attachments/assets/6a09eec3-4d99-4e29-a7cc-c914bab1aa67" /> | <img width="308" height="437" alt="image" src="https://github.com/user-attachments/assets/85ce5be5-77fe-4458-8beb-e325d70ea686" /> | 

**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
