### PR TITLE
BUGFIX: Scroll to focused element in guest frame

### DIFF
--- a/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.tsx
+++ b/packages/neos-ui-guest-frame/src/InlineUI/NodeToolbar/index.tsx
@@ -9,8 +9,7 @@ import {
 // @ts-ignore
 } from '@neos-project/neos-ui-guest-frame/src/dom';
 import {neos} from '@neos-project/neos-ui-decorators';
-import {selectors, useSelector} from '@neos-project/neos-ui-redux-store';
-import {InsertPosition} from '@neos-project/neos-ts-interfaces';
+import {InsertPosition, Node} from '@neos-project/neos-ts-interfaces';
 import {NodeTypesRegistry} from '@neos-project/neos-ui-contentrepository';
 import {I18nRegistry} from '@neos-project/neos-ui-i18n';
 
@@ -36,6 +35,7 @@ type NodeToolbarProps = {
     canBeDeleted: boolean;
     canBeEdited: boolean;
     destructiveOperationsAreDisabled: boolean;
+    focusedNode?: Node;
     fusionPath?: string;
     isCopied: boolean;
     isCut: boolean;
@@ -49,6 +49,7 @@ const NodeToolbar: React.FC<NodeToolbarProps & InjectedNodeToolbarProps> = ({
     canBeDeleted,
     canBeEdited,
     destructiveOperationsAreDisabled,
+    focusedNode,
     fusionPath,
     i18nRegistry,
     isCopied,
@@ -59,7 +60,6 @@ const NodeToolbar: React.FC<NodeToolbarProps & InjectedNodeToolbarProps> = ({
     visibilityCanBeToggled,
     visible
 }) => {
-    const focusedNode = useSelector(selectors.CR.Nodes.focusedSelector);
     const [insertPosition, setInsertPosition] = useState<InsertPosition>(InsertPosition.AFTER);
     const [anchorPosition, setAnchorPosition] = useState<{top: number, left: number, height: number, right: number, width: number}|null>(null);
 

--- a/packages/neos-ui-guest-frame/src/InlineUI/index.js
+++ b/packages/neos-ui-guest-frame/src/InlineUI/index.js
@@ -79,6 +79,7 @@ export default class InlineUI extends PureComponent {
                     canBeEdited={canBeEdited}
                     visibilityCanBeToggled={visibilityCanBeToggled}
                     visible={!isWorkspaceReadOnly}
+                    focusedNode={focusedNode}
                     {...focused}
                     />}
                 <InlineValidationErrors />


### PR DESCRIPTION
This solves a regression in Neos 9.1 when the toolbar was refactored to a functional component. The focusedNode in the state was still the previous node in the function instead of the newly selected one. With this change we make sure that the focusedNode matches the updated state with the scroll request.

Resolves: #4064
