### PR TITLE
BUGFIX: clear dataloader debounce timers

### DIFF
--- a/packages/neos-ui/src/manifest.dataloaders.js
+++ b/packages/neos-ui/src/manifest.dataloaders.js
@@ -126,6 +126,9 @@ manifest('main.dataloaders', {}, globalRegistry => {
 
             const cacheKey = makeCacheKey('search', {options, searchTerm});
             if (this._lru().has(cacheKey)) {
+                if (this._debounceTimer) {
+                    window.clearTimeout(this._debounceTimer);
+                }
                 return this._lru().get(cacheKey);
             }
 
@@ -215,6 +218,9 @@ manifest('main.dataloaders', {}, globalRegistry => {
             const cacheKey = makeCacheKey('search', {options, searchTerm});
 
             if (this._lru().has(cacheKey)) {
+                if (this._debounceTimer) {
+                    window.clearTimeout(this._debounceTimer);
+                }
                 return this._lru().get(cacheKey);
             }
 
@@ -292,6 +298,9 @@ manifest('main.dataloaders', {}, globalRegistry => {
             const cacheKey = makeCacheKey('search', {options, searchTerm});
 
             if (this._lru().has(cacheKey)) {
+                if (this._debounceTimer) {
+                    window.clearTimeout(this._debounceTimer);
+                }
                 return this._lru().get(cacheKey);
             }
 


### PR DESCRIPTION
If the search is not cancelled, when a cached search term is requested, the last uncached substring of the search term will be requested and its results returned.

Resolves #4047 