### PR TITLE
BUGFIX: Properly handle variation of tethered children of root nodes…

### DIFF
--- a/Classes/Domain/Model/Changes/Property.php
+++ b/Classes/Domain/Model/Changes/Property.php
@@ -311,7 +311,12 @@ class Property extends AbstractChange
             $subgraph = $this->contentRepositoryRegistry->subgraphForNode($subject);
             // if the node to vary is tethered, traverse to the closest non-tethered ancestor and vary that one instead
             while ($nodeToVary?->classification->isTethered()) {
-                $nodeToVary = $subgraph->findParentNode($nodeToVary->aggregateId);
+                $parentNode = $subgraph->findParentNode($nodeToVary->aggregateId);
+                if ($parentNode?->classification->isRoot()) {
+                    // varying tethered children of root nodes is allowed (as opposed to varying root nodes)
+                    break;
+                }
+                $nodeToVary = $parentNode;
             }
             if ($nodeToVary === null) {
                 throw new \RuntimeException('Could not find a non-tethered ancestor for node ' . $subject->aggregateId->value, 1761246525);

--- a/Tests/Behavior/Features/VariationOfNodesWithUnvariedTetheredAncestors.feature
+++ b/Tests/Behavior/Features/VariationOfNodesWithUnvariedTetheredAncestors.feature
@@ -10,6 +10,9 @@ Feature: When triggering auto-variation via property set, vary the closest non-t
     'Neos.Neos:Sites':
       superTypes:
         Neos.ContentRepository:Root: true
+      childNodes:
+        tetheredsite:
+          type: 'Neos.ContentRepository.Testing:Site'
     'Neos.Neos:Site': []
     'Neos.ContentRepository.Testing:AnotherTethered':
       properties:
@@ -25,6 +28,9 @@ Feature: When triggering auto-variation via property set, vary the closest non-t
       childNodes:
         tethered:
           type: 'Neos.ContentRepository.Testing:Tethered'
+      properties:
+        siteText:
+          type: string
     """
         And using identifier "default", I define a content repository
         And I am in content repository "default"
@@ -35,12 +41,13 @@ Feature: When triggering auto-variation via property set, vary the closest non-t
             | newContentStreamId | "cs-identifier" |
         And I am in workspace "live" and dimension space point {"example":"source"}
         And the command CreateRootNodeAggregateWithNode is executed with payload:
-            | Key             | Value                    |
-            | nodeAggregateId | "lady-eleonode-rootford" |
-            | nodeTypeName    | "Neos.Neos:Sites"        |
+            | Key                                | Value                                                                                                                                              |
+            | nodeAggregateId                    | "lady-eleonode-rootford"                                                                                                                           |
+            | nodeTypeName                       | "Neos.Neos:Sites"                                                                                                                                  |
+            | tetheredDescendantNodeAggregateIds | {"tetheredsite": "nody-mc-siteface", "tetheredsite/tethered": "nodewyn-sitetherton", "tetheredsite/tethered/child-tethered": "nody-mc-tetherface"} |
         And the following CreateNodeAggregateWithNode commands are executed:
-            | nodeAggregateId        | nodeTypeName                           | parentNodeAggregateId  | nodeName | tetheredDescendantNodeAggregateIds                                                |
-            | sir-david-nodenborough | Neos.ContentRepository.Testing:Site    | lady-eleonode-rootford | site     | {"tethered": "nodewyn-tetherton", "tethered/child-tethered": "nody-mc-nodeface"} |
+            | nodeAggregateId        | nodeTypeName                        | parentNodeAggregateId  | nodeName | tetheredDescendantNodeAggregateIds                                               |
+            | sir-david-nodenborough | Neos.ContentRepository.Testing:Site | lady-eleonode-rootford | site     | {"tethered": "nodewyn-tetherton", "tethered/child-tethered": "nody-mc-nodeface"} |
         And A site exists for node name "site" and domain "http://localhost"
         And the sites configuration is:
             """yaml
@@ -78,6 +85,46 @@ Feature: When triggering auto-variation via property set, vary the closest non-t
         Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-id;sir-david-nodenborough;{"example":"spec"}
         And I expect node aggregate identifier "nodewyn-tetherton" to lead to node user-cs-id;nodewyn-tetherton;{"example":"spec"}
         And I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-id;nody-mc-nodeface;{"example":"spec"}
+        And I expect this node to have the following properties:
+            | Key  | Value           |
+            | text | my variant text |
+
+    Scenario: Create a variant of a node whose tethered parent is a root node
+        When I dispatch the following neos-ui change:
+        """json
+        {
+            "type": "Neos.Neos.Ui:Property",
+            "subject": "{\"contentRepositoryId\":\"default\",\"workspaceName\":\"user-workspace\",\"dimensionSpacePoint\":{\"example\":\"spec\"},\"aggregateId\":\"nody-mc-siteface\"}",
+            "payload": {
+                "propertyName": "siteText",
+                "value": "my variant site text"
+            }
+        }
+        """
+
+        When I am in workspace "user-workspace" and dimension space point {"example":"spec"}
+        And I expect node aggregate identifier "nody-mc-siteface" to lead to node user-cs-id;nody-mc-siteface;{"example":"spec"}
+        And I expect this node to have the following properties:
+            | Key      | Value                |
+            | siteText | my variant site text |
+
+    Scenario: Create a variant of a node whose tethered parent is not yet varied and the non-tethered ancestor is a root node
+        When I dispatch the following neos-ui change:
+        """json
+        {
+            "type": "Neos.Neos.Ui:Property",
+            "subject": "{\"contentRepositoryId\":\"default\",\"workspaceName\":\"user-workspace\",\"dimensionSpacePoint\":{\"example\":\"spec\"},\"aggregateId\":\"nody-mc-tetherface\"}",
+            "payload": {
+                "propertyName": "text",
+                "value": "my variant text"
+            }
+        }
+        """
+
+        When I am in workspace "user-workspace" and dimension space point {"example":"spec"}
+        And I expect node aggregate identifier "nody-mc-siteface" to lead to node user-cs-id;nody-mc-siteface;{"example":"spec"}
+        And I expect node aggregate identifier "nodewyn-sitetherton" to lead to node user-cs-id;nodewyn-sitetherton;{"example":"spec"}
+        And I expect node aggregate identifier "nody-mc-tetherface" to lead to node user-cs-id;nody-mc-tetherface;{"example":"spec"}
         And I expect this node to have the following properties:
             | Key  | Value           |
             | text | my variant text |


### PR DESCRIPTION
…and their descendants

**What I did**

Tethered nodes cannot be varied (except if they can, see below), so the UI finds the closest un-tethered ancestor to vary instead.
This becomes a problem if said ancestor is a root node, which can happen if one e.g. tethers a site node to the sites root.
The CR already covers this case by making an exception for tethered variation - in exactly that case.
The UI now uses that functionality to avoid unresolvable errors.

**How I did it**

I threw tests at it and checked for root classification

**How to verify it**

Run the tests of try for yourself
