### PR TITLE
TASK: deprecate and disable not use-full and broken keyboard shortcuts

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -84,7 +84,8 @@ Neos:
       # const {someKey} = getFrontendConfigurationForPackage('Your.Own:Package');
       #
       frontendConfiguration:
-
+        # keyboard shortcuts will be removed in the next version of neos
+        enableLegacyKeyboardShortcuts: false
         # we use the frontendConfiguration for hotkeys here to preserve compatibility. For new settings the neos ui should use the ConfigurationProvider instead.
         hotkeys:
           'UI.RightSideBar.toggle': 't i'

--- a/packages/neos-ui-sagas/src/manifest.js
+++ b/packages/neos-ui-sagas/src/manifest.js
@@ -1,4 +1,5 @@
 import manifest from '@neos-project/neos-ui-extensibility';
+import {getFullPackageFrontendConfiguration} from '@neos-project/neos-ui-configuration';
 import {SynchronousRegistry} from '@neos-project/neos-ui-registry';
 
 import {
@@ -80,7 +81,9 @@ manifest('main.sagas', {}, globalRegistry => {
     sagasRegistry.set('neos-ui/UI/PageTree/watchSearch', {saga: uiPageTree.watchSearch});
     sagasRegistry.set('neos-ui/UI/PageTree/watchToggle', {saga: uiPageTree.watchToggle});
 
-    sagasRegistry.set('neos-ui/UI/Hotkeys/handleHotkeys', {saga: uiHotkeys.handleHotkeys});
+    if (getFullPackageFrontendConfiguration().enableLegacyKeyboardShortcuts === true) {
+        sagasRegistry.set('neos-ui/UI/Hotkeys/handleHotkeys', {saga: uiHotkeys.handleHotkeys});
+    }
 
     sagasRegistry.set('neos-ui/UI/Impersonate/impersonateRestore', {saga: impersonate.impersonateRestore});
 

--- a/packages/neos-ui/src/manifest.containers.js
+++ b/packages/neos-ui/src/manifest.containers.js
@@ -1,4 +1,5 @@
 import manifest from '@neos-project/neos-ui-extensibility';
+import {getFullPackageFrontendConfiguration} from '@neos-project/neos-ui-configuration';
 
 import App from './Containers/App';
 
@@ -64,7 +65,11 @@ manifest('main.containers', {}, globalRegistry => {
     containerRegistry.set('PrimaryToolbar', PrimaryToolbar);
     containerRegistry.set('PrimaryToolbar/Left/MenuToggler', MenuToggler);
     containerRegistry.set('PrimaryToolbar/Left/Brand', Brand);
-    containerRegistry.set('PrimaryToolbar/Right/KeyboardShortcutButton', KeyboardShortcutButton);
+
+    if (getFullPackageFrontendConfiguration().enableLegacyKeyboardShortcuts === true) {
+        containerRegistry.set('PrimaryToolbar/Right/KeyboardShortcutButton', KeyboardShortcutButton);
+    }
+
     containerRegistry.set('PrimaryToolbar/Right/DimensionSwitcher', DimensionSwitcher);
     containerRegistry.set('PrimaryToolbar/Right/WorkspaceSelector', WorkspaceSelector);
     containerRegistry.set('PrimaryToolbar/Right/WorkspaceSync', WorkspaceSync);


### PR DESCRIPTION
Related https://github.com/neos/neos-ui/issues/4153
Related https://github.com/neos/neos-ui/issues/3100

We have discussed thousand times that our keyboard shortcuts are too absurd to be useful and that we want to free the space in the ui and reduce complexity in the code for a feature which doesnt really work.

Notice the missing button? Me neither
 
<img width="773" height="145" alt="image" src="https://github.com/user-attachments/assets/8f8a6305-e976-4a5a-b24d-b1a31e6938df" />


`Neos.Neos.Ui.frontendConfiguration.enableLegacyKeyboardShortcuts` allows to re-enable it in case its really used somewhere and might then lead us to not removing it in 9.3
