### PR TITLE
Bugfix: add ability for view only users to interact with preview page and view data in inspector

### DIFF
--- a/Classes/Aspects/AugmentationAspect.php
+++ b/Classes/Aspects/AugmentationAspect.php
@@ -22,6 +22,7 @@ use Neos\Fusion\Service\HtmlAugmenter;
 use Neos\Neos\Domain\Service\ContentContext;
 use Neos\Neos\Ui\Domain\Service\UserLocaleService;
 use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
+use Neos\Neos\Ui\Service\NodePolicyService;
 
 /**
  * - Serialize all nodes related to the currently rendered document
@@ -60,6 +61,12 @@ class AugmentationAspect
      * @var ?\Neos\Flow\Mvc\Controller\ControllerContext
      */
     protected $controllerContext = null;
+
+    /**
+     * @Flow\Inject
+     * @var NodePolicyService
+     */
+    protected $nodePolicyService;
 
     /**
      * @Flow\Before("method(Neos\Neos\Fusion\ContentElementWrappingImplementation->evaluate())")
@@ -145,7 +152,7 @@ class AugmentationAspect
             return $content;
         }
 
-        if ($this->nodeAuthorizationService->isGrantedToEditNode($node) === false) {
+        if ($this->nodePolicyService->canReadProperties($node) === false) {
             return $content;
         }
 

--- a/Classes/Service/NodePolicyService.php
+++ b/Classes/Service/NodePolicyService.php
@@ -19,6 +19,7 @@ use Neos\ContentRepository\Security\Authorization\Privilege\Node\EditNodePrivile
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\EditNodePropertyPrivilege;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\NodePrivilegeSubject;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\PropertyAwareNodePrivilegeSubject;
+use Neos\ContentRepository\Security\Authorization\Privilege\Node\ReadNodePrivilege;
 use Neos\ContentRepository\Security\Authorization\Privilege\Node\RemoveNodePrivilege;
 use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
@@ -82,6 +83,7 @@ class NodePolicyService
             'disallowedNodeTypes' => $this->getDisallowedNodeTypes($node),
             'canRemove' => $this->canRemoveNode($node),
             'canEdit' => $this->canEditNode($node),
+            'canReadProperties' => $this->canReadProperties($node),
             'disallowedProperties' => $this->getDisallowedProperties($node)
         ];
     }
@@ -98,6 +100,30 @@ class NodePolicyService
 
         return $this->privilegeManager->isGranted(
             NodeTreePrivilege::class,
+            new NodePrivilegeSubject($node)
+        );
+    }
+
+    /**
+     * @param NodeInterface $node
+     * @return bool
+     */
+    public function canReadProperties(NodeInterface $node): bool
+    {
+        // In our current understanding, this canReadProperties check can NEVER return false under normal
+        // Neos UI circumstances, because we test for ReadNodePrivilege.
+        // if a node should be hidden via ReadNodePrivilege, it is not returned from persistence, thus
+        // you would not be able to get the $node instance.
+        //
+        // We left the method in there nevertheless for:
+        // - if users want to override this via AOP
+        // - if somebody would want to create a new PrivilegeType for it (!! node privilege concept changes with Neos 9 !!)
+        if (!isset(self::getUsedPrivilegeClassNames($this->objectManager)[ReadNodePrivilege::class])) {
+            return true;
+        }
+
+        return $this->privilegeManager->isGranted(
+            ReadNodePrivilege::class,
             new NodePrivilegeSubject($node)
         );
     }

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -112,9 +112,11 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
 
     const editPreviewMode = $get(['ui', 'editPreviewMode'], state);
     const editPreviewModes = globalRegistry.get('frontendConfiguration').get('editPreviewModes');
-    const isWorkspaceReadOnly = selectors.CR.Workspaces.isWorkspaceReadOnlySelector(state);
     const currentEditMode = editPreviewModes[editPreviewMode];
