### PR TITLE
TASK: Replace removed and deprecated PhpUnit mock APIs in test

### DIFF
--- a/Tests/Functional/Domain/Service/NodePropertyConverterServiceTest.php
+++ b/Tests/Functional/Domain/Service/NodePropertyConverterServiceTest.php
@@ -27,7 +27,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
 
         $nodeType = $this
             ->getMockBuilder(NodeType::class)
-            ->setMethods(['getPropertyType'])
+            ->onlyMethods(['getPropertyType'])
             ->disableOriginalConstructor()
             ->getMock();
         $nodeType
@@ -37,7 +37,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
 
         $node = $this
             ->getMockBuilder(Node::class)
-            ->setMethods(['getProperty', 'getNodeType'])
+            ->onlyMethods(['getProperty', 'getNodeType'])
             ->disableOriginalConstructor()
             ->getMock();
         $node
@@ -71,7 +71,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
 
         $nodeType = $this
             ->getMockBuilder(NodeType::class)
-            ->setMethods(['getPropertyType'])
+            ->onlyMethods(['getPropertyType'])
             ->disableOriginalConstructor()
             ->getMock();
         $nodeType
@@ -81,7 +81,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
 
         $node = $this
             ->getMockBuilder(Node::class)
-            ->setMethods(['getProperty', 'getNodeType'])
+            ->onlyMethods(['getProperty', 'getNodeType'])
             ->disableOriginalConstructor()
             ->getMock();
         $node
@@ -109,7 +109,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
 
         $nodeType = $this
             ->getMockBuilder(NodeType::class)
-            ->setMethods(['getPropertyType'])
+            ->onlyMethods(['getPropertyType'])
             ->disableOriginalConstructor()
             ->getMock();
         $nodeType
@@ -119,7 +119,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
 
         $node = $this
             ->getMockBuilder(Node::class)
-            ->setMethods(['getProperty', 'getNodeType'])
+            ->onlyMethods(['getProperty', 'getNodeType'])
             ->disableOriginalConstructor()
             ->getMock();
         $node
@@ -143,7 +143,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
     {
         $this->markTestSkipped('Has to be converted into behat test.');
 
-        $propertyValue = $this->getMockForAbstractClass(ImageInterface::class);
+        $propertyValue = $this->createMock(ImageInterface::class);
         $expected = [
             '__identity' => null,
             '__type' => get_class($propertyValue)
@@ -151,7 +151,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
 
         $nodeType = $this
             ->getMockBuilder(NodeType::class)
-            ->setMethods(['getPropertyType'])
+            ->onlyMethods(['getPropertyType'])
             ->disableOriginalConstructor()
             ->getMock();
         $nodeType
@@ -161,7 +161,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
 
         $node = $this
             ->getMockBuilder(Node::class)
-            ->setMethods(['getProperty', 'getNodeType'])
+            ->onlyMethods(['getProperty', 'getNodeType'])
             ->disableOriginalConstructor()
             ->getMock();
         $node
@@ -214,7 +214,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
 
         $nodeType = $this
             ->getMockBuilder(NodeType::class)
-            ->setMethods(['getPropertyType'])
+            ->onlyMethods(['getPropertyType'])
             ->disableOriginalConstructor()
             ->getMock();
         $nodeType
@@ -224,7 +224,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
 
         $node = $this
             ->getMockBuilder(Node::class)
-            ->setMethods(['getProperty', 'getNodeType'])
+            ->onlyMethods(['getProperty', 'getNodeType'])
             ->disableOriginalConstructor()
             ->getMock();
         $node


### PR DESCRIPTION
getMockForAbstractClass() is removed in PHPUnit 12 without replacement; for a plain interface createMock() is the direct equivalent.

The same file still used MockBuilder::setMethods(), which was already removed in PHPUnit 10 - it stayed unnoticed because every test in this class is skipped. Renamed to onlyMethods() so the file does not fatal the day these tests are revived.