### PR TITLE
BUGFIX: Dont attempt to manipulate MediaBrowser iframe in LinkEditor which disables search input

### DIFF
--- a/packages/neos-ui-link-editor-core/src/application/LinkTypes/Asset/MediaBrowser.tsx
+++ b/packages/neos-ui-link-editor-core/src/application/LinkTypes/Asset/MediaBrowser.tsx
@@ -10,8 +10,6 @@ interface Props {
 }
 
 export const MediaBrowser: React.FC<Props> = (props) => {
-    const containerRef = React.useRef<HTMLDivElement>(null)
-
     const secondaryEditorsRegistry = getRegistryById('inspector')?.get('secondaryEditors');
 
     const secondaryEditorId = 'Neos.Neos/Inspector/Secondary/Editors/MediaSelectionScreen';
@@ -19,31 +17,8 @@ export const MediaBrowser: React.FC<Props> = (props) => {
 
     const MediaSelectionScreenComponent = secondaryEditor?.component;
 
-    // The standard MediaBrowser of Neos uses an iframe and requires some styles to be applied to the iframe content
-    const iframe = containerRef.current?.querySelector('& > iframe') as HTMLIFrameElement
-
-    React.useEffect(() => {
-        const handleIframeLoad = (ev: Event) => {
-            const iframeDocument = (ev.target as HTMLIFrameElement).contentDocument
-            if (iframeDocument) {
-                iframeDocument.body.style.overflowX = 'hidden'
-                iframeDocument.body.style.padding = '0'
-                iframeDocument.querySelector('form > .neos-footer')?.remove()
-                iframeDocument.querySelectorAll('input, select, textarea')?.forEach((input) => {
-                    (input as HTMLInputElement).readOnly = true
-                })
-            }
-        }
-
-        iframe?.addEventListener('load', handleIframeLoad)
-
-        return () => {
-            iframe?.removeEventListener('load', handleIframeLoad)
-        }
-    }, [iframe])
-
     return (
-        <div className={style.container} ref={containerRef}>
+        <div className={style.container}>
             {
                 MediaSelectionScreenComponent ? (
                     <MediaSelectionScreenComponent


### PR DESCRIPTION
Subtask of https://github.com/neos/neos-ui/issues/4059
Solves https://github.com/neos/neos-ui/issues/4076

As part of an artefact from the original Archaeopteryx LinkEditor implementation the iframe html was modfied to has less spacing around, no footer (for navigation) and all inputs were attempted to be disabled.

Due to a timing issue this modification to the iframe only takes place for new links. Existing asset links did show the media browser in its original form.

Now the html manipulation is flawed (obviously):
- Because its a hack and behaviour should instead be configured via a query parameter or new route
- Editing of images was attempted to be prohibited, but "Edit", "Delete" was still clickable
- From the "Edit" screen there is no navigation back because we remove the footer
- In the "Edit" screen checkboxes are still clickable because they were not considered
- Valid inputs like the search field do no longer work
- The html manipulation is hard to properly apply on an iframe and did not apply for existing asset links

Instead this change removes the manipulation as it is totally superfluous in the first way considering that in other points the Neos Ui - linke for image selection in the inspector - shows also the full Media Module with all its features. Also the padding is now slightly bigger around the MediaSelection but everything is still well accessible.

| Type | Overview | Details (dot menu -> "Edit") |
|--------|--------|--------|
| Before | ![Bildschirmfoto 2026-02-25 um 19 15](https://github.com/user-attachments/assets/b72a26ad-7528-430b-9036-88793bf3d576) | ![Bildschirmfoto 2026-02-25 um 19 16](https://github.com/user-attachments/assets/0b11f94e-afff-4cf3-8ea7-360662aaabaf) | 
| After | ![Bildschirmfoto 2026-02-25 um 19 14 01](https://github.com/user-attachments/assets/47cd4e83-f744-4562-bf98-7c3adaf2f7d1) | ![Bildschirmfoto 2026-02-25 um 19 14](https://github.com/user-attachments/assets/51fda5cd-b7f6-4656-adef-f94e6c182cea) |

**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
