### PR TITLE
BUGFIX: Fix and simplify jenkins ui compiled dev branch handling

### DIFF
--- a/Build/Jenkins/update-neos-ui-compiled.sh
+++ b/Build/Jenkins/update-neos-ui-compiled.sh
@@ -48,13 +48,23 @@ cd tmp_compiled_pkg
 git add Resources/Public/
 git commit -m "Compile Neos UI - $GIT_SHA1" || true
 
-if [[ "$GIT_BRANCH" == "origin/7.3" || "$GIT_BRANCH" == "origin/8.0" || "$GIT_BRANCH" == "origin/8.1" || "$GIT_BRANCH" == "origin/8.2" || "$GIT_BRANCH" == "origin/8.3" || "$GIT_BRANCH" == "origin/8.4" || "$GIT_BRANCH" == "origin/9.0" ]]; then
-    echo "Git branch $GIT_BRANCH found, pushing to this branch."
+BRANCH_OR_TAG_PUSHED=0
+
+BASE_BRANCH_PATTERN="^origin\/[0-9]+\.[0-9]$"
+if [[ "$GIT_BRANCH" =~ $BASE_BRANCH_PATTERN ]]; then
+    echo "Git branch '$GIT_BRANCH' matches pattern, pushing to this branch."
     git push origin HEAD:${GIT_BRANCH#*/}
+    BRANCH_OR_TAG_PUSHED=1
 fi
 
 if [ "$GIT_TAG" != "" ]; then
     echo "Git tag $GIT_TAG found; also tagging the UI-compiled package."
     git tag -a -m "$GIT_TAG" $GIT_TAG
     git push origin $GIT_TAG
+    BRANCH_OR_TAG_PUSHED=1
+fi
+
+if [[ BRANCH_OR_TAG_PUSHED -eq 0 ]]; then
+  echo "Git branch '$GIT_BRANCH' is not a valid development git branch like ('origin/X.X') and git tag is empty '$GIT_TAG'"
+  exit 1
 fi


### PR DESCRIPTION
The branches 9.1 and 9.2 have not been updated in 8 months... because they are not updated. Only tags are updated or branches matching the pattern.

Because its tedious to manually keep track of all branches (and hopeless) we should just regex our way out:)

see https://neos-project.slack.com/archives/C0U0KEGDQ/p1779429243177099

Also added a check that if no push occurred the script fails. This is as precaution in case the pattern becomes outdated. Currently the jenkins is happy doing nothing:

```
10:12:16 + git commit -m 'Compile Neos UI - 1819d1e5292ede5dcd86b728e81d4454d39d6197'
10:12:16 [9.1 0a0701b] Compile Neos UI - 1819d1e5292ede5dcd86b728e81d4454d39d6197
10:12:16  8 files changed, 2907 insertions(+), 1419 deletions(-)
10:12:16 + [[ origin/9.1 == \o\r\i\g\i\n\/\7\.\3 ]]
10:12:16 + [[ origin/9.1 == \o\r\i\g\i\n\/\8\.\0 ]]
10:12:16 + [[ origin/9.1 == \o\r\i\g\i\n\/\8\.\1 ]]
10:12:16 + [[ origin/9.1 == \o\r\i\g\i\n\/\8\.\2 ]]
10:12:16 + [[ origin/9.1 == \o\r\i\g\i\n\/\8\.\3 ]]
10:12:16 + [[ origin/9.1 == \o\r\i\g\i\n\/\8\.\4 ]]
10:12:16 + [[ origin/9.1 == \o\r\i\g\i\n\/\9\.\0 ]]
10:12:16 + '[' '' '!=' '' ']'
10:12:16 Finished: SUCCESS
```

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
