### PR TITLE
BUGFIX: Scope pending changes indicator to the current site

### DIFF
--- a/Classes/ContentRepository/Service/WorkspaceService.php
+++ b/Classes/ContentRepository/Service/WorkspaceService.php
@@ -12,14 +12,17 @@ namespace Neos\Neos\Ui\ContentRepository\Service;
  * source code.
  */
 
+use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindClosestNodeFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
+use Neos\Neos\Domain\Model\SiteNodeName;
 use Neos\Neos\Domain\Service\NodeTypeNameFactory;
 use Neos\Neos\Domain\Service\WorkspacePublishingService;
 use Neos\Neos\PendingChangesProjection\Change;
@@ -47,9 +50,14 @@ class WorkspaceService
     /**
      * Get all publishable node context paths for a workspace
      *
+     * If $siteNodeName is given, only changes belonging to that site are returned. This matches the scope
+     * of {@see WorkspacePublishingService::publishChangesInSite()} which the Neos UI uses for "publish all".
+     * Without that restriction the UI would offer changes for publication that it cannot publish at all.
+     * See https://github.com/neos/neos-ui/issues/4151 and https://github.com/neos/neos-ui/issues/3923
+     *
      * @return array{contextPath:string,documentContextPath:string,typeOfChange:int}[]
      */
-    public function getPublishableNodeInfo(WorkspaceName $workspaceName, ContentRepositoryId $contentRepositoryId): array
+    public function getPublishableNodeInfo(WorkspaceName $workspaceName, ContentRepositoryId $contentRepositoryId, ?SiteNodeName $siteNodeName = null): array
     {
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
         $contentGraph = $contentRepository->getContentGraph($workspaceName);
@@ -59,6 +67,16 @@ class WorkspaceService
         foreach ($pendingChanges as $change) {
             if (method_exists($change, 'getLegacyRemovalAttachmentPoint') && $change->getLegacyRemovalAttachmentPoint() && $change->originDimensionSpacePoint !== null) {
                 // deprecated LegacyRemovalAttachmentPoint handling
+                if ($siteNodeName !== null) {
+                    $subgraph = $contentGraph->getSubgraph(
+                        $change->originDimensionSpacePoint->toDimensionSpacePoint(),
+                        VisibilityConstraints::createEmpty()
+                    );
+                    if (!$this->changeBelongsToSite($subgraph, $change->getLegacyRemovalAttachmentPoint(), $siteNodeName)) {
+                        continue;
+                    }
+                }
+
                 $nodeAddress = NodeAddress::create(
                     $contentRepositoryId,
                     $workspaceName,
@@ -97,6 +115,9 @@ class WorkspaceService
                     $subgraph = $contentGraph->getSubgraph($originDimensionSpacePoint->toDimensionSpacePoint(), VisibilityConstraints::createEmpty());
                     $node = $subgraph->findNodeById($change->nodeAggregateId);
                     if ($node instanceof Node) {
+                        if ($siteNodeName !== null && !$this->changeBelongsToSite($subgraph, $node->aggregateId, $siteNodeName)) {
+                            continue;
+                        }
                         $documentNode = $subgraph->findClosestNode($node->aggregateId, FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_DOCUMENT));
                         if ($documentNode instanceof Node) {
                             $unpublishedNodes[] = [
@@ -111,6 +132,22 @@ class WorkspaceService
         }
 
         return $unpublishedNodes;
+    }
+
+    /**
+     * Whether the closest site node of the given node is the site we are currently working in
+     */
+    private function changeBelongsToSite(
+        ContentSubgraphInterface $subgraph,
+        NodeAggregateId $nodeAggregateId,
+        SiteNodeName $siteNodeName
+    ): bool {
+        $siteNode = $subgraph->findClosestNode(
+            $nodeAggregateId,
+            FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_SITE)
+        );
+
+        return $siteNode?->name?->value === $siteNodeName->value;
     }
 
     // todo remove for now lol :D

--- a/Classes/Controller/BackendServiceController.php
+++ b/Classes/Controller/BackendServiceController.php
@@ -17,6 +17,7 @@ namespace Neos\Neos\Ui\Controller;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Dto\RebaseErrorHandlingStrategy;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindAncestorNodesFilter;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindClosestNodeFilter;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceContainsPublishableChanges;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
@@ -31,6 +32,8 @@ use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Mvc\View\JsonView;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Security\Context;
+use Neos\Neos\Domain\Model\SiteNodeName;
+use Neos\Neos\Domain\Service\NodeTypeNameFactory;
 use Neos\Neos\Domain\Service\WorkspacePublishingService;
 use Neos\Neos\Domain\Service\WorkspaceService;
 use Neos\Neos\FrontendRouting\SiteDetection\SiteDetectionResult;
@@ -462,15 +465,23 @@ class BackendServiceController extends ActionController
         );
         $this->feedbackCollection->add($success);
 
-        $updateWorkspaceInfo = new UpdateWorkspaceInfo($command->contentRepositoryId, $userWorkspace->workspaceName);
-        $this->feedbackCollection->add($updateWorkspaceInfo);
-
         $contentRepository = $this->contentRepositoryRegistry->get($command->contentRepositoryId);
 
         $subgraph = $contentRepository->getContentSubgraph(
             $command->workspaceName,
             $command->documentNode->dimensionSpacePoint,
         );
+
+        $siteNodeInstance = $subgraph->findClosestNode(
+            $command->documentNode->aggregateId,
+            FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_SITE)
+        );
+        $updateWorkspaceInfo = new UpdateWorkspaceInfo(
+            $command->contentRepositoryId,
+            $userWorkspace->workspaceName,
+            $siteNodeInstance?->name !== null ? SiteNodeName::fromNodeName($siteNodeInstance->name) : null
+        );
+        $this->feedbackCollection->add($updateWorkspaceInfo);
 
         $newDocumentNodeToRedirect = $subgraph->findNodeById($command->documentNode->aggregateId);
 
@@ -558,8 +569,11 @@ class BackendServiceController extends ActionController
 
     public function getWorkspaceInfoAction(): void
     {
-        $contentRepositoryId = SiteDetectionResult::fromRequest($this->request->getHttpRequest())->contentRepositoryId;
-        $personalWorkspaceInfo = (new WorkspaceHelper())->getPersonalWorkspace($contentRepositoryId);
+        $siteDetectionResult = SiteDetectionResult::fromRequest($this->request->getHttpRequest());
+        $personalWorkspaceInfo = (new WorkspaceHelper())->getPersonalWorkspace(
+            $siteDetectionResult->contentRepositoryId,
+            $siteDetectionResult->siteNodeName->toNodeName()
+        );
         $this->view->assign('value', $personalWorkspaceInfo);
     }
 

--- a/Classes/Domain/Model/AbstractChange.php
+++ b/Classes/Domain/Model/AbstractChange.php
@@ -17,6 +17,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Neos\Domain\Model\SiteNodeName;
 use Neos\Neos\Domain\Service\NodeTypeNameFactory;
 use Neos\Neos\Service\UserService;
 use Neos\Neos\Ui\Domain\Model\Feedback\Operations\NodeCreated;
@@ -69,7 +70,12 @@ abstract class AbstractChange implements ChangeInterface
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($this->subject);
         $documentNode = $subgraph->findClosestNode($this->subject->aggregateId, FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_DOCUMENT));
         if (!is_null($documentNode)) {
-            $updateWorkspaceInfo = new UpdateWorkspaceInfo($documentNode->contentRepositoryId, $documentNode->workspaceName);
+            $siteNode = $subgraph->findClosestNode($this->subject->aggregateId, FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_SITE));
+            $updateWorkspaceInfo = new UpdateWorkspaceInfo(
+                $documentNode->contentRepositoryId,
+                $documentNode->workspaceName,
+                $siteNode?->name !== null ? SiteNodeName::fromNodeName($siteNode->name) : null
+            );
             $this->feedbackCollection->add($updateWorkspaceInfo);
         }
     }

