### PR TITLE
TASK: Harden new gh e2e tests, use `pull_request`.

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,9 +2,9 @@ name: E2E (Client, Server)
 on:
   workflow_dispatch:
   push:
-    branches: [ '9.[0-9]', '1[0-9].[0-9]' ]
-  pull_request_target:
-    branches: [ '9.[0-9]', '1[0-9].[0-9]' ]
+    branches: [ '[0-9]+.[0-9]' ]
+  pull_request:
+    branches: [ '[0-9]+.[0-9]' ]
 
 env:
   SAUCE_USERNAME: ${{secrets.SAUCE_USERNAME}}
@@ -46,12 +46,12 @@ jobs:
           - "3306:3306"
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
+    if: ${{ env.SAUCE_USERNAME && env.SAUCE_ACCESS_KEY }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        if: ${{ env.SAUCE_USERNAME && env.SAUCE_ACCESS_KEY }}
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           path: ${{ env.PACKAGE_FOLDER }}
 
       - name: Setup PHP


### PR DESCRIPTION
In combination with https://github.com/neos/neos-ui/pull/4100

Currently we use `pull_request_target` since https://github.com/neos/neos-ui/commit/473476391894a166aeca15cf5d8048bf44bcf8be to have the secrets `SAUCE_ACCESS_KEY` available.

Technically this workaround works but is possibly really dangerous. Our secrets currently contain only the sauce credentials wich are not critical and dont allow anything but running tests (though people could even use these to use the browser to access illegal content or something) - but more importantly we might add more valuable secrets like NPM tokens which definitely must not land in wrong hands.

Additionally using `pull_request_target` has the unfortunate side-effect that the 9.1 (e.g. master branch) ci configuration is always used for the test setup instead of the actual ci configuration on that branch e.g. 9.0. That leads to testing the Neos Ui 9.0 against a 9.1 Neos which is not intentional.

Also tweaks to the CI currently are also only effective once merged and cannot be tested within a PR.

Thats why we revert and  acknowledge the limitation.

<img width="456" height="127" alt="image" src="https://github.com/user-attachments/assets/53786d27-eee8-43a3-8fc5-7a7117411426" />


We should now distribute the sauce key to frequent trusted committers - like myself :D - so the tests continue to run there. But i fear github also limits this stupidly by not respecting ANY secrets in a fork pr, neither the secrets of the base repo which is acceptable but also for some reason not the secrets of the forked repo. -> Probably they think the maintainers might otherwise steal the secret of the fork repo which is starting to be hilarious.