### PR TITLE
BUGFIX: Icon not part of multiline option grid

### DIFF
--- a/packages/neos-ui-editors/src/Editors/SelectBox/selectBoxHelpers.ts
+++ b/packages/neos-ui-editors/src/Editors/SelectBox/selectBoxHelpers.ts
@@ -48,7 +48,6 @@ export const processSelectBoxOptions = (i18nRegistry: I18nRegistry, selectBoxOpt
         if (!selectBoxOption || !selectBoxOption.label) {
             continue;
         }
-
         const processedSelectBoxOption: SelectBoxOption = {
             value: key,
             ...selectBoxOption, // a value in here overrules value based on the key above.

--- a/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/__snapshots__/selectBox_Option_MultiLineWithThumbnail.spec.js.snap
+++ b/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/__snapshots__/selectBox_Option_MultiLineWithThumbnail.spec.js.snap
@@ -11,6 +11,7 @@ exports[`<SelectBox_Option_MultiLineWithThumbnail/> should render correctly. 1`]
       "label": "Bar label",
     }
   }
+  theme={Object {}}
 >
   <img
     alt="Foo label"

--- a/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/selectBox_Option_MultiLineWithThumbnail.js
+++ b/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/selectBox_Option_MultiLineWithThumbnail.js
@@ -18,6 +18,8 @@ class SelectBox_Option_MultiLineWithThumbnail extends PureComponent {
         theme: PropTypes.shape({
             multiLineWithThumbnail__item: PropTypes.string.isRequired,
             'multiLineWithThumbnail__item--multiLine': PropTypes.string.isRequired,
+            'multiLineWithThumbnail__item--withIcon': PropTypes.string.isRequired,
+            multiLineWithThumbnail__label: PropTypes.string.isRequired,
             multiLineWithThumbnail__secondaryLabel: PropTypes.string.isRequired,
             multiLineWithThumbnail__tertiaryLabel: PropTypes.string.isRequired,
             multiLineWithThumbnail__image: PropTypes.string.isRequired
@@ -40,13 +42,14 @@ class SelectBox_Option_MultiLineWithThumbnail extends PureComponent {
         const finalClassNames = mergeClassNames({
             [theme.multiLineWithThumbnail__item]: true,
             [theme['multiLineWithThumbnail__item--multiLine']]: secondaryLabel || tertiaryLabel,
+            [theme['multiLineWithThumbnail__item--withIcon']]: icon,
             [className]: className
         });
 
         return (
-            <ListPreviewElement {...rest} icon={icon} className={finalClassNames}>
+            <ListPreviewElement {...rest} theme={theme} icon={icon} className={finalClassNames}>
                 {Boolean(imageUri) && <img src={imageUri} alt={label} className={theme.multiLineWithThumbnail__image}/>}
-                <span title={title ? title : label}>{label}</span>
+                <span className={theme.multiLineWithThumbnail__label} title={title ? title : label}>{label}</span>
                 {Boolean(secondaryLabel) && <span className={theme.multiLineWithThumbnail__secondaryLabel} title={secondaryLabel}>{secondaryLabel}</span>}
                 {Boolean(tertiaryLabel) && <span className={theme.multiLineWithThumbnail__tertiaryLabel} title={tertiaryLabel}>{tertiaryLabel}</span>}
             </ListPreviewElement>

--- a/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/style.module.css
+++ b/packages/react-ui-components/src/SelectBox_Option_MultiLineWithThumbnail/style.module.css
@@ -1,46 +1,56 @@
 .multiLineWithThumbnail__item {
     display: grid;
-    grid-template-columns: auto 1fr;
+    grid-template-columns: auto min-content 1fr;
     column-gap: var(--spacing-Half);
     align-items: start;
     box-sizing: content-box;
-    background: var(--colors-ContrastDarkest);
+    background-color: var(--colors-ContrastDarkest);
+    padding: 5px var(--spacing-Half) 5px var(--spacing-Full);
 }
 
-.multiLineWithThumbnail__item span {
+.listPreviewElement__iconWrapper {
     grid-column: 2;
     grid-row: 1;
+    margin-right: 0;
+    width: fit-content;
+}
+
+.multiLineWithThumbnail__label {
+    grid-column: 2 / 4;
+    grid-row: 1 / auto;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-
-    &.multiLineWithThumbnail__secondaryLabel {
-        grid-row: 2;
-    }
-
-    &.multiLineWithThumbnail__tertiaryLabel {
-        grid-row: 3;
-    }
 }
 
-.multiLineWithThumbnail__item--multiLine {
-    line-height: 20px;
+.multiLineWithThumbnail__item--withIcon .multiLineWithThumbnail__label {
+    grid-column-start: 3;
 }
 
 .multiLineWithThumbnail__secondaryLabel {
+    grid-column: 2 / 4;
+    grid-row: auto;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     color: var(--colors-ContrastBright);
     display: block;
     font-size: 12px;
-    text-overflow: ellipsis;
-    overflow: hidden;
 }
 
 .multiLineWithThumbnail__tertiaryLabel {
+    grid-column: 2 / 4;
+    grid-row: auto;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     color: var(--colors-ContrastBright);
     display: block;
     font-size: 12px;
-    text-overflow: ellipsis;
-    overflow: hidden;
+}
+
+.multiLineWithThumbnail__item--multiLine {
+    line-height: 1.4em;
 }
 
 .multiLineWithThumbnail__image {
@@ -53,14 +63,17 @@
     background-size: 10px 10px;
     background-position: 0 0, 25px 25px;
     background-image: linear-gradient(45deg, #cccccc 25%, transparent 25%, transparent 75%, #cccccc 75%, #cccccc), linear-gradient(45deg, #cccccc 25%, transparent 25%, transparent 75%, #cccccc 75%, #cccccc);
-    margin-right: .75em;
     display: inline-block;
     vertical-align: middle;
     margin-left: calc(var(--spacing-Full) * -1);
     align-self: center;
 }
 
-.multiLineWithThumbnail__item:hover .multiLineWithThumbnail__secondaryLabel,
-.multiLineWithThumbnail__item:hover .multiLineWithThumbnail__tertiaryLabel {
-    color: white;
+.multiLineWithThumbnail__item:hover {
+    background-color: var(--colors-ContrastDarker);
+
+    .multiLineWithThumbnail__secondaryLabel,
+    .multiLineWithThumbnail__tertiaryLabel {
+        color: white;
+    }
 }


### PR DESCRIPTION
The multiline option layout had a few quirks and bugs and the icon was in the wrong position.
Also added a big of highlighting on hover.

Before:

<img width="606" height="728" alt="CleanShot 2026-06-23 at 18 26 08@2x" src="https://github.com/user-attachments/assets/725f2f63-c10d-48e5-9c50-38c5dc3283c6" />

After:

<img width="630" height="676" alt="CleanShot 2026-06-23 at 18 20 19@2x" src="https://github.com/user-attachments/assets/4d1f1522-7a12-4216-a831-dc4b1d355d0b" />

With hover but no icons:

<img width="582" height="568" alt="CleanShot 2026-06-23 at 18 31 50@2x" src="https://github.com/user-attachments/assets/596c2082-6531-4617-94cd-72d4567762c1" />
