### PR TITLE
TASK: Expose UI framework functions to plugin extensibility api

### DIFF
--- a/packages/neos-ui-extensibility/extensibilityMap.json
+++ b/packages/neos-ui-extensibility/extensibilityMap.json
@@ -34,5 +34,8 @@
     "@neos-project/neos-ui-guest-frame": "@neos-project/neos-ui-extensibility/dist/shims/neosProjectPackages/neos-ui-guest-frame",
     "@neos-project/neos-ui-registry": "@neos-project/neos-ui-extensibility/dist/shims/neosProjectPackages/neos-ui-registry",
     "@neos-project/neos-ui-configuration": "@neos-project/neos-ui-extensibility/dist/shims/neosProjectPackages/neos-ui-configuration",
+    "@neos-project/framework-observable": "@neos-project/neos-ui-extensibility/dist/shims/neosProjectPackages/framework-observable",
+    "@neos-project/framework-observable-react": "@neos-project/neos-ui-extensibility/dist/shims/neosProjectPackages/framework-observable-react",
+    "@neos-project/framework-promise-react": "@neos-project/neos-ui-extensibility/dist/shims/neosProjectPackages/framework-promise-react",
     "@neos-project/utils-redux": "@neos-project/neos-ui-extensibility/dist/shims/neosProjectPackages/utils-redux"
 }

--- a/packages/neos-ui-extensibility/src/shims/neosProjectPackages/framework-observable-react/index.js
+++ b/packages/neos-ui-extensibility/src/shims/neosProjectPackages/framework-observable-react/index.js
@@ -1,0 +1,3 @@
+import readFromConsumerApi from '../../../readFromConsumerApi';
+
+module.exports = readFromConsumerApi('NeosProjectPackages')().NeosUiObservableReact;

--- a/packages/neos-ui-extensibility/src/shims/neosProjectPackages/framework-observable/index.js
+++ b/packages/neos-ui-extensibility/src/shims/neosProjectPackages/framework-observable/index.js
@@ -1,0 +1,3 @@
+import readFromConsumerApi from '../../../readFromConsumerApi';
+
+module.exports = readFromConsumerApi('NeosProjectPackages')().NeosUiObservable;

--- a/packages/neos-ui-extensibility/src/shims/neosProjectPackages/framework-promise-react/index.js
+++ b/packages/neos-ui-extensibility/src/shims/neosProjectPackages/framework-promise-react/index.js
@@ -1,0 +1,3 @@
+import readFromConsumerApi from '../../../readFromConsumerApi';
+
+module.exports = readFromConsumerApi('NeosProjectPackages')().NeosUiPromiseReact;

--- a/packages/neos-ui/src/apiExposureMap.js
+++ b/packages/neos-ui/src/apiExposureMap.js
@@ -16,7 +16,7 @@ import * as NeosUiReduxStore from '@neos-project/neos-ui-redux-store';
 import * as NeosUiDecorators from '@neos-project/neos-ui-decorators';
 import * as NeosUiEditors from '@neos-project/neos-ui-editors/src/index';
 import * as UtilsRedux from '@neos-project/utils-redux';
-import NeosUiI18n from '@neos-project/neos-ui-i18n';
+import * as NeosUiI18n from '@neos-project/neos-ui-i18n';
 import * as CkEditorApi from '@neos-project/neos-ui-ckeditor5-bindings/src/ckEditorApi';
 import NeosUiBackendConnectorDefault, * as NeosUiBackendConnector from '@neos-project/neos-ui-backend-connector';
 import * as NeosUiViews from '@neos-project/neos-ui-views';
@@ -108,7 +108,13 @@ export default {
         CkEditorApi,
         NeosUiDecorators,
         NeosUiEditors,
-        NeosUiI18n,
+        NeosUiI18n: {
+            ...NeosUiI18n,
+            // declare export to be an ESM, otherwise the default legacy export `<I18n>` will not be resolved in a plugin.
+            // Usually done via see `Object.defineProperty(exports, "__esModule", { value: true });`.
+            // As this object will later be assigned to module.exports we configure it here already.
+            __esModule: true
+        },
         NeosUiReduxStore,
         NeosUiViews,
         NeosUiGuestFrameDom,

--- a/packages/neos-ui/src/apiExposureMap.js
+++ b/packages/neos-ui/src/apiExposureMap.js
@@ -23,6 +23,9 @@ import * as NeosUiViews from '@neos-project/neos-ui-views';
 import * as NeosUiGuestFrameDom from '@neos-project/neos-ui-guest-frame/src/dom';
 import * as NeosUiRegistry from '@neos-project/neos-ui-registry';
 import * as NeosUiConfiguration from '@neos-project/neos-ui-configuration';
+import * as NeosUiObservable from '@neos-project/framework-observable';
+import * as NeosUiObservableReact from '@neos-project/framework-observable-react';
+import * as NeosUiPromiseReact from '@neos-project/framework-promise-react';
 
 // We export most needed components from CKE5 to be used when making custom plugins.
 // It's not safe to just install CKE5 packages from the extension because then "instanceof" checks will no longer work,
@@ -122,6 +125,9 @@ export default {
         ReactUiComponents,
         NeosUiRegistry,
         NeosUiConfiguration,
+        NeosUiObservable,
+        NeosUiObservableReact,
+        NeosUiPromiseReact,
         UtilsRedux
 
         // TODO: how to write new reducers?


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

With https://github.com/neos/neos-ui/pull/3804 a new `translate` method was made available.
This change now exposes this new `translate()` function for plugins while preserving the legacy default export.

Currently, translation is possibly by importing (the default export)

```
import I18n from '@neos-project/neos-ui-i18n';
```

Now by allowing 

```
import {translate} from '@neos-project/neos-ui-i18n';
```

We are in the struggle as the default export is now due to the CJS conversion as `import I18n from` no longer accessible but double nested into `I18n.default`. This is perfectly elaborated here:

https://blog.andrewbran.ch/default-exports-in-commonjs-libraries/

To denote that everything we put into `module.exports` is to be taken as ESM - meaning the `default` key is special - we use the conventional flag `__esModule`.

As we adjust this part in the host Neos Ui code existing plugins will not break and continue to be able to import `<I18n>` from the default export. Simultaneously though we allow the use of `{translate}`

--------

Framework libraries for building the Neos Ui itself (e.g state handling) is now also exposed via the respective import. See the packages readmes for more detail, but be aware that these packages are currently for advanced plugin authors only and still under development.

- `@neos-project/framework-observable`
- `@neos-project/framework-observable-react`
- `@neos-project/framework-promise-react`

**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
