### PR TITLE
BUGFIX: Exception when using cut and paste node to move node to current position

### DIFF
--- a/Classes/Domain/Model/Changes/MoveAfter.php
+++ b/Classes/Domain/Model/Changes/MoveAfter.php
@@ -67,6 +67,10 @@ class MoveAfter extends AbstractStructuralChange
             } catch (InvalidArgumentException $e) {
                 // do nothing; $succeedingSibling is null.
             }
+            if ($succeedingSibling?->aggregateId->equals($subject->aggregateId)) {
+                // we move the node to its current position. This is a noop for the zero dimensional case but with dimensions we might still want to execute the command to possibly adjust other variants
+                $succeedingSibling = null;
+            }
 
             $hasEqualParentNode = $parentNode->aggregateId
                 ->equals($parentNodeOfPreviousSibling->aggregateId);

--- a/Classes/Domain/Model/Changes/MoveBefore.php
+++ b/Classes/Domain/Model/Changes/MoveBefore.php
@@ -63,6 +63,10 @@ class MoveBefore extends AbstractStructuralChange
             } catch (\InvalidArgumentException $e) {
                 // do nothing; $precedingSibling is null.
             }
+            if ($precedingSibling?->aggregateId->equals($subject->aggregateId)) {
+                // we move the node to its current position. This is a noop for the zero dimensional case but with dimensions we might still want to execute the command to possibly adjust other variants
+                $precedingSibling = null;
+            }
 
             $hasEqualParentNode = $parentNode->aggregateId
                 ->equals($succeedingSiblingParent->aggregateId);


### PR DESCRIPTION

The CR rightfully complains as we kinda do bungus here :)

> Node aggregate "d8a8a5e5-275f-c01b-c6be-f082ef11d0ad" is no sibling of node aggregate "d8a8a5e5-275f-c01b-c6be-f082ef11d0ad" but was expected to be in dimension space point {"language":"en_US"}

While we could `return;` here in the operation the Move operation could still have an effect with multiple dimension at play and depending on the `RelationDistributionStrategy` - so for consistency we still execute the move.

This fix will be especially relevant with drag and drop where the source node is removed optimistically and not reset because of missing error handling

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
