### PR TITLE
FEATURE: Show content tree by default when opening the Neos Ui for the first time

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -175,7 +175,7 @@ Neos:
           leftSideBar:
             isHidden: false
             contentTree:
-              isHidden: true
+              isHidden: false
             searchBar:
               isVisible: false
           rightSideBar:

--- a/Tests/IntegrationTests/Fixtures/1Dimension/createNewNodeInContainer.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/createNewNodeInContainer.e2e.js
@@ -10,8 +10,6 @@ fixture`Create new nodes`
     .afterEach(() => checkPropTypes());
 
 test('Create a text node in a new container element at the correct position', async t => {
-    await t.click(Selector('#neos-ContentTree-ToggleContentTree'));
-
     subSection('Create content collection node');
     await t
         .click(Page.treeNode.withText('Content Collection (main)'))

--- a/Tests/IntegrationTests/Fixtures/1Dimension/createNewNodes.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/createNewNodes.e2e.js
@@ -16,7 +16,6 @@ fixture`Create new nodes`
 test('Check ClientEval for dependencies between properties of NodeTypes in Creation Dialog', async t => {
     // create node with NodeType labeled: NodeWithDependingProperties_Test
     await t
-        .click(Selector('#neos-ContentTree-ToggleContentTree'))
         .click(Page.treeNode.withText('Content Collection (main)'))
         .click(Selector('#neos-ContentTree-AddNode'))
         .click(ReactSelector('NodeTypeItem').find('button>span>span').withText('NodeWithDependingProperties_Test'))
@@ -115,7 +114,6 @@ test('Create an Image node from ContentTree', async t => {
 
     subSection('Create Image node');
     await t
-        .click(Selector('#neos-ContentTree-ToggleContentTree'))
         .click(Page.treeNode.withText('Content Collection (main)'))
         .click(Selector('#neos-ContentTree-AddNode'))
         .click(ReactSelector('NodeTypeItem').find('button>span>span').withText('Image_Test'));
@@ -221,7 +219,6 @@ test('Can duplicate content node from inside InlineUI', async t => {
 test('Inline CKEditor mode `paragraph: false` works as expected', async t => {
     subSection('Create an inline headline node');
     await t
-        .click(Selector('#neos-ContentTree-ToggleContentTree'))
         .click(Page.treeNode.withText('Content Collection (main)'))
         .click(Selector('#neos-ContentTree-AddNode'))
         .click(ReactSelector('NodeTypeItem').withProps({nodeType: {label: 'Inline_Headline_Test'}}));

--- a/Tests/IntegrationTests/Fixtures/1Dimension/discarding.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/discarding.e2e.js
@@ -99,7 +99,6 @@ test('Discarding: create a content node and then discard it', async t => {
 
     subSection('Create a content node');
     await t
-        .click(Selector('#neos-ContentTree-ToggleContentTree'))
         .click(Page.treeNode.withText('Content Collection (main)'))
         .click(Selector('#neos-ContentTree-AddNode'))
         .click(ReactSelector('NodeTypeItem').find('button>span>span').withText('Headline_Test'));
@@ -134,7 +133,6 @@ test('Discarding: delete a content node and then discard deletion', async t => {
 
     subSection('Delete this headline');
     await t
-        .click(Selector('#neos-ContentTree-ToggleContentTree'))
         .click(Page.treeNode.withText(headlineToDelete))
         .click(Selector('#neos-ContentTree-DeleteSelectedNode'))
         .click(Selector('#neos-DeleteNodeModal-Confirm'));

--- a/Tests/IntegrationTests/Fixtures/1Dimension/inspector.e2e.js
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/inspector.e2e.js
@@ -75,7 +75,6 @@ test('Can edit the page title via inspector', async t => {
 
 test('Check ClientEval for dependencies between properties of NodeTypes in Inspector', async t => {
     await t
-        .click(Selector('#neos-ContentTree-ToggleContentTree'))
         .click(Page.treeNode.withText('Content Collection (main)'))
         .click(Selector('#neos-ContentTree-AddNode'))
         .click(ReactSelector('NodeTypeItem').find('button>span>span').withText('NodeWithDependingProperties_Test'))

--- a/Tests/IntegrationTests/Fixtures/1Dimension/linkEditor.e2e.ts
+++ b/Tests/IntegrationTests/Fixtures/1Dimension/linkEditor.e2e.ts
@@ -31,7 +31,6 @@ test('Open and close link editor dialog without saving the change', async t => {
     const LinkStringValue = ReactSelector('EditorEnvelope').withProps({ identifier: 'linkString' }).getReact(({props}) => props.value);
 
     await Page.goToPage('Link editor')
-    await t.click(Selector('#neos-ContentTree-ToggleContentTree'));
     await t.click(Page.treeNode.withText('LinkEditor_Test'));
 
     // after each subSection the state must be reset -> order of these subsections does not matter
@@ -436,7 +435,6 @@ test('Open and close link editor dialog without saving the change', async t => {
 
 test('Can edit property links via inspector and save the change', async t => {
     await Page.goToPage('Link editor')
-    await t.click(Selector('#neos-ContentTree-ToggleContentTree'));
     await t.click(Page.treeNode.withText('LinkEditor_Test'));
 
     await t.switchToIframe('[name="neos-content-main"]');
@@ -654,7 +652,6 @@ test('Can edit property links via inspector and save the change', async t => {
 
 test('PageTree search and filter in link editor document selection', async t => {
     await Page.goToPage('Link editor')
-    await t.click(Selector('#neos-ContentTree-ToggleContentTree'));
     await t.click(Page.treeNode.withText('LinkEditor_Test'));
 
     await t.click(LinkStringProperty.withExactText('Create Link'));


### PR DESCRIPTION
The toggle state of the content tree (structure tree) is persisted in the local storage.

We as users known to users open it on new projects out of reflex but new users might not even be aware that it exists.

To ensure new users to neos get familiar with the structure of a site its crucial to see the layout of the content nodes which also sometimes eases operations that are not possible in the inline Ui because of too complex visual layouts.

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
