### PR TITLE
BUGFIX: Remove extra <ul> from react ui component SelectBox

### DIFF
--- a/packages/neos-ui/src/Containers/PrimaryToolbar/EditPreviewDropDown/index.js
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/EditPreviewDropDown/index.js
@@ -70,27 +70,31 @@ export default class EditPreviewModeDropDown extends PureComponent {
                         <span className={style.dropDown__currentEditMode}><I18n id={currentEditMode.title}/></span>
                     </DropDown.Header>
                     <DropDown.Contents className={style.dropDown__contents}>
-                        <div className={style.dropDown__groupHeader}>
-                            <Icon className={style.dropDown__btnIcon} icon={'pencil'}/> {i18nRegistry.translate('content.components.editPreviewPanel.modes', 'Editing Modes')}
-                        </div>
-                        <ul>
-                            {editingModes.map(editingMode => (
-                                <li className={style.dropDown__item} key={editingMode.id}>
-                                    <Button
-                                        disabled={editingMode.id === editPreviewMode}
-                                        onClick={this.handleEditPreviewModeClick(editingMode.id)}
-                                        style={editingMode.id === editPreviewMode ? 'brand' : null}
-                                    >
-                                        <I18n id={editingMode.title}/>
-                                    </Button>
-                                </li>
-                            ))}
-                        </ul>
+                        <li>
+                            <p className={style.dropDown__groupHeader}>
+                                <Icon className={style.dropDown__btnIcon} icon={'pencil'}/>
+                                <span>{i18nRegistry.translate('content.components.editPreviewPanel.modes', 'Editing Modes')}</span>
+                            </p>
+                            <ul>
+                                {editingModes.map(editingMode => (
+                                    <li className={style.dropDown__item} key={editingMode.id}>
+                                        <Button
+                                            disabled={editingMode.id === editPreviewMode}
+                                            onClick={this.handleEditPreviewModeClick(editingMode.id)}
+                                            style={editingMode.id === editPreviewMode ? 'brand' : null}
+                                        >
+                                            <I18n id={editingMode.title}/>
+                                        </Button>
+                                    </li>
+                                ))}
+                            </ul>
+                        </li>
                         {previewModes.length > 0 && (
-                            <>
-                                <div className={style.dropDown__groupHeader}>
-                                    <Icon className={style.dropDown__btnIcon} icon={'eye'}/> {i18nRegistry.translate('content.components.editPreviewPanel.previewCentral', 'Preview Central')}
-                                </div>
+                            <li>
+                                <p className={style.dropDown__groupHeader}>
+                                    <Icon className={style.dropDown__btnIcon} icon={'eye'}/>
+                                    <span>{i18nRegistry.translate('content.components.editPreviewPanel.previewCentral', 'Preview Central')}</span>
+                                </p>
                                 <ul>
                                     {previewModes.map(previewMode => (
                                         <li className={style.dropDown__item} key={previewMode.id}>
@@ -104,7 +108,7 @@ export default class EditPreviewModeDropDown extends PureComponent {
                                         </li>
                                     ))}
                                 </ul>
-                            </>
+                            </li>
                         )}
                     </DropDown.Contents>
                 </DropDown>

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/EditPreviewDropDown/style.module.css
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/EditPreviewDropDown/style.module.css
@@ -69,6 +69,9 @@
     color: #FFF;
     padding: var(--spacing-Half) var(--spacing-Full);
     margin: 0;
+    display: flex;
+    gap: var(--spacing-Half);
+    align-items: center;
 }
 .dropDown__itemIcon {
     margin-right: .5em;

--- a/packages/neos-ui/src/Containers/PrimaryToolbar/EditPreviewDropDown/style.module.css
+++ b/packages/neos-ui/src/Containers/PrimaryToolbar/EditPreviewDropDown/style.module.css
@@ -18,9 +18,7 @@
         color: var(--colors-PrimaryBlue);
     }
 }
