### PR TITLE
FEATURE: Show property scope indicator in inspector

### DIFF
--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -607,15 +607,15 @@
       </trans-unit>
       <trans-unit id="propertyScope.node" xml:space="preserve">
         <source>Changes to this property scope will affect only the current variant.</source>
-        <target state="translated">Änderungen an diesem Eigenschaftsbereich wirken sich nur auf die aktuelle Variante aus.</target>
+        <target state="translated">Änderungen an dieser Eigenschaft wirken sich nur auf die aktuelle Variante aus.</target>
       </trans-unit>
       <trans-unit id="propertyScope.nodeAggregate" xml:space="preserve">
         <source>Changes to this property scope will affect all variants.</source>
-        <target>Änderungen an diesem Eigenschaftsbereich wirken sich auf alle Varianten aus.</target>
+        <target state="translated">Änderungen an dieser Eigenschaft wirken sich auf alle Varianten aus.</target>
       </trans-unit>
       <trans-unit id="propertyScope.specializations" xml:space="preserve">
         <source>Changes to this property scope will affect all specialization variants.</source>
-        <target>Änderungen an diesem Eigenschaftsbereich wirken sich auf alle Spezialisierungsvarianten aus.</target>
+        <target state="translated">Änderungen an dieser Eigenschaft wirken sich auf alle Spezialisierungsvarianten aus.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -605,6 +605,18 @@
         <source>More</source>
         <target state="needs-translation" state-qualifier="leveraged-mt">Mehr</target>
       </trans-unit>
+      <trans-unit id="propertyScope.node" xml:space="preserve">
+        <source>Changes to this property scope will affect only the current variant.</source>
+        <target state="translated">Änderungen an diesem Eigenschaftsbereich wirken sich nur auf die aktuelle Variante aus.</target>
+      </trans-unit>
+      <trans-unit id="propertyScope.nodeAggregate" xml:space="preserve">
+        <source>Changes to this property scope will affect all variants.</source>
+        <target>Änderungen an diesem Eigenschaftsbereich wirken sich auf alle Varianten aus.</target>
+      </trans-unit>
+      <trans-unit id="propertyScope.specializations" xml:space="preserve">
+        <source>Changes to this property scope will affect all specialization variants.</source>
+        <target>Änderungen an diesem Eigenschaftsbereich wirken sich auf alle Spezialisierungsvarianten aus.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -395,13 +395,13 @@
                 <source>Add content</source>
             </trans-unit>
             <trans-unit id="propertyScope.node" xml:space="preserve">
-                <source>Changes to this property scope will affect only the current variant.</source>
+                <source>Changes to this property will affect only the current variant.</source>
             </trans-unit>
             <trans-unit id="propertyScope.nodeAggregate" xml:space="preserve">
-                <source>Changes to this property scope will affect all variants.</source>
+                <source>Changes to this property will affect all variants.</source>
             </trans-unit>
             <trans-unit id="propertyScope.specializations" xml:space="preserve">
-                <source>Changes to this property scope will affect all specialization variants.</source>
+                <source>Changes to this property will affect all specialization variants.</source>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -394,6 +394,15 @@
             <trans-unit id="emptyCollection" xml:space="preserve">
                 <source>Add content</source>
             </trans-unit>
+            <trans-unit id="propertyScope.node" xml:space="preserve">
+                <source>Changes to this property scope will affect only the current variant.</source>
+            </trans-unit>
+            <trans-unit id="propertyScope.nodeAggregate" xml:space="preserve">
+                <source>Changes to this property scope will affect all variants.</source>
+            </trans-unit>
+            <trans-unit id="propertyScope.specializations" xml:space="preserve">
+                <source>Changes to this property scope will affect all specialization variants.</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/packages/neos-ts-interfaces/src/index.ts
+++ b/packages/neos-ts-interfaces/src/index.ts
@@ -107,12 +107,19 @@ export enum WorkspaceStatus {
     OUTDATED = 'OUTDATED'
 }
 
