### PR TITLE
BUGFIX: Prevent type error in `Object.keys()` when node type is no longer existant and also its configuration

### DIFF
--- a/packages/neos-ui/src/preprocessNodeConfiguration.spec.js
+++ b/packages/neos-ui/src/preprocessNodeConfiguration.spec.js
@@ -17,6 +17,12 @@ describe(`preprocessing NodeConfiguration`, () => {
         expect(processedConfig).toEqual({});
     });
 
+    test(`empty configuration via null`, () => {
+        const processedConfig = preprocessNodeConfiguration(context, null);
+
+        expect(processedConfig).toEqual({});
+    });
+
     test(`creation dialog configuration without clientEval`, () => {
         const givenConfig = {
             elements: {

--- a/packages/neos-ui/src/preprocessNodeConfiguration.ts
+++ b/packages/neos-ui/src/preprocessNodeConfiguration.ts
@@ -7,8 +7,11 @@ type NodeConfiguration = Record<string, any>;
 export default function preprocessNodeConfiguration(
     // FIXME: Create better Node typings (Inspector has a real Node while CreationDialog has a transientNode)
     context: { node: NodeChild, parentNode: Node },
-    configuration: NodeConfiguration,
+    configuration?: NodeConfiguration,
 ): NodeConfiguration {
+    if (!configuration) {
+        return {}
+    }
     return Object.keys(configuration).reduce((config, propertyKey) => {
         const propertyValue = config[propertyKey];
 


### PR DESCRIPTION


>  TypeError null is not an object (evaluating 'Object.keys(configuration3)')

Called in `Inspector`

Now instead the ui half loads but it doesnt throw cryptic errors and you should see that a node type is missing;)

<img width="368" height="341" alt="image" src="https://github.com/user-attachments/assets/ab805bc0-f04d-4f80-af79-3de4778aa51f" />


<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
