### PR TITLE
FEATURE: Setup ContentRepository Command Execution in E2E Tests

### DIFF
--- a/Tests/E2E/features/create-node.feature
+++ b/Tests/E2E/features/create-node.feature
@@ -1,0 +1,12 @@
+Feature: Create node
+
+    Background:
+        Given A user with username "admin", password "password" and role "Neos.Neos:Administrator" exists
+        And I log in with username "admin" and password "password"
+
+    Scenario: Create node
+        When I navigate to the "Home" page
+        And the command "CreateRootNodeAggregateWithNode" is executed with payload:
+        | Key             | Value                         |
+        | nodeAggregateId | "lady-eleonode-rootford"      |
+        | nodeTypeName    | "Neos.ContentRepository:Root" |

--- a/Tests/E2E/helpers/system.ts
+++ b/Tests/E2E/helpers/system.ts
@@ -19,3 +19,22 @@ export function removeAllUsers() {
 export async function logout(page: Page) {
     await page.context().request.post("/neos/logout");
 }
+
+export async function executeGenericCommand(command: string, payload: Record<string, string> = {}) {
+    const baseUrl = process.env.NEOS_BASE_URL ?? "http://localhost:8081";
+    const response = await fetch(`${baseUrl}/neos/generic-command?commandClassName=${command}`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({arguments: payload}),
+    });
+
+    if (!response.ok) {
+        throw new Error(
+            `executeGenericCommand failed: ${response.status} ${response.statusText}`
+        );
+    }
+
+    return response.json();
+}

--- a/Tests/E2E/steps/generic-command.steps.ts
+++ b/Tests/E2E/steps/generic-command.steps.ts
@@ -1,0 +1,22 @@
+import {createBdd, DataTable} from "playwright-bdd";
+import {createUser, executeGenericCommand, logout} from "../helpers/system.ts";
+
+const {Given, When, Then} = createBdd();
+
+When(
+    "the command {string} is executed with payload:",
+    async ({}, command: string, dataTable: DataTable) => {
+        const payload: Record<string, string> = {};
+        const [, ...rows] = dataTable.raw();
+        for (const row of rows) {
+            const key = row[0]!;
+            const value = row[1]!;
+            payload[key] = value;
+        }
+        await executeGenericCommand(command, payload).then(
+            (res) => {
+                console.log(res)
+            }
+        )
+    },
+);

--- a/Tests/E2E/system_under_test/docker-compose.yaml
+++ b/Tests/E2E/system_under_test/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
       - ../../../Migrations:/neos-ui/Migrations:cached
       - ../../../Resources:/neos-ui/Resources:cached
       - ../../../composer.json:/neos-ui/composer.json:cached
+      - ./sut_file_system_overrides/app/DistributionPackages:/app/DistributionPackages
       - composer_cache:/composer_cache
     networks:
       - neos_SUT

--- a/Tests/E2E/system_under_test/sut_file_system_overrides/app/DistributionPackages/Neos.Test.CrInteraction/Classes/Controller/GenericCommandController.php
+++ b/Tests/E2E/system_under_test/sut_file_system_overrides/app/DistributionPackages/Neos.Test.CrInteraction/Classes/Controller/GenericCommandController.php
@@ -1,0 +1,34 @@
+<?php
+namespace Neos\Test\CrInteraction\Controller;
+
+/*
+ * This file is part of the Neos.Test.CrInteraction package.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\Controller\ActionController;
+use Neos\Test\CrInteraction\Service\CommandHandler;
+use Psr\Log\LoggerInterface;
+
+class GenericCommandController extends ActionController
+{
+    /**
+     * @Flow\Inject
+     * @var LoggerInterface
+     */
+    protected $systemLogger;
+
+    /**
+     * @Flow\Inject
+     * @var CommandHandler
+     */
+    protected CommandHandler $commandHandler;
+
+    #[Flow\Route('neos/generic-command')]
+    public function executeAction(string $commandClassName)
+    {
+        $arguments = json_decode($this->request->getArgument("arguments"), true);
+
+        $this->commandHandler->handleCommand($commandClassName, $arguments);
+    }
+}

