### PR TITLE
BUGFIX: Do not create inline editors for nodes without edit permission

### DIFF
--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -1,4 +1,4 @@
-import {put, select, takeEvery} from 'redux-saga/effects';
+import {all, call, put, select, takeEvery} from 'redux-saga/effects';
 
 import {actions, actionTypes, selectors} from '@neos-project/neos-ui-redux-store';
 import {requestIdleCallback} from '@neos-project/utils-helpers';
@@ -40,6 +40,18 @@ const eventPath = event => {
     return path;
 };
 
+//
+// Load the node data for the given nodes.
+//
+const loadNodeData = (q, nodeContextPaths) =>
+    nodeContextPaths.length > 0 ? q(nodeContextPaths).get() : [];
+
+//
+// Load the policies for the given nodes, telling us what the user is allowed to do with them.
+//
+const loadNodePolicies = (endpoints, nodeContextPaths) =>
+    nodeContextPaths.length > 0 ? endpoints.getAdditionalNodeMetadata(nodeContextPaths) : {};
+
 export default ({globalRegistry, store}) => function * initializeGuestFrame() {
     const nodeTypesRegistry = globalRegistry.get('@neos-project/neos-ui-contentrepository');
     const inlineEditorRegistry = globalRegistry.get('inlineEditors');
@@ -62,22 +74,36 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
     }
 
     // Load all nodedata for nodes in the guest frame and filter duplicates
-    const {q} = yield backend.get();
+    const {q, endpoints} = yield backend.get();
     const nodeContextPathsInGuestFrame = findAllNodesInGuestFrame().map(node => node.getAttribute('data-__neos-node-contextpath'));
 
     // Filter nodes that are already present in the redux store and duplicates
     const nodesByContextPath = store.getState().cr.nodes.byContextPath;
