### PR TITLE
BUGFIX: Prevent clicking structural toolbar to be behind content

### DIFF
--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/StructuralToolbar/style.module.css
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/StructuralToolbar/style.module.css
@@ -38,7 +38,6 @@
     margin-bottom: -12px;
 }
 .structuralToolBar__popover.structuralToolBar__popover--isBelow {
-    z-index: initial;
     position-anchor: --inline-ui-node-toolbar-anchor;
     position-area: bottom center;
     position-try-fallbacks: --structural-toolbar-align-bottom-fallback;


### PR DESCRIPTION
In the „below“ case it was possible that the structural toolbar was behind the next content element of the currently selected one. With this change we increase the z-index for the standard and hover case, to also allow selecting the toolbar on hover when the formatting toolbar is also at the bottom.

Resolves: #4054

<img width="1116" height="1628" alt="CleanShot 2025-12-18 at 09 30 29@2x" src="https://github.com/user-attachments/assets/7dec83e3-620b-41c2-be46-3eb206525972" />

