### PR TITLE
TASK: New 9.1 Drag and drop: Let server feedback determine node removal from the dom

### DIFF
--- a/packages/neos-ui-guest-frame/src/InlineUI/DragAndDropUi/index.tsx
+++ b/packages/neos-ui-guest-frame/src/InlineUI/DragAndDropUi/index.tsx
@@ -9,7 +9,6 @@ import {FusionPath, InsertPosition, Node, NodeContextPath} from '@neos-project/n
 import {
     closestContextPathInGuestFrame,
     closestNodeInGuestFrame,
-    findNodeInGuestFrame,
     getGuestFrameDocument
     // @ts-ignore
 } from '@neos-project/neos-ui-guest-frame/src/dom';
@@ -225,13 +224,6 @@ const DragAndDropUi: React.FC<DragAndDropUiProps & InjectedDragAndDropUiProps> =
             targetNodeContextPath,
             insertPosition
         );
-
-        // Remove the original node from the DOM
-        // TODO: Verify that the move was successful before removing the node
-        const movedNode = findNodeInGuestFrame(draggedNodeContextPath, draggedNodeFusionPath);
-        if (movedNode) {
-            movedNode.remove();
-        }
     }, []);
 
     const handleDragEnd = useCallback(() => {


### PR DESCRIPTION
With the 9.0 fix https://github.com/neos/neos-ui/pull/4018 we can adjust Neos 9.1 where we currently get the inline drag and drop to function by removing the dom node manually. This is no longer necessary and saves us the todo to actually verify that the server can move the node

How to reproduce: Implement a command hook or ACL which the Neos Ui is unaware of.

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
