### PR TITLE
BUGFIX: Sort NodeType groups in NodeTypeGroupsAndRolesProvider

### DIFF
--- a/Classes/Infrastructure/ContentRepository/NodeTypeGroupsAndRolesProvider.php
+++ b/Classes/Infrastructure/ContentRepository/NodeTypeGroupsAndRolesProvider.php
@@ -16,6 +16,8 @@ namespace Neos\Neos\Ui\Infrastructure\ContentRepository;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Neos\Ui\Domain\InitialData\NodeTypeGroupsAndRolesProviderInterface;
+use Neos\Utility\Exception\InvalidPositionException;
+use Neos\Utility\PositionalArraySorter;
 
 /**
  * @internal
@@ -31,11 +33,15 @@ final class NodeTypeGroupsAndRolesProvider implements NodeTypeGroupsAndRolesProv
     #[Flow\InjectConfiguration(path: 'nodeTypes.groups', package: 'Neos.Neos')]
     protected array $groups;
 
+    /**
+     * @throws InvalidPositionException
+     */
     public function getNodeTypeGroupsAndRoles(): array
     {
+        $sortedGroups = new PositionalArraySorter($this->groups);
         return [
             'roles' => $this->roles,
-            'groups' => $this->groups,
+            'groups' => $sortedGroups->toArray(),
         ];
     }
 }


### PR DESCRIPTION
To prevent sorting the groups within the NeosUI on the JavaScript side, the NodeTypeGroupsAndRolesProvider is taking care of it, and so the initialState in the Neos backend will already start with correctly sorted groups.

In earlier versions, this was handled by Fusion.

Fixes: #4087