--- a/Tests/E2E/system_under_test/sut_file_system_overrides/app/DistributionPackages/Neos.Test.CrInteraction/Classes/Service/CommandHandler.php
+++ b/Tests/E2E/system_under_test/sut_file_system_overrides/app/DistributionPackages/Neos.Test.CrInteraction/Classes/Service/CommandHandler.php
@@ -1,0 +1,153 @@
+<?php
+namespace Neos\Test\CrInteraction\Service;
+
+use Neos\ContentRepository\Core\CommandHandler\CommandInterface;
+use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\Factory\ContentRepositoryFactory;
+use Neos\ContentRepository\Core\Feature\Common\RebasableToOtherWorkspaceInterface;
+use Neos\ContentRepository\Core\Feature\DimensionSpaceAdjustment\Command\AddDimensionShineThrough;
+use Neos\ContentRepository\Core\Feature\DimensionSpaceAdjustment\Command\MoveDimensionSpacePoint;
+use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode;
+use Neos\ContentRepository\Core\Feature\NodeDisabling\Command\DisableNodeAggregate;
+use Neos\ContentRepository\Core\Feature\NodeDisabling\Command\EnableNodeAggregate;
+use Neos\ContentRepository\Core\Feature\NodeModification\Command\SetNodeProperties;
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
+use Neos\ContentRepository\Core\Feature\NodeMove\Command\MoveNodeAggregate;
+use Neos\ContentRepository\Core\Feature\NodeReferencing\Command\SetNodeReferences;
+use Neos\ContentRepository\Core\Feature\NodeRemoval\Command\RemoveNodeAggregate;
+use Neos\ContentRepository\Core\Feature\NodeRenaming\Command\ChangeNodeAggregateName;
+use Neos\ContentRepository\Core\Feature\NodeTypeChange\Command\ChangeNodeAggregateType;
+use Neos\ContentRepository\Core\Feature\NodeVariation\Command\CreateNodeVariant;
+use Neos\ContentRepository\Core\Feature\RootNodeCreation\Command\CreateRootNodeAggregateWithNode;
+use Neos\ContentRepository\Core\Feature\RootNodeCreation\Command\UpdateRootNodeAggregateDimensions;
+use Neos\ContentRepository\Core\Feature\SubtreeTagging\Command\TagSubtree;
+use Neos\ContentRepository\Core\Feature\SubtreeTagging\Command\UntagSubtree;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceModification\Command\ChangeBaseWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceModification\Command\DeleteWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\DiscardIndividualNodesFromWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\DiscardWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\PublishIndividualNodesFromWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\PublishWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Command\RebaseWorkspace;
+
+/**
+ * Simplified version of {@see Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\GenericCommandExecutionAndEventPublication::handleCommand}
+ */
+final readonly class CommandHandler
+{
+    public function __construct(
+        private ContentRepository $contentRepository
+    ) {
+    }
+
+    /**
+     * @param array<mixed> $commandArguments
+     */
+    public function handleCommand(string $shortCommandName, array $commandArguments): void
+    {
+        $commandClassName = self::resolveShortCommandName($shortCommandName);
+
+        $commandArguments = $this->addDefaultCommandArgumentValues($commandClassName, $commandArguments);
+        $command = $commandClassName::fromArray($commandArguments);
+        $this->contentRepository->handle($command);
+    }
+
+    /**
+     * @param class-string<CommandInterface> $commandClassName
+     * @param array<mixed> $commandArguments
+     * @return array<mixed>
+     */
+    private function addDefaultCommandArgumentValues(string $commandClassName, array $commandArguments): array
+    {
+        if (is_string($commandArguments['coveredDimensionSpacePoint'] ?? null)) {
+            $commandArguments['coveredDimensionSpacePoint'] = \json_decode($commandArguments['coveredDimensionSpacePoint'], true, 512, JSON_THROW_ON_ERROR);
+        }
+        if ($commandClassName === CreateNodeAggregateWithNode::class) {
+            if (is_string($commandArguments['initialPropertyValues'] ?? null)) {
+                $commandArguments['initialPropertyValues'] = self::deserializeProperties(json_decode($commandArguments['initialPropertyValues'], true, 512, JSON_THROW_ON_ERROR))->values;
+            }
+            if (isset($commandArguments['succeedingSiblingNodeAggregateId']) && $commandArguments['succeedingSiblingNodeAggregateId'] === '') {
+                unset($commandArguments['succeedingSiblingNodeAggregateId']);
+            }
+            if (empty($commandArguments['nodeName'])) {
+                unset($commandArguments['nodeName']);
+            }
+        }
+        if ($commandClassName === SetNodeProperties::class) {
+            if (is_string($commandArguments['propertyValues'] ?? null)) {
+                $commandArguments['propertyValues'] = self::deserializeProperties(json_decode($commandArguments['propertyValues'], true, 512, JSON_THROW_ON_ERROR))->values;
+            }
+        }
+        if ($commandClassName === CreateNodeAggregateWithNode::class || $commandClassName === SetNodeProperties::class) {
+            if (is_string($commandArguments['originDimensionSpacePoint'] ?? null) && !empty($commandArguments['originDimensionSpacePoint'])) {
+                $commandArguments['originDimensionSpacePoint'] = OriginDimensionSpacePoint::fromJsonString($commandArguments['originDimensionSpacePoint'])->coordinates;
+            }
+        }
+        if ($commandClassName === CreateNodeAggregateWithNode::class || $commandClassName === ChangeNodeAggregateType::class || $commandClassName === CreateRootNodeAggregateWithNode::class) {
+            if (is_string($commandArguments['tetheredDescendantNodeAggregateIds'] ?? null)) {
+                if ($commandArguments['tetheredDescendantNodeAggregateIds'] === '') {
+                    unset($commandArguments['tetheredDescendantNodeAggregateIds']);
+                } else {
+                    $commandArguments['tetheredDescendantNodeAggregateIds'] = json_decode($commandArguments['tetheredDescendantNodeAggregateIds'], true, 512, JSON_THROW_ON_ERROR);
+                }
+            }
+        }
+        return $commandArguments;
+    }
+
+    /**
+     * @param array<mixed> $properties
+     */
+    private static function deserializeProperties(array $properties): PropertyValuesToWrite
+    {
+        return PropertyValuesToWrite::fromArray(
+            array_map(
+                static fn (mixed $value) => is_array($value) && isset($value['__type']) ? new $value['__type']($value['value']) : $value,
+                $properties
+            )
+        );
+    }
+
+    /**
+     * @return class-string<CommandInterface>
+     */
+    protected static function resolveShortCommandName(string $shortCommandName): string
+    {
+        $commandClassNames = [
+            AddDimensionShineThrough::class,
+            ChangeBaseWorkspace::class,
+            ChangeNodeAggregateName::class,
+            ChangeNodeAggregateType::class,
+            CreateNodeAggregateWithNode::class,
+            CreateNodeVariant::class,
+            CreateRootNodeAggregateWithNode::class,
+            CreateRootWorkspace::class,
+            CreateWorkspace::class,
+            DeleteWorkspace::class,
+            DisableNodeAggregate::class,
+            DiscardIndividualNodesFromWorkspace::class,
+            DiscardWorkspace::class,
+            EnableNodeAggregate::class,
+            MoveDimensionSpacePoint::class,
+            MoveNodeAggregate::class,
+            PublishIndividualNodesFromWorkspace::class,
+            PublishWorkspace::class,
+            RebasableToOtherWorkspaceInterface::class,
+            RebaseWorkspace::class,
+            RemoveNodeAggregate::class,
+            SetNodeProperties::class,
+            SetNodeReferences::class,
+            TagSubtree::class,
+            UntagSubtree::class,
+            UpdateRootNodeAggregateDimensions::class,
+        ];
+        foreach ($commandClassNames as $commandClassName) {
+            if (substr(strrchr($commandClassName, '\\'), 1) === $shortCommandName) {
+                return $commandClassName;
+            }
+        }
+        throw new \RuntimeException('The short command name "' . $shortCommandName . '" is currently not supported by the tests.');
+    }
+}

