### PR TITLE
BUGFIX: New `translate()` function return address if no fallback specified and dont crash

### DIFF
--- a/packages/neos-ui-i18n/src/translate.spec.ts
+++ b/packages/neos-ui-i18n/src/translate.spec.ts
@@ -27,6 +27,11 @@ describe('translate', () => {
                 .toBe('This is another fallback');
         });
 
+        it('returns the address if no fallback is specified', () => {
+            expect(translate('Unknown.Package:UnknownSource:unknown.trans-unit.id'))
+                .toBe('Unknown.Package:UnknownSource:unknown.trans-unit.id');
+        });
+
         it('returns given "other" form of fallback when quantity = 0', () => {
             expect(translate('Unknown.Package:UnknownSource:unknown.trans-unit.id', ['Singular Fallback', 'Plural Fallback'], [], 0))
                 .toBe('Plural Fallback');

--- a/packages/neos-ui-i18n/src/translate.ts
+++ b/packages/neos-ui-i18n/src/translate.ts
@@ -36,7 +36,7 @@ import {substitutePlaceholders} from './registry';
  */
 export function translate(
     fullyQualifiedTranslationAddressAsString: string,
-    fallback: string | [string, string],
+    fallback: string | [string, string] = '',
     parameters: Parameters = [],
     quantity: number = 0
 ): string {
@@ -45,6 +45,10 @@ export function translate(
     const translation = translationRepository.findOneByAddress(translationAddress);
 
     if (translation === null) {
+        if (!fallback) {
+            console.warn(`The translation "${translationAddress.fullyQualified}" cannot be found and no fallback was specified.`)
+            return fullyQualifiedTranslationAddressAsString;
+        }
         return renderFallback(fallback, quantity, parameters);
     }
 


### PR DESCRIPTION
Followup to https://github.com/neos/neos-ui/pull/3804

Due to the assumption `fallback` is specified and a string we run in `substitutePlaceholders:22` into:

> TypeError: undefined is not an object (evaluating 'e.indexOf') —

Now instead we return the given translation address (as in Flow and with the Ui legacy translation functionality) and additionally emit a console warning:

> The translation address "Neos.Neos.Ui:Main:notexisint" cannot be resolved and no fallback was specified.

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->

Preparation for https://github.com/neos/neos-ui/pull/3912#issuecomment-3654337034

**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
