### PR TITLE
BUGFIX: Support enums in value objects

### DIFF
--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -14,6 +14,7 @@ namespace Neos\Neos\Ui\Controller;
  * source code.
  */
 
+use GuzzleHttp\Psr7\Response;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Dto\RebaseErrorHandlingStrategy;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceContainsPublishableChanges;
@@ -27,7 +28,6 @@ use Neos\Flow\Log\ThrowableStorageInterface;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\ActionResponse;
 use Neos\Flow\Mvc\Controller\ActionController;
-use Neos\Flow\Mvc\View\JsonView;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Security\Context;
 use Neos\Neos\Domain\Service\WorkspacePublishingService;
@@ -60,6 +60,7 @@ use Neos\Neos\Ui\Fusion\Helper\WorkspaceHelper;
 use Neos\Neos\Ui\Service\NodeClipboard;
 use Neos\Neos\Ui\TypeConverter\ChangeCollectionConverter;
 use Neos\Neos\Utility\NodeUriPathSegmentGenerator;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * @internal
@@ -72,11 +73,6 @@ class BackendServiceController extends ActionController
      * @var array<int,string>
      */
     protected $supportedMediaTypes = ['application/json'];
-
-    /**
-     * @var string
-     */
-    protected $defaultViewObjectName = JsonView::class;
 
     /**
      * @Flow\Inject
@@ -196,7 +192,7 @@ class BackendServiceController extends ActionController
      * Apply a set of changes to the system
      * @phpstan-param list<array<string,mixed>> $changes
      */
-    public function changeAction(array $changes): void
+    public function changeAction(array $changes): ResponseInterface
     {
         $contentRepositoryId = SiteDetectionResult::fromRequest($this->request->getHttpRequest())->contentRepositoryId;
 
@@ -218,7 +214,7 @@ class BackendServiceController extends ActionController
             $this->feedbackCollection->add($error);
         }
 
-        $this->view->assign('value', $this->feedbackCollection);
+        return $this->createJsonResponse($this->feedbackCollection);
     }
 
     /**
@@ -226,7 +222,7 @@ class BackendServiceController extends ActionController
      *
      * @phpstan-param array{workspaceName:string,siteId:string,preferredDimensionSpacePoint?:array<string,string[]>} $command
      */
