### PR TITLE
BUGFIX: Add missing title prop to multiline option

### DIFF
--- a/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/__snapshots__/selectBox_Option_MultiLineWithThumbnail.spec.js.snap
+++ b/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/__snapshots__/selectBox_Option_MultiLineWithThumbnail.spec.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SelectBox_Option_MultiLineWithThumbnail/> should render correctly. 1`] = `
+<ThemedListPreviewElement
+  ListPreviewElement={[Function]}
+  className=""
+  icon="<i class=\\"fas fa-question\\"></i>"
+  onClick={[MockFunction]}
+  option={
+    Object {
+      "label": "Bar label",
+    }
+  }
+>
+  <img
+    alt="Foo label"
+    src="https://some.image.uri/foo.png"
+  />
+  <span
+    title="Foo title"
+  >
+    Foo label
+  </span>
+  <span
+    title="Foo secondary label"
+  >
+    Foo secondary label
+  </span>
+  <span
+    title="Foo tertiary label"
+  >
+    Foo tertiary label
+  </span>
+</ThemedListPreviewElement>
+`;

--- a/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/selectBox_Option_MultiLineWithThumbnail.js
+++ b/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/selectBox_Option_MultiLineWithThumbnail.js
@@ -11,6 +11,7 @@ class SelectBox_Option_MultiLineWithThumbnail extends PureComponent {
         tertiaryLabel: PropTypes.string,
         imageUri: PropTypes.string,
         icon: PropTypes.string,
+        title: PropTypes.string,
 
         className: PropTypes.string,
 
@@ -29,6 +30,7 @@ class SelectBox_Option_MultiLineWithThumbnail extends PureComponent {
             secondaryLabel,
             tertiaryLabel,
             imageUri,
+            title,
             icon,
             className,
             theme,
@@ -44,7 +46,7 @@ class SelectBox_Option_MultiLineWithThumbnail extends PureComponent {
         return (
             <ListPreviewElement {...rest} icon={icon} className={finalClassNames}>
                 {Boolean(imageUri) && <img src={imageUri} alt={label} className={theme.multiLineWithThumbnail__image}/>}
-                <span title={label}>{label}</span>
+                <span title={title ? title : label}>{label}</span>
                 {Boolean(secondaryLabel) && <span className={theme.multiLineWithThumbnail__secondaryLabel} title={secondaryLabel}>{secondaryLabel}</span>}
                 {Boolean(tertiaryLabel) && <span className={theme.multiLineWithThumbnail__tertiaryLabel} title={tertiaryLabel}>{tertiaryLabel}</span>}
             </ListPreviewElement>

--- a/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/selectBox_Option_MultiLineWithThumbnail.spec.js
+++ b/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/selectBox_Option_MultiLineWithThumbnail.spec.js
@@ -1,0 +1,31 @@
+/* eslint-disable camelcase, react/jsx-pascal-case */
+import React from 'react';
+import {shallow} from 'enzyme';
+import toJson from 'enzyme-to-json';
+import {createStubComponent} from '../_lib/testUtils';
+import SelectBox_Option_MultiLineWithThumbnail from './selectBox_Option_MultiLineWithThumbnail';
+
+describe('<SelectBox_Option_MultiLineWithThumbnail/>', () => {
+    let props;
+
+    beforeEach(() => {
+        props = {
+            label: 'Foo label',
+            title: 'Foo title',
+            secondaryLabel: 'Foo secondary label',
+            tertiaryLabel: 'Foo tertiary label',
+            imageUri: 'https://some.image.uri/foo.png',
+            icon: '<i class="fas fa-question"></i>',
+            option: {label: 'Bar label'},
+            onClick: jest.fn(),
+            theme: {},
+            ListPreviewElement: createStubComponent()
+        };
+    });
+
+    it('should render correctly.', () => {
+        const wrapper = shallow(<SelectBox_Option_MultiLineWithThumbnail {...props}/>);
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
**What I did**

Resolves: #4119

**How I did it**

Add title prop for multiline options like we do in the SingleLine component since 8.4.

**How to verify it**

See included test
