### PR TITLE
BUGFIX: Icon margin in selectbox

### DIFF
--- a/packages/react-ui-components/src/ListPreviewElement/style.module.css
+++ b/packages/react-ui-components/src/ListPreviewElement/style.module.css
@@ -25,7 +25,6 @@
 
 .listPreviewElement__icon {
     composes: reset from '../reset.module.css';
-    margin-right: .5em;
 }
 
 .listPreviewElement__iconWrapper {
@@ -33,4 +32,5 @@
     width: 2em;
     display: inline-block;
     text-align: center;
+    margin-right: 14px;
 }


### PR DESCRIPTION
Adjust margin between icon and value to match the padding of the selectbox

Resolves: #4089

<img width="644" height="518" alt="CleanShot 2026-03-04 at 11 58 00@2x" src="https://github.com/user-attachments/assets/a3133bfa-9750-422d-8d38-8e2ba0b32cae" />