-.dropDown__btnIcon {
-    margin-right: .5em;
-}
+
 .dropDown__currentEditMode {
     @media(max-width: 1024px) {
         display: none;
@@ -70,6 +68,7 @@
 .dropDown__groupHeader {
     color: #FFF;
     padding: var(--spacing-Half) var(--spacing-Full);
+    margin: 0;
 }
 .dropDown__itemIcon {
     margin-right: .5em;

--- a/packages/react-ui-components/src/DropDown/header.tsx
+++ b/packages/react-ui-components/src/DropDown/header.tsx
@@ -127,6 +127,7 @@ class ShallowDropDownHeader extends PureComponent<ShallowDropDownHeaderProps> {
                 ref={this.handleReferenceHandler}
                 className={finalClassName}
                 aria-haspopup="true"
+                aria-expanded={isOpen ? 'true' : 'false'}
             >
                 {children}
                 {showDropDownToggle && <Icon icon={iconName} className={theme!.dropDown__chevron} {...iconRest} />}

--- a/packages/react-ui-components/src/DropDown/style.module.css
+++ b/packages/react-ui-components/src/DropDown/style.module.css
@@ -22,12 +22,21 @@
     line-height: var(--spacing-GoldenUnit);
     background: var(--colors-ContrastNeutral);
 
-    &:focus {
+    @media (hover: hover) {
+        &:hover {
+            color: var(--colors-PrimaryBlue);
+        }
+    }
+
+    &:focus-visible {
         outline: 1px solid var(--colors-PrimaryBlue);
     }
 
-    & svg {
+    > svg {
         pointer-events: none;
+        &:first-child{
+            margin-right: var(--spacing-Half);
+        }
     }
 }
 .dropDown__btn--withChevron {

--- a/packages/react-ui-components/src/ListPreviewElement/style.module.css
+++ b/packages/react-ui-components/src/ListPreviewElement/style.module.css
@@ -29,8 +29,7 @@
 
 .listPreviewElement__iconWrapper {
     padding: 0 !important;
-    width: 2em;
     display: inline-block;
     text-align: center;
-    margin-right: 14px;
+    margin-right: var(--spacing-Half);
 }

--- a/packages/react-ui-components/src/SelectBox/selectBox.js
+++ b/packages/react-ui-components/src/SelectBox/selectBox.js
@@ -236,8 +236,8 @@ export default class SelectBox extends PureComponent {
                 <DropDown.Header id={id ? `${id}-header` : undefined} className={headerClassName} shouldKeepFocusState={false} showDropDownToggle={showDropDownToggle && Boolean(options.length)}>
                     {this.renderHeader()}
                 </DropDown.Header>
-                <DropDown.Contents id={id ? `${id}-contents` : undefined} className={dropDownContentsClassName} scrollable={true}>
-                    {!plainInputMode && <ul className={theme.selectBox__list}>
+                <DropDown.Contents id={id ? `${id}-contents` : undefined} className={dropDownContentsClassName} scrollable={true} wrapperTag='div'>
+                    {!plainInputMode && (
                         <SelectBox_ListPreview
                             {...this.props}
 
@@ -251,7 +251,7 @@ export default class SelectBox extends PureComponent {
                             noMatchesFound={noMatchesFound}
                             searchTerm={searchTerm}
                             />
-                    </ul>}
+                    )}
                 </DropDown.Contents>
             </DropDown.Stateless>
         );
@@ -274,7 +274,7 @@ export default class SelectBox extends PureComponent {
         const searchTerm = this.getSearchTerm();
         const optionValueAccessor = this.getOptionValueAccessor();
 
-        // Compare selected value less strictly: allow loose comparision and deep equality of objects
+        // Compare selected value less strictly: allow loose comparison and deep equality of objects
         const selectedOption = options.find(option => optionValueAccessor(option) == value || isEqual(optionValueAccessor(option), value)); // eslint-disable-line eqeqeq
 
         /* eslint-disable no-eq-null, eqeqeq */ // to check for null or undefined, we cannot use the isNil helper as it's not published to npm

--- a/packages/react-ui-components/src/SelectBox/style.module.css
+++ b/packages/react-ui-components/src/SelectBox/style.module.css
@@ -1,7 +1,3 @@
-.selectBox__list {
-    padding: 0;
-}
-
 .selectBox {
     composes: reset from  '../reset.module.css', dropDown from './../DropDown/style.css';
     position: relative;


### PR DESCRIPTION
Resolves: #3826

**What I did and how**
* selectBox react ui component: fixing invalid double `<ul>` wrap
* editPreviewDropdown: fixing invalid markup - `<div>`is direct child of `<ul>`
* same icon spacing in editPreviewDropdown, dimensionDropdown & userDropdown

**How I did it**
* selectBox: removing `<ul>` from SelectBox.js - it uses drowdown.contents which already returns a `<ul>`
* editPreviewDropdown: wrapping groupHeader & it's options in `<li>`and options in own `<ul>`
* icon spacing: setting spacing to `var(--spacing-Half)`

**How to verify it**
checking for proper list markup for the following dropdowns

* node tree presets
* workspace dropdown
* dimension dropdown
* view/preview dropdown
* node type dropdown (inspector)
* open graph type (inspector)
* twitter card - card type (inspector)
* xml sitemap (inspector)

checking that dropdown ui component still produces valid markup by checking user dropdown.