### PR TITLE
BUGFIX: Prevent duplicate nodes in structure tree

### DIFF
--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -572,11 +572,12 @@ class BackendServiceController extends ActionController
                 );
                 break;
             case 'getForTree':
+                $usage = $finisher['payload']['usage'] ?? 'ALL';
                 $result = $nodeInfoHelper->renderNodes(
                     array_filter($flowQuery->get()),
                     $this->getControllerContext(),
-                    true,
-                    ($finisher['payload']['usage'] ?? 'ALL') !== 'PAGE_TREE',
+                    $usage === 'PAGE_TREE', // We only need minimal data for the document tree
+                    $usage !== 'PAGE_TREE', // Child node are only required for the structure tree
                 );
                 break;
             case 'getForTreeWithParents':

--- a/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
+++ b/packages/neos-ui-redux-store/src/CR/Nodes/index.ts
@@ -469,11 +469,19 @@ export const reducer = (state: State = defaultState, action: InitAction | EditPr
                     if (newNode.isFullyLoaded || !existingNode.children) {
                         mergedNode.children = newNode.children;
                     } else {
-                        // A non fully loaded node only contains document children, so we need to preserve existing non-document children
+                        // A non fully loaded node is either a node that was loaded for the document tree, or
+                        // a content node that didn't have all its children loaded. This can happen either when the
+                        // initial loading depth doesn't include the nodes children, or if not all children have been
+                        // rendered in the guest frame with a content element wrapping.
                         mergedNode.children = [
                             ...existingNode.children.filter(({role}) => role !== 'document'),
                             ...newNode.children
                         ];
+                        // Remove duplicates after merging in case the node was not fully loaded but the list of
+                        // children has already partially been populated by content loaded in the guest frame.
+                        mergedNode.children = mergedNode.children.filter((child, index, self) =>
+                            index === self.findIndex(c => c.contextPath === child.contextPath)
+                        );
                     }
                 }
                 // Force overwrite of matchesCurrentDimensions


### PR DESCRIPTION
**What I did**

Prevent nodes from appearing twice in the structure tree under certain circumstances described in #4071.

Resolves: #4071

**How I did it**

1. Always return fully loaded nodes when requested for structure tree. 
2. Deduplicate childnodes when merging partially loaded nodes in redux store. (This is just for safety in case there are more ways to cause this kind of issue, performance wise this should be fine, as we always need fully loaded content nodes anyway and only some requests only loaded partial nodes before).

**How to verify it**

Set structure tree loading depth to 1:

```yaml
Neos:
  Neos:
    userInterface:
      navigateComponent:
        structureTree:
          loadingDepth: 1
```

Have these two node types:

```yaml
'Neos.Demo:Test.Collection':
  superTypes:
    'Neos.Neos:Content': true
    'Neos.Neos:ContentCollection': true
    'Neos.Demo:Constraint.Content.Column': true
    'Neos.Demo:Constraint.Content.Main': true
  ui:
    label: 'Test collection'
    icon: 'atom'
  constraints:
    nodeTypes:
      '*': false
      'Neos.Demo:Content.ItemForTestCollection': true

'Neos.Demo:Content.ItemForTestCollection':
  superTypes:
    'Neos.Neos:Content': true
  ui:
    label: 'Item for test collection'
    icon: 'atom'
```

With the following Fusion:

```
prototype(Neos.Demo:Test.Collection) < prototype(Neos.Neos:ContentComponent) {
    renderer = Neos.Neos:ContentCollectionRenderer
}
prototype(Neos.Demo:Content.ItemForTestCollection) < prototype(Neos.Fusion:Component) {
    renderer = afx`
        <div>I am a test item</div>
    `
}
```

Create a test collection with a test item. Reload the backend and uncollapse the structure tree. The test item should then appear twice.