### PR TITLE
Obsolete - Part of Neos.Neos - Add custom rendering for hidden document nodes in preview mode

### DIFF
--- a/Resources/Private/Fusion/Prototypes/NotVisibleDocument.fusion
+++ b/Resources/Private/Fusion/Prototypes/NotVisibleDocument.fusion
@@ -1,0 +1,18 @@
+prototype(Neos.Neos:Page) {
+    head {
+        notVisibleDocumentCSS = Neos.Fusion:Tag {
+            @position = 'after guestFrameApplication'
+
+            tagName = 'style'
+            content = Neos.Fusion:Value {
+                value = '#neos-not-visible-document {position: fixed;top: 0;left: 0;width: 100%;height: 100%;background-color: #323232;z-index: 9999;font-family: "Noto Sans", sans-serif;-webkit-font-smoothing: antialiased;}#neos-not-visible-document p {position: relative;margin: 0 auto;width: 500px;height: 60px;top: 50%;margin-top: -30px;color: #fff;font-size: 22px;line-height: 1.4;text-align: center;}'
+            }
+
+            @if {
+                inBackend = ${documentNode.context.inBackend}
+                isPreview = ${documentNode.context.currentRenderingMode.preview}
+                isNotVisible = ${!documentNode.visible}
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds additional styling for dedicated screen to show hidden document nodes in preview mode

Is required for: https://github.com/neos/neos-development-collection/pull/5843
Relates to https://github.com/neos/neos-development-collection/issues/5724