### PR TITLE
BUGFIX: Convert enums to their backing value for the UI

### DIFF
--- a/Classes/Domain/Service/NodePropertyConverterService.php
+++ b/Classes/Domain/Service/NodePropertyConverterService.php
@@ -197,6 +197,9 @@ class NodePropertyConverterService
      */
     protected function convertValue($propertyValue, $dataType)
     {
+        if ($propertyValue instanceof \BackedEnum) {
+            return $propertyValue->value;
+        }
         if ($propertyValue instanceof \JsonSerializable && DenormalizingObjectConverter::isDenormalizable($propertyValue::class)) {
             /**
              * Value object support, as they can be stored directly the node properties


### PR DESCRIPTION
**What I did**

I tried to edit enums in the UI and found out that they were serialized as an array. This fixes that.

**How I did it**

I added a specific check to the NodePropertyConverterService

**How to verify it**

declare an enum property value using the textfield editor and try editing it