+export enum PropertyScope {
+    NODE = 'node',
+    NODE_AGGREGATE = 'nodeAggregate',
+    SPECIALIZATIONS = 'specializations'
+}
+
 export interface ValidatorConfiguration {
     [propName: string]: any;
 }
 
 export interface PropertyConfiguration {
     type?: string;
+    scope?: PropertyScope;
     ui?: {
         label?: string;
         reloadIfChanged?: boolean;
@@ -145,6 +152,7 @@ export interface PropertyConfiguration {
 }
 export interface ReferencesConfiguration {
     type?: string;
+    scope?: PropertyScope;
     ui?: {
         label?: string;
         reloadIfChanged?: boolean;

--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.ts
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.ts
@@ -215,7 +215,8 @@ export default class NodeTypesRegistry extends SynchronousRegistry<NodeType> {
                                     position: property.ui?.inspector?.position,
                                     hidden: property.ui?.inspector?.hidden,
                                     helpMessage: property.ui?.help?.message,
-                                    helpThumbnail: property.ui?.help?.thumbnail
+                                    helpThumbnail: property.ui?.help?.thumbnail,
+                                    scope: property.scope,
                                 })
                             ),
                         ...references.filter(p => p.ui?.inspector?.group === group.id)
@@ -228,7 +229,8 @@ export default class NodeTypesRegistry extends SynchronousRegistry<NodeType> {
                                     position: reference.ui?.inspector?.position,
                                     hidden: reference.ui?.inspector?.hidden,
                                     helpMessage: reference.ui?.help?.message,
-                                    helpThumbnail: reference.ui?.help?.thumbnail
+                                    helpThumbnail: reference.ui?.help?.thumbnail,
+                                    scope: reference.scope,
                                 })
                             ),
                         ...views.filter(v => v.group === group.id)

--- a/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.ts
+++ b/packages/neos-ui-contentrepository/src/registry/NodeTypesRegistry.ts
@@ -216,7 +216,7 @@ export default class NodeTypesRegistry extends SynchronousRegistry<NodeType> {
                                     hidden: property.ui?.inspector?.hidden,
                                     helpMessage: property.ui?.help?.message,
                                     helpThumbnail: property.ui?.help?.thumbnail,
-                                    scope: property.scope,
+                                    scope: property.scope
                                 })
                             ),
                         ...references.filter(p => p.ui?.inspector?.group === group.id)
@@ -230,7 +230,7 @@ export default class NodeTypesRegistry extends SynchronousRegistry<NodeType> {
                                     hidden: reference.ui?.inspector?.hidden,
                                     helpMessage: reference.ui?.help?.message,
                                     helpThumbnail: reference.ui?.help?.thumbnail,
-                                    scope: reference.scope,
+                                    scope: reference.scope
                                 })
                             ),
                         ...views.filter(v => v.group === group.id)

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -109,8 +109,8 @@ export default class EditorEnvelope extends PureComponent {
         return (
             <Label className={style.envelope__label} htmlFor={this.generateIdentifier()}>
                 <I18n id={label}/>
-                {this.renderHelpIcon()}
                 {this.renderScopeIcon()}
+                {this.renderHelpIcon()}
             </Label>
         );
     }

--- a/packages/neos-ui-editors/src/EditorEnvelope/index.js
+++ b/packages/neos-ui-editors/src/EditorEnvelope/index.js
@@ -16,12 +16,14 @@ import style from './style.module.css';
 }))
 export default class EditorEnvelope extends PureComponent {
     state = {
-        showHelpMessage: false
+        showHelpMessage: false,
+        showScopeHint: false
     };
 
     static defaultProps = {
         helpMessage: '',
         helpThumbnail: '',
+        scopeHint: '',
         highlight: false
     };
 
@@ -40,6 +42,7 @@ export default class EditorEnvelope extends PureComponent {
         helpMessage: PropTypes.string,
         helpThumbnail: PropTypes.string,
         highlight: PropTypes.bool,
+        scope: PropTypes.oneOf(['node', 'nodeAggregate', 'specializations']),
 
         commit: PropTypes.func.isRequired
     };
@@ -79,6 +82,7 @@ export default class EditorEnvelope extends PureComponent {
                 <EditorComponent className={classNames}
                     id={this.generateIdentifier()}
                     renderHelpIcon={this.renderHelpIcon}
+                    renderScopeHint={this.renderScopeHint}
                     {...restProps} />
             );
         }