-    const notFullyLoadedNodeContextPaths = [...new Set(nodeContextPathsInGuestFrame)].filter((contextPath) => {
+    const uniqueNodeContextPathsInGuestFrame = [...new Set(nodeContextPathsInGuestFrame)];
+    const notFullyLoadedNodeContextPaths = uniqueNodeContextPathsInGuestFrame.filter((contextPath) => {
         const node = nodesByContextPath[contextPath];
         const nodeIsLoaded = node !== undefined && node.isFullyLoaded;
         return !nodeIsLoaded;
     });
 
-    // Load remaining list of not fully loaded nodes from the backend if there are any
-    const fullyLoadedNodesFromContent = notFullyLoadedNodeContextPaths.length > 0 ? (yield q(notFullyLoadedNodeContextPaths).get()).reduce((nodes, node) => {
+    // The node policies tell us whether the user may edit a node at all. They are usually fetched
+    // lazily (see the CR/Policies saga), which is too late for us: The inline editors are created
+    // right after this saga merged the node data, so we would create editors before knowing whether
+    // the user is allowed to change the content. We therefore load them together with the node data.
+    const nodeContextPathsWithoutPolicy = uniqueNodeContextPathsInGuestFrame.filter(
+        contextPath => !nodesByContextPath[contextPath]?.policy
+    );
+
+    // Load remaining list of not fully loaded nodes and the missing policies from the backend if there are any
+    const [nodesFromContent, additionalNodeMetadata] = yield all([
+        call(loadNodeData, q, notFullyLoadedNodeContextPaths),
+        call(loadNodePolicies, endpoints, nodeContextPathsWithoutPolicy)
+    ]);
+
+    const fullyLoadedNodesFromContent = nodesFromContent.reduce((nodes, node) => {
         nodes[node.contextPath] = node;
         return nodes;
-    }, {}) : {};
+    }, {});
 
     const nodes = Object.assign(
         {},
@@ -86,6 +112,12 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
             [documentInformation.metaData.documentNode]: documentInformation.metaData.documentNodeSerialization
         }
     );
+
+    // Merge the freshly loaded policies into the node data, so that they are part of the same store
+    // update. This also keeps the CR/Policies saga from requesting them a second time.
+    Object.entries(additionalNodeMetadata || {}).forEach(([contextPath, metadata]) => {
+        nodes[contextPath] = Object.assign({}, nodes[contextPath], metadata);
+    });
 
     // Merge new nodes into the store
     yield put(actions.CR.Nodes.merge(nodes));

--- a/packages/neos-ui-guest-frame/src/initializePropertyDomNode.js
+++ b/packages/neos-ui-guest-frame/src/initializePropertyDomNode.js
@@ -3,6 +3,22 @@ import {validateElement} from '@neos-project/neos-ui-validators';
 
 import {getGuestFrameWindow, closestContextPathInGuestFrame} from './dom';
 
+//
+// Determine whether an inline editor may be created for the given property.
+//
+// Besides the node type configuration this respects the node policy: The Content Repository rejects
+// modifications of nodes the user has no edit permission for, so an editor for such a node would
+// happily accept input just to fail once the change is persisted.
+//
+// A missing `canEdit` is deliberately treated as "editable": the policy is loaded asynchronously
+// and we must not lock down content just because it has not arrived yet.
+//
+export const isPropertyInlineEditable = ({nodeType, propertyName, nodePolicy}) => (
+    nodeType?.properties?.[propertyName]?.ui?.inlineEditable !== false &&
+    nodePolicy?.canEdit !== false &&
+    !nodePolicy?.disallowedProperties?.includes(propertyName)
+);
+
 export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry, nodes}) => propertyDomNode => {
     const guestFrameWindow = getGuestFrameWindow();
     if (!guestFrameWindow['@Neos.Neos.Ui:InitializedInlineEditors']) {
@@ -21,10 +37,11 @@ export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry,
 
     const nodeTypeName = nodes?.[contextPath]?.nodeType;
     const nodeType = nodeTypesRegistry.get(nodeTypeName);
-    const isInlineEditable = (
-        nodeType?.properties?.[propertyName]?.ui?.inlineEditable !== false &&
-        !nodes?.[contextPath]?.policy?.disallowedProperties?.includes(propertyName)
-    );
+    const isInlineEditable = isPropertyInlineEditable({
+        nodeType,
+        propertyName,
+        nodePolicy: nodes?.[contextPath]?.policy
+    });
 
     if (isInlineEditable) {
         const editorIdentifier = 'ckeditor5';

--- a/packages/neos-ui-guest-frame/src/initializePropertyDomNode.spec.js
+++ b/packages/neos-ui-guest-frame/src/initializePropertyDomNode.spec.js
@@ -1,0 +1,47 @@
+import {isPropertyInlineEditable} from './initializePropertyDomNode';
+
+const nodeType = {
+    properties: {
+        title: {ui: {inlineEditable: true}},
+        text: {},
+        assetIdentifier: {ui: {inlineEditable: false}}
+    }
+};
+
+describe('node type configuration', () => {
+    test('property that is configured as inline editable is editable', () => {
+        expect(isPropertyInlineEditable({nodeType, propertyName: 'title'})).toBe(true);
+    });
+
+    test('property without inline editor configuration is editable', () => {
+        expect(isPropertyInlineEditable({nodeType, propertyName: 'text'})).toBe(true);
+    });
+
+    test('property that is configured as not inline editable is not editable', () => {
+        expect(isPropertyInlineEditable({nodeType, propertyName: 'assetIdentifier'})).toBe(false);
+    });
+});
+
+describe('node policy', () => {
+    test('property of a node the user may edit is editable', () => {
+        const nodePolicy = {canEdit: true, disallowedProperties: []};
+
+        expect(isPropertyInlineEditable({nodeType, propertyName: 'title', nodePolicy})).toBe(true);
+    });
+
+    test('property of a node the user may not edit is not editable', () => {
+        const nodePolicy = {canEdit: false, disallowedProperties: []};
+
+        expect(isPropertyInlineEditable({nodeType, propertyName: 'title', nodePolicy})).toBe(false);
+    });
+
+    test('property that is disallowed for the user is not editable', () => {
+        const nodePolicy = {canEdit: true, disallowedProperties: ['title']};
+
+        expect(isPropertyInlineEditable({nodeType, propertyName: 'title', nodePolicy})).toBe(false);
+    });
+
+    test('property is editable while the policy has not been loaded yet', () => {
+        expect(isPropertyInlineEditable({nodeType, propertyName: 'title', nodePolicy: undefined})).toBe(true);
+    });
+});


### PR DESCRIPTION
Resolves #4171

**What I did**

Inline editors were created for every inline editable property, regardless of whether the user is allowed to edit the node. Editors could type into content protected by an `EditNodePrivilege`, and the change was only rejected once it was persisted — with a raw `AccessDenied` exception from the Content Repository. This is the behaviour described in the note of neos/neos-development-collection#5298.

The node policy already carries the required information (`policy.canEdit`, computed server side by `ContentRepositoryAuthorizationService::getNodePermissions()`), but it was never consulted when creating the inline editors — and it was not even available at that point in time.

**How I did it**

Two changes, both in `neos-ui-guest-frame`:

1. `initializePropertyDomNode.js` now respects `policy.canEdit`. The decision moved into a small pure function `isPropertyInlineEditable()` so it can be unit tested. A missing `canEdit` is deliberately treated as "editable", so nothing is locked down if the policy is unavailable.

2. `initializeGuestFrame.js` loads the node policies **together with** the node data (`all([call(loadNodeData, …), call(loadNodePolicies, …)])`) and merges them in a single store update. Previously the policies were fetched lazily by the `CR/Policies` saga *after* the node data had been merged, while the content DOM nodes are initialized immediately afterwards — and `initializeContentDomNode` reads the store at call time. Whether the policy was there was therefore a race.

The second part is what makes the first one reliable. Gating on `canEdit` alone is flaky: measured on the same page over three identical reloads, a gate-only build initialized **1, 5 and 1** editors — i.e. forbidden editors leak in depending on when the policy request returns. With the policies loaded up front the result is deterministic.

Because both requests now run concurrently, this costs no extra latency: in the network timeline the guest frame's `flow-query` and `get-additional-node-metadata` start simultaneously. The merged policies also keep the `CR/Policies` saga from requesting them a second time (its filter skips nodes that already have a policy).

No security logic was added on the client side — the decision stays entirely server side, as requested in #4079. The removed `NodePolicyService` is *not* revived and no new endpoint is introduced.

Regarding the ongoing security concept work: I asked in neos/neos-development-collection#5650 (comment) whether a UX fix against the current privilege API is welcome now; no objection in two weeks, so here it is — happy to rework if the concept lands on a different model.

**How to verify it**

Reproduction on the Neos demo site (a small command controller is needed to apply the subtree tag, since there is no CLI for it yet — see neos/neos-development-collection#5931):

1. `./flow site:importAll --package-key Neos.Demo`
2. Tag a subtree, e.g. the "Blog" document, via `TagSubtree::create(...)`
3. `Policy.yaml` — note the **site-wide** target: for nodes that no privilege target matches at all, Flow defaults to "granted", so without it the restricted role could edit everything and nothing would reproduce. Note also `LivePublisher`: without it the personal workspace is reported read-only and the UI disables editing altogether, which hides the node-level problem behind the workspace-level one.
   ```yaml
   privilegeTargets:
     'Neos\Neos\Security\Authorization\Privilege\EditNodePrivilege':
       'Neos.Demo:EditAllNodes':
         matcher: 'demosite'
       'Neos.Demo:EditBlogNodes':
         matcher: 'blog'
   roles:
     'Neos.Neos:Editor':
       privileges:
         - privilegeTarget: 'Neos.Demo:EditAllNodes'
           permission: GRANT
         - privilegeTarget: 'Neos.Demo:EditBlogNodes'
           permission: GRANT
     'Neos.Demo:BlogEditor':
       parentRoles: ['Neos.Neos:AbstractEditor', 'Neos.Neos:LivePublisher']
       privileges:
         - privilegeTarget: 'Neos.Demo:EditBlogNodes'
           permission: GRANT
   ```
4. Log in with a user that only has `Neos.Demo:BlogEditor` and open a document outside the tagged subtree
5. **Before:** clicking into any text starts an inline editor; saving fails with `Command "…SetNodeProperties" was denied: No edit permissions for node "…"`
   **After:** the text is not editable; content inside the tagged subtree still is

Measured on the demo site with the setup above, comparing every property against what `get-additional-node-metadata` reports for its node:

| page | 9.1.6 as released | with this PR | server verdict | mismatches |
|---|---|---|---|---|
| Features (not permitted) | 16 of 16 editors | **0 of 16** | all 16 `canEdit: false` | 0 |
| Blog posting (permitted) | 6 of 6 editors | **5 of 6** | 5× `true`, 1× `false` (element outside the blog subtree) | 0 |

And in a real 8.3→9.1 customer migration (74 inline editable properties on one page, editor role scoped to a single tagged element):

| Build | inline editors initialized |
|---|---|
| 9.1.6 as released | 54 of 74 (53 of them forbidden for that role) |
| gate only, policies still lazy | 1 / 5 / 1 over three identical reloads (flaky) |
| this PR | 1 / 1 / 1 — exactly the one node the role may edit |

Before/after GIFs recorded on the demo site follow in a comment.

Side note, unrelated to this PR: the deny message names the wrong privilege type — it says `No privilege of type "…\ReadNodePrivilege" matched` while evaluating an **Edit** target (`"Neos.Demo:EditAllNodes": ABSTAIN`). Happy to file that separately.

Tests: 7 new Jest cases in `initializePropertyDomNode.spec.js`; full suite green (151 suites / 826 tests / 52 snapshots), ESLint clean, production build succeeds.

**Known limitations (deliberately out of scope)**

- The inspector still uses `canEdit` as a *visibility* predicate (`Inspector/index.js`, `TabPanel/index.js`), so it renders empty instead of read-only for such nodes. That is a separate change and overlaps with the inspector part of #4152 — happy to prepare it once the direction here is clear.
- `policy.disallowedProperties` is still hardcoded to `[]` server side (`// not implemented for Neos 9.0`), so per-property restrictions remain unavailable. That belongs to the security concept in neos/neos-development-collection#5650.
