### PR TITLE
TASK: Provide Missing Ckeditor5 Extension Points

### DIFF
--- a/packages/neos-ui-extensibility/extensibilityMap.json
+++ b/packages/neos-ui-extensibility/extensibilityMap.json
@@ -17,6 +17,11 @@
     "@ckeditor/ckeditor5-widget": "@neos-project/neos-ui-extensibility/dist/shims/vendor/ckeditor5-widget",
     "@ckeditor/ckeditor5-highlight": "@neos-project/neos-ui-extensibility/dist/shims/vendor/ckeditor5-highlight",
     "@ckeditor/ckeditor5-ui": "@neos-project/neos-ui-extensibility/dist/shims/vendor/ckeditor5-ui",
+    "@ckeditor/ckeditor5-clipboard": "@neos-project/neos-ui-extensibility/dist/shims/vendor/ckeditor5-clipboard",
+    "@ckeditor/ckeditor5-typing": "@neos-project/neos-ui-extensibility/dist/shims/vendor/ckeditor5-typing",
+    "@ckeditor/ckeditor5-undo": "@neos-project/neos-ui-extensibility/dist/shims/vendor/ckeditor5-undo",
+    "@ckeditor/ckeditor5-upload": "@neos-project/neos-ui-extensibility/dist/shims/vendor/ckeditor5-upload",
+    "@ckeditor/ckeditor5-utils": "@neos-project/neos-ui-extensibility/dist/shims/vendor/ckeditor5-utils",
 
     "@neos-project/react-ui-components": "@neos-project/neos-ui-extensibility/dist/shims/neosProjectPackages/react-ui-components",
     "@neos-project/neos-ui-backend-connector": "@neos-project/neos-ui-extensibility/dist/shims/neosProjectPackages/neos-ui-backend-connector",

--- a/packages/neos-ui-extensibility/src/shims/vendor/ckeditor5-clipboard/index.js
+++ b/packages/neos-ui-extensibility/src/shims/vendor/ckeditor5-clipboard/index.js
@@ -1,0 +1,3 @@
+import readFromConsumerApi from '../../../readFromConsumerApi';
+
+module.exports = readFromConsumerApi('vendor')().CkEditor5Clipboard;

--- a/packages/neos-ui-extensibility/src/shims/vendor/ckeditor5-typing/index.js
+++ b/packages/neos-ui-extensibility/src/shims/vendor/ckeditor5-typing/index.js
@@ -1,0 +1,3 @@
+import readFromConsumerApi from '../../../readFromConsumerApi';
+
+module.exports = readFromConsumerApi('vendor')().CkEditor5Typing;

--- a/packages/neos-ui-extensibility/src/shims/vendor/ckeditor5-undo/index.js
+++ b/packages/neos-ui-extensibility/src/shims/vendor/ckeditor5-undo/index.js
@@ -1,0 +1,3 @@
+import readFromConsumerApi from '../../../readFromConsumerApi';
+
+module.exports = readFromConsumerApi('vendor')().CkEditor5Undo;

--- a/packages/neos-ui-extensibility/src/shims/vendor/ckeditor5-upload/index.js
+++ b/packages/neos-ui-extensibility/src/shims/vendor/ckeditor5-upload/index.js
@@ -1,0 +1,3 @@
+import readFromConsumerApi from '../../../readFromConsumerApi';
+
+module.exports = readFromConsumerApi('vendor')().CkEditor5Upload;

--- a/packages/neos-ui-extensibility/src/shims/vendor/ckeditor5-utils/index.js
+++ b/packages/neos-ui-extensibility/src/shims/vendor/ckeditor5-utils/index.js
@@ -1,0 +1,3 @@
+import readFromConsumerApi from '../../../readFromConsumerApi';
+
+module.exports = readFromConsumerApi('vendor')().CkEditor5Utils;

--- a/packages/neos-ui/src/apiExposureMap.js
+++ b/packages/neos-ui/src/apiExposureMap.js
@@ -47,6 +47,11 @@ import * as CkEditor5Engine from '@ckeditor/ckeditor5-engine';
 import * as CkEditor5Widget from '@ckeditor/ckeditor5-widget';
 import * as CkEditor5Highlight from '@ckeditor/ckeditor5-highlight';
 import * as CkEditor5Ui from '@ckeditor/ckeditor5-ui';
+import * as CkEditor5Clipboard from '@ckeditor/ckeditor5-clipboard';
+import * as CkEditor5Typing from '@ckeditor/ckeditor5-typing';
+import * as CkEditor5Undo from '@ckeditor/ckeditor5-undo';
+import * as CkEditor5Upload from '@ckeditor/ckeditor5-upload';
+import * as CkEditor5Utils from '@ckeditor/ckeditor5-utils';
 
 // Compatibility export for CkEditor5 for plugins using older CKE5 versions (<46)
 const CkEditor5 = {
@@ -88,6 +93,11 @@ export default {
         CkEditor5Widget,
         CkEditor5Highlight,
         CkEditor5Ui,
+        CkEditor5Clipboard,
+        CkEditor5Typing,
+        CkEditor5Undo,
+        CkEditor5Upload,
+        CkEditor5Utils,
         HTML5Backend,
         ReactDND
     }),


### PR DESCRIPTION
see https://github.com/neos/neos-ui/pull/4028#issuecomment-3779141448

this will allow for a plugin to bundle the ckeditor image plugin:) see https://codeberg.org/PackageFactory/PackageFactory.CkInlineImages

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
