### PR TITLE
BUGFIX: Label of current dimension selection was trimmed

### DIFF
--- a/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/style.module.css
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/DimensionSwitcher/style.module.css
@@ -102,6 +102,6 @@
     }
 
     .dimensionSwitcherDropDown div[role='button'] {
-        padding: 5px 0 5px var(--spacing-Full);
+        padding: 5px 0;
     }
 }

--- a/packages/react-ui-components/src/SelectBox_Option_SingleLine/selectBox_Option_SingleLine.js
+++ b/packages/react-ui-components/src/SelectBox_Option_SingleLine/selectBox_Option_SingleLine.js
@@ -38,8 +38,7 @@ class SelectBox_Option_SingleLine extends PureComponent {
             [style.linkedItem]: linkOptions
         });
         const linkClassname = mergeClassNames({
-            [style.dropdownLink]: true,
-            [style.hasIcon]: (Boolean(option.icon || icon))
+            [style.dropdownLink]: true
         });
 
         const previewElementIcon = option.icon ? option.icon : (icon ? icon : null);

--- a/packages/react-ui-components/src/SelectBox_Option_SingleLine/style.module.css
+++ b/packages/react-ui-components/src/SelectBox_Option_SingleLine/style.module.css
@@ -1,14 +1,4 @@
 .dropdownLink {
     color: white;
-    padding: 5px 14px;
-    display: inline-block;
-    width: 100%;
-
-}
-.hasIcon {
-    width: calc(100% - 2em);
-    padding: 5px 0px;
-}
-.linkedItem {
-    padding: 0px !important;
+    display: inline;
 }


### PR DESCRIPTION
**What I did**

This fixes a regression that was introduced with the bugfix #4090 that was incompatible with the styles introduced with #3680. Luckily it works again by removing most of those styles :D

Resolves: #4117

**How to verify it**

Before:

<img width="1334" height="668" alt="Image" src="https://github.com/user-attachments/assets/1b5ab0b0-7969-4dcb-8489-8676c8a4f903" />

After:

<img width="1152" height="464" alt="CleanShot 2026-05-12 at 09 05 32@2x" src="https://github.com/user-attachments/assets/cab0c9db-b56d-4ab4-8044-8a786a9f1f3a" />