-    if (!currentEditMode || !currentEditMode.isEditingMode || isWorkspaceReadOnly) {
+
+    // Read-only workspaces are handled in initializePropertyDomNode, where no
+    // inline editor is initialized for content the user is not allowed to edit
+    if (!currentEditMode || !currentEditMode.isEditingMode) {
         return;
     }
 

--- a/packages/neos-ui-guest-frame/src/initializePropertyDomNode.js
+++ b/packages/neos-ui-guest-frame/src/initializePropertyDomNode.js
@@ -1,9 +1,9 @@
-import {$get, $contains} from 'plow-js';
+import {$contains, $get} from 'plow-js';
 
-import {actions} from '@neos-project/neos-ui-redux-store';
+import {actions, selectors} from '@neos-project/neos-ui-redux-store';
 import {validateElement} from '@neos-project/neos-ui-validators';
 
-import {getGuestFrameWindow, closestContextPathInGuestFrame} from './dom';
+import {closestContextPathInGuestFrame, getGuestFrameDocument, getGuestFrameWindow} from './dom';
 
 export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry, nodes}) => propertyDomNode => {
     const guestFrameWindow = getGuestFrameWindow();
@@ -23,12 +23,19 @@ export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry,
 
     const nodeTypeName = $get([contextPath, 'nodeType'], nodes);
     const nodeType = nodeTypesRegistry.get(nodeTypeName);
-    const isInlineEditable = (
-        $get(['properties', propertyName, 'ui', 'inlineEditable'], nodeType) !== false &&
-        !$contains(propertyName, [contextPath, 'policy', 'disallowedProperties'], nodes)
-    );
+    const isInlineEditable = $get(['properties', propertyName, 'ui', 'inlineEditable'], nodeType) !== false;
 
-    if (isInlineEditable) {
+    // We do not initialize an inline editor for content the user is not
+    // allowed to edit (read-only workspace or missing edit permission on the node or
+    // property). The server-rendered markup is not editable by itself, which makes
+    // not booting the editor the most robust way to prevent editing.
+    const isWorkspaceReadOnly = selectors.CR.Workspaces.isWorkspaceReadOnlySelector(store.getState());
+
+    if (!isInlineEditable || isWorkspaceReadOnly) {
+        return;
+    }
+
+    const initializeInlineEditor = () => {
         const editorIdentifier = 'ckeditor5';
         const editorOptions = nodeTypesRegistry.getInlineEditorOptionsForProperty(nodeTypeName, propertyName);
         const {bootstrap, createInlineEditor} = inlineEditorRegistry.get(editorIdentifier);
@@ -107,5 +114,41 @@ export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry,
             //
             console.error(err);
         }
+    };
+
+    const initializeInlineEditorIfPermitted = policy => {
+        const isEditingDisallowed = $get('canEdit', policy) === false ||
+            $contains(propertyName, 'disallowedProperties', policy);
+
+        if (!isEditingDisallowed) {
+            initializeInlineEditor();
+        }
+    };
+
+    // The node policy is lazy-loaded after the initial node data arrived in the store, so it is usually not available
+    // yet while the guest frame content is initialized. We have to wait for it before we can decide
+    // whether an inline editor may be created for this property.
+    const selectNodePolicy = () => $get([contextPath, 'policy'], store.getState().cr.nodes.byContextPath);
+    const nodePolicy = selectNodePolicy();
+
+    if (nodePolicy) {
+        initializeInlineEditorIfPermitted(nodePolicy);
+        return;
     }
+
+    const unsubscribe = store.subscribe(() => {
+        const nodePolicy = selectNodePolicy();
+        if (!nodePolicy) {
+            return;
+        }
+
+        unsubscribe();
+
+        // The guest frame might have been reloaded while we waited for the policy
+        if (getGuestFrameDocument() !== propertyDomNode.ownerDocument) {
+            return;
+        }
+
+        initializeInlineEditorIfPermitted(nodePolicy);
+    });
 };

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/InspectorEditorEnvelope/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/InspectorEditorEnvelope/index.js
@@ -6,6 +6,7 @@ import EditorEnvelope from '@neos-project/neos-ui-editors/src/EditorEnvelope/ind
 import {neos} from '@neos-project/neos-ui-decorators';
 import {connect} from 'react-redux';
 import {selectors} from '@neos-project/neos-ui-redux-store';
