### PR TITLE
BUGFIX: Fixing content module view for user language codes with region

### DIFF
--- a/Classes/Presentation/ApplicationView.php
+++ b/Classes/Presentation/ApplicationView.php
@@ -118,13 +118,14 @@ final class ApplicationView extends AbstractView
             )
         );
 
-        $locale = new Locale($this->userService->getInterfaceLanguage());
+        $userLang = $this->userService->getInterfaceLanguage();
+        $locale = new Locale($userLang);
         // @TODO: All endpoints should be treated this way and be isolated from
         //        initial data. -> Evaluate whether to do that also for routes which require parameters (they cannot be prefetched)
         $result .= sprintf(
             '<link id="neos-ui-uri:/neos/xliff.json" rel="prefetch" href="%s" data-locale="%s" data-locale-plural-rules="%s">',
             $this->variables['prefetchRoutes']['translations'],
-            (string) $locale,
+            (string) $userLang,
             implode(',', $this->pluralsReader->getPluralForms($locale)),
         );
         $result .= sprintf(

--- a/packages/neos-ui-i18n/src/global/initializeI18n.ts
+++ b/packages/neos-ui-i18n/src/global/initializeI18n.ts
@@ -49,7 +49,7 @@ function getLocaleFromLinkTag(link: HTMLLinkElement) {
         throw I18nCouldNotBeInitialized
             .becauseRouteLinkHasNoLocale();
     }
-    return locale;
+    return locale.replace('_', '-');
 }
 
 function getLinkTag() {

--- a/packages/neos-ui-i18n/src/global/initializeI18n.ts
+++ b/packages/neos-ui-i18n/src/global/initializeI18n.ts
@@ -49,7 +49,7 @@ function getLocaleFromLinkTag(link: HTMLLinkElement) {
         throw I18nCouldNotBeInitialized
             .becauseRouteLinkHasNoLocale();
     }
-    return locale.replace('_', '-');
+    return locale;
 }
 
 function getLinkTag() {


### PR DESCRIPTION
Resolves: #4084

**What I did**
Updating application view to render valid Intl.Locale values for data-locale attribute to resolve script error "not a valid locale identifier".


**How I did it**
Expected value was "pt-BR" but value was "pt_BR".
In ApplicationView the value for data-local attribute (`<link>` in `<head>`) is now $this->userService->getInterfaceLanguage instead of Locale() value.

**How to verify it**
* go to user settings
* choose "portuguese" as language & save
* go to site content
--> view should load and no error shown in console
