### PR TITLE
TASK: Ensure preview and fullscreen buttons are rightmost (move new edit preview mode left)

### DIFF
--- a/packages/neos-ui/src/manifest.containers.js
+++ b/packages/neos-ui/src/manifest.containers.js
@@ -74,9 +74,9 @@ manifest('main.containers', {}, globalRegistry => {
     containerRegistry.set('SecondaryToolbar/LoadingIndicator', LoadingIndicator);
     containerRegistry.set('SecondaryToolbar/Left/Breadcrumb', Breadcrumb);
     containerRegistry.set('SecondaryToolbar/Right/InlineEditorToolbar', InlineEditorToolbar);
+    containerRegistry.set('SecondaryToolbar/Right/EditPreviewDropDown', EditPreviewDropDown);
     containerRegistry.set('SecondaryToolbar/Right/PreviewButton', PreviewButton);
     containerRegistry.set('SecondaryToolbar/Right/FullScreenButton', FullScreenButton);
-    containerRegistry.set('SecondaryToolbar/Right/EditPreviewDropDown', EditPreviewDropDown);
 
     containerRegistry.set('Drawer', Drawer);
     containerRegistry.set('Drawer/Bottom/UserDropDown', UserDropDown);


### PR DESCRIPTION
Followup to https://github.com/neos/neos-ui/pull/4160

<img width="788" height="151" alt="image" src="https://github.com/user-attachments/assets/4231da43-6d1d-436a-b410-40653da5d224" />

Because of muscle memory it took a bit to find the old preview button - also the position is not absolutely fixed but depending on the width of the edit preview label which also makes it harder to fully understand the layout.

Dektop (previously in corner)

<img width="683" height="296" alt="image" src="https://github.com/user-attachments/assets/d6f3c82e-2986-4c2d-9d0b-7a221f942879" />

Tablet both corners never match

<img width="580" height="314" alt="image" src="https://github.com/user-attachments/assets/2745ba67-635a-4cfa-a20f-3a68789e7e7e" />
