### PR TITLE
BUGFIX: Check baseworkspace for write permission

### DIFF
--- a/Classes/Fusion/Helper/WorkspaceHelper.php
+++ b/Classes/Fusion/Helper/WorkspaceHelper.php
@@ -77,14 +77,19 @@ class WorkspaceHelper implements ProtectedContextAwareInterface
         $personalWorkspace = $this->workspaceService->getPersonalWorkspaceForUser($contentRepositoryId, $currentUser->getId());
         $personalWorkspacePermissions = $this->contentRepositoryAuthorizationService->getWorkspacePermissions($contentRepositoryId, $personalWorkspace->workspaceName, $this->securityContext->getRoles(), $currentUser->getId());
         $publishableNodes = $this->uiWorkspaceService->getPublishableNodeInfo($personalWorkspace->workspaceName, $contentRepository->id);
+        $allowedTargetWorkspaces = $this->getAllowedTargetWorkspaces($contentRepository);
+        $baseWorkspace = $personalWorkspace->baseWorkspaceName ? $allowedTargetWorkspaces[$personalWorkspace->baseWorkspaceName->value] : null;
+
         return [
             'name' => $personalWorkspace->workspaceName->value,
             'totalNumberOfChanges' => count($publishableNodes),
             'publishableNodes' => $publishableNodes,
             'baseWorkspace' => $personalWorkspace->baseWorkspaceName?->value,
-            'readOnly' => !($personalWorkspace->baseWorkspaceName !== null && $personalWorkspacePermissions->write),
+            'readOnly' => !$baseWorkspace
+                || $baseWorkspace['readonly']
+                || !$personalWorkspacePermissions->write,
             'status' => $personalWorkspace->status->value,
-            'allowedTargetWorkspaces' => $this->getAllowedTargetWorkspaces($contentRepository)
+            'allowedTargetWorkspaces' => $allowedTargetWorkspaces,
         ];
     }
 

--- a/packages/neos-ui-redux-store/src/CR/Workspaces/selectors.ts
+++ b/packages/neos-ui-redux-store/src/CR/Workspaces/selectors.ts
@@ -12,7 +12,8 @@ export const baseWorkspaceSelector = (state: GlobalState) => state?.cr?.workspac
 export const allowedTargetWorkspacesSelector = defaultMemoize((state: GlobalState) => state?.cr?.workspaces?.personalWorkspace?.allowedTargetWorkspaces);
 
 export const isWorkspaceReadOnlySelector = (state: GlobalState) => {
-    return state?.cr?.workspaces?.personalWorkspace?.readOnly || false
+    const personalWorkspace = state?.cr?.workspaces?.personalWorkspace;
+    return !personalWorkspace || personalWorkspace.readOnly;
 };
 
 export const publishableNodesSelector = (state: GlobalState) => state?.cr?.workspaces?.personalWorkspace?.publishableNodes;


### PR DESCRIPTION
Resolves: #4133

Switching to a (base)workspace in which the user is only a `viewer` will not disable all editing features.
Switching to a (base)workspace with write permissions works as normal.