--- a/Classes/Domain/Model/Feedback/Operations/UpdateWorkspaceInfo.php
+++ b/Classes/Domain/Model/Feedback/Operations/UpdateWorkspaceInfo.php
@@ -16,6 +16,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ControllerContext;
+use Neos\Neos\Domain\Model\SiteNodeName;
 use Neos\Neos\Ui\ContentRepository\Service\WorkspaceService as UiWorkspaceService;
 use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
 use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
@@ -44,7 +45,8 @@ class UpdateWorkspaceInfo extends AbstractFeedback
      */
     public function __construct(
         private readonly ContentRepositoryId $contentRepositoryId,
-        private readonly WorkspaceName $workspaceName
+        private readonly WorkspaceName $workspaceName,
+        private readonly ?SiteNodeName $siteNodeName = null
     ) {
     }
 
@@ -107,7 +109,7 @@ class UpdateWorkspaceInfo extends AbstractFeedback
         if ($workspace === null) {
             return null;
         }
-        $publishableNodes = $this->uiWorkspaceService->getPublishableNodeInfo($workspace->workspaceName, $contentRepository->id);
+        $publishableNodes = $this->uiWorkspaceService->getPublishableNodeInfo($workspace->workspaceName, $contentRepository->id, $this->siteNodeName);
         return [
             'name' => $this->workspaceName->value,
             'totalNumberOfChanges' => count($publishableNodes),

--- a/Classes/Fusion/Helper/WorkspaceHelper.php
+++ b/Classes/Fusion/Helper/WorkspaceHelper.php
@@ -13,10 +13,12 @@ namespace Neos\Neos\Ui\Fusion\Helper;
 
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Security\Context;
+use Neos\Neos\Domain\Model\SiteNodeName;
 use Neos\Neos\Domain\Model\WorkspaceClassification;
 use Neos\Neos\Domain\Service\UserService;
 use Neos\Neos\Domain\Service\WorkspaceService;
@@ -67,7 +69,7 @@ class WorkspaceHelper implements ProtectedContextAwareInterface
     /**
      * @return array<string,mixed>
      */
-    public function getPersonalWorkspace(ContentRepositoryId $contentRepositoryId): array
+    public function getPersonalWorkspace(ContentRepositoryId $contentRepositoryId, ?NodeName $siteNodeName = null): array
     {
         $currentUser = $this->userService->getCurrentUser();
         if ($currentUser === null) {
@@ -76,7 +78,11 @@ class WorkspaceHelper implements ProtectedContextAwareInterface
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
         $personalWorkspace = $this->workspaceService->getPersonalWorkspaceForUser($contentRepositoryId, $currentUser->getId());
         $personalWorkspacePermissions = $this->contentRepositoryAuthorizationService->getWorkspacePermissions($contentRepositoryId, $personalWorkspace->workspaceName, $this->securityContext->getRoles(), $currentUser->getId());
-        $publishableNodes = $this->uiWorkspaceService->getPublishableNodeInfo($personalWorkspace->workspaceName, $contentRepository->id);
+        $publishableNodes = $this->uiWorkspaceService->getPublishableNodeInfo(
+            $personalWorkspace->workspaceName,
+            $contentRepository->id,
+            $siteNodeName !== null ? SiteNodeName::fromNodeName($siteNodeName) : null
+        );
         $allowedTargetWorkspaces = $this->getAllowedTargetWorkspaces($contentRepository);
         $baseWorkspace = $personalWorkspace->baseWorkspaceName ? $allowedTargetWorkspaces[$personalWorkspace->baseWorkspaceName->value] : null;
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -159,7 +159,7 @@ Neos:
             active: '${Neos.Ui.ContentDimensions.dimensionSpacePointArray(documentNode.dimensionSpacePoint)}'
             allowedPresets: '${Neos.Ui.ContentDimensions.allowedPresetsByName(documentNode.dimensionSpacePoint, documentNode.contentRepositoryId)}'
           workspaces:
-            personalWorkspace: '${Neos.Ui.Workspace.getPersonalWorkspace(documentNode.contentRepositoryId)}'
+            personalWorkspace: '${Neos.Ui.Workspace.getPersonalWorkspace(documentNode.contentRepositoryId, site.name)}'
         ui:
           contentCanvas:
             src: '${Neos.Ui.NodeInfo.previewUri(documentNode, request)}'


### PR DESCRIPTION
## What I did

Fixes #4151 and #3923.

In a multi-site setup with a single content repository, `WorkspaceService::getPublishableNodeInfo()` returns **all** pending changes of the personal workspace, while "publish all" is scoped to the current site via `WorkspacePublishingService::publishChangesInSite()`.

So editors working in site A see an orange publish indicator for changes that belong to site B, and publishing fails with:

> The command "PublishIndividualNodesFromWorkspace" for workspace `<user>` must contain nodes to publish

`getPublishableNodeInfo()` now takes an optional `SiteNodeName` and skips changes whose closest site node does not match — mirroring the scope that is actually used for publishing. The four places that build the workspace info pass the current site:

| Where | Source of the site |
| --- | --- |
| `Configuration/Settings.yaml` (initial state) | `site.name` from the Fusion context |
| `AbstractChange::updateWorkspaceInfo()` | closest site node of the changed node |
| `BackendServiceController::getWorkspaceInfoAction()` | `SiteDetectionResult` |
| `BackendServiceController` after changing the base workspace | closest site node of the document |

All four matter: if any of them keeps counting workspace-wide, the indicator falls back to the wrong number as soon as that code path runs.

The parameter is optional and defaults to the previous behaviour, so other callers of this `@internal` API are unaffected.

## How to verify it

In a multi-site setup with a single content repository:

1. Change something in site A, do not publish
2. Switch to site B → the indicator no longer shows the change from site A
3. Change something in site B → only that change is counted
4. Publish in site B → succeeds, the change in site A is untouched
5. Switch back to site A → the change shows up again and can be published

Also worth checking that the normal case still works: several documents changed within the *same* site are all counted and published together.

## Notes

As @mhsdesign points out in #3923 and #4151, the change calculation is due for a rewrite (neos/neos-development-collection#5459). This is the pragmatic fix in the meantime — it makes the indicator agree with what publishing actually does, without touching the change projection.

The content repository side is neos/neos-development-collection#5975, which makes publishing an empty changeset a no-op instead of an exception. The two are independent: this PR stops the UI from offering unpublishable changes, that one stops the exception for any other caller.

One trade-off worth flagging: the filter does an additional `findClosestNode()` per pending change. On workspaces with many pending changes this makes building the initial state slightly more expensive.