### PR TITLE
BUGFIX: Sanitise breadcrumb label

### DIFF
--- a/packages/neos-ui/src/Containers/Breadcrumb/index.tsx
+++ b/packages/neos-ui/src/Containers/Breadcrumb/index.tsx
@@ -6,8 +6,11 @@ import {neos} from '@neos-project/neos-ui-decorators';
 import {Node} from '@neos-project/neos-ts-interfaces';
 import {NodeTypesRegistry} from '@neos-project/neos-ui-contentrepository';
 import {Button, Icon} from '@neos-project/react-ui-components';
+import {stripTags, decodeHtml} from '@neos-project/utils-helpers';
 
 import style from './style.module.css';
+
+const decodeLabel = (label: string) => decodeHtml(stripTags(label || ''));
 
 const withReduxState = connect((state: GlobalState) => ({
     focusedNodeParentLine: selectors.CR.Nodes.focusedNodeParentLineSelector(state),
@@ -57,6 +60,7 @@ const Breadcrumb: React.FC<{
                         const nodeType = nodeTypesRegistry.get(node.nodeType);
                         const isActive = node.contextPath === focusedNode?.contextPath;
                         const labelMaxLength = isActive ? 30 : 15;
+                        const label = decodeLabel(node.label).trim();
                         return (
                             <li key={node.contextPath}>
                                 <Button
@@ -64,10 +68,10 @@ const Breadcrumb: React.FC<{
                                     style="transparent"
                                     hoverStyle="clean"
                                     size="small"
-                                    title={node.label}
+                                    title={label}
                                 >
                                     <Icon icon={nodeType?.ui?.icon || 'file'} />
-                                    {node.label.slice(0, labelMaxLength) + (node.label.length > labelMaxLength ? '…' : '')}
+                                    {label.slice(0, labelMaxLength) + (label.length > labelMaxLength ? '…' : '')}
                                 </Button>
                             </li>
                         )

--- a/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
+++ b/packages/neos-ui/src/Containers/LeftSideBar/NodeTree/Node/index.js
@@ -290,7 +290,7 @@ export default class Node extends PureComponent {
 
         const directLink = (isContentTreeNode ? undefined : this.createDirectNodeLink());
 
-        const labelTitle = decodeLabel(node?.label) + ' (' + this.getNodeTypeLabel() + ')';
+        const labelTitle = decodeLabel(node?.label).trim() + ' (' + this.getNodeTypeLabel() + ')';
 
         // Autocreated or we have nested nodes and the node that we are dragging belongs to the selection
         // For read only workspaces we also forbid drag and drop
@@ -314,7 +314,7 @@ export default class Node extends PureComponent {
                     isHiddenInIndex={node?.properties?.hiddenInMenu || this.isIntermediate()}
                     isDragging={currentlyDraggedNodes.includes(node.contextPath)}
                     hasError={this.hasError()}
-                    label={decodeLabel(node?.label)}
+                    label={decodeLabel(node?.label).trim()}
                     icon={this.getIcon()}
                     customIconComponent={this.getCustomIconComponent()}
                     iconLabel={this.getNodeTypeLabel()}


### PR DESCRIPTION
Also trims spaces around labels in breadcrumb and node tree

Resolves: #4067