### PR TITLE
BUGFIX: Prevent confirmation dialog when switching inspector tabs

### DIFF
--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/style.module.css
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/style.module.css
@@ -61,8 +61,7 @@
         content: '';
         top: 0;
         right: 0;
-        /* 101px accounts for the "Selected element" drop down */
-        height: calc(var(--spacing-GoldenUnit) + 101px);
+        height: calc(var(--spacing-GoldenUnit));
         width: var(--size-SidebarWidth);
     }
 }


### PR DESCRIPTION
The overlay that triggers the dialog was not adjusted for the removed „Current Selection“ element.

Resolves: #4061

<img width="1224" height="870" alt="CleanShot 2026-01-07 at 10 32 40@2x" src="https://github.com/user-attachments/assets/5e874241-696b-4fe1-acfa-436a81abfc9c" />