@@ -106,6 +110,7 @@ export default class EditorEnvelope extends PureComponent {
             <Label className={style.envelope__label} htmlFor={this.generateIdentifier()}>
                 <I18n id={label}/>
                 {this.renderHelpIcon()}
+                {this.renderScopeIcon()}
             </Label>
         );
     }
@@ -114,6 +119,13 @@ export default class EditorEnvelope extends PureComponent {
         event.preventDefault();
         this.setState({
             showHelpMessage: !this.state.showHelpMessage
+        });
+    };
+
+    toggleScopeHint = event => {
+        event.preventDefault();
+        this.setState({
+            showScopeHint: !this.state.showScopeHint
         });
     };
 
@@ -151,6 +163,40 @@ export default class EditorEnvelope extends PureComponent {
         return '';
     }
 
+    renderScopeIcon = () => {
+        const {i18nRegistry, scope} = this.props;
+
+        // TODO: Use enum value here when we refactor the file to typescript
+        if (scope && scope !== 'node') {
+            const translatedScopeHint = i18nRegistry.translate(`Neos.Neos.Ui:Main:propertyScope.${scope}`);
+
+            return (
+                <span
+                    role="button"
+                    onClick={this.toggleScopeHint}
+                    className={style.envelope__tooltipButton}
+                    title={translatedScopeHint}
+                >
+                    <Icon icon="arrow-right-arrow-left" />
+                </span>
+            );
+        }
+
+        return '';
+    }
+
+    renderScopeHint() {
+        const {i18nRegistry, scope} = this.props;
+
+        const translatedScopeHint = i18nRegistry.translate(`Neos.Neos.Ui:Main:propertyScope.${scope}`);
+
+        return (
+            <Tooltip renderInline className={style.envelope__helpmessage}>
+                {translatedScopeHint}
+            </Tooltip>
+        );
+    }
+
     render() {
         if (!this.props.editor) {
             return <div className={style.envelope__error}>Missing editor definition</div>;
@@ -168,6 +214,7 @@ export default class EditorEnvelope extends PureComponent {
                 </span>
                 {this.renderEditorComponent()}
                 {this.state.showHelpMessage ? this.renderHelpMessage() : ''}
+                {this.state.showScopeHint ? this.renderScopeHint() : ''}
                 {this.isInvalid() && <Tooltip renderInline asError><ul>{validationErrors.map((error, index) => <li key={index}>{error}</li>)}</ul></Tooltip>}
             </Fragment>
         );

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/PropertyGroup/index.js
@@ -62,6 +62,7 @@ export default class PropertyGroup extends PureComponent {
                                     onEnterKey={handleInspectorApply}
                                     helpMessage={item?.helpMessage}
                                     helpThumbnail={item?.helpThumbnail}
+                                    scope={item?.scope}
                                 />);
                         }
                         if (itemType === 'view') {

--- a/packages/react-proptypes/src/propertyDefinition.js
+++ b/packages/react-proptypes/src/propertyDefinition.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 
 export default PropTypes.shape({
     type: PropTypes.string.isRequired,
+    scope: PropTypes.oneOf(['node', 'nodeAggregate', 'specializations']),
     ui: PropTypes.shape({
         label: PropTypes.string,
         help: PropTypes.shape({


### PR DESCRIPTION
**What I did**

This change adds another icon the the property editors like for the help message, but only if the property or reference has a scope defined that is not „node“. This should help editors to understand that changes to a property can affect other variants.

Resolves: #4106

**How to verify it**

<img width="630" height="978" alt="CleanShot 2026-06-04 at 10 08 04@2x" src="https://github.com/user-attachments/assets/3fac9a72-a7fb-4383-9916-74de9b77b0bf" />