--- a/Tests/E2E/system_under_test/sut_file_system_overrides/app/DistributionPackages/Neos.Test.CrInteraction/Configuration/Policy.yaml
+++ b/Tests/E2E/system_under_test/sut_file_system_overrides/app/DistributionPackages/Neos.Test.CrInteraction/Configuration/Policy.yaml
@@ -1,0 +1,15 @@
+---
+privilegeTargets:
+
+  'Neos\Flow\Security\Authorization\Privilege\Method\MethodPrivilege':
+
+    'Neos.Test.CrInteraction:GenericCommandAccess':
+      matcher: 'method(Neos\Test\CrInteraction\.*Controller->.*())'
+
+roles:
+
+    'Neos.Flow:Everybody':
+      privileges:
+        -
+          privilegeTarget: 'Neos.Test.CrInteraction:GenericCommandAccess'
+          permission: GRANT

--- a/Tests/E2E/system_under_test/sut_file_system_overrides/app/DistributionPackages/Neos.Test.CrInteraction/Configuration/Settings.yaml
+++ b/Tests/E2E/system_under_test/sut_file_system_overrides/app/DistributionPackages/Neos.Test.CrInteraction/Configuration/Settings.yaml
@@ -1,0 +1,10 @@
+Neos:
+  Flow:
+    mvc:
+      routes:
+        'Neos.Test.CrInteraction:Endpoints':
+          position: 'before Neos.Neos'
+          providerFactory: Neos\Flow\Mvc\Routing\AttributeRoutesProviderFactory
+          providerOptions:
+            classNames:
+              - Neos\Test\CrInteraction\Controller\*Controller

--- a/Tests/E2E/system_under_test/sut_file_system_overrides/app/DistributionPackages/Neos.Test.CrInteraction/composer.json
+++ b/Tests/E2E/system_under_test/sut_file_system_overrides/app/DistributionPackages/Neos.Test.CrInteraction/composer.json
@@ -1,0 +1,18 @@
+{
+    "description": "",
+    "type": "neos-package",
+    "name": "neos/test-crinteraction",
+    "require": {
+        "neos/flow": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "Neos\\Test\\CrInteraction\\": "Classes/"
+        }
+    },
+    "extra": {
+        "neos": {
+            "package-key": "Neos.Test.CrInteraction"
+        }
+    }
+}

--- a/Tests/E2E/system_under_test/sut_file_system_overrides/app/composer.json
+++ b/Tests/E2E/system_under_test/sut_file_system_overrides/app/composer.json
@@ -23,6 +23,7 @@
       "neos/test-onedimension": "@dev",
       "neos/test-twodimensions": "@dev",
       "neos/test-nodetypes": "@dev",
+      "neos/test-crinteraction": "@dev",
 
       "cweagans/composer-patches": "^1.7.3"
     },


### PR DESCRIPTION
This is a WIP setup to execute generic ContentRepository Commands from the E2E Tests in NeosUI.

This should help to set up a state in the content repository to more easily test different scenarios in the E2E tests. In the future using these generic commands might replace the base db import used.