### PR TITLE
BUGFIX: Allow toggling selectbox with searchbox and value

### DIFF
--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -326,19 +326,15 @@ export default class SelectBox extends PureComponent {
     }
 
     handleToggleExpanded = () => {
-        // Return earyl if disabled
+        // Return early if disabled
         if (this.props.disabled) {
             return;
         }
 
         let isExpanded;
         if (this.props.displaySearchBox) {
-            if (this.props.value) {
-                isExpanded = true;
-            } else {
-                // Force expanded dropdown unless has showDropDownToggle (e.g. for nodetypes filter in the PageTree)
-                isExpanded = this.props.showDropDownToggle ? !this.state.isExpanded : true;
-            }
+            // Force expanded dropdown unless has showDropDownToggle (e.g. for nodetypes filter in the PageTree)
+            isExpanded = this.props.showDropDownToggle ? !this.state.isExpanded : true;
         } else {
             // If simple SelectBox, just toggle it
             isExpanded = !this.state.isExpanded;

--- a/packages/react-ui-components/src/SelectBox_HeaderWithSearchInput/selectBox_HeaderWithSearchInput.js
+++ b/packages/react-ui-components/src/SelectBox_HeaderWithSearchInput/selectBox_HeaderWithSearchInput.js
@@ -45,6 +45,11 @@ class SelectBox_HeaderWithSearchInput extends PureComponent {
         this.props.onSearchTermChange('');
     }
 
+    onClick = event => {
+        // Prevent the click event from propagating to the parent SelectBox, which would cause the dropdown to toggle.
+        event.stopPropagation();
+    }
+
     render() {
         const {
             searchTerm,
@@ -71,6 +76,7 @@ class SelectBox_HeaderWithSearchInput extends PureComponent {
                     containerClassName={theme.selectBoxHeaderWithSearchInput__inputContainer}
                     className={theme.selectBoxHeaderWithSearchInput__input}
                     value={searchTerm}
+                    onClick={this.onClick}
                     onChange={onSearchTermChange}
                     onKeyDown={onKeyDown}
                     placeholder={placeholder}


### PR DESCRIPTION
Before this change the selectbox accepted the click event on the filter box and prevent toggling with the value change which was „random“.

Now the filter prevents bubbling of the click and the toggle is not triggered.