-    public function publishChangesInSiteAction(array $command): void
+    public function publishChangesInSiteAction(array $command): ResponseInterface
     {
         try {
             /** @todo send from UI */
@@ -240,10 +236,10 @@ class BackendServiceController extends ActionController
             $result = $this->publishChangesInSiteCommandHandler
                 ->handle($command);
 
-            $this->view->assign('value', $result);
+            return $this->createJsonResponse($result);
         } catch (\Exception $e) {
             $this->throwableStorage2->logThrowable($e);
-            $this->view->assign('value', [
+            return $this->createJsonResponse([
                 'error' => [
                     'class' => $e::class,
                     'code' => $e->getCode(),
@@ -259,7 +255,7 @@ class BackendServiceController extends ActionController
      *
      * @phpstan-param array{workspaceName:string,documentId:string,preferredDimensionSpacePoint?:array<string,string[]>} $command
      */
-    public function publishChangesInDocumentAction(array $command): void
+    public function publishChangesInDocumentAction(array $command): ResponseInterface
     {
         try {
             /** @todo send from UI */
@@ -273,10 +269,10 @@ class BackendServiceController extends ActionController
             $result = $this->publishChangesInDocumentCommandHandler
                 ->handle($command);
 
-            $this->view->assign('value', $result);
+            return $this->createJsonResponse($result);
         } catch (\Exception $e) {
             $this->throwableStorage2->logThrowable($e);
-            $this->view->assign('value', [
+            return $this->createJsonResponse([
                 'error' => [
                     'class' => $e::class,
                     'code' => $e->getCode(),
@@ -292,7 +288,7 @@ class BackendServiceController extends ActionController
      *
      * @phpstan-param array<string,string> $command
      */
-    public function discardAllChangesAction(array $command): void
+    public function discardAllChangesAction(array $command): ResponseInterface
     {
         try {
             /** @todo send from UI */
@@ -305,14 +301,14 @@ class BackendServiceController extends ActionController
                 $command->workspaceName
             );
 
-            $this->view->assign('value', [
+            return $this->createJsonResponse([
                 'success' => [
                     'numberOfAffectedChanges' => $discardingResult->numberOfDiscardedChanges
                 ]
             ]);
         } catch (\Exception $e) {
             $this->throwableStorage2->logThrowable($e);
-            $this->view->assign('value', [
+            return $this->createJsonResponse([
                 'error' => [
                     'class' => $e::class,
                     'code' => $e->getCode(),
@@ -328,7 +324,7 @@ class BackendServiceController extends ActionController
      *
      * @phpstan-param array<string,string> $command
      */
-    public function discardChangesInSiteAction(array $command): void
+    public function discardChangesInSiteAction(array $command): ResponseInterface
     {
         try {
             /** @todo send from UI */
@@ -345,14 +341,14 @@ class BackendServiceController extends ActionController
                 $command->siteId
             );
 
-            $this->view->assign('value', [
+            return $this->createJsonResponse([
                 'success' => [
                     'numberOfAffectedChanges' => $discardingResult->numberOfDiscardedChanges
                 ]
             ]);
         } catch (\Exception $e) {
             $this->throwableStorage2->logThrowable($e);
-            $this->view->assign('value', [
+            return $this->createJsonResponse([
                 'error' => [
                     'class' => $e::class,
                     'code' => $e->getCode(),
@@ -368,7 +364,7 @@ class BackendServiceController extends ActionController
      *
      * @phpstan-param array<string,string> $command
      */
-    public function discardChangesInDocumentAction(array $command): void
+    public function discardChangesInDocumentAction(array $command): ResponseInterface
     {
         try {
             /** @todo send from UI */
@@ -385,14 +381,14 @@ class BackendServiceController extends ActionController
                 $command->documentId
             );
 
-            $this->view->assign('value', [
+            return $this->createJsonResponse([
                 'success' => [
                     'numberOfAffectedChanges' => $discardingResult->numberOfDiscardedChanges
                 ]
             ]);
         } catch (\Exception $e) {
             $this->throwableStorage2->logThrowable($e);
-            $this->view->assign('value', [
+            return $this->createJsonResponse([
                 'error' => [
                     'class' => $e::class,
                     'code' => $e->getCode(),
@@ -411,7 +407,7 @@ class BackendServiceController extends ActionController
      * @return void
      * @throws \Exception
      */
-    public function changeBaseWorkspaceAction(string $targetWorkspaceName, string $documentNode): void
+    public function changeBaseWorkspaceAction(string $targetWorkspaceName, string $documentNode): ResponseInterface
     {
         $documentNodeAddress = NodeAddress::fromJsonString($documentNode);
 
@@ -420,8 +416,7 @@ class BackendServiceController extends ActionController
             $error = new Error();
             $error->setMessage('No authenticated account');
             $this->feedbackCollection->add($error);
-            $this->view->assign('value', $this->feedbackCollection);
-            return;
+            return $this->createJsonResponse($this->feedbackCollection);
         }
         $userWorkspace = $this->workspaceService->getPersonalWorkspaceForUser($documentNodeAddress->contentRepositoryId, $user->getId());
 
@@ -443,16 +438,14 @@ class BackendServiceController extends ActionController
             );
 
             $this->feedbackCollection->add($error);
-            $this->view->assign('value', $this->feedbackCollection);
-            return;
+            return $this->createJsonResponse($this->feedbackCollection);
         } catch (\Exception $e) {
             $this->throwableStorage2->logThrowable($e);
             $error = new Error();
             $error->setMessage($e->getMessage());
 
             $this->feedbackCollection->add($error);
-            $this->view->assign('value', $this->feedbackCollection);
-            return;
+            return $this->createJsonResponse($this->feedbackCollection);
         }
 
         $contentRepository = $this->contentRepositoryRegistry->get($documentNodeAddress->contentRepositoryId);
@@ -507,7 +500,7 @@ class BackendServiceController extends ActionController
             $this->feedbackCollection->add($redirect);
         }
 
-        $this->view->assign('value', $this->feedbackCollection);
+        return $this->createJsonResponse($this->feedbackCollection);
     }
 
 
@@ -519,7 +512,7 @@ class BackendServiceController extends ActionController
      * @throws \Neos\Flow\Property\Exception
      * @throws \Neos\Flow\Security\Exception
      */
-    public function copyNodesAction(array $nodes): void
+    public function copyNodesAction(array $nodes): ResponseInterface
     {
         /** @var array<int,NodeAddress> $nodeAddresses */
         $nodeAddresses = array_map(
@@ -546,7 +539,7 @@ class BackendServiceController extends ActionController
      * @throws \Neos\Flow\Property\Exception
      * @throws \Neos\Flow\Security\Exception
      */
-    public function cutNodesAction(array $nodes): void
+    public function cutNodesAction(array $nodes): ResponseInterface
     {
         /** @var array<int,NodeAddress> $nodeAddresses */
         $nodeAddresses = array_map(
@@ -557,17 +550,17 @@ class BackendServiceController extends ActionController
         $this->clipboard->cutNodes($nodeAddresses);
     }
 
-    public function getWorkspaceInfoAction(): void
+    public function getWorkspaceInfoAction(): ResponseInterface
     {
         $contentRepositoryId = SiteDetectionResult::fromRequest($this->request->getHttpRequest())->contentRepositoryId;
         $personalWorkspaceInfo = (new WorkspaceHelper())->getPersonalWorkspace($contentRepositoryId);
-        $this->view->assign('value', $personalWorkspaceInfo);
+        return $this->createJsonResponse($personalWorkspaceInfo);
     }
 
     /**
      * @throws \Neos\Flow\Mvc\Exception\NoSuchArgumentException
      */
-    public function initializeGetAdditionalNodeMetadataAction(): void
+    public function initializeGetAdditionalNodeMetadataAction(): ResponseInterface
     {
         $this->arguments->getArgument('nodes')
             ->getPropertyMappingConfiguration()->allowAllProperties();
@@ -577,7 +570,7 @@ class BackendServiceController extends ActionController
      * Fetches all the node information that can be lazy-loaded
      * @phpstan-param list<string> $nodes
      */
-    public function getAdditionalNodeMetadataAction(array $nodes): void
+    public function getAdditionalNodeMetadataAction(array $nodes): ResponseInterface
     {
         $result = [];
         foreach ($nodes as $nodeAddressString) {
@@ -608,7 +601,7 @@ class BackendServiceController extends ActionController
             }
         }
 
-        $this->view->assign('value', $result);
+        return $this->createJsonResponse($result);
     }
 
     /**
@@ -669,7 +662,7 @@ class BackendServiceController extends ActionController
      *
      * @throws \Neos\Neos\Exception
      */
-    public function generateUriPathSegmentAction(string $contextNode, string $text): void
+    public function generateUriPathSegmentAction(string $contextNode, string $text): ResponseInterface
     {
         $contextNodeAddress = NodeAddress::fromJsonString($contextNode);
         $contentRepository = $this->contentRepositoryRegistry->get($contextNodeAddress->contentRepositoryId);
@@ -680,7 +673,7 @@ class BackendServiceController extends ActionController
         $contextNode = $subgraph->findNodeById($contextNodeAddress->aggregateId);
 
         $slug = $this->nodeUriPathSegmentGenerator->generateUriPathSegment($contextNode, $text);
-        $this->view->assign('value', $slug);
+        return $this->createJsonResponse($slug);
     }
 
     /**
@@ -691,7 +684,7 @@ class BackendServiceController extends ActionController
      * @phpstan-param null|array<mixed> $dimensionSpacePoint
      * @return void
      */
-    public function syncWorkspaceAction(string $targetWorkspaceName, bool $force, ?array $dimensionSpacePoint): void
+    public function syncWorkspaceAction(string $targetWorkspaceName, bool $force, ?array $dimensionSpacePoint): ResponseInterface
     {
         try {
             $contentRepositoryId = SiteDetectionResult::fromRequest($this->request->getHttpRequest())->contentRepositoryId;
@@ -712,10 +705,10 @@ class BackendServiceController extends ActionController
 
             $result = $this->syncWorkspaceCommandHandler->handle($command);
 
-            $this->view->assign('value', $result);
+            return $this->createJsonResponse($result);
         } catch (\Exception $e) {
             $this->throwableStorage2->logThrowable($e);
-            $this->view->assign('value', [
+            return $this->createJsonResponse([
                 'error' => [
                     'class' => $e::class,
                     'code' => $e->getCode(),
@@ -730,7 +723,7 @@ class BackendServiceController extends ActionController
      * @phpstan-param array<mixed> $query
      * @return void
      */
-    public function reloadNodesAction(array $query): void
+    public function reloadNodesAction(array $query): ResponseInterface
     {
         /** @todo send from UI */
         $contentRepositoryId = SiteDetectionResult::fromRequest($this->request->getHttpRequest())->contentRepositoryId;
@@ -767,12 +760,12 @@ class BackendServiceController extends ActionController
 
         try {
             $result = $this->reloadNodesQueryHandler->handle($query, $this->request);
-            $this->view->assign('value', [
+            return $this->createJsonResponse([
                 'success' => $result
             ]);
         } catch (\Exception $e) {
             $this->throwableStorage2->logThrowable($e);
-            $this->view->assign('value', [
+            return $this->createJsonResponse([
                 'error' => [
                     'class' => $e::class,
                     'code' => $e->getCode(),
@@ -781,5 +774,14 @@ class BackendServiceController extends ActionController
                 ]
             ]);
         }
+    }
+
+    private function createJsonResponse(mixed $value): ResponseInterface
+    {
+        $jsonEncoded = json_encode($value, JSON_THROW_ON_ERROR);
+        return new Response(
+            headers: ['Content-Type' => 'application/json'],
+            body: $jsonEncoded
+        );
     }
 }

--- a/Classes/Domain/Service/NodePropertyConverterService.php
+++ b/Classes/Domain/Service/NodePropertyConverterService.php
@@ -192,13 +192,13 @@ class NodePropertyConverterService
      *
      * @param mixed $propertyValue the deserialized node property value
      * @param string $dataType the property type from the node type schema
-     * @return \JsonSerializable|int|float|string|bool|null|array<mixed>
+     * @return \JsonSerializable|\BackedEnum|int|float|string|bool|null|array<mixed>
      * @throws PropertyException
      */
     protected function convertValue($propertyValue, $dataType)
     {
         if ($propertyValue instanceof \BackedEnum) {
-            return $propertyValue->value;
+            return $propertyValue;
         }
         if ($propertyValue instanceof \JsonSerializable && DenormalizingObjectConverter::isDenormalizable($propertyValue::class)) {
             /**


### PR DESCRIPTION
Followup to https://github.com/neos/neos-ui/pull/4058

Before the deprecated JsonView from Flow was used which rendered enums as

```
{"name": "FOO", "value": "FOO"}
```

as enums are magically json serializable, jet dont specify to implement `JsonSerializable` directly.

That's way the condition `is_object($value) && $value instanceof \JsonSerializable` is skipped and all enum "properties" are serialized.

https://github.com/neos/flow-development-collection/blob/9e281f9fdf8490bc409038acb2f250728fb3c614/Neos.Flow/Classes/Mvc/View/JsonView.php#L270

To fix this we use plain json_encode wich encodes enums as expected without the developer having to implement `JsonSerializable` redundantly

```
"FOO"
```

see also https://3v4l.org/OZb1n#vnull

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