+
 /**
  * (Stateful) Editor envelope
  *
@@ -43,7 +44,11 @@ export default class InspectorEditorEnvelope extends PureComponent {
     get options() {
         // This makes sure that auto-created child nodes cannot be hidden
         // via the insprector (see: #2282)
-        if (this.props.isWorkspaceReadOnly || ($get('isAutoCreated', this.props.node) === true && this.props.id === '_hidden')) {
+        const isAutoCreatedHiddenProperty = $get('isAutoCreated', this.props.node) === true && this.props.id === '_hidden';
+        // Nodes the user is not allowed to edit are shown read-only in the inspector
+        const isNodeEditingDisallowed = $get(['policy', 'canEdit'], this.props.node) === false;
+
+        if (this.props.isWorkspaceReadOnly || isNodeEditingDisallowed || isAutoCreatedHiddenProperty) {
             return {...this.props.options, disabled: true};
         }
 

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
@@ -30,7 +30,7 @@ export default class TabPanel extends PureComponent {
             return false;
         }
 
-        return $get(['policy', 'canEdit'], node) && !$contains(item.id, 'policy.disallowedProperties', node);
+        return $get(['policy', 'canReadProperties'], node) && !$contains(item.id, 'policy.disallowedProperties', node);
     };
 
     renderTabPanel = groups => {

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -251,7 +251,7 @@ export default class Inspector extends PureComponent {
             return false;
         }
 
-        return $get(['policy', 'canEdit'], focusedNode) && !$contains(item.id, 'policy.disallowedProperties', focusedNode);
+        return $get(['policy', 'canReadProperties'], focusedNode) && !$contains(item.id, 'policy.disallowedProperties', focusedNode);
     };
 
     /**


### PR DESCRIPTION
This is the successor of #3921. It contains the bugfix and implements all remarks from the comments of the original PR.

**What I did**
Previous Behaviour:
- When a view-only user clicks on a node on the preview page nothing happens.
- The user can only select nodes via the content tree (left sidebar)
- The user can not see any node data in the inspector (right sidebar)

Fixed Behaviour:
- The user can interact with nodes on the preview page (highlighting is visible)
- The user can view - but not edit - node data in the inspector (right sidebar)

**How I did it**
- Backend: gate rendering on read permission instead of edit permission — added a canReadProperties check (based on ReadNodePrivilege) to NodePolicyService, exposed it in the node policy data, and switched AugmentationAspect to use it so content metadata is still rendered for view-only users. 
- Frontend: don't boot inline editors for content the user can't edit — initializePropertyDomNode.js skips editor initialization when the workspace is read-only or the (lazy-loaded, awaited via store subscription) node policy disallows editing, replacing the old approach of blocking the whole guest frame / read-only CKEditor instances, so view-only users can interact with the preview page normally.                                                                                                                                                               
- Inspector: show node data read-only — tab/property visibility now checks canReadProperties instead of canEdit, and InspectorEditorEnvelope disables editors when the node policy has canEdit: false, letting view-only users see values without editing them.

**How to verify it**
- Create a role (e.g. with the Sandstorm.NeosAcl package) that has permission to view but not to edit/create.
- When browsing content the user should be able to click on nodes in the preview page and see their data in the inspector.

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
**BEFORE**
![Screenshot before change](https://github.com/user-attachments/assets/637bd2c8-51ef-4c7d-a42f-7e3dd6e2d829)
**AFTER**
![Screenshot after change](https://github.com/user-attachments/assets/e1e4c832-02c7-49eb-9ec0-ce3204a3b4ee)
