### PR TITLE
BUGFIX: Refactor `tryFromString` 

### DIFF
--- a/packages/neos-ui-i18n/src/model/TranslationAddress.spec.ts
+++ b/packages/neos-ui-i18n/src/model/TranslationAddress.spec.ts
@@ -77,7 +77,6 @@ describe('TranslationAddress', () => {
         expect(translationAddress?.fullyQualified).toBe('Some.Package:SomeSource:some.transunit.id:extra');
     });
 
-
     it('try with invalid string returns null', () => {
         expect(TranslationAddress.tryFromString('foo bar')).toBeNull();
         expect(TranslationAddress.tryFromString('something:')).toBeNull();

--- a/packages/neos-ui-i18n/src/model/TranslationAddress.spec.ts
+++ b/packages/neos-ui-i18n/src/model/TranslationAddress.spec.ts
@@ -83,4 +83,15 @@ describe('TranslationAddress', () => {
         // error in placeholder https://github.com/neos/neos-ui/pull/3907
         expect(TranslationAddress.tryFromString('ClientEval: node.properties.tagName')).toBeNull();
     });
+
+    it('try with empty segments returns null', () => {
+        expect(TranslationAddress.tryFromString('::')).toBeNull();
+        expect(TranslationAddress.tryFromString('a::')).toBeNull();
+        expect(TranslationAddress.tryFromString(':a:')).toBeNull();
+        expect(TranslationAddress.tryFromString(':a')).toBeNull();
+        expect(TranslationAddress.tryFromString('::a')).toBeNull();
+
+        expect(TranslationAddress.tryFromString('a:b:')).toBeNull();
+        expect(TranslationAddress.tryFromString('a::b')).toBeNull();
+    });
 });

--- a/packages/neos-ui-i18n/src/model/TranslationAddress.spec.ts
+++ b/packages/neos-ui-i18n/src/model/TranslationAddress.spec.ts
@@ -34,6 +34,17 @@ describe('TranslationAddress', () => {
         expect(translationAddress.fullyQualified).toBe('Some.Package:SomeSource:some.transunit.id');
     });
 
+    it('can be created from string with more than one colon', () => {
+        const translationAddress = TranslationAddress.fromString(
+            'Some.Package:SomeSource:some.transunit.id:extra'
+        );
+
+        expect(translationAddress.id).toBe('some.transunit.id:extra');
+        expect(translationAddress.sourceName).toBe('SomeSource');
+        expect(translationAddress.packageKey).toBe('Some.Package');
+        expect(translationAddress.fullyQualified).toBe('Some.Package:SomeSource:some.transunit.id:extra');
+    });
+
     it('throws if given an invalid string', () => {
         expect(() => TranslationAddress.fromString('foo bar'))
             .toThrow(
@@ -53,6 +64,19 @@ describe('TranslationAddress', () => {
         expect(translationAddress?.packageKey).toBe('Some.Package');
         expect(translationAddress?.fullyQualified).toBe('Some.Package:SomeSource:some.transunit.id');
     });
+
+    it('can be trycreated from string with more than one colon', () => {
+        const translationAddress = TranslationAddress.tryFromString(
+            'Some.Package:SomeSource:some.transunit.id:extra'
+        );
+
+        expect(translationAddress).not.toBeNull();
+        expect(translationAddress?.id).toBe('some.transunit.id:extra');
+        expect(translationAddress?.sourceName).toBe('SomeSource');
+        expect(translationAddress?.packageKey).toBe('Some.Package');
+        expect(translationAddress?.fullyQualified).toBe('Some.Package:SomeSource:some.transunit.id:extra');
+    });
+
 
     it('try with invalid string returns null', () => {
         expect(TranslationAddress.tryFromString('foo bar')).toBeNull();

--- a/packages/neos-ui-i18n/src/model/TranslationAddress.ts
+++ b/packages/neos-ui-i18n/src/model/TranslationAddress.ts
@@ -25,7 +25,9 @@ export class TranslationAddress {
         new TranslationAddress(props.id, props.sourceName, props.packageKey, `${props.packageKey}:${props.sourceName}:${props.id}`);
 
     public static tryFromString = (value: string): TranslationAddress | null => {
-        const [packageKey, sourceName, ...rest] = value.split(TRANSLATION_ADDRESS_SEPARATOR);
+        const split = value.split(TRANSLATION_ADDRESS_SEPARATOR);
+        if(split.length < 3) return null;
+        const [packageKey, sourceName, ...rest] = split;
 
         if (!packageKey || !sourceName || rest.length === 0) {
             return null;

--- a/packages/neos-ui-i18n/src/model/TranslationAddress.ts
+++ b/packages/neos-ui-i18n/src/model/TranslationAddress.ts
@@ -24,16 +24,17 @@ export class TranslationAddress {
     }): TranslationAddress =>
         new TranslationAddress(props.id, props.sourceName, props.packageKey, `${props.packageKey}:${props.sourceName}:${props.id}`);
 
-    public static tryFromString = (string: string): TranslationAddress|null => {
-        const parts = string.split(TRANSLATION_ADDRESS_SEPARATOR);
-        if (parts.length !== 3) {
+    public static tryFromString = (value: string): TranslationAddress | null => {
+        const [packageKey, sourceName, ...rest] = value.split(TRANSLATION_ADDRESS_SEPARATOR);
+
+        if (!packageKey || !sourceName || rest.length === 0) {
             return null;
         }
 
-        const [packageKey, sourceName, id] = parts;
+        const id = rest.join(TRANSLATION_ADDRESS_SEPARATOR);
 
-        return new TranslationAddress(id, sourceName, packageKey, string);
-    }
+        return new TranslationAddress(id, sourceName, packageKey, value);
+    };
 
     public static fromString = (string: string): TranslationAddress => {
         const translationAddress = TranslationAddress.tryFromString(string);

--- a/packages/neos-ui-i18n/src/model/TranslationAddress.ts
+++ b/packages/neos-ui-i18n/src/model/TranslationAddress.ts
@@ -33,11 +33,11 @@ export class TranslationAddress {
 
         const [packageKey, sourceName, ...rest] = split;
 
-        if (!packageKey || !sourceName || rest.length === 0) {
+        const id = rest?.join(TRANSLATION_ADDRESS_SEPARATOR) ?? null;
+
+        if (!packageKey || !sourceName || !id) {
             return null;
         }
-
-        const id = rest.join(TRANSLATION_ADDRESS_SEPARATOR);
 
         return new TranslationAddress(id, sourceName, packageKey, value);
     };

--- a/packages/neos-ui-i18n/src/model/TranslationAddress.ts
+++ b/packages/neos-ui-i18n/src/model/TranslationAddress.ts
@@ -26,7 +26,11 @@ export class TranslationAddress {
 
     public static tryFromString = (value: string): TranslationAddress | null => {
         const split = value.split(TRANSLATION_ADDRESS_SEPARATOR);
-        if(split.length < 3) return null;
+
+        if (split.length < 3) {
+            return null;
+        }
+
         const [packageKey, sourceName, ...rest] = split;
 
         if (!packageKey || !sourceName || rest.length === 0) {


### PR DESCRIPTION
Currently, it is not possible to have a colon in a translation identifier. I don't see a reason for prohibit this, it only confuses people.

With this change, it is now possible to have as many colons as you want after the file XLF file definition.

Example from my use case, which failed:

```
Medienreaktor.Site:Content.Section:properties.renderComponent.values.Medienreaktor.Site:Component.Section.Default
```

Didn't work before, not it